### PR TITLE
Fix a dht_callback threading problem in hidden community

### DIFF
--- a/Tribler/community/tunnel/hidden_community.py
+++ b/Tribler/community/tunnel/hidden_community.py
@@ -205,6 +205,7 @@ class HiddenTunnelCommunity(TunnelCommunity):
 
     def do_lookup(self, info_hash, hops):
         # Get seeders from the DHT and establish an e2e encrypted tunnel to them
+        @call_on_reactor_thread
         def dht_callback(info_hash, peers, _):
             if not peers:
                 return


### PR DESCRIPTION
Fixes a backtrace mention in #1204 
```
 CRITICAL 1423226122.23     minitwisted:105   MINITWISTED CRASHED
 ERROR   1423226122.23     minitwisted:106   MINITWISTED CRASHED 
 Traceback (most recent call last):
   File "/home/rob/git/tribler/Tribler/Core/DecentralizedTracking/pymdht/core/minitwisted.py", line 103, in run2
    self.run_one_step()
  File "/home/rob/git/tribler/Tribler/Core/DecentralizedTracking/pymdht/core/minitwisted.py", line 179, in run_one_step
    datagram_received)
  File "/home/rob/git/tribler/Tribler/Core/DecentralizedTracking/pymdht/core/controller.py", line 262, in on_datagram_received
    callback_f(lookup_id, peers, msg.src_node)
  File "/home/rob/git/tribler/Tribler/community/tunnel/hidden_community.py", line 227, in dht_callback
    self.create_key_request(info_hash, peer)
  File "/home/rob/git/tribler/Tribler/community/tunnel/hidden_community.py", line 240, in create_key_request
    cache = self.request_cache.add(KeyRequestCache(self, circuit, sock_addr, info_hash))
  File "/home/rob/git/tribler/Tribler/community/tunnel/hidden_community.py", line 60, in __init__
    super(KeyRequestCache, self).__init__(community.request_cache, u"key-request")
  File "/home/rob/git/tribler/Tribler/dispersy/requestcache.py", line 50, in __init__
    number = RandomNumberCache.find_unclaimed_identifier(request_cache, prefix)
  File "/home/rob/git/tribler/Tribler/dispersy/requestcache.py", line 57, in find_unclaimed_identifier
    if not request_cache.has(prefix, number):
  File "/home/rob/git/tribler/Tribler/dispersy/requestcache.py", line 172, in has
    assert isInIOThread(), "RequestCache must be used on the reactor's thread"
AssertionError: RequestCache must be used on the reactor's thread
MINITWISTED CRASHED (see logs)
```