### PR TITLE
Rebuild tunnels when rendezvous or introduction circuits break down

### DIFF
--- a/Tribler/Core/defaults.py
+++ b/Tribler/Core/defaults.py
@@ -69,7 +69,6 @@ sessdefaults['search_community']['enabled'] = True
 
 # Tunnel community section
 sessdefaults['tunnel_community'] = OrderedDict()
-sessdefaults['tunnel_community']['enabled'] = False
 sessdefaults['tunnel_community']['socks5_listen_ports'] = [-1] * 5
 sessdefaults['tunnel_community']['exitnode_enabled'] = False
 

--- a/Tribler/Test/test_tunnel_community.py
+++ b/Tribler/Test/test_tunnel_community.py
@@ -469,6 +469,10 @@ class TestTunnelCommunity(TestGuiAsServer):
                 if not crypto_enabled:
                     settings.crypto = NoCrypto()
                 settings.become_exitnode = become_exit_node
+
+                # To test recovery: circuit breaks down after each 2 megebaytes
+                settings.max_traffic = 2 * 1024 * 1024
+
                 return dispersy.define_auto_load(HiddenTunnelCommunity,
                                                  dispersy_member,
                                                  (session, settings),

--- a/Tribler/Test/test_tunnel_community.py
+++ b/Tribler/Test/test_tunnel_community.py
@@ -470,7 +470,7 @@ class TestTunnelCommunity(TestGuiAsServer):
                     settings.crypto = NoCrypto()
                 settings.become_exitnode = become_exit_node
 
-                # To test recovery: circuit breaks down after each 2 megebaytes
+                # To test circuit recovery: circuit breaks down after each 2 megabytes
                 settings.max_traffic = 2 * 1024 * 1024
 
                 return dispersy.define_auto_load(HiddenTunnelCommunity,

--- a/Tribler/community/tunnel/hidden_community.py
+++ b/Tribler/community/tunnel/hidden_community.py
@@ -13,7 +13,7 @@ from Tribler.Core.DecentralizedTracking.pymdht.core.identifier import Id
 from Tribler.Core.Utilities.encoding import encode, decode
 
 from Tribler.community.tunnel import CIRCUIT_TYPE_IP, CIRCUIT_TYPE_RP, CIRCUIT_TYPE_RENDEZVOUS, \
-                                     EXIT_NODE, EXIT_NODE_SALT, CIRCUIT_ID_PORT
+    EXIT_NODE, EXIT_NODE_SALT, CIRCUIT_ID_PORT
 
 from Tribler.community.tunnel.payload import (EstablishIntroPayload, IntroEstablishedPayload,
                                               EstablishRendezvousPayload, RendezvousEstablishedPayload,
@@ -107,10 +107,14 @@ class HiddenTunnelCommunity(TunnelCommunity):
 
         self.intro_point_for = {}
         self.rendezvous_point_for = {}
+        self.infohash_rp_circuits = defaultdict(list)
+        self.seeding_introduction = {}
+
+        self.infohashes_ip_waiting_for_circuit = defaultdict(list)
 
         self.dht_blacklist = defaultdict(list)
         self.last_dht_lookup = {}
-        
+
         self.hops = {}
 
     def initiate_meta_messages(self):
@@ -147,15 +151,18 @@ class HiddenTunnelCommunity(TunnelCommunity):
                      self.on_rendezvous_established)]
 
     def remove_circuit(self, circuit_id, additional_info='', destroy=False):
+        if circuit_id in self.circuits:
+            info_hash = self.circuits[circuit_id].info_hash
+            self.infohashes_ip_waiting_for_circuit.pop(info_hash, None)
+
         super(HiddenTunnelCommunity, self).remove_circuit(circuit_id, additional_info, destroy)
 
-        # Remove introduction/rendezvous points
         if circuit_id in self.my_intro_points:
             self._logger.debug("removed introduction point")
             self.my_intro_points.pop(circuit_id)
 
         if circuit_id in self.my_download_points:
-            self._logger.error("removed rendezvous point")
+            self._logger.debug("removed rendezvous point")
             self.my_download_points.pop(circuit_id)
 
     def ip_to_circuit_id(self, ip_str):
@@ -178,7 +185,7 @@ class HiddenTunnelCommunity(TunnelCommunity):
                 info_hash = self.get_lookup_info_hash(real_info_hash)
                 hops[info_hash] = download.get_hops()
                 new_states[info_hash] = ds.get_status()
-                
+
         self.hops = hops
 
         for info_hash in set(new_states.keys() + self.download_states.keys()):
@@ -186,9 +193,32 @@ class HiddenTunnelCommunity(TunnelCommunity):
             old_state = self.download_states.get(info_hash, None)
             state_changed = new_state != old_state
 
-            force_dht_lookup = (time.time() - self.last_dht_lookup.get(info_hash, 0)) >= 300
+            time_elapsed = (time.time() - self.last_dht_lookup.get(info_hash, 0))
+            force_dht_lookup = time_elapsed >= self.settings.dht_lookup_interval
+
+            # If the introducing circuit does not exist anymore or timed out: Built a new circuit
+            if info_hash in self.seeding_introduction:
+                circuit_id, required_exit = self.seeding_introduction[info_hash]
+                if circuit_id not in self.my_intro_points and info_hash not in self.infohashes_ip_waiting_for_circuit:
+                    self._logger.debug('Recreate the introducing circuit for %s' % info_hash.encode('hex'))
+                    # check whether required_exit is still a candidate here
+                    if (required_exit[0], required_exit[1]) not in self._candidates:
+                        self._logger.debug('Candidate for exiting introducing circuit does not exist anymore')
+                        self.seeding_introduction.pop(info_hash)
+                        required_exit = None
+                    self.create_introduction_point(info_hash,
+                                                   required_exit=required_exit)
+
+            # If the rendezvous point circuit does not exist anymore: Initiate circuit generation again
+            if info_hash in self.infohash_rp_circuits:
+                for circuit_id in self.infohash_rp_circuits[info_hash]:
+                    if circuit_id not in self.my_download_points:
+                        self.infohash_rp_circuits.pop(info_hash)
+                        self._logger.debug('Force a new lookup for infohash %s' % info_hash.encode('hex'))
+                        force_dht_lookup = True
 
             if (state_changed or force_dht_lookup) and new_state == DLSTATUS_DOWNLOADING:
+                self._logger.debug('Do dht lookup for hidden services download %s' % info_hash.encode('hex'))
                 self.do_lookup(info_hash)
 
             elif state_changed and new_state == DLSTATUS_SEEDING:
@@ -208,7 +238,7 @@ class HiddenTunnelCommunity(TunnelCommunity):
                         self.remove_circuit(cid, 'all downloads stopped', destroy=True)
 
         self.download_states = new_states
-        
+
     def find_download(self, lookup_info_hash):
         for download in self.trsession.get_downloads():
             if lookup_info_hash == self.get_lookup_info_hash(download.get_def().get_infohash()):
@@ -326,10 +356,11 @@ class HiddenTunnelCommunity(TunnelCommunity):
                 relay_circuit.tunnel_data(message.candidate.sock_addr, TUNNEL_PREFIX + message.packet)
             else:
                 self._logger.debug('On create e2e: create rendezvous point')
-                
-                self.create_rendezvous_point(self.hops[message.payload.info_hash],
-                                             lambda rendezvous_point, message=message: 
-                                             self.create_created_e2e(rendezvous_point, message))
+                self.create_rendezvous_point(
+                    self.hops[message.payload.info_hash],
+                    lambda rendezvous_point, message=message: self.create_created_e2e(rendezvous_point,
+                                                                                      message),
+                    message.payload.info_hash)
 
     def create_created_e2e(self, rendezvous_point, message):
         info_hash = message.payload.info_hash
@@ -363,21 +394,29 @@ class HiddenTunnelCommunity(TunnelCommunity):
     def on_created_e2e(self, messages):
         for message in messages:
             cache = self.request_cache.pop(u"e2e-request", message.payload.identifier)
-            shared_secret = self.crypto.verify_and_generate_shared_secret(cache.hop.dh_secret, message.payload.key, 
-                                                                          message.payload.auth, 
+            shared_secret = self.crypto.verify_and_generate_shared_secret(cache.hop.dh_secret,
+                                                                          message.payload.key,
+                                                                          message.payload.auth,
                                                                           cache.hop.public_key.key.pk)
             session_keys = self.crypto.generate_session_keys(shared_secret)
 
-            _, rp_info = decode(self.crypto.decrypt_str(message.payload.rp_sock_addr, session_keys[EXIT_NODE], 
+            _, rp_info = decode(self.crypto.decrypt_str(message.payload.rp_sock_addr,
+                                                        session_keys[EXIT_NODE],
                                                         session_keys[EXIT_NODE_SALT]))
-            
-            # Since it is the seeder that chose the rendezvous_point, we're essentially losing 1 hop of anonymity
-            # at the downloader end. To compensate we add an extra hop.
+
+            # Since it is the downloader that chose the rendezvous_point, we're essentially losing 1 hop of anonymity
+            # at the seeders end. To compensate we add an extra hop.
             self.create_circuit(self.hops[cache.info_hash] + 1,
-                                CIRCUIT_TYPE_RENDEZVOUS, callback=lambda circuit, cookie=rp_info[1], 
-                                session_keys=session_keys, info_hash=cache.info_hash, sock_addr=cache.sock_addr: 
-                                self.create_link_e2e(circuit, cookie, session_keys, info_hash, sock_addr),
-                                max_retries=5, required_exit=rp_info[0])
+                                CIRCUIT_TYPE_RENDEZVOUS,
+                                callback=lambda circuit, cookie=rp_info[1], session_keys=session_keys,
+                                info_hash=cache.info_hash, sock_addr=cache.sock_addr: self.create_link_e2e(circuit,
+                                                                                                           cookie,
+                                                                                                           session_keys,
+                                                                                                           info_hash,
+                                                                                                           sock_addr),
+                                max_retries=5,
+                                required_exit=rp_info[0],
+                                info_hash=cache.info_hash)
 
     def create_link_e2e(self, circuit, cookie, session_keys, info_hash, sock_addr):
         self.my_download_points[circuit.circuit_id] = (info_hash, circuit.goal_hops, sock_addr)
@@ -437,22 +476,30 @@ class HiddenTunnelCommunity(TunnelCommunity):
     def on_linked_e2e(self, messages):
         for message in messages:
             cache = self.request_cache.pop(u"link-request", message.payload.identifier)
-            
             download = self.find_download(cache.info_hash)
             if download:
                 download.add_peer((self.circuit_id_to_ip(cache.circuit.circuit_id), CIRCUIT_ID_PORT))
             else:
                 self._logger.error('On linked e2e: could not find download!')
 
-    def create_introduction_point(self, info_hash, amount=1):
+            for download in self.trsession.get_downloads():
+                if cache.info_hash == self.get_lookup_info_hash(download.get_def().get_infohash()):
+                    download.add_peer((self.circuit_id_to_ip(cache.circuit.circuit_id), CIRCUIT_ID_PORT))
+                    break
+
+    def create_introduction_point(self, info_hash, amount=1, required_exit=None):
         # Create a separate key per infohash
         if info_hash not in self.session_keys:
             self.session_keys[info_hash] = self.crypto.generate_key(u"curve25519")
 
         def callback(circuit):
-            # We got a circuit, now let's create a introduction point
+            # We got a circuit, now let's create an introduction point
             circuit_id = circuit.circuit_id
-            self.my_intro_points[circuit_id].append(info_hash)
+            self._logger.debug("We got an introduction circuit ending in %s:%s" %
+                               (circuit.required_exit[0], circuit.required_exit[1]))
+            self.my_intro_points[circuit_id].append((info_hash))
+            self.seeding_introduction[info_hash] = (circuit_id, circuit.required_exit)
+            self.infohashes_ip_waiting_for_circuit.pop(info_hash)
 
             cache = self.request_cache.add(IPRequestCache(self, circuit))
             self.send_cell([Candidate(circuit.first_hop, False)],
@@ -460,7 +507,15 @@ class HiddenTunnelCommunity(TunnelCommunity):
             self._logger.debug("Established introduction tunnel %s", circuit_id)
 
         for _ in range(amount):
-            self.create_circuit(self.hops[info_hash], CIRCUIT_TYPE_IP, callback, max_retries=5)
+            self.infohashes_ip_waiting_for_circuit[info_hash] = time.time()
+            # Create a circuit to the introduction point + 1 hop, to prevent the introduction 
+            # point from knowing what the seeder is seeding
+            self.create_circuit(self.hops[info_hash] + 1,
+                                CIRCUIT_TYPE_IP,
+                                callback,
+                                max_retries=5,
+                                required_exit=required_exit,
+                                info_hash=info_hash)
 
     def check_establish_intro(self, messages):
         for message in messages:
@@ -493,18 +548,23 @@ class HiddenTunnelCommunity(TunnelCommunity):
             self.request_cache.pop(u"establish-intro", message.payload.identifier)
             self._logger.info("Got intro-established from %s", message.candidate)
 
-    def create_rendezvous_point(self, hops, finished_callback):
+    def create_rendezvous_point(self, hops, finished_callback, info_hash):
         def callback(circuit):
             # We got a circuit, now let's create a rendezvous point
             circuit_id = circuit.circuit_id
+            self.infohash_rp_circuits[info_hash].append(circuit_id)
             rp = RendezvousPoint(circuit, os.urandom(20), finished_callback)
 
             cache = self.request_cache.add(RPRequestCache(self, rp))
             self.send_cell([Candidate(circuit.first_hop, False)],
                            u'establish-rendezvous', (circuit_id, cache.number, rp.cookie))
 
-        # create a new circuit to be used to transfer data
-        self.create_circuit(hops, CIRCUIT_TYPE_RP, callback, max_retries=5)
+        # create a new circuit to be used for transfering data
+        self.create_circuit(hops,
+                            CIRCUIT_TYPE_RP,
+                            callback,
+                            max_retries=5,
+                            info_hash=info_hash)
 
     def check_establish_rendezvous(self, messages):
         for message in messages:
@@ -548,7 +608,7 @@ class HiddenTunnelCommunity(TunnelCommunity):
     def dht_announce(self, info_hash):
         if self.trsession:
             def cb(info_hash, peers, source):
-                self._logger.error("Announced %s to the DHT", info_hash.encode('hex'))
+                self._logger.debug("Announced %s to the DHT", info_hash.encode('hex'))
 
             port = self.trsession.get_dispersy_port()
             self.trsession.lm.mainline_dht.get_peers(info_hash, Id(info_hash), cb, bt_port=port)

--- a/Tribler/community/tunnel/main.py
+++ b/Tribler/community/tunnel/main.py
@@ -374,6 +374,12 @@ def main(argv):
         sys.exit(1)
 
     settings = TunnelSettings()
+    settings.max_time = 60
+
+    # For disbling anonymous downloading, limiting download to hidden services only
+    settings.min_circuits = 0
+    settings.max_circuits = 0
+
     if socks5_port is not None:
         settings.socks_listen_ports = range(socks5_port, socks5_port + 5)
     else:

--- a/Tribler/community/tunnel/main.py
+++ b/Tribler/community/tunnel/main.py
@@ -248,13 +248,18 @@ class LineHandler(LineReceiver):
                 logger.error("Profiling disabled!")
 
         elif line == 'c':
-            print "========\nCircuits\n========\nid\taddress\t\t\t\t\tgoal\thops\tIN (MB)\tOUT (MB)"
+            print "========\nCircuits\n========\nid\taddress\t\t\t\t\tgoal\thops\tIN (MB)\tOUT (MB)\tinfohash\ttype"
             for circuit_id, circuit in anon_tunnel.community.circuits.items():
-                print "%d\t%s:%d\t%d\t%d\t\t%.2f\t\t%.2f" % (circuit_id, circuit.first_hop[0],
-                                                             circuit.first_hop[1], circuit.goal_hops,
+                info_hash = circuit.info_hash.encode('hex')[:10] if circuit.info_hash else '?'
+                print "%d\t%s:%d\t%d\t%d\t\t%.2f\t\t%.2f\t\t%s\t%s" % (circuit_id,
+                                                             circuit.first_hop[0],
+                                                             circuit.first_hop[1],
+                                                             circuit.goal_hops,
                                                              len(circuit.hops),
                                                              circuit.bytes_down / 1024.0 / 1024.0,
-                                                             circuit.bytes_up / 1024.0 / 1024.0)
+                                                             circuit.bytes_up / 1024.0 / 1024.0,
+                                                             info_hash,
+                                                             circuit.ctype)
 
         elif line.startswith('s'):
             cur_path = os.getcwd()

--- a/Tribler/community/tunnel/routing.py
+++ b/Tribler/community/tunnel/routing.py
@@ -3,6 +3,7 @@ import time
 from Tribler.community.tunnel import CIRCUIT_STATE_READY, CIRCUIT_STATE_BROKEN, CIRCUIT_STATE_EXTENDING, \
     CIRCUIT_TYPE_DATA
 from Tribler.dispersy.crypto import LibNaCLPK
+import logging
 
 __author__ = 'chris'
 
@@ -12,7 +13,8 @@ class Circuit(object):
     """ Circuit data structure storing the id, state and hops """
 
     def __init__(self, circuit_id, goal_hops=0, first_hop=None, proxy=None,
-                 ctype=CIRCUIT_TYPE_DATA, callback=None, required_exit=None, mid=None):
+                 ctype=CIRCUIT_TYPE_DATA, callback=None, required_exit=None, 
+                 mid=None, info_hash=None):
         """
         Instantiate a new Circuit data structure
         :type proxy: TunnelCommunity
@@ -45,6 +47,9 @@ class Circuit(object):
         self.required_exit = required_exit
         self.mid = mid
         self.hs_session_keys = None
+        self.info_hash = info_hash
+
+        self._logger = logging.getLogger(self.__class__.__name__)
 
     @property
     def hops(self):

--- a/Tribler/community/tunnel/tunnel_community.py
+++ b/Tribler/community/tunnel/tunnel_community.py
@@ -199,6 +199,7 @@ class TunnelSettings(object):
         self.max_traffic = 55 * 1024 * 1024
 
         self.max_packets_without_reply = 50
+        self.dht_lookup_interval = 30
 
         if tribler_session:
             self.become_exitnode = tribler_session.get_tunnel_community_exitnode_enabled()
@@ -473,7 +474,7 @@ class TunnelCommunity(Community):
                 self.exit_candidates.pop(pubkey)
                 logging.debug("Removed candidate from exit_candidates dictionary")
 
-    def create_circuit(self, goal_hops, ctype=CIRCUIT_TYPE_DATA, callback=None, max_retries=0, required_exit=None):
+    def create_circuit(self, goal_hops, ctype=CIRCUIT_TYPE_DATA, callback=None, max_retries=0, required_exit=None, info_hash=None):
         assert required_exit is None or isinstance(required_exit, tuple), type(required_exit)
         assert required_exit is None or len(required_exit) == 3, required_exit
         retry_lambda = first_hop = None
@@ -529,7 +530,7 @@ class TunnelCommunity(Community):
 
         circuit_id = self._generate_circuit_id(first_hop.sock_addr)
         circuit = Circuit(circuit_id, goal_hops, first_hop.sock_addr, self, ctype, callback,
-                          required_exit, first_hop.get_member().mid.encode('hex'))
+                          required_exit, first_hop.get_member().mid.encode('hex'), info_hash)
 
         self.request_cache.add(CircuitRequestCache(self, circuit, retry_lambda))
 

--- a/Tribler/community/tunnel/tunnel_community.py
+++ b/Tribler/community/tunnel/tunnel_community.py
@@ -551,7 +551,7 @@ class TunnelCommunity(Community):
                                                                      circuit.unverified_hop.dh_first_part)))
 
         _barter_statistics.dict_inc_bartercast(BartercastStatisticTypes.TUNNELS_CREATED, "%s:%s" % (first_hop.sock_addr[0], first_hop.sock_addr[1]))
-        return True
+        return circuit_id
 
     def readd_bittorrent_peers(self):
         for torrent, peers in self.bittorrent_peers.items():


### PR DESCRIPTION
Hidden services should recover from circuits that break down because of time-limits / throughput limits. 