### PR TITLE
Windows openssl applink fix

### DIFF
--- a/Tribler/Core/permid.py
+++ b/Tribler/Core/permid.py
@@ -2,7 +2,7 @@
 # see LICENSE.txt for license information
 import os
 import logging
-from M2Crypto import Rand, EC
+from M2Crypto import Rand, EC, BIO
 
 logger = logging.getLogger(__name__)
 
@@ -12,6 +12,9 @@ NUM_RANDOM_BITS = 1024 * 8  # bits
 
 # Exported functions
 
+# a workaround is needed for Tribler to function on Windows 64 bit
+# instead of invoking EC.load_key(filename), we should use the M2Crypto.BIO buffer
+# see http://stackoverflow.com/questions/33720087/error-when-importing-m2crypto-in-python-on-windows-x64
 
 def init():
     Rand.rand_seed(os.urandom(NUM_RANDOM_BITS / 8))
@@ -24,12 +27,23 @@ def generate_keypair():
 
 
 def read_keypair(keypairfilename):
-    return EC.load_key(keypairfilename)
+    membuf = BIO.MemoryBuffer(open(keypairfilename, 'rb').read())
+    key = EC.load_key_bio(membuf)
+    membuf.close()
+    return key
 
 
 def save_keypair(keypair, keypairfilename):
-    keypair.save_key(keypairfilename, None)
+    membuf = BIO.MemoryBuffer()
+    keypair.save_key_bio(membuf, None)
+    with open(keypairfilename, 'w') as file:
+        file.write(membuf.read())
+    membuf.close()
 
 
 def save_pub_key(keypair, pubkeyfilename):
-    keypair.save_pub_key(pubkeyfilename)
+    membuf = BIO.MemoryBuffer()
+    keypair.save_pub_key_bio(membuf)
+    with open(pubkeyfilename, 'w') as file:
+        file.write(membuf.read())
+    membuf.close()


### PR DESCRIPTION
On Windows, I encountered an issue when setting up a 64-bit environment. The problem occurred when invoking M2Crypto functions. I've explained the issue in more detail on Stack Overflow [here](http://stackoverflow.com/questions/33720087/error-when-importing-m2crypto-in-python-on-windows-x64/33728728#33728728).

One solution for this problem is to recompile Python and to include `openssl/applink.c` in the `Python.c` file. Since recompiling Python turned out to be quite hard (and not very desirable), I believe we can use the workaround as given by the answer on Stack Overflow. By making use of M2Crypto.BIO, we avoid using the openssl applink interface and thus the No OPENSSL_AppLink error.

Note that this problem only occurs on Windows (and I believe in particular 64-bit builds). On Linux and OS X, it is working without any problem.