### PR TITLE
Added python-cherrypy3, needed for the web interface

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -15,6 +15,7 @@ Architecture: all
 Depends: libav-tools,
          libjs-mootools,
          python-apsw,
+         python-cherrypy3,
          python-feedparser,
          python-libtorrent,
          python-m2crypto,


### PR DESCRIPTION
I installed tribler in a clean environment, and this module was missing
http://forum.tribler.org/viewtopic.php?f=6&t=5311&p=8838#p8838
 File "Tribler/Main/tribler.py", line 322, in **init**
from Tribler.Main.webUI.webUI import WebUI
File "/usr/share/tribler/Tribler/Main/webUI/webUI.py", line 1, in <module>
import cherrypy
ImportError: No module named cherrypy
