### PR TITLE
Call OnExit on the wx thread.

### DIFF
--- a/Tribler/Main/tribler_main.py
+++ b/Tribler/Main/tribler_main.py
@@ -926,6 +926,7 @@ class ABCApp():
         target = FileDropTarget(self.frame)
         target.OnDropFiles(None, None, [filename])
 
+    @forceWxThread
     def OnExit(self):
         self._logger.info("main: ONEXIT")
         self.ready = False


### PR DESCRIPTION
Fixes test runs hanging indefinitely raising a bunch of PyDeadObject exceptions.
Ready to merge.
