### PR TITLE
Bugfix, default anonymous circuit length to 1

### DIFF
--- a/Tribler/Main/Utility/utility.py
+++ b/Tribler/Main/Utility/utility.py
@@ -35,7 +35,7 @@ class Utility(object):
                             # Misc
                             'torrentassociationwarned': 0,
                             # anonymous
-                            'default_anonymous_level': 0,
+                            'default_anonymous_level': 1,
                             'default_anonimity_enabled': True,
 
                             # GUI


### PR DESCRIPTION
The current circuit length was set to 0, which gives strange results on adding new .torrents via gui to the downloads list in Tribler. Anonymous downloading can only be disabled by unchecking the box in the saveas dialog. 