### PR TITLE
Add timeout to checker_thread.join()

### DIFF
--- a/Tribler/Core/TorrentChecker/torrent_checker.py
+++ b/Tribler/Core/TorrentChecker/torrent_checker.py
@@ -23,6 +23,8 @@ DEFAULT_TORRENT_CHECK_INTERVAL = 900  # base multipier for the check delay
 DEFAULT_MAX_TORRENT_CHECK_RETRIES = 8  # max check delay increments when failed.
 DEFAULT_TORRENT_CHECK_RETRY_INTERVAL = 30  # interval when the torrent was successfully checked for the last time
 
+CHECKER_JOIN_TIMEOUT = 2
+
 
 class TorrentCheckerThread(Thread):
 
@@ -126,7 +128,9 @@ class TorrentChecker(TaskManager):
         # stop the checking thread
         self._should_stop = True
         self._checker_thread.interrupt()
-        self._checker_thread.join()
+        self._checker_thread.join(CHECKER_JOIN_TIMEOUT)
+        if self._checker_thread.isAlive():
+            self._logger.error("_checker_thread.join(%d) timed out.", CHECKER_JOIN_TIMEOUT)
         self._checker_thread = None
 
         # kill all the tracker sessions


### PR DESCRIPTION
To avoid a deadlock.