### PR TITLE
Change Tracker Checking interval mechanism

### DIFF
--- a/Tribler/Core/TorrentChecker/torrent_checker.py
+++ b/Tribler/Core/TorrentChecker/torrent_checker.py
@@ -379,7 +379,7 @@ class TorrentChecker(TaskManager):
 
         # before creating a new session, check if the tracker is alive
         if not self._session.lm.tracker_manager.should_check_tracker(tracker_url):
-            self._logger.warn(u"skipping dead tracker %s", tracker_url)
+            self._logger.warn(u"skipping recently failed tracker %s", tracker_url)
             return
 
         session = None


### PR DESCRIPTION
Closes #1565

The old tracker checking interval was a bit crazy. If a tracker is "alive", we will check it as much as we want; if a tracker is "dead", we will only check it after at least 60 seconds since the last check. If tracker has failed 5 times, it will be marked as "dead". So that's why we see those log messages appearing every 60 seconds or so.

In this PR, I changed it to use an incremental interval:
`this_interval = default_interval * 2^failures`
where `default_interval` is 60 seconds.