### PR TITLE
Skip livinglab reporter tests, not used.

### DIFF
--- a/Tribler/Test/test_status.py
+++ b/Tribler/Test/test_status.py
@@ -10,6 +10,8 @@ from Tribler.Core.Statistics.Status import LivingLabReporter
 from Tribler.Test.test_as_server import AbstractServer
 
 
+raise unittest.SkipTest("We are not using any of this")
+
 class TestOnChangeStatusReporter(Status.OnChangeStatusReporter):
 
     name = None


### PR DESCRIPTION
Also they output xml which seems to break jenkins xunit plugin.