### PR TITLE
added some files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 /Tribler/Test/test_.Tribler/
 /Tribler/Test/test_.Tribler2
 /Tribler/Test/test_TriblerDownloads2
+/Tribler/community/tunnel/.Tribler*
 /bootstraptribler.txt
 /core
 /debian/files
@@ -26,4 +27,5 @@
 /debian/tribler/
 /output
 \#*\#
+memorydump.out
 flycheck_*


### PR DESCRIPTION
Main in tunnel community creates .Tribler-\* folders, and dispersy dowser creates memorydump.out. Both should not be in git.
