### PR TITLE
Auto version for packages and UI

### DIFF
--- a/Tribler/Core/__init__.py
+++ b/Tribler/Core/__init__.py
@@ -5,15 +5,15 @@ from threading import RLock
 # Written by BitTornado authors and Arno Bakker
 # see LICENSE.txt for license information
 
-# Arno: FIXME _idprefix is also defined in .__init__ and that's the one
-# actually used in connections, so make sure they are defined in one place
-# (here) and correct.
-#
+## Arno: FIXME _idprefix is also defined in .__init__ and that's the one
+## actually used in connections, so make sure they are defined in one place
+## (here) and correct.
+##
 
 from Tribler.__init__ import LIBRARYNAME
+from Tribler.Core.version import version_id
 
 if LIBRARYNAME == "Tribler":
-    version_id = '6.2.0'
     product_name = 'Tribler'
     version_short = 'Tribler-' + version_id
     report_email = 'tribler@tribler.org'

--- a/Tribler/Core/version.py
+++ b/Tribler/Core/version.py
@@ -1,10 +1,2 @@
-#!/usr/bin/env python
-
-#WARNING!#WARNING!#WARNING!#WARNING!#WARNING!#WARNING!#WARNING!#WARNING!#
-###                                                                   ###
-###  This file will be overwritten when building a package/installer! ###
-###                                                                   ###
-#WARNING!#WARNING!#WARNING!#WARNING!#WARNING!#WARNING!#WARNING!#WARNING!#
-
-version_id='GIT'
-build_date='0/0/0'
+version_id = "6.2.0-GIT"
+build_date = "Thu Apr 18 17:12:34 2013"

--- a/Tribler/Lang/lang.py
+++ b/Tribler/Lang/lang.py
@@ -9,7 +9,7 @@ from cStringIO import StringIO
 
 from Tribler.__init__ import LIBRARYNAME
 from Tribler.Utilities.configreader import ConfigReader
-from Tribler.Core.__init__ import version_id
+from Tribler.Core.version import version_id
 
 #
 #

--- a/Tribler/Main/Build/Win32/tribler.nsi
+++ b/Tribler/Main/Build/Win32/tribler.nsi
@@ -1,5 +1,5 @@
 !define PRODUCT "Tribler"
-!define VERSION "6.2.0"
+!define VERSION "__GIT__"
 
 !include "MUI.nsh"
 !include "UAC.nsh"
@@ -50,10 +50,10 @@ BrandingText "${PRODUCT}"
 
 ; Arno, 2010-02-09: On Vista+Win7 the default value for RequestExecutionLevel
 ; is auto, so this installer will be run as Administrator. Hence also the
-; Tribler.exe that is launched by FINISHPAGE_RUN will be launched as that user. 
-; This is not what we want. We do want an admin-level install, in particular 
+; Tribler.exe that is launched by FINISHPAGE_RUN will be launched as that user.
+; This is not what we want. We do want an admin-level install, in particular
 ; for configuring the Windows firewall automatically. Alternative is the
-; UAC plugin (http://nsis.sourceforge.net/UAC_plug-in) but that's still beta. 
+; UAC plugin (http://nsis.sourceforge.net/UAC_plug-in) but that's still beta.
 ; Bouman, 2012-04-13: Now using the UAC plugin.
 !define MUI_FINISHPAGE_RUN
 !define MUI_FINISHPAGE_RUN_FUNCTION PageFinishRun
@@ -73,7 +73,7 @@ BrandingText "${PRODUCT}"
 ;Languages
 
 !insertmacro MUI_LANGUAGE "English"
- 
+
 ;--------------------------------
 ;Language Strings
 
@@ -157,7 +157,7 @@ Section "!Main EXE" SecMain
  SetOutPath "$INSTDIR\Tribler\Category"
  File Tribler\Category\*.conf
  File Tribler\Category\*.filter
- 
+
  ; Arno, 2012-05-25: data files for pymdht
  CreateDirectory "$INSTDIR\Tribler\Core\DecentralizedTracking"
  CreateDirectory "$INSTDIR\Tribler\Core\DecentralizedTracking\pymdht"
@@ -165,7 +165,7 @@ Section "!Main EXE" SecMain
  SetOutPath "$INSTDIR\Tribler\Core\DecentralizedTracking\pymdht\core"
  File Tribler\Core\DecentralizedTracking\pymdht\core\bootstrap.main
  File Tribler\Core\DecentralizedTracking\pymdht\core\bootstrap.backup
- 
+
  ; End
  SetOutPath "$INSTDIR"
  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT}" "DisplayName" "${PRODUCT}"
@@ -205,7 +205,7 @@ SectionEnd
 
 Section "Startmenu Icons" SecStart
    CreateDirectory "$SMPROGRAMS\${PRODUCT}"
-   CreateShortCut "$SMPROGRAMS\${PRODUCT}\Uninstall ${PRODUCT}.lnk" "$INSTDIR\Uninstall.exe"   
+   CreateShortCut "$SMPROGRAMS\${PRODUCT}\Uninstall ${PRODUCT}.lnk" "$INSTDIR\Uninstall.exe"
    CreateShortCut "$SMPROGRAMS\${PRODUCT}\${PRODUCT}.lnk" "$INSTDIR\${PRODUCT}.exe"
 SectionEnd
 
@@ -228,7 +228,7 @@ Section "Make Default For .tstream" SecDefaultTStream
    ; Arno: Poor man's attempt to check if already registered
    ReadRegStr $0 HKCR .tstream ""
    ReadRegStr $1 HKCR "tstream\shell\open\command" ""
-   StrCpy $2 $1 -4 
+   StrCpy $2 $1 -4
    StrCmp $0 "" 0 +2
       return
    MessageBox MB_YESNO ".tstream already registered to $2. Overwrite?" IDYES +2 IDNO 0
@@ -284,11 +284,11 @@ Section "Uninstall"
  RMDir /r "$INSTDIR"
 
  Delete "$DESKTOP\${PRODUCT}.lnk"
- 
+
  SetShellVarContext all
  RMDir "$SMPROGRAMS\${PRODUCT}"
  RMDir /r "$SMPROGRAMS\${PRODUCT}"
- 
+
  DeleteRegKey HKEY_LOCAL_MACHINE "SOFTWARE\${PRODUCT}"
  DeleteRegKey HKEY_LOCAL_MACHINE "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT}"
 
@@ -323,7 +323,7 @@ ${Default}
 	MessageBox mb_IconStop|mb_TopMost|mb_SetForeground "Unable to elevate , error $0"
 	Quit
 ${EndSwitch}
- 
+
 SetShellVarContext all
 !macroend
 
@@ -331,15 +331,15 @@ SetShellVarContext all
 Function .onInit
   !insertmacro Init "installer"
 
-  System::Call 'kernel32::CreateMutexA(i 0, i 0, t "Tribler") i .r1 ?e' 
+  System::Call 'kernel32::CreateMutexA(i 0, i 0, t "Tribler") i .r1 ?e'
 
-  Pop $R0 
+  Pop $R0
 
-  StrCmp $R0 0 +3 
+  StrCmp $R0 0 +3
 
   MessageBox MB_OK "The installer is already running."
 
-  Abort 
+  Abort
 
   ReadRegStr $R0 HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT}" "UninstallString"
   StrCmp $R0 "" done

--- a/Tribler/Main/Build/update_version_from_git.py
+++ b/Tribler/Main/Build/update_version_from_git.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+
+from subprocess import Popen, PIPE
+from time import ctime
+from os import path, linesep
+from sys import platform
+
+#We aren't using python-git because we don't want to install the dependency on all the builders.
+
+def runCommand(cmd):
+    p = Popen(cmd, stdout=PIPE, stderr=PIPE)
+    p.wait()
+    assert(p.returncode == 0)
+    stdout = p.communicate()[0]
+    return stdout.strip()
+
+if __name__ == '__main__':
+    cmd = ['git', 'describe', '--tags', 'HEAD']
+    version_id = runCommand(cmd).strip()[1:]
+    print "Version:", version_id
+
+    build_date = ctime()
+    print "Build date:", build_date
+
+    print 'Writing runtime version info.'
+    f = open(path.join('Tribler', 'Core', 'version.py'), 'w')
+    f.write('version_id = "%s"%sbuild_date = "%s"' % (version_id, linesep, build_date))
+    f.close()
+
+    f = open('.TriblerVersion', 'w')
+    f.write(version_id)
+    f.close()
+
+    if platform == 'linux2':
+        runCommand('dch -v {} New upstream release.'.format(version_id).split())
+    elif platform == 'win32':
+        print 'Replacing NSI string.'
+        f = open(path.join('Tribler', 'Main', 'Build', 'Win32', 'tribler.nsi'), 'r+')
+        content = f.read().replace('__GIT__', version_id)
+        f.seek(0)
+        f.write(content)
+        f.close()

--- a/makedistmac.sh
+++ b/makedistmac.sh
@@ -8,6 +8,10 @@
 # Based on original Makefile by JD Mol.
 
 APPNAME=Tribler
+if [ -e .TriblerVersion ]; then
+    DMGNAME="Tribler-$(cat .TriblerVersion)"
+fi
+
 export LIBRARYNAME=Tribler
 
 PYVER=2.7
@@ -115,8 +119,11 @@ hdiutil convert dist/temp/rw.dmg -format UDZO -imagekey zlib-level=9 -o dist/$AP
 rm -f dist/temp/rw.dmg
 
 # add EULA
-hdiutil unflatten dist/$APPNAME.dmg 
+hdiutil unflatten dist/$APPNAME.dmg
 /Developer/Tools/DeRez -useDF $LIBRARYNAME/Main/Build/Mac/SLAResources.rsrc > dist/temp/sla.r
-/Developer/Tools/Rez -a dist/temp/sla.r -o dist/$APPNAME.dmg 
-hdiutil flatten dist/$APPNAME.dmg 
+/Developer/Tools/Rez -a dist/temp/sla.r -o dist/$APPNAME.dmg
+hdiutil flatten dist/$APPNAME.dmg
 
+if [ ! -z "$DMGNAME" ]; then
+    mv dist/$APPNAME.dmg dist/$DMGNAME.dmg
+fi


### PR DESCRIPTION
This is the first approach at having fully automated version number generation for the packaged versions of Tribler.
Now by just running Tribler/Main/Build/update_version_from_git.py before starting the packaging script for every platform, all the necessary files/fields will get updated. The resulting packages will be something like:
Tribler-6.2.0-36-g80f0eea.dmg where 6.2.0 is extracted from the latest release tag on the branch we are building, 36 are the number of commits between the last tag and the current point and g80f0eea the actual abbreviated commit hash.

The same applies to the windows installer and .deb packages.

There are test jobs for each platform at

http://jenkins.tribler.org/job/Build-Tribler_OSX_next_auto_version/ 
http://jenkins.tribler.org/job/Build-Tribler_Ubuntu-12-10_amd64_next_auto_version/
http://jenkins.tribler.org/job/Build-Tribler_Ubuntu-12-10_next_auto_version/
http://jenkins.tribler.org/job/Build-Tribler_WinXP32_next_auto_version/

When running directly from the git repo, Tribler will show 6.2.0-GIT as version.
