### PR TITLE
Raise if len(key) != 16 to avoid segfaulting m2crypto.

### DIFF
--- a/Tribler/community/tunnel/crypto/cryptowrapper.py
+++ b/Tribler/community/tunnel/crypto/cryptowrapper.py
@@ -28,6 +28,11 @@ try:
     def aes_decrypt_str(aes_key, encr_str):
         if isinstance(aes_key, long):
             aes_key = long_to_bytes(aes_key, 16)
+        # ATTENTION: If the key has the wrong length M2Crypto will segfault!!!
+        if len(aes_key) != 16:
+            raise ValueError("aes_encrypt_str: wrong key length: %s for key %s " % (len(aes_key),
+                                                                                    aes_key.encode('HEX')))
+
         cipher = EVP.Cipher(alg='aes_128_ecb', key=aes_key, iv='\x00' * 16, op=0)
         ret = cipher.update(encr_str)
         return ret + cipher.final()
@@ -51,4 +56,3 @@ try:
 
 except ImportError as e:
     raise RuntimeError("Cannot continue without M2Crypto" + str(e))
-


### PR DESCRIPTION
I know it will break tests until the underlying issue (getting bad keys there from the anontunnel stuff) gets fixed. But we really need a new release with the optional tunneling and this makes Tribler crash way too much.
