### PR TITLE
[WIP] Add Plyvel support to TorrentStore

### DIFF
--- a/Tribler/Core/torrentstore.py
+++ b/Tribler/Core/torrentstore.py
@@ -37,7 +37,6 @@ from collections import MutableMapping
 from itertools import chain
 
 try:
-    raise ImportError("Fake import error")
     from leveldb import LevelDB, WriteBatch
     LEVELDBPROVIDER = "leveldb"
 except:
@@ -133,6 +132,7 @@ class TorrentStore(MutableMapping, TaskManager):
 
     def put(self, k, v):
         self.__setitem__(k, v)
+        # self._db.Put(key, value)
 
     if LEVELDBPROVIDER == "leveldb":
         def rangescan(self, start=None, end=None):


### PR DESCRIPTION
So we tried to go with an adapter like approach, but this became complicated as the behaviour of WriteBatch is different. Does this work with you guys? Using this there is no need for subclasses or changing the calls to TorrentStore. It looks pretty ugly however.

One problem I noticed is with the TFTP handler. This requests the infohash in unicode, in _load_torrent, and py-leveldb supports this but plyvel gives an error on it. As far as I can tell, it should be no problem to do some conversion in the function.