### PR TITLE
Use a temporary dir as tribler state dir.

### DIFF
--- a/Tribler/Main/vwxGUI/list.py
+++ b/Tribler/Main/vwxGUI/list.py
@@ -1871,6 +1871,9 @@ class LibraryList(SizeList):
 
     @warnWxThread
     def SetData(self, data):
+        if (not self) or (not self.list):
+            return
+
         SizeList.SetData(self, data)
 
         if len(data) > 0:

--- a/Tribler/Test/API/test_seeding.py
+++ b/Tribler/Test/API/test_seeding.py
@@ -7,7 +7,7 @@ import time
 import socket
 import threading
 
-from Tribler.Test.test_as_server import TestAsServer, BASE_DIR
+from Tribler.Test.test_as_server import TestAsServer, TESTS_API_DIR
 from Tribler.Test.btconn import BTConnection
 
 from Tribler.Core.simpledefs import dlstatus_strings, DLSTATUS_SEEDING
@@ -56,7 +56,7 @@ class TestSeeding(TestAsServer):
 
     def setup_seeder(self, filename='video.avi'):
         self.tdef = TorrentDef()
-        self.sourcefn = os.path.join(BASE_DIR, "API", filename)
+        self.sourcefn = os.path.join(TESTS_API_DIR, filename)
         self.tdef.add_content(self.sourcefn)
         self.tdef.set_tracker("http://fake.net/announce")
         self.tdef.finalize()
@@ -67,7 +67,7 @@ class TestSeeding(TestAsServer):
         self._logger.debug("name is %s", self.tdef.metainfo['info']['name'])
 
         self.dscfg = DownloadStartupConfig()
-        self.dscfg.set_dest_dir(os.path.join(BASE_DIR, "API"))  # basedir of the file we are seeding
+        self.dscfg.set_dest_dir(TESTS_API_DIR)  # basedir of the file we are seeding
         d = self.session.start_download(self.tdef, self.dscfg)
         d.set_state_callback(self.seeder_state_callback)
 

--- a/Tribler/Test/API/test_tdef.py
+++ b/Tribler/Test/API/test_tdef.py
@@ -7,11 +7,10 @@
 import os
 from libtorrent import bdecode
 
-from Tribler.Test.test_as_server import BaseTestCase
+from Tribler.Test.test_as_server import BaseTestCase, TESTS_DATA_DIR, TESTS_API_DIR
 
 from Tribler.Core.TorrentDef import TorrentDef
 from Tribler.Core.Utilities.utilities import isValidTorrentFile
-from Tribler.Test.test_as_server import BASE_DIR
 
 
 DEBUG = False
@@ -49,8 +48,8 @@ class TestTorrentDef(BaseTestCase):
         self.subtest_add_content_file_save()
 
     def test_is_private(self):
-        privatefn = os.path.join(BASE_DIR, "data", "private.torrent")
-        publicfn = os.path.join(BASE_DIR, "data", "bak_single.torrent")
+        privatefn = os.path.join(TESTS_DATA_DIR, "private.torrent")
+        publicfn = os.path.join(TESTS_DATA_DIR, "bak_single.torrent")
 
         t1 = TorrentDef.load(privatefn)
         t2 = TorrentDef.load(publicfn)
@@ -61,7 +60,7 @@ class TestTorrentDef(BaseTestCase):
     def subtest_add_content_file(self):
         """ Add a single file to a TorrentDef """
         t = TorrentDef()
-        fn = os.path.join(BASE_DIR, "API", "video.avi")
+        fn = os.path.join(TESTS_API_DIR, "video.avi")
         t.add_content(fn)
         t.set_tracker(TRACKER)
         t.finalize()
@@ -77,7 +76,7 @@ class TestTorrentDef(BaseTestCase):
     def subtest_add_content_dir(self):
         """ Add a single dir to a TorrentDef """
         t = TorrentDef()
-        dn = os.path.join(BASE_DIR, "API", "contentdir")
+        dn = os.path.join(TESTS_API_DIR, "contentdir")
         t.add_content(dn, "dirintorrent")
         t.set_tracker(TRACKER)
         t.finalize()
@@ -111,10 +110,10 @@ class TestTorrentDef(BaseTestCase):
         """ Add a single dir and single file to a TorrentDef """
         t = TorrentDef()
 
-        dn = os.path.join(BASE_DIR, "API", "contentdir")
+        dn = os.path.join(TESTS_API_DIR, "contentdir")
         t.add_content(dn, "dirintorrent")
 
-        fn = os.path.join(BASE_DIR, "API", "video.avi")
+        fn = os.path.join(TESTS_API_DIR, "video.avi")
         t.add_content(fn, os.path.join("dirintorrent", "video.avi"))
 
         t.set_tracker(TRACKER)
@@ -140,7 +139,8 @@ class TestTorrentDef(BaseTestCase):
     def subtest_add_content_announce_list(self):
         """ Add a single file with announce-list to a TorrentDef """
         t = TorrentDef()
-        fn = os.path.join(BASE_DIR, "API", "video.avi")
+        fn = os.path.join(TESTS_API_DIR, "video.avi")
+
         t.add_content(fn)
         t.set_tracker(TRACKER)
         exphier = [[TRACKER], ['http://tracker1.tribler.org:6969/announce', 'http://tracker2.tribler.org:7070/ann'],
@@ -156,7 +156,7 @@ class TestTorrentDef(BaseTestCase):
     def subtest_add_content_httpseeds(self):
         """ Add a single file with BitTornado httpseeds to a TorrentDef """
         t = TorrentDef()
-        fn = os.path.join(BASE_DIR, "API", "video.avi")
+        fn = os.path.join(TESTS_API_DIR, "video.avi")
         t.add_content(fn)
         t.set_tracker(TRACKER)
         expseeds = ['http://www.cs.vu.nl/index.html', 'http://www.st.ewi.tudelft.nl/index.html']
@@ -171,7 +171,7 @@ class TestTorrentDef(BaseTestCase):
     def subtest_add_content_piece_length(self):
         """ Add a single file with piece length to a TorrentDef """
         t = TorrentDef()
-        fn = os.path.join(BASE_DIR, "API", "video.avi")
+        fn = os.path.join(TESTS_API_DIR, "video.avi")
         t.add_content(fn)
         t.set_piece_length(2 ** 16)
         t.set_tracker(TRACKER)
@@ -184,7 +184,7 @@ class TestTorrentDef(BaseTestCase):
     def subtest_add_content_file_save(self):
         """ Add a single file to a TorrentDef and save the latter"""
         t = TorrentDef()
-        fn = os.path.join(BASE_DIR, "API", "video.avi")
+        fn = os.path.join(TESTS_API_DIR, "video.avi")
         t.add_content(fn)
         t.set_tracker(TRACKER)
         t.finalize()

--- a/Tribler/Test/bak_tribler_sdb.py
+++ b/Tribler/Test/bak_tribler_sdb.py
@@ -3,22 +3,22 @@ import sys
 
 from traceback import print_exc
 from shutil import copy as copyFile, move
-from Tribler.Test.test_as_server import FILES_DIR
+from Tribler.Test.test_as_server import TESTS_DATA_DIR
 
 
-def init_bak_tribler_sdb(backup='bak_tribler.sdb', destination='tribler.sdb', destination_path=FILES_DIR, overwrite=False):
-    backup_path = os.path.join(FILES_DIR, backup)
+def init_bak_tribler_sdb(backup='bak_tribler.sdb', destination='tribler.sdb', destination_path=TESTS_DATA_DIR, overwrite=False):
+    backup_path = os.path.join(TESTS_DATA_DIR, backup)
     destination_path = os.path.join(destination_path, destination)
 
     if not os.path.isfile(backup_path) or overwrite:
-        got = extract_db_files(FILES_DIR, backup_path + ".tar.gz", overwrite)
+        got = extract_db_files(TESTS_DATA_DIR, backup_path + ".tar.gz", overwrite)
         if not got:
             print >> sys.stderr, "Missing", backup_path + ".tar.gz"
             sys.exit(1)
 
-    for f in os.listdir(FILES_DIR):
+    for f in os.listdir(TESTS_DATA_DIR):
         if f.startswith(destination):
-            os.remove(os.path.join(FILES_DIR, f))
+            os.remove(os.path.join(TESTS_DATA_DIR, f))
 
     if os.path.isfile(backup_path):
         copyFile(backup_path, destination_path)

--- a/Tribler/Test/test_gui_dialogs.py
+++ b/Tribler/Test/test_gui_dialogs.py
@@ -7,7 +7,9 @@ import os
 from threading import Event
 from traceback import print_exc
 
-from Tribler.Test.test_as_server import TestGuiAsServer, BASE_DIR, wx  # import wx after selecting the WX version
+
+# Import WX after selecting the version
+from Tribler.Test.test_as_server import TestGuiAsServer, TESTS_DATA_DIR, wx
 
 from Tribler.Main.Dialogs.ConfirmationDialog import ConfirmationDialog
 from Tribler.Main.Dialogs.AddTorrent import AddTorrent
@@ -74,7 +76,7 @@ class TestGuiDialogs(TestGuiAsServer):
 
         def do_downloadfromfile():
             self.guiUtility.showLibrary()
-            self.frame.startDownload(os.path.join(BASE_DIR, "data", "Pioneer.One.S01E06.720p.x264-VODO.torrent"),
+            self.frame.startDownload(os.path.join(TESTS_DATA_DIR, "Pioneer.One.S01E06.720p.x264-VODO.torrent"),
                                      self.getDestDir())
 
             self.CallConditional(30, lambda: self.session.get_download(infohash), download_object_ready)

--- a/Tribler/Test/test_libtorrent_download.py
+++ b/Tribler/Test/test_libtorrent_download.py
@@ -1,13 +1,12 @@
 # see LICENSE.txt for license information
-
-import unittest
-import os
-from time import time
 import binascii
+import os
+import unittest
+from time import time
 
-from Tribler.Core.simpledefs import DOWNLOAD
 from Tribler.Test.common import UBUNTU_1504_INFOHASH
-from Tribler.Test.test_as_server import TestGuiAsServer, BASE_DIR
+from Tribler.Test.test_as_server import TestGuiAsServer, TESTS_DATA_DIR
+from Tribler.Core.simpledefs import DOWNLOAD
 
 
 TORRENT_R = r'http://torrent.fedoraproject.org/torrents/Fedora-Live-Workstation-x86_64-21.torrent'
@@ -33,7 +32,7 @@ class TestLibtorrentDownload(TestGuiAsServer):
         def do_downloadfromfile():
             self.guiUtility.showLibrary()
             self.frame.startDownload(
-                os.path.join(BASE_DIR, "data", "Pioneer.One.S01E06.720p.x264-VODO.torrent"), self.getDestDir())
+                os.path.join(TESTS_DATA_DIR, "Pioneer.One.S01E06.720p.x264-VODO.torrent"), self.getDestDir())
 
             self.CallConditional(30, lambda: self.session.get_download(infohash), download_object_ready,
                                  'do_downloadfromfile() failed')
@@ -173,7 +172,9 @@ class TestLibtorrentDownload(TestGuiAsServer):
                                  .vod_playing, check_playlist, "streaming did not start")
 
         def do_vod():
-            ds = self.frame.startDownload(os.path.join(BASE_DIR, "data", "Pioneer.One.S01E06.720p.x264-VODO.torrent"),
+            from Tribler.Core.Video.VideoPlayer import VideoPlayer
+
+            ds = self.frame.startDownload(os.path.join(TESTS_DATA_DIR, "Pioneer.One.S01E06.720p.x264-VODO.torrent"),
                                           self.getDestDir(),
                                           selectedFiles=[
                                               os.path.join('Sample', 'Pioneer.One.S01E06.720p.x264.Sample-VODO.mkv')],

--- a/Tribler/Test/test_libtorrent_download.py
+++ b/Tribler/Test/test_libtorrent_download.py
@@ -182,8 +182,7 @@ class TestLibtorrentDownload(TestGuiAsServer):
             # set the max prebuffsize to be smaller so that the unit test runs faster
             ds.max_prebuffsize = 16 * 1024
             self.guiUtility.ShowPlayer()
-            self.CallConditional(30, lambda: self.guiUtility.videoplayer
-                                 .get_vod_download(), do_monitor, "VOD download not found")
+            self.CallConditional(30, self.guiUtility.videoplayer.get_vod_download, do_monitor, "VOD download not found")
 
         self.startTest(do_vod)
 

--- a/Tribler/Test/test_magnetlink.py
+++ b/Tribler/Test/test_magnetlink.py
@@ -9,7 +9,8 @@ import libtorrent as lt
 from libtorrent import bencode, bdecode
 
 from Tribler.Test.common import UBUNTU_1504_INFOHASH
-from Tribler.Test.test_as_server import TestAsServer, BASE_DIR
+from Tribler.Test.test_as_server import TestAsServer, TESTS_API_DIR
+
 from btconn import BTConnection
 from Tribler.Core.TorrentDef import TorrentDef
 from Tribler.Core.DownloadConfig import DownloadStartupConfig
@@ -172,7 +173,7 @@ class TestMagnetFakePeer(TestAsServer, MagnetHelpers):
 
         # the metadata that we want to transfer
         self.tdef = TorrentDef()
-        self.tdef.add_content(os.path.join(BASE_DIR, "API", "video.avi"))
+        self.tdef.add_content(os.path.join(TESTS_API_DIR, "video.avi"))
         self.tdef.set_tracker("http://fake.net/announce")
         # we use a small piece length to obtain multiple pieces
         self.tdef.set_piece_length(1)
@@ -255,7 +256,7 @@ class TestMetadataFakePeer(TestAsServer, MagnetHelpers):
 
         # the metadata that we want to transfer
         self.tdef = TorrentDef()
-        self.tdef.add_content(os.path.join(BASE_DIR, "API", "file.wmv"))
+        self.tdef.add_content(os.path.join(TESTS_API_DIR, "file.wmv"))
         self.tdef.set_tracker("http://fake.net/announce")
         # we use a small piece length to obtain multiple pieces
         self.tdef.set_piece_length(1)
@@ -279,7 +280,7 @@ class TestMetadataFakePeer(TestAsServer, MagnetHelpers):
         self.seeder_setup_complete = threading.Event()
 
         self.dscfg = DownloadStartupConfig()
-        self.dscfg.set_dest_dir(os.path.join(BASE_DIR, "API"))
+        self.dscfg.set_dest_dir(TESTS_API_DIR)
         self.download = self.session.start_download(self.tdef, self.dscfg)
         self.download.set_state_callback(self.seeder_state_callback)
 

--- a/Tribler/Test/test_metadata_community.py
+++ b/Tribler/Test/test_metadata_community.py
@@ -6,7 +6,7 @@ import json
 import time
 from unittest.case import skip
 
-from Tribler.Test.test_as_server import TestGuiAsServer, BASE_DIR
+from Tribler.Test.test_as_server import TestGuiAsServer, TESTS_DATA_DIR
 
 from Tribler.Core.TorrentDef import TorrentDef
 from Tribler.Core.simpledefs import dlstatus_strings
@@ -96,14 +96,14 @@ class TestMetadataCommunity(TestGuiAsServer):
         self.session2.start()
 
         tdef = TorrentDef()
-        tdef.add_content(os.path.join(BASE_DIR, "data", "video.avi"))
+        tdef.add_content(os.path.join(TESTS_DATA_DIR, "video.avi"))
         tdef.set_tracker("http://fake.net/announce")
         tdef.finalize()
         torrentfn = os.path.join(self.session.get_state_dir(), "gen.torrent")
         tdef.save(torrentfn)
 
         dscfg = DownloadStartupConfig()
-        dscfg.set_dest_dir(os.path.join(BASE_DIR, "data"))  # basedir of the file we are seeding
+        dscfg.set_dest_dir(TESTS_DATA_DIR)  # basedir of the file we are seeding
         d = self.session2.start_download(tdef, dscfg)
         d.set_state_callback(self.seeder_state_callback)
 

--- a/Tribler/Test/test_my_channel.py
+++ b/Tribler/Test/test_my_channel.py
@@ -5,7 +5,7 @@ from binascii import hexlify
 import os
 
 from Tribler.Test.common import UBUNTU_1504_INFOHASH
-from Tribler.Test.test_as_server import TestGuiAsServer, BASE_DIR
+from Tribler.Test.test_as_server import TestGuiAsServer, TESTS_DATA_DIR
 
 from Tribler.Core.TorrentDef import TorrentDef
 
@@ -141,7 +141,7 @@ class TestMyChannel(TestGuiAsServer):
 
     def createTorrent(self):
         tdef = TorrentDef()
-        tdef.add_content(os.path.join(BASE_DIR, "data", "video.avi"))
+        tdef.add_content(os.path.join(TESTS_DATA_DIR, "video.avi"))
         tdef.set_tracker("http://fake.net/announce")
         tdef.finalize()
         torrentfn = os.path.join(self.session.get_state_dir(), "gen.torrent")

--- a/Tribler/Test/test_remote_torrent_handler.py
+++ b/Tribler/Test/test_remote_torrent_handler.py
@@ -5,7 +5,7 @@ from shutil import rmtree, copytree
 from time import sleep
 from threading import Event
 
-from Tribler.Test.test_as_server import TestAsServer, BASE_DIR
+from Tribler.Test.test_as_server import TestAsServer, TESTS_DATA_DIR
 from Tribler.dispersy.candidate import Candidate
 from Tribler.dispersy.util import call_on_reactor_thread
 
@@ -80,7 +80,7 @@ class TestRemoteTorrentHandler(TestAsServer):
             self.file_names[i] = file_name = u"%s.torrent" % infohash
 
             # Put the torrents into the uploader's store
-            with open(os.path.join(BASE_DIR, u"data", file_name), 'r') as torrent_file:
+            with open(os.path.join(TESTS_DATA_DIR, file_name), 'r') as torrent_file:
                 self.session.lm.torrent_store.put(infohash, torrent_file.read())
 
         from Tribler.Core.Session import Session
@@ -139,7 +139,7 @@ class TestRemoteTorrentHandler(TestAsServer):
         self.metadata_subpath = os.path.join(self.metadata_dir, u"421px-Pots_10k_100k.jpeg")
 
         # copy file to the uploader's torrent_collecting_dir
-        src_dir_path = os.path.join(BASE_DIR, u"data", self.metadata_dir)
+        src_dir_path = os.path.join(TESTS_DATA_DIR, self.metadata_dir)
         des_dir_path = os.path.join(u"", self.metadata_dir)
         self._logger.info(u"Uploader's torrent_collect_dir = %s", u"")
         copytree(src_dir_path, des_dir_path)

--- a/Tribler/Test/test_sqlitecachedbhandler.py
+++ b/Tribler/Test/test_sqlitecachedbhandler.py
@@ -14,13 +14,13 @@ from Tribler.Core.CacheDB.sqlitecachedb import str2bin, SQLiteCacheDB
 from Tribler.Core.Session import Session
 from Tribler.Core.SessionConfig import SessionStartupConfig
 from Tribler.Core.TorrentDef import TorrentDef
-from Tribler.Test.bak_tribler_sdb import FILES_DIR, init_bak_tribler_sdb
+from Tribler.Test.bak_tribler_sdb import TESTS_DATA_DIR, init_bak_tribler_sdb
 from Tribler.Test.test_as_server import AbstractServer
 from Tribler.dispersy.util import blocking_call_on_reactor_thread
 
 
-S_TORRENT_PATH_BACKUP = os.path.join(FILES_DIR, 'bak_single.torrent')
-M_TORRENT_PATH_BACKUP = os.path.join(FILES_DIR, 'bak_multiple.torrent')
+S_TORRENT_PATH_BACKUP = os.path.join(TESTS_DATA_DIR, 'bak_single.torrent')
+M_TORRENT_PATH_BACKUP = os.path.join(TESTS_DATA_DIR, 'bak_multiple.torrent')
 
 BUSYTIMEOUT = 5000
 DEBUG = False
@@ -171,7 +171,7 @@ class TestTorrentDBHandler(AbstractDB):
         self.session.lm.tracker_manager = TrackerManager(self.session)
         self.session.lm.tracker_manager.initialize()
         self.tdb = TorrentDBHandler(self.session)
-        self.tdb.torrent_dir = FILES_DIR
+        self.tdb.torrent_dir = TESTS_DATA_DIR
         self.tdb.category = Category.getInstance()
         self.tdb.mypref_db = MyPreferenceDBHandler(self.session)
 

--- a/Tribler/Test/test_torrent_checking.py
+++ b/Tribler/Test/test_torrent_checking.py
@@ -4,7 +4,7 @@ from time import sleep
 from Tribler.Core.simpledefs import NTFY_TORRENTS, NTFY_MYPREFERENCES
 from Tribler.Core.TorrentDef import TorrentDef
 
-from Tribler.Test.test_as_server import BASE_DIR, TestAsServer
+from Tribler.Test.test_as_server import TESTS_DATA_DIR, TestAsServer
 
 
 class TestTorrentChecking(TestAsServer):
@@ -23,7 +23,7 @@ class TestTorrentChecking(TestAsServer):
         self.config.set_libtorrent(True)
 
     def test_torrent_checking(self):
-        tdef = TorrentDef.load(os.path.join(BASE_DIR, "data", "Pioneer.One.S01E06.720p.x264-VODO.torrent"))
+        tdef = TorrentDef.load(os.path.join(TESTS_DATA_DIR, "Pioneer.One.S01E06.720p.x264-VODO.torrent"))
         tdef.set_tracker("http://95.211.198.141:2710/announce")
         tdef.metainfo_valid = True
 

--- a/Tribler/Test/test_video_server.py
+++ b/Tribler/Test/test_video_server.py
@@ -6,7 +6,7 @@ import socket
 import binascii
 from traceback import print_exc
 
-from Tribler.Test.test_as_server import BASE_DIR, TestAsServer
+from Tribler.Test.test_as_server import TESTS_DATA_DIR, TestAsServer
 from Tribler.Core.TorrentDef import TorrentDef
 from Tribler.Core.DownloadConfig import DownloadStartupConfig
 
@@ -25,7 +25,7 @@ class TestVideoHTTPServer(TestAsServer):
         """ unittest test setup code """
         TestAsServer.setUp(self)
         self.port = self.session.get_videoplayer_port()
-        self.sourcefn = os.path.join(BASE_DIR, "data", "video.avi")
+        self.sourcefn = os.path.join(TESTS_DATA_DIR, "video.avi")
         self.sourcesize = os.path.getsize(self.sourcefn)
 
         # wait 5s to allow server to start

--- a/Tribler/community/bartercast4/community.py
+++ b/Tribler/community/bartercast4/community.py
@@ -133,7 +133,7 @@ class BarterCommunity(Community):
     # bartercast accounting stuff
     def backup_bartercast_statistics(self):
         self._logger.debug("merging bartercast statistics")
-        _barter_statistics.persist(self, self._dispersy)
+        _barter_statistics.persist(self._dispersy)
 
     def unload_community(self):
         self._logger.debug("unloading the Barter4 community")


### PR DESCRIPTION
This is needed to be able to parallelize test execution.