### PR TITLE
Remove unnecessary grep in SingleInstanceChecker.py

### DIFF
--- a/Tribler/Utilities/SingleInstanceChecker.py
+++ b/Tribler/Utilities/SingleInstanceChecker.py
@@ -32,7 +32,7 @@ class SingleInstanceChecker(object):
         return self._wx_checker.IsAnotherRunning()
 
     def __get_process_num_on_linux(self):
-        cmd = 'pgrep -fl "%s\.py" | grep -v pgrep' % self._basename
+        cmd = 'pgrep -fl "%s\.py"' % self._basename
         progress_info = commands.getoutput(cmd)
 
         self._logger.info(u"Linux cmd returned %s", progress_info)


### PR DESCRIPTION
pgrep removes itself from the list of results and with grep 2.21 or greater grep will print `grep: warning: GREP_OPTIONS is deprecated; please use an alias or script` if GREP_OPTIONS is set, causing Tribler to believe there is already a process running.