### PR TITLE
Disable BarterCommunity.

### DIFF
--- a/Tribler/Main/tribler.py
+++ b/Tribler/Main/tribler.py
@@ -402,7 +402,9 @@ class ABCApp():
         self.sconfig.set_install_dir(self.installdir)
 
         # Boudewijn, 2013-06-17: Enable Dispersy tunnel (hard-coded)
-        self.sconfig.set_dispersy_tunnel_over_swift(True)
+        # self.sconfig.set_dispersy_tunnel_over_swift(True)
+        # Boudewijn, 2013-07-17: Disabling Dispersy tunnel (hard-coded)
+        self.sconfig.set_dispersy_tunnel_over_swift(False)
 
         # Arno, 2010-03-31: Hard upgrade to 50000 torrents collected
         self.sconfig.set_torrent_collecting_max_torrents(50000)
@@ -460,7 +462,6 @@ class ABCApp():
             # 17/07/13 Boudewijn: the missing-member message send by the BarterCommunity on the swift port is crashing
             # 6.1 clients.  We will disable the BarterCommunity for version 6.2, giving people some time to upgrade
             # their version before enabling it again.
-
             # if swift_process:
             #     dispersy.define_auto_load(BarterCommunity,
             #                               (swift_process,),


### PR DESCRIPTION
The missing-member message send by the BarterCommunity on the swift
port is crashing 6.1 clients.  We will disable the BarterCommunity for
version 6.2, giving people some time to upgrade their version before
enabling it again.
