### PR TITLE
Use correct Image module import

### DIFF
--- a/Tribler/Core/Video/VideoUtility.py
+++ b/Tribler/Core/Video/VideoUtility.py
@@ -7,7 +7,7 @@ import subprocess
 from re import search
 from math import sqrt
 
-import Image
+from PIL import Image
 
 from Tribler.Core.osutils import is_android
 


### PR DESCRIPTION
Otherwise Tribler doesn't start (Ubuntu 14.04)
