### PR TITLE
Shutdown VLC wrapper

### DIFF
--- a/Tribler/Core/Video/VLCWrapper.py
+++ b/Tribler/Core/Video/VLCWrapper.py
@@ -38,10 +38,12 @@ class VLCWrapper(object):
     def __init__(self):
         self._logger = logging.getLogger(self.__class__.__name__)
 
+        self.media = None
         self.player = None
         self.window = None
         self.windowpassedtovlc = -1
         self.initialized = False
+        self.is_shutting_down = False
 
     def _init_vlc(self):
         """
@@ -49,6 +51,8 @@ class VLCWrapper(object):
         GUI to instantly exit, we need to delay importing vlc and
         setting the window.
         """
+        if self.is_shutting_down:
+            return
         try:
             import Tribler.vlc as vlc
         except:
@@ -58,6 +62,15 @@ class VLCWrapper(object):
         self.initialized = True
         self.vlc = vlc
         self.media = self.get_vlc_mediactrl()
+
+    def shutdown(self):
+        self.is_shutting_down = True
+        if self.media:
+            self.media.release()
+            self.media = None
+        if self.player:
+            self.player.release()
+            self.player = None
 
     def set_window(self, wxwindow):
         self.window = wxwindow

--- a/Tribler/Core/Video/VideoPlayer.py
+++ b/Tribler/Core/Video/VideoPlayer.py
@@ -79,6 +79,9 @@ class VideoPlayer(object):
         if self.videoserver:
             self.videoserver.shutdown()
             self.videoserver.server_close()
+        if self.vlcwrap:
+            self.vlcwrap.shutdown()
+            self.vlcwrap = None
         self.set_vod_download(None)
 
     def get_vlcwrap(self):


### PR DESCRIPTION
Got a backtrace on Windows during shutdown. It may be related to the error message problem during shutdown on Windows. Somehow some code still tries to initialize the VLC stuff even after shutdown, so I added a `is_shutting_down` flag there.
```
Traceback (most recent call last):
  File "wx\_misc.pyo", line 1358, in Notify
    
  File "wx\_core.pyo", line 14771, in Notify
    
  File "D:\workspaces\tribler\Tribler\Core\Video\VLCWrapper.py", line 61, in _init_vlc
    self.media = self.get_vlc_mediactrl()
  File "D:\workspaces\tribler\Tribler\Core\Video\VLCWrapper.py", line 20, in invoke_func
    raise Exception("VLCWrapper: Thread violation!")
Exception: VLCWrapper: Thread violation!
```