### PR TITLE
Add eclipse files in Tribler folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@
 /.noseids
 /.project
 /.pydevproject
+/Tribler/.project
+/Tribler/.pydevproject
 /TAGS
 /bootstraptribler.txt
 /core


### PR DESCRIPTION
Adds ignores for the .project and .pydevproject files within the
Tribler folder.
Setting up the Eclipse project according to the "Compiling Tribler
from Sources under Eclipse" wiki page, results in these files
being recognised by Git.

Edit: [Compiling Tribler from Sources under Eclipse] (https://github.com/Tribler/tribler/wiki/Compiling-Tribler-from-sources-under-Eclipse)