### PR TITLE
Fixed a segfault crash when trying to go full-screen

### DIFF
--- a/Tribler/Main/vwxGUI/EmbeddedPlayer.py
+++ b/Tribler/Main/vwxGUI/EmbeddedPlayer.py
@@ -367,6 +367,7 @@ class EmbeddedPlayerPanel(wx.Panel):
             eventPanel.SetBackgroundColour(wx.BLACK)
             eventPanel.Bind(wx.EVT_KEY_DOWN, lambda event: self.OnFullScreenKey(event))
             self.fullscreenwindow.Bind(wx.EVT_CLOSE, lambda event: self._ToggleFullScreen())
+            self.fullscreenwindow.Show()
             self.fullscreenwindow.ShowFullScreen(True)
             eventPanel.SetFocus()
             self.vlcwrap.set_window(self.fullscreenwindow)


### PR DESCRIPTION
Due to a bug in ShowFullScreen(), not calling Show() before calling it can cause unexpected behaviour. This was resulting in a segfault crash with certain window managers (xmonad, dwm, maybe others too), preventing some users from going full-screen in the embedded player.

This is literally a one-line fix, and it shouldn't have any detrimental side-effects.
