### PR TITLE
Fix a DHT check bug

### DIFF
--- a/Tribler/Core/Libtorrent/LibtorrentMgr.py
+++ b/Tribler/Core/Libtorrent/LibtorrentMgr.py
@@ -392,12 +392,11 @@ class LibtorrentMgr(object):
                             metainfo["announce"] = trackers[0]
                         else:
                             metainfo["nodes"] = []
-                        if peers:
-                            metainfo["initial peers"] = peers
-                            metainfo["leechers"] = leechers
-                            metainfo["seeders"] = seeders
-                            if notify:
-                                self.notifier.notify(NTFY_TORRENTS, NTFY_MAGNET_GOT_PEERS, infohash_bin, len(peers))
+                        if peers and notify:
+                            self.notifier.notify(NTFY_TORRENTS, NTFY_MAGNET_GOT_PEERS, infohash_bin, len(peers))
+                        metainfo["initial peers"] = peers
+                        metainfo["leechers"] = leechers
+                        metainfo["seeders"] = seeders
 
                         self._add_cached_metainfo(infohash, metainfo)
 


### PR DESCRIPTION
Fix this error:
```
Unhandled Error
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 763, in run
    self.__target(*self.__args, **self.__kwargs)
  File "/home/lfei/workspace/tud/p2p/tribler/Tribler/Core/Utilities/twisted_thread.py", line 54, in _reactor_runner
    reactor.run(installSignalHandlers=False)
  File "/usr/lib/python2.7/dist-packages/twisted/internet/base.py", line 1192, in run
    self.mainLoop()
  File "/usr/lib/python2.7/dist-packages/twisted/internet/base.py", line 1201, in mainLoop
    self.runUntilCurrent()
--- <exception caught here> ---
  File "/usr/lib/python2.7/dist-packages/twisted/internet/base.py", line 797, in runUntilCurrent
    f(*a, **kw)
  File "/home/lfei/workspace/tud/p2p/tribler/Tribler/Core/TorrentChecker/session.py", line 607, in on_metainfo_received
    self._on_result_callback(infohash, metainfo['seeders'], metainfo['leechers'])
exceptions.KeyError: 'seeders'
```