### PR TITLE
fix a logging problem in MetadataCommunity

### DIFF
--- a/Tribler/community/metadata/community.py
+++ b/Tribler/community/metadata/community.py
@@ -140,7 +140,7 @@ class MetadataCommunity(Community):
                         _, sub_file_path, thumbnail_hash_str = json.loads(value)
 
                         if not self._rth.has_metadata(infohash, sub_file_path):
-                            self._logger.debug(u"try to download %s with %s from %s", key, thumbnail_hash_str,
+                            self._logger.debug(u"try to download %s key=%s with %s from %s", thumbnail_hash_str, key,
                                                message.candidate.sock_addr[0], message.candidate.sock_addr[1])
 
                             @call_on_reactor_thread


### PR DESCRIPTION
Fixes this backtrace:

```
ERROR   1418250960.63       community:2188  exception during check_callback for metadata
Traceback (most recent call last):
  File "/home/jenkins/workspace/GH_Tribler_pull-request-tester_devel/tribler/Tribler/dispersy/community.py", line 2186, in on_messages
    possibly_messages = list(meta.check_callback(messages))
  File "/home/jenkins/workspace/GH_Tribler_pull-request-tester_devel/tribler/Tribler/community/metadata/community.py", line 144, in check_metadata
    message.candidate.sock_addr[0], message.candidate.sock_addr[1])
  File "/usr/lib/python2.7/logging/__init__.py", line 1148, in debug
    self._log(DEBUG, msg, args, **kwargs)
  File "/usr/lib/python2.7/logging/__init__.py", line 1279, in _log
    self.handle(record)
  File "/usr/lib/python2.7/logging/__init__.py", line 1289, in handle
    self.callHandlers(record)
  File "/usr/lib/python2.7/logging/__init__.py", line 1329, in callHandlers
    hdlr.handle(record)
  File "/usr/lib/python2.7/logging/__init__.py", line 757, in handle
    self.emit(record)
  File "/usr/lib/python2.7/dist-packages/nose/plugins/logcapture.py", line 82, in emit
    self.buffer.append(self.format(record))
  File "/usr/lib/python2.7/logging/__init__.py", line 732, in format
    return fmt.format(record)
  File "/usr/lib/python2.7/logging/__init__.py", line 471, in format
    record.message = record.getMessage()
  File "/usr/lib/python2.7/logging/__init__.py", line 335, in getMessage
    msg = msg % self.args
TypeError: not all arguments converted during string formatting
```
