### PR TITLE
Use shutil.move instead of os.rename in several places

### DIFF
--- a/Tribler/Core/Upgrade/torrent_upgrade64.py
+++ b/Tribler/Core/Upgrade/torrent_upgrade64.py
@@ -171,7 +171,7 @@ class TorrentMigrator64(object):
                 file_path = os.path.join(root, name)
                 try:
                     tdef = TorrentDef.load(file_path)
-                    os.rename(file_path, os.path.join(self.tmp_migration_dir, hexlify(tdef.infohash) + u".torrent"))
+                    move(file_path, os.path.join(self.tmp_migration_dir, hexlify(tdef.infohash) + u".torrent"))
                     self.torrent_files_migrated += 1
                 except Exception as e:
                     self._logger.error(u"dropping corrupted torrent file %s: %s", file_path, str(e))

--- a/Tribler/Core/Upgrade/upgrade.py
+++ b/Tribler/Core/Upgrade/upgrade.py
@@ -1,11 +1,12 @@
 import logging
 import os
+import shutil
 
 from Tribler.Core.CacheDB.db_versions import LATEST_DB_VERSION
 from Tribler.Core.Upgrade.db_upgrader import DBUpgrader
 from Tribler.Core.Upgrade.torrent_upgrade64 import TorrentMigrator64
-
 from Tribler.dispersy.util import call_on_reactor_thread
+
 
 # Database versions:
 #   *earlier versions are no longer supported
@@ -68,6 +69,6 @@ class TriblerUpgrader(object):
         self.db.close()
         old_dir = os.path.dirname(self.db.sqlite_db_path)
         new_dir = u'%s_backup_%d' % (old_dir, LATEST_DB_VERSION)
-        os.rename(old_dir, new_dir)
+        shutil.move(old_dir, new_dir)
         os.makedirs(old_dir)
         self.db.initialize()

--- a/Tribler/Main/Utility/Feeds/rssparser.py
+++ b/Tribler/Main/Utility/Feeds/rssparser.py
@@ -1,23 +1,22 @@
 # Written by Niels Zeilemaker
-
-import os
-import sha
-import time
-import re
+import imghdr
 import logging
+import os
+import re
+import sha
+import tempfile
+import time
 from copy import deepcopy
 from shutil import copyfile
-from urlparse import urlparse
-import imghdr
-import tempfile
-from traceback import print_exc
 from threading import Thread, RLock, Event
+from traceback import print_exc
+
 import requests
 
-from Tribler.Core.TorrentDef import TorrentDef
-from Tribler.Core.Utilities.timeouturlopen import urlOpenTimeout
-from Tribler.Core.Utilities.bencode import bdecode
 from Tribler.Core.RemoteTorrentHandler import RemoteTorrentHandler
+from Tribler.Core.TorrentDef import TorrentDef
+from Tribler.Core.Utilities.bencode import bdecode
+
 
 try:
     from Tribler.Main.Utility.Feeds import feedparser
@@ -354,7 +353,7 @@ class URLResourceRetriever(object):
             old_filepath = filepath
             new_filename = u"thumbnail-%d.%s" % (image_count, image_type)
             new_filepath = os.path.join(work_dir, new_filename)
-            os.rename(old_filepath, new_filepath)
+            move(old_filepath, new_filepath)
 
             return new_filepath
         else:

--- a/Tribler/Main/vwxGUI/list_item.py
+++ b/Tribler/Main/vwxGUI/list_item.py
@@ -610,9 +610,9 @@ class TorrentListItem(DoubleLineListItemWithButtons):
 
                         elif os.path.exists(newfile):
                             os.remove(newfile)
-                            os.rename(oldfile, newfile)
+                            shutil.move(oldfile, newfile)
                         else:
-                            os.rename(oldfile, newfile)
+                            shutil.move(oldfile, newfile)
                 else:
                     os.renames(old, new)
 
@@ -974,7 +974,7 @@ class ThumbnailListItemNoTorrent(FancyPanel, ListItem):
     def CreateBitmaps(self):
         # Temporary silence wx errors. Avoids "No handler found for image type" errors.
         nolog = wx.LogNull()
-        
+
         bitmap = None
 
         thumb_dir = os.path.join(self.guiutility.utility.session.get_torrent_collecting_dir(), binascii.hexlify(self.original_data.infohash))

--- a/Tribler/Main/vwxGUI/settingsDialog.py
+++ b/Tribler/Main/vwxGUI/settingsDialog.py
@@ -1,27 +1,26 @@
 # Written by Niels Zeilemaker
 
 # see LICENSE.txt for license information
-import wx
-import wx.lib.masked.textctrl
-import wx.lib.imagebrowser as ib
-import sys
-import os
-import tempfile
 import atexit
-import time
 import logging
+import os
+import shutil
+import sys
+import tempfile
+import time
 
-from Tribler.Core.simpledefs import UPLOAD, DOWNLOAD, STATEDIR_TORRENTCOLL_DIR
+import wx.lib.imagebrowser as ib
+import wx.lib.masked.textctrl
+
 from Tribler.Core.Session import Session
 from Tribler.Core.SessionConfig import SessionStartupConfig
 from Tribler.Core.osutils import get_picture_dir
-
+from Tribler.Core.simpledefs import UPLOAD, DOWNLOAD, STATEDIR_TORRENTCOLL_DIR
 from Tribler.Main.globals import DefaultDownloadStartupConfig, get_default_dscfg_filename
-from Tribler.Main.vwxGUI.GuiUtility import GUIUtility
 from Tribler.Main.vwxGUI.GuiImageManager import GuiImageManager, data2wxBitmap, ICON_MAX_DIM
+from Tribler.Main.vwxGUI.GuiUtility import GUIUtility
+from Tribler.Main.vwxGUI.validator import DirectoryValidator, NetworkSpeedValidator,NumberValidator
 from Tribler.Main.vwxGUI.widgets import _set_font, EditText, AnonymousSlidebar
-from Tribler.Main.vwxGUI.validator import DirectoryValidator, NetworkSpeedValidator, \
-    NumberValidator
 
 
 def create_section(parent, hsizer, label):
@@ -370,9 +369,9 @@ class SettingsDialog(wx.Dialog):
                         elif os.path.exists(newfile):
                             if not ignore:
                                 os.remove(newfile)
-                                os.rename(oldfile, newfile)
+                                shutil.move(oldfile, newfile)
                         else:
-                            os.rename(oldfile, newfile)
+                            shutil.move(oldfile, newfile)
                 else:
                     os.renames(old, new)
 


### PR DESCRIPTION
To allow to move files across filesystems. 
Related to: #1115