### PR TITLE
Fixing issue 305.

### DIFF
--- a/Tribler/Test/test_sqlitecachedbhandler.py
+++ b/Tribler/Test/test_sqlitecachedbhandler.py
@@ -6,7 +6,7 @@ from time import time
 from binascii import unhexlify
 from shutil import copy as copyFile
 
-
+from Tribler.Core.Session import Session
 from Tribler.Core.CacheDB.sqlitecachedb import SQLiteCacheDB
 from bak_tribler_sdb import *
 
@@ -24,6 +24,12 @@ BUSYTIMEOUT = 5000
 SQLiteCacheDB.DEBUG = False
 DEBUG = False
 
+# ------------------------------------------------------------
+# The global teardown that will delete the Session.
+# ------------------------------------------------------------
+def teardown():
+    if Session.has_instance():
+        Session.del_instance()
 
 class AbstractDB(AbstractServer):
 


### PR DESCRIPTION
Added a Session deletion for unit test "test_sqlitecachedbhandler" to solve the "Session is singleton" problem in running batched unit tests.
