### PR TITLE
Move the twisted utility methods to its own module.

### DIFF
--- a/Tribler/Core/CacheDB/Notifier.py
+++ b/Tribler/Core/CacheDB/Notifier.py
@@ -4,7 +4,7 @@
 import threading
 import logging
 
-from Tribler.Core.Utilities.twisted_thread import callInThreadPool
+from Tribler.Core.Utilities.twisted_utils import callInThreadPool
 from Tribler.Core.simpledefs import (NTFY_TORRENTS, NTFY_PLAYLISTS, NTFY_COMMENTS,
                                      NTFY_MODIFICATIONS, NTFY_MODERATIONS, NTFY_MARKINGS, NTFY_MYPREFERENCES,
                                      NTFY_ACTIVITIES, NTFY_REACHABLE, NTFY_CHANNELCAST, NTFY_VOTECAST, NTFY_DISPERSY,

--- a/Tribler/Core/Libtorrent/LibtorrentDownloadImpl.py
+++ b/Tribler/Core/Libtorrent/LibtorrentDownloadImpl.py
@@ -14,7 +14,6 @@ from Tribler.Core.DownloadConfig import DownloadStartupConfig, DownloadConfigInt
 from Tribler.Core.DownloadState import DownloadState
 from Tribler.Core.Libtorrent import checkHandleAndSynchronize, waitForHandleAndSynchronize
 from Tribler.Core.TorrentDef import TorrentDefNoMetainfo, TorrentDef
-from Tribler.Core.Utilities.twisted_thread import callInThreadPool
 from Tribler.Core.osutils import fix_filebasename
 from Tribler.Core.simpledefs import (DLSTATUS_WAITING4HASHCHECK, DLSTATUS_HASHCHECKING, DLSTATUS_METADATA,
                                      DLSTATUS_DOWNLOADING, DLSTATUS_SEEDING, DLSTATUS_ALLOCATING_DISKSPACE,

--- a/Tribler/Core/RemoteTorrentHandler.py
+++ b/Tribler/Core/RemoteTorrentHandler.py
@@ -18,7 +18,6 @@ from twisted.internet.task import LoopingCall
 from Tribler.dispersy.taskmanager import TaskManager
 from Tribler.dispersy.util import call_on_reactor_thread
 
-from Tribler.Core.Utilities.twisted_thread import callInThreadPool
 from Tribler.Core.TorrentDef import TorrentDef
 from Tribler.Core.simpledefs import NTFY_TORRENTS, INFOHASH_LENGTH
 

--- a/Tribler/Core/Utilities/twisted_thread.py
+++ b/Tribler/Core/Utilities/twisted_thread.py
@@ -179,20 +179,3 @@ def deferred(timeout=None):
         wrapper = make_decorator(func)(wrapper)
         return wrapper
     return decorate
-
-
-def callInThreadPool(fun, *args, **kwargs):
-    """
-    Calls fun(*args, **kwargs) in the reactor's thread pool.
-    """
-    if isInThreadPool():
-        fun(*args, **kwargs)
-    else:
-        reactor.callFromThread(reactor.callInThread, fun, *args, **kwargs)
-
-
-def isInThreadPool():
-    """
-    Check if we are currently on one of twisted threadpool threads.
-    """
-    return current_thread() in reactor.threadpool.threads

--- a/Tribler/Core/Utilities/twisted_utils.py
+++ b/Tribler/Core/Utilities/twisted_utils.py
@@ -1,0 +1,60 @@
+# twisted.py ---
+#
+# Filename: twisted.py
+# Description:
+# Author: Elric Milon
+# Maintainer:
+# Created: Mon Jun 22 13:13:36 2015 (+0200)
+
+# Commentary:
+#
+# Misc. utility methods and classes for twisted.
+#
+#
+
+# Change Log:
+#
+#
+#
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or (at
+# your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GNU Emacs.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+
+# Code:
+
+from threading import current_thread
+
+from twisted.internet import reactor
+
+
+def callInThreadPool(fun, *args, **kwargs):
+    """
+    Calls fun(*args, **kwargs) in the reactor's thread pool.
+    """
+    if isInThreadPool():
+        fun(*args, **kwargs)
+    else:
+        reactor.callFromThread(reactor.callInThread, fun, *args, **kwargs)
+
+
+def isInThreadPool():
+    """
+    Check if we are currently on one of twisted threadpool threads.
+    """
+    return current_thread() in reactor.threadpool.threads
+
+
+#
+# twisted.py ends here

--- a/Tribler/Main/Utility/GuiDBHandler.py
+++ b/Tribler/Main/Utility/GuiDBHandler.py
@@ -16,7 +16,7 @@ from twisted.internet import reactor
 from twisted.python.threadable import isInIOThread
 from wx.lib.delayedresult import (AbortedException, SenderCallAfter, SenderNoWx, SenderWxEvent)
 
-from Tribler.Core.Utilities.twisted_thread import isInThreadPool
+from Tribler.Core.Utilities.twisted_utils import isInThreadPool
 from Tribler.Main.Dialogs.GUITaskQueue import GUITaskQueue
 from Tribler.dispersy.taskmanager import TaskManager
 

--- a/Tribler/community/metadata/community.py
+++ b/Tribler/community/metadata/community.py
@@ -1,7 +1,6 @@
 import binascii
 import json
 
-from Tribler.Core.Utilities.twisted_thread import callInThreadPool
 from Tribler.dispersy.authentication import MemberAuthentication
 from Tribler.dispersy.candidate import CANDIDATE_WALK_LIFETIME
 from Tribler.dispersy.community import Community

--- a/Tribler/community/tunnel/main.py
+++ b/Tribler/community/tunnel/main.py
@@ -17,7 +17,7 @@ from twisted.internet.threads import blockingCallFromThread
 from Tribler.community.tunnel.tunnel_community import TunnelSettings
 from Tribler.Core.SessionConfig import SessionStartupConfig
 from Tribler.Core.Session import Session
-from Tribler.Core.Utilities.twisted_thread import callInThreadPool, reactor
+from Tribler.Core.Utilities.twisted_thread import reactor
 from Tribler.Core.permid import read_keypair
 from Tribler.Core.TorrentDef import TorrentDef
 from Tribler.Main.globals import DefaultDownloadStartupConfig


### PR DESCRIPTION
To avoid problems when not running the reactor on a separate thread.