### PR TITLE
Set delimiter for linehandler in tunnel main to \n

### DIFF
--- a/Tribler/community/tunnel/main.py
+++ b/Tribler/community/tunnel/main.py
@@ -202,7 +202,7 @@ class Tunnel(object):
 
 class LineHandler(LineReceiver):
     
-    delimiter = '\n'
+    delimiter = os.linesep
     
     def __init__(self, anon_tunnel, profile):
         self.anon_tunnel = anon_tunnel

--- a/Tribler/community/tunnel/main.py
+++ b/Tribler/community/tunnel/main.py
@@ -201,6 +201,9 @@ class Tunnel(object):
 
 
 class LineHandler(LineReceiver):
+    
+    delimiter = '\n'
+    
     def __init__(self, anon_tunnel, profile):
         self.anon_tunnel = anon_tunnel
         self.profile = profile


### PR DESCRIPTION
Small fix - for some reason Ubuntu on my mac stopped recognizing the enter key, rendering the main debugger useless. By specifying \n hardcoded, problems is solved. 