### PR TITLE
Change error to warning for communication errors in crypto

### DIFF
--- a/Tribler/community/tunnel/tunnel_community.py
+++ b/Tribler/community/tunnel/tunnel_community.py
@@ -895,7 +895,7 @@ class TunnelCommunity(Community):
                     try:
                         encrypted = self.crypto_in(circuit_id, encrypted)
                     except CryptoException, e:
-                        self.tunnel_logger.error(str(e))
+                        self.tunnel_logger.warning(str(e))
                         continue
 
                 packet = plaintext + encrypted


### PR DESCRIPTION
Crypto errors sometimes happen when a circuit breaks (due to security limiters or timeouts) and there are still messages in transit on the circuit. Those messages can't be decrypted because the keys have already been cleaned up. Those errors are useful for debugging but not relevant in production, as they can happen any time.

Change error to warning for communication errors related to encrypting / decrypting. Solves #1559
