### PR TITLE
Fix nickname problem

### DIFF
--- a/Tribler/Core/SessionConfig.py
+++ b/Tribler/Core/SessionConfig.py
@@ -383,7 +383,7 @@ class SessionConfigInterface(object):
     def get_nickname(self):
         """ Returns the set nickname.
         @return A Unicode string. """
-        return self.sessconfig.get(u'general', u'nickname')
+        return unicode(self.sessconfig.get(u'general', u'nickname'))
 
     def set_mugshot(self, value, mime='image/jpeg'):
         """ The picture of yourself you want to show to others.


### PR DESCRIPTION
When getting nickname from the config file, we should convert it into unicode. Otherwise if the nickname is a number like 1234, then `get()` will get the nickname as an `int`, and the Settings Dialog will break.

This should fix #825.
