### PR TITLE
Fix pstate dir

### DIFF
--- a/Tribler/Core/APIImplementation/LaunchManyCore.py
+++ b/Tribler/Core/APIImplementation/LaunchManyCore.py
@@ -464,7 +464,7 @@ class TriblerLaunchMany(Thread):
         """ Called by any thread, assume sesslock already held """
         try:
             basename = binascii.hexlify(infohash) + '.state'
-            filename = os.path.join(dir, basename)
+            filename = os.path.join(self.session.get_downloads_pstate_dir(), basename)
             return self.load_download_pstate(filename)
 
         except Exception:


### PR DESCRIPTION
Fix this backtrace
```
Traceback (most recent call last):
  File "/home/lfei/workspace/tud/p2p/tribler/Tribler/Core/APIImplementation/LaunchManyCore.py", line 467, in load_download_pstate_noexc
    filename = os.path.join(dir, basename)
  File "/usr/lib/python2.7/posixpath.py", line 77, in join
    elif path == '' or path.endswith('/'):
AttributeError: 'builtin_function_or_method' object has no attribute 'endswith'
```