### PR TITLE
Retry for TFTP data transmission

### DIFF
--- a/Tribler/Core/TFTP/session.py
+++ b/Tribler/Core/TFTP/session.py
@@ -35,6 +35,8 @@ class Session(object):
         self.last_sent_packet = None
         self.is_waiting_for_last_ack = False
 
+        self.retries = 0
+
         self.is_done = False
         self.is_failed = False
 


### PR DESCRIPTION
TFTP retry mechanism for data transmission ONLY. Negotiation packets such as OP_RRQ and OP_OACK will not be retransmitted.

Closes #1392 and #903