### PR TITLE
record ip for peer1 in interaction_log 

### DIFF
--- a/Tribler/community/bartercast4/community.py
+++ b/Tribler/community/bartercast4/community.py
@@ -127,7 +127,7 @@ class BarterCommunity(Community):
             for r in message.payload.records:
                 _barter_statistics.log_interaction(self._dispersy,
                                                            message.payload.stats_type,
-                                                           message.authentication.member.mid.encode('hex'),
+                                                           "%s:%s" % (message.candidate.sock_addr[0], message.candidate.sock_addr[1]),
                                                            r[0], int(r[1].encode('hex'), 16))
 
     # bartercast accounting stuff

--- a/Tribler/community/channel/community.py
+++ b/Tribler/community/channel/community.py
@@ -381,8 +381,10 @@ class ChannelCommunity(Community):
                      message.payload.name,
                      message.payload.files,
                      message.payload.trackers))
+                self._logger.debug("torrent received: %s on channel: %s", message.payload.infohash, self._master_member)
                 if message.candidate and message.candidate.sock_addr:
-                    _barter_statistics.dict_inc_bartercast(
+                      self._logger.debug("logging torrent in bartercast statistics (%s)" % message.candidate.sock_addr)
+                      _barter_statistics.dict_inc_bartercast(
                         BartercastStatisticTypes.TORRENTS_RECEIVED,
                         # sha_other_peer)
                         "%s:%s" % (message.candidate.sock_addr[0], message.candidate.sock_addr[1]))

--- a/Tribler/community/channel/community.py
+++ b/Tribler/community/channel/community.py
@@ -383,8 +383,7 @@ class ChannelCommunity(Community):
                      message.payload.trackers))
                 self._logger.debug("torrent received: %s on channel: %s", message.payload.infohash, self._master_member)
                 if message.candidate and message.candidate.sock_addr:
-                      self._logger.debug("logging torrent in bartercast statistics (%s)" % message.candidate.sock_addr)
-                      _barter_statistics.dict_inc_bartercast(
+                    _barter_statistics.dict_inc_bartercast(
                         BartercastStatisticTypes.TORRENTS_RECEIVED,
                         # sha_other_peer)
                         "%s:%s" % (message.candidate.sock_addr[0], message.candidate.sock_addr[1]))


### PR DESCRIPTION
instead of member id so we can generate a coherent bartercast graph