### PR TITLE
Fix restart on Windows

### DIFF
--- a/Tribler/Main/vwxGUI/MainFrame.py
+++ b/Tribler/Main/vwxGUI/MainFrame.py
@@ -653,7 +653,8 @@ class MainFrame(wx.Frame):
         elif sys.platform == "darwin":
             executable = "?"
 
-        executable = os.path.join(path, executable)
+        if sys.platform != "win32":
+            executable = os.path.join(path, executable)
         self._logger.info(repr(executable))
 
         def start_tribler():


### PR DESCRIPTION
Fixes this problem:
```
Traceback (most recent call last):
File "Tribler\Main\vwxGUI\MainFrame.pyo", line 661, in start_tribler
File "subprocess.pyo", line 710, in init
File "subprocess.pyo", line 958, in _execute_child
WindowsError: [Error 2] The system cannot find the file specified
```