### PR TITLE
Fix mute-button in mediaplayer

### DIFF
--- a/Tribler/Main/vwxGUI/EmbeddedPlayer.py
+++ b/Tribler/Main/vwxGUI/EmbeddedPlayer.py
@@ -74,6 +74,7 @@ class EmbeddedPlayerPanel(wx.Panel):
         self.download_hash = None
         self.update = True
         self.timeoffset = None
+        self.oldvolume = 0
 
         vSizer = wx.BoxSizer(wx.VERTICAL)
 


### PR DESCRIPTION
Fix for attributeError: 'EmbeddedPlayerPanel' object has no attribute 'oldvolume'
Traceback (most recent call last):
  File "/home/rob/git/tribler/Tribler/Main/vwxGUI/EmbeddedPlayer.py", line 205, in MuteClicked
    self.volume = self.oldvolume
AttributeError: 'EmbeddedPlayerPanel' object has no attribute 'oldvolume'
