### PR TITLE
For now use custom long_to_bytes/bytes_to_long

### DIFF
--- a/Tribler/community/tunnel/community.py
+++ b/Tribler/community/tunnel/community.py
@@ -19,7 +19,7 @@ from Tribler.Core.simpledefs import DLSTATUS_DOWNLOADING, DLSTATUS_SEEDING, DLST
 from Tribler.Core.DecentralizedTracking.pymdht.core.identifier import Id
 from Tribler.Core.Utilities.encoding import encode, decode
 
-from crypto.cryptowrapper import long_to_bytes, bytes_to_long
+from Crypto.Util.number import bytes_to_long, long_to_bytes
 
 from Tribler.community.tunnel import (CIRCUIT_STATE_READY, CIRCUIT_STATE_EXTENDING, ORIGINATOR,
                                       PING_INTERVAL, EXIT_NODE, CIRCUIT_TYPE_DATA, CIRCUIT_TYPE_IP,

--- a/Tribler/community/tunnel/crypto/cryptowrapper.py
+++ b/Tribler/community/tunnel/crypto/cryptowrapper.py
@@ -1,6 +1,8 @@
 import logging
 logger = logging.getLogger(__name__)
 
+from ..conversion import long_to_bytes, bytes_to_long
+
 try:
     from gmpy import mpz, invert, gcd
 
@@ -9,7 +11,7 @@ except ImportError:
 
 try:
     from Crypto.Random.random import StrongRandom
-    from Crypto.Util.number import long_to_bytes, bytes_to_long, GCD
+    from Crypto.Util.number import GCD
 
 except ImportError:
     raise RuntimeError("Cannot continue without pycrypto")


### PR DESCRIPTION
For now use custom long_to_bytes/bytes_to_long to provide compatibility with 6.4 TunnelCommunity. Alternatively, we could break compatibility and change the TunnelCommunity id.
