### PR TITLE
UTF-8 paths for shutil functions.

### DIFF
--- a/Tribler/Test/test_as_server.py
+++ b/Tribler/Test/test_as_server.py
@@ -54,7 +54,7 @@ class AbstractServer(unittest.TestCase):
         for path in os.listdir(BASE_DIR):
             path = os.path.join(BASE_DIR, path)
             if path.startswith(STATE_DIR) or path.startswith(DEST_DIR):
-                shutil.rmtree(path)
+                shutil.rmtree(unicode(path))
 
     def tearDown(self):
         self.tearDownCleanup()


### PR DESCRIPTION
Do NOT merge.

To solve UTF-8 path issue on Windows.

ERROR:

```
Traceback (most recent call last):
  File "C:\Python27\x86\lib\unittest\case.py", line 322, in run
    self.setUp()
  File "D:\jenkins\workspace\Test_tribler_devel_win2008r2\tribler\Tribler\Test\test_as_server.py", line 47, in setUp
    self.setUpCleanup()
  File "D:\jenkins\workspace\Test_tribler_devel_win2008r2\tribler\Tribler\Test\test_as_server.py", line 57, in setUpCleanup
    shutil.rmtree(path)
  File "C:\Python27\x86\lib\shutil.py", line 252, in rmtree
    onerror(os.remove, fullname, sys.exc_info())
  File "C:\Python27\x86\lib\shutil.py", line 250, in rmtree
    os.remove(fullname)
WindowsError: [Error 2] The system cannot find the file specified: 'D:\\jenkins\\workspace\\Test_tribler_devel_win2008r2\\tribler\\Tribler\\Test\\test_.Tribler\\Serg\xe9HarrO'
```
