### PR TITLE
Fix debian/bin/tribler security issue.

### DIFF
--- a/debian/bin/tribler
+++ b/debian/bin/tribler
@@ -7,4 +7,4 @@ export PYTHONPATH="$PYTHONPATH":$_TRIBLERPATH
 
 echo "Starting Tribler..."
 cd $_TRIBLERPATH
-exec python -O Tribler/Main/tribler.py "$@" > /tmp/$USER-tribler.log 2>&1
+exec python -O Tribler/Main/tribler.py "$@" > `mktemp /tmp/$USER-tribler-XXXXXXXX.log` 2>&1


### PR DESCRIPTION
Use mktemp to put the log in temp directory with some random template
to avoid malicious user to overwrite someone's file by symlinks.

Please see https://bugs.debian.org/760561

Signed-off-by: Ying-Chun Liu (PaulLiu) paulliu@debian.org
