### PR TITLE
Removed some unused variables in the ABCApp class

### DIFF
--- a/Tribler/Main/tribler_main.py
+++ b/Tribler/Main/tribler_main.py
@@ -125,6 +125,7 @@ class ABCApp(object):
 
         # DISPERSY will be set when available
         self.dispersy = None
+        self.tunnel_community = None
 
         self.torrentfeed = None
         self.webUI = None

--- a/Tribler/Main/tribler_main.py
+++ b/Tribler/Main/tribler_main.py
@@ -123,16 +123,8 @@ class ABCApp(object):
         self.done = False
         self.frame = None
 
-        self.said_start_playback = False
-        self.decodeprogress = 0
-
-        self.old_reputation = 0
-
         # DISPERSY will be set when available
         self.dispersy = None
-        # BARTER_COMMUNITY will be set when both Dispersy and the EffortCommunity are available
-        self.barter_community = None
-        self.tunnel_community = None
 
         self.torrentfeed = None
         self.webUI = None


### PR DESCRIPTION
It appears that some variables in the ABCApp class are not used anymore and are probably safe to remove.