### PR TITLE
Fix metadata TFTP

### DIFF
--- a/Tribler/Core/APIImplementation/LaunchManyCore.py
+++ b/Tribler/Core/APIImplementation/LaunchManyCore.py
@@ -97,8 +97,8 @@ class TriblerLaunchMany(object):
             self.sesslock = sesslock
 
             if self.session.get_torrent_store():
-                from Tribler.Core.torrentstore import TorrentStore
-                self.torrent_store = TorrentStore(self.session.get_torrent_store_dir())
+                from Tribler.Core.leveldbstore import LevelDbStore
+                self.torrent_store = LevelDbStore(self.session.get_torrent_store_dir())
 
             # torrent collecting: RemoteTorrentHandler
             if self.session.get_torrent_collecting():

--- a/Tribler/Core/APIImplementation/LaunchManyCore.py
+++ b/Tribler/Core/APIImplementation/LaunchManyCore.py
@@ -67,6 +67,7 @@ class TriblerLaunchMany(object):
         # modules
         self.rawserver = TwistedRawServer()
         self.torrent_store = None
+        self.metadata_store = None
         self.rtorrent_handler = None
         self.tftp_handler = None
 
@@ -99,6 +100,10 @@ class TriblerLaunchMany(object):
             if self.session.get_torrent_store():
                 from Tribler.Core.leveldbstore import LevelDbStore
                 self.torrent_store = LevelDbStore(self.session.get_torrent_store_dir())
+
+            if self.session.get_enable_metadata():
+                from Tribler.Core.leveldbstore import LevelDbStore
+                self.metadata_store = LevelDbStore(self.session.get_metadata_store_dir())
 
             # torrent collecting: RemoteTorrentHandler
             if self.session.get_torrent_collecting():
@@ -651,6 +656,10 @@ class TriblerLaunchMany(object):
                 self._logger.info("lmc: Dispersy successfully shutdown in %.2f seconds", diff)
             else:
                 self._logger.info("lmc: Dispersy failed to shutdown in %.2f seconds", diff)
+
+        if self.metadata_store is not None:
+            self.metadata_store.close()
+            self.metadata_store = None
 
         if self.tftp_handler:
             self.tftp_handler.shutdown()

--- a/Tribler/Core/APIImplementation/LaunchManyCore.py
+++ b/Tribler/Core/APIImplementation/LaunchManyCore.py
@@ -159,8 +159,7 @@ class TriblerLaunchMany(object):
 
                 # register TFTP service
                 from Tribler.Core.TFTP.handler import TftpHandler
-                self.tftp_handler = TftpHandler(self.session, u'', endpoint,
-                                                "fffffffd".decode('hex'), block_size=1024)
+                self.tftp_handler = TftpHandler(self.session, endpoint, "fffffffd".decode('hex'), block_size=1024)
                 self.tftp_handler.initialize()
 
             if self.session.get_enable_torrent_search() or self.session.get_enable_channel_search():

--- a/Tribler/Core/RemoteTorrentHandler.py
+++ b/Tribler/Core/RemoteTorrentHandler.py
@@ -526,7 +526,7 @@ class TftpRequester(Requester):
 
         if key.startswith(METADATA_PREFIX):
             # metadata requests has a METADATA_PREFIX prefix
-            thumb_hash = unhexlify(key.replace(METADATA_PREFIX, ''))
+            thumb_hash = unhexlify(key[len(METADATA_PREFIX):])
             file_name = key
             extra_info = {u'key': key, u'thumb_hash': thumb_hash}
         else:

--- a/Tribler/Core/Session.py
+++ b/Tribler/Core/Session.py
@@ -15,7 +15,8 @@ from Tribler.Core.Upgrade.upgrade import TriblerUpgrader
 from Tribler.Core.exceptions import NotYetImplementedException, OperationNotEnabledByConfigurationException
 from Tribler.Core.simpledefs import (STATEDIR_PEERICON_DIR, STATEDIR_DLPSTATE_DIR, NTFY_PEERS, NTFY_TORRENTS,
                                      NTFY_MYPREFERENCES, NTFY_VOTECAST, NTFY_CHANNELCAST, NTFY_UPDATE, NTFY_INSERT,
-                                     NTFY_DELETE, NTFY_METADATA, STATEDIR_TORRENT_STORE_DIR)
+                                     NTFY_DELETE, NTFY_METADATA, STATEDIR_TORRENT_STORE_DIR,
+                                     STATEDIR_METADATA_STORE_DIR)
 from Tribler.Core.CacheDB.Notifier import Notifier
 
 
@@ -86,6 +87,11 @@ class Session(SessionConfigInterface):
         set_and_create_dir(scfg.get_torrent_store_dir(),
                            scfg.set_torrent_store_dir,
                            os.path.join(scfg.get_state_dir(), STATEDIR_TORRENT_STORE_DIR))
+
+        # metadata store
+        set_and_create_dir(scfg.get_metadata_store_dir(),
+                           scfg.set_metadata_store_dir,
+                           os.path.join(scfg.get_state_dir(), STATEDIR_METADATA_STORE_DIR))
 
         set_and_create_dir(scfg.get_peer_icon_path(), scfg.set_peer_icon_path,
                            os.path.join(scfg.get_state_dir(), STATEDIR_PEERICON_DIR))

--- a/Tribler/Core/SessionConfig.py
+++ b/Tribler/Core/SessionConfig.py
@@ -607,6 +607,34 @@ class SessionConfigInterface(object):
         """
         self.sessconfig.set(u'allchannel_community', u'enabled', mode)
 
+    def get_enable_metadata(self):
+        """
+        Gets if to enable metadata.
+        :return: True or False.
+        """
+        return self.sessconfig.get(u'metadata', u'enabled')
+
+    def set_enable_metadata(self, mode):
+        """
+        Sets if to enable metadata.
+        :param mode: True or False.
+        """
+        return self.sessconfig.set(u'metadata', u'enabled', mode)
+
+    def get_metadata_store_dir(self):
+        """
+        Gets the metadata_store directory.
+        :return: The metadata_store directory.
+        """
+        return self.sessconfig.get(u'metadata', u'store_dir')
+
+    def set_metadata_store_dir(self, value):
+        """
+        Sets the metadata_store directory.
+        :param store_dir: The metadata_store directory.
+        """
+        return self.sessconfig.set(u'metadata', u'store_dir', value)
+
     #
     # Static methods
     #

--- a/Tribler/Core/TFTP/handler.py
+++ b/Tribler/Core/TFTP/handler.py
@@ -1,10 +1,7 @@
-import os
 import logging
 from socket import inet_aton
 from struct import unpack
 from random import randint
-from tempfile import mkstemp
-from tarfile import TarFile
 from binascii import hexlify
 from time import time
 from hashlib import sha1
@@ -34,11 +31,10 @@ class TftpHandler(TaskManager):
     This is the TFTP handler that should be registered at the RawServer to handle TFTP packets.
     """
 
-    def __init__(self, session, root_dir, endpoint, prefix, block_size=DEFAULT_BLOCK_SIZE, timeout=DEFAULT_TIMEOUT,
+    def __init__(self, session, endpoint, prefix, block_size=DEFAULT_BLOCK_SIZE, timeout=DEFAULT_TIMEOUT,
                  max_retries=DEFAULT_RETIES):
         """ The constructor.
         :param session:     The tribler session.
-        :param root_dir:    The root directory to use.
         :param endpoint:    The endpoint to use.
         :param prefix:      The prefix to use.
         :param block_size:  Transmission block size.
@@ -49,7 +45,6 @@ class TftpHandler(TaskManager):
         self._logger = logging.getLogger(self.__class__.__name__)
 
         self.session = session
-        self.root_dir = root_dir
 
         self._endpoint = endpoint
         self._prefix = prefix

--- a/Tribler/Core/TFTP/handler.py
+++ b/Tribler/Core/TFTP/handler.py
@@ -296,7 +296,7 @@ class TftpHandler(TaskManager):
         # read the file/directory into memory
         try:
             if file_name.startswith(METADATA_PREFIX):
-                file_data, file_size = self._load_metadata(file_name.replace(METADATA_PREFIX, ''))
+                file_data, file_size = self._load_metadata(file_name[len(METADATA_PREFIX):])
             else:
                 file_data, file_size = self._load_torrent(file_name)
             checksum = b64encode(sha1(file_data).digest())

--- a/Tribler/Core/Upgrade/upgrade.py
+++ b/Tribler/Core/Upgrade/upgrade.py
@@ -52,8 +52,8 @@ class TriblerUpgrader(object):
         else:
             # upgrade
             try:
-                from Tribler.Core.torrentstore import TorrentStore
-                torrent_store = TorrentStore(self.session.get_torrent_store_dir())
+                from Tribler.Core.leveldbstore import LevelDbStore
+                torrent_store = LevelDbStore(self.session.get_torrent_store_dir())
                 torrent_migrator = TorrentMigrator65(
                     self.session, self.db, torrent_store=torrent_store, status_update_func=self.update_status)
                 yield torrent_migrator.start_migrate()

--- a/Tribler/Core/defaults.py
+++ b/Tribler/Core/defaults.py
@@ -33,7 +33,7 @@ DEFAULTPORT = 7760
 #  Version 4: remove swift
 #  Version 7: exitnode optin switch added
 
-SESSDEFAULTS_VERSION = 8
+SESSDEFAULTS_VERSION = 9
 sessdefaults = OrderedDict()
 
 # General Tribler settings
@@ -71,6 +71,11 @@ sessdefaults['search_community']['enabled'] = True
 sessdefaults['tunnel_community'] = OrderedDict()
 sessdefaults['tunnel_community']['socks5_listen_ports'] = [-1] * 5
 sessdefaults['tunnel_community']['exitnode_enabled'] = False
+
+# Metadata section
+sessdefaults['metadata'] = OrderedDict()
+sessdefaults['metadata']['enabled'] = True
+sessdefaults['metadata']['store_dir'] = None
 
 # Mainline DHT settings
 sessdefaults['mainline_dht'] = OrderedDict()

--- a/Tribler/Core/leveldbstore.py
+++ b/Tribler/Core/leveldbstore.py
@@ -56,17 +56,16 @@ from Tribler.dispersy.taskmanager import TaskManager
 
 WRITEBACK_PERIOD = 120
 
-# TODO(emilon): This could be easily abstracted into a generic cached store
 # TODO(emilon): Make sure the caching makes an actual difference in IO and kill
 # it if it doesn't as it complicates the code.
 
 
-class TorrentStore(MutableMapping, TaskManager):
+class LevelDbStore(MutableMapping, TaskManager):
     _reactor = reactor
     _leveldb = LevelDB
 
     def __init__(self, store_dir):
-        super(TorrentStore, self).__init__()
+        super(LevelDbStore, self).__init__()
 
         self._store_dir = store_dir
         self._pending_torrents = {}

--- a/Tribler/Core/simpledefs.py
+++ b/Tribler/Core/simpledefs.py
@@ -42,6 +42,7 @@ For details see API.py
 STATEDIR_DLPSTATE_DIR = 'dlcheckpoints'
 STATEDIR_PEERICON_DIR = 'icons'
 STATEDIR_TORRENT_STORE_DIR = 'collected_torrents'
+STATEDIR_METADATA_STORE_DIR = 'collected_metadata'
 
 STATEDIR_SESSCONFIG = 'libtribler.conf'
 

--- a/Tribler/Test/test_as_server.py
+++ b/Tribler/Test/test_as_server.py
@@ -182,8 +182,7 @@ class TestAsServer(AbstractServer):
         self.config.set_libtorrent(False)
         self.config.set_dht_torrent_collecting(False)
         self.config.set_videoplayer(False)
-        self.config.set_enable_metadata_store(False)
-        self.config.set_enable_metadata_community(False)
+        self.config.set_enable_metadata(False)
 
     def tearDown(self):
         self.annotate(self._testMethodName, start=False)

--- a/Tribler/Test/test_as_server.py
+++ b/Tribler/Test/test_as_server.py
@@ -182,6 +182,8 @@ class TestAsServer(AbstractServer):
         self.config.set_libtorrent(False)
         self.config.set_dht_torrent_collecting(False)
         self.config.set_videoplayer(False)
+        self.config.set_enable_metadata_store(False)
+        self.config.set_enable_metadata_community(False)
 
     def tearDown(self):
         self.annotate(self._testMethodName, start=False)

--- a/Tribler/Test/test_leveldb_store.py
+++ b/Tribler/Test/test_leveldb_store.py
@@ -1,6 +1,6 @@
 # test_torrent_store.py ---
 #
-# Filename: test_torrent_store.py
+# Filename: test_leveldb_store.py
 # Description:
 # Author: Elric Milon
 # Maintainer:
@@ -40,7 +40,8 @@ from tempfile import mkdtemp
 
 from twisted.internet.task import Clock
 
-from Tribler.Core.torrentstore import TorrentStore, WRITEBACK_PERIOD
+from Tribler.Core.Utilities.twisted_thread import deferred
+from Tribler.Core.leveldbstore import LevelDbStore, WRITEBACK_PERIOD
 from Tribler.Test.test_as_server import BaseTestCase
 
 
@@ -48,11 +49,11 @@ K = "foo"
 V = "bar"
 
 
-class ClockedTorrentStore(TorrentStore):
+class ClockedLevelDbStore(LevelDbStore):
     _reactor = Clock()
 
 
-class TestTorrentStore(BaseTestCase):
+class TestLevelDbStore(BaseTestCase):
 
     def __init__(self, *argv, **kwargs):
         super(TestTorrentStore, self).__init__(*argv, **kwargs)
@@ -73,7 +74,7 @@ class TestTorrentStore(BaseTestCase):
 
     def openStore(self, store_dir):
         self.store_dir = store_dir
-        self.store = ClockedTorrentStore(store_dir=self.store_dir)
+        self.store = ClockedLevelDbStore(store_dir=self.store_dir)
 
 
     def test_storeIsPersistent(self):
@@ -107,4 +108,4 @@ class TestTorrentStore(BaseTestCase):
         self.assertEqual(1, len(self.store), 2)
 
 #
-# test_torrent_store.py ends here
+# test_leveldb_store.py ends here

--- a/Tribler/Test/test_leveldb_store.py
+++ b/Tribler/Test/test_leveldb_store.py
@@ -56,7 +56,7 @@ class ClockedLevelDbStore(LevelDbStore):
 class TestLevelDbStore(BaseTestCase):
 
     def __init__(self, *argv, **kwargs):
-        super(TestTorrentStore, self).__init__(*argv, **kwargs)
+        super(TestLevelDbStore, self).__init__(*argv, **kwargs)
 
         self.store_dir = None
         self.store = None

--- a/Tribler/Test/test_leveldb_store_plyvel.py
+++ b/Tribler/Test/test_leveldb_store_plyvel.py
@@ -35,20 +35,19 @@
 # Code:
 from twisted.internet.task import Clock
 
-from tempfile import mkdtemp
-
-from Tribler.Core.torrentstore import TorrentStore
+from Tribler.Core.leveldbstore import LevelDbStore
 from Tribler.Core.plyveladapter import LevelDB
-from Tribler.Test.test_torrent_store import TestTorrentStore, K, V
+from Tribler.Test.test_leveldb_store import TestLevelDbStore, K, V
 
 
-class ClockedTorrentStore(TorrentStore):
+class ClockedTorrentStore(LevelDbStore):
     _reactor = Clock()
     _leveldb = LevelDB
 
-class TestTorrentStore_Plyvel(TestTorrentStore):
+
+class TestLevelDbStore_Plyvel(TestLevelDbStore):
     pass
     
 
 #
-# test_torrent_store_plyvel.py ends here
+# test_leveldb_store_plyvel.py ends here

--- a/Tribler/community/channel/community.py
+++ b/Tribler/community/channel/community.py
@@ -743,8 +743,9 @@ class ChannelCommunity(Community):
                                 "Will try to download swift-thumbnails with infohash %s from %s",
                                 infohash.encode("HEX"),
                                 message.candidate.sock_addr[0])
-                            th_handler.download_metadata("thumbs", message.candidate, infohash, thumbnail_subpath,
-                                                         timeout=CANDIDATE_WALK_LIFETIME, usercallback=callback)
+                            # FIXME(lipu): enable thumbnail download when it's ready
+                            #th_handler.download_metadata("thumbs", message.candidate, infohash, thumbnail_subpath,
+                            #                             timeout=CANDIDATE_WALK_LIFETIME, usercallback=callback)
                             continue
 
             yield message


### PR DESCRIPTION
Fix metadata download through TFTP.

Thumbnails are stored in LevelDb. The key is the SHA1 hash of the thumbnail file.