### PR TITLE
Moved register_callback(dispersy.callback) from tribler.py to allchannel

### DIFF
--- a/Tribler/Main/tribler.py
+++ b/Tribler/Main/tribler.py
@@ -462,11 +462,9 @@ class ABCApp():
                 dispersy.define_auto_load(BarterCommunity,
                                           (swift_process,),
                                           load=True)
+                
             dispersy.define_auto_load(ChannelCommunity, load=True)
             dispersy.define_auto_load(PreviewChannelCommunity)
-
-            from Tribler.community.channel.community import register_callback
-            register_callback(dispersy.callback)
 
             print >> sys.stderr, "tribler: Dispersy communities are ready"
 

--- a/Tribler/community/allchannel/community.py
+++ b/Tribler/community/allchannel/community.py
@@ -109,6 +109,9 @@ class AllChannelCommunity(Community):
 
         self._blocklist = {}
         self._searchCallbacks = {}
+        
+        from Tribler.community.channel.community import register_callback
+        register_callback(dispersy.callback)
 
     def initiate_meta_messages(self):
         batch_delay = 1.0


### PR DESCRIPTION
community.
