### PR TITLE
Added documentation about setting up development environment on Windows, Linux and OS X

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,57 +27,7 @@ Have a look at the [issue tracker](https://github.com/Tribler/tribler/issues) if
 
 ## Getting your development environment up and running
 
-### Runtime dependencies
-
-#### Debian/Ubuntu/Mint
-```bash
-sudo apt-get install libav-tools libjs-excanvas libjs-mootools libsodium13 libx11-6 python-apsw python-cherrypy3 python-crypto python-cryptography python-feedparser python-gmpy python-leveldb python-libtorrent python-m2crypto python-netifaces python-pil python-pyasn1 python-requests python-twisted python-wxgtk2.8 python2.7 vlc python-pip
-pip install decorator
-```
-##### **Installing libsodium13 and python-cryptography on Ubuntu 14.04**
-
-While installing libsodium13 and python-cryptography on a clean Ubuntu 14.04 install (possibly other versions as well), the situation can occur where the Ubuntu terminal throws the following error when trying to install the dependencies mentioned earlier in the README.md:
-
-    E: Unable to locate package libsodium13
-    E: Unable to locate package python-cryptography
-
-This means that the required packages are not directly in the available package list of Ubuntu 14.04.
-
-To install the packages, the required files have to be downloaded from their respecive websites.
-
-For libsodium13, download libsodium13\_1.0.1-1\_<ProcessorType\>.deb from [http://packages.ubuntu.com/vivid/libsodium13](http://packages.ubuntu.com/vivid/libsodium13)
-
-For python-cryptography, download python-cryptography\_0.5.2-1\_<ProcessorType\>.deb from [http://packages.ubuntu.com/utopic/python-cryptography](http://packages.ubuntu.com/utopic/python-cryptography)
-
-###### **Installing the files**
-**Through terminal**
-
-After downloading files go to the download folder and install the files through terminal:
-
-**For amd64:**
-
-```bash
-cd ./Downloads
-dpkg -i libsodium13_1.0.1-1_amd64.deb
-dpkg -i python-cryptography_0.5.2-1_amd64.deb
-```
-**For i386:**
-
-```bash
-cd ./Downloads
-dpkg -i libsodium13_1.0.1-1_i386.deb
-dpkg -i python-cryptography_0.5.2-1_i386.deb
-```
-
-**Through file navigator:**
-
-Using the file navigator to go to the download folder and by clicking on the .deb files to have the software installer install the packages.
-
-Now installing the list of dependencies should no longer throw an error.
-
-#### Windows and OSX
-
-Tribler runs on Windows and OSX, but development is only supported on Linux.
+We support development on Linux, OS X and Windows. We have written documentation that guides you through installing the required packages when setting up a Tribler development environment. Click [here](docs/Tribler development on Linux.md) for the guide on setting up a development environment on Linux distributions. Click [here](docs/Tribler development on Windows.md) for the guide on setting everything up on Windows. The guide for setting up the development environment on OS X can be found [here](docs/Tribler development on OS X.md).
 
 ### Running Tribler from this repository
 #### Unix
@@ -100,9 +50,6 @@ Now you can run tribler by executing the ```tribler.sh``` script on the root of 
 cd tribler
 ./tribler.sh
 ```
-#### Windows
-
-Tribler runs on Windows and OSX, but development is only supported on Linux.
 
 ## Packaging Tribler
 

--- a/doc/Tribler development on Linux.md
+++ b/doc/Tribler development on Linux.md
@@ -1,0 +1,53 @@
+This page contains information about setting up a Tribler development environment on Linux systems.
+
+## Getting your development environment up and running
+
+### Runtime dependencies
+
+#### Debian/Ubuntu/Mint
+```bash
+sudo apt-get install libav-tools libjs-excanvas libjs-mootools libsodium13 libx11-6 python-apsw python-cherrypy3 python-crypto python-cryptography python-feedparser python-gmpy python-leveldb python-libtorrent python-m2crypto python-netifaces python-pil python-pyasn1 python-requests python-twisted python-wxgtk2.8 python2.7 vlc python-pip
+pip install decorator
+```
+##### **Installing libsodium13 and python-cryptography on Ubuntu 14.04**
+
+While installing libsodium13 and python-cryptography on a clean Ubuntu 14.04 install (possibly other versions as well), the situation can occur where the Ubuntu terminal throws the following error when trying to install the dependencies mentioned earlier in the README.md:
+
+    E: Unable to locate package libsodium13
+    E: Unable to locate package python-cryptography
+
+This means that the required packages are not directly in the available package list of Ubuntu 14.04.
+
+To install the packages, the required files have to be downloaded from their respecive websites.
+
+For libsodium13, download libsodium13\_1.0.1-1\_<ProcessorType\>.deb from [http://packages.ubuntu.com/vivid/libsodium13](http://packages.ubuntu.com/vivid/libsodium13)
+
+For python-cryptography, download python-cryptography\_0.5.2-1\_<ProcessorType\>.deb from [http://packages.ubuntu.com/utopic/python-cryptography](http://packages.ubuntu.com/utopic/python-cryptography)
+
+###### **Installing the files**
+**Through terminal**
+
+After downloading files go to the download folder and install the files through terminal:
+
+**For amd64:**
+
+```bash
+cd ./Downloads
+dpkg -i libsodium13_1.0.1-1_amd64.deb
+dpkg -i python-cryptography_0.5.2-1_amd64.deb
+```
+**For i386:**
+
+```bash
+cd ./Downloads
+dpkg -i libsodium13_1.0.1-1_i386.deb
+dpkg -i python-cryptography_0.5.2-1_i386.deb
+```
+
+**Through file navigator:**
+
+Using the file navigator to go to the download folder and by clicking on the .deb files to have the software installer install the packages.
+
+Now installing the list of dependencies should no longer throw an error.
+
+If there are any problems with the guide above, please feel free to fix any errors or [create an issue](https://github.com/Tribler/tribler/issues/new) so we can look into it.

--- a/doc/Tribler development on OS X.md
+++ b/doc/Tribler development on OS X.md
@@ -1,0 +1,125 @@
+This page contains information about setting up a Tribler development environment on OS X. Unlike Linux based systems where installing third-party libraries is often a single `apt-get` command, installing and configuring the necessary libraries requires more attention on OS X. This guide has been tested with OS X 10.10.5 (Yosemite) but should also work for OS X 10.11 (El Capitan).
+
+Note that the guide below assumes that Python is installed in the default location of Python (shipped with OS X). This location is normally in `/Library/Python/2.7`. Writing to this location requires root acccess when using easy_install or pip. To avoid root commands, you can install Python in a virtualenv. More information about setting up Python in a virtualenv can be found [here](http://www.marinamele.com/2014/05/install-python-virtualenv-virtualenvwrapper-mavericks.html).
+
+## Introduction
+Compilation of C/C++ libraries should be performed using Clang which is part of the Xcode Command Line Tools. The Python version shipped with OS X can be used and this guide has been tested using Python 2.7. The current installed version and binary of Python can be found by executing:
+
+```
+python --version # gets the python version
+which python # prints the path of the Python executable
+```
+
+Note that the default location of third-party Python libraries (for example, installed with `pip`) can be found in `/Library/Python/2.7/site-packages`.
+
+Many packages can be installed by using the popular brew and pip executables. Brew and pip can be installed by using:
+
+```
+ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+sudo easy_install pip
+```
+
+## Installing the Required Packages
+In this section, the installation of the packages required by Tribler will be discussed in a step-by-step manner.
+
+### Xcode Tools
+The installation of Xcode is required in order to compile some C/C++ libraries. Xcode is an IDE developed by Apple and can be downloaded for free from the Mac App Store. After installation, the Command Line Tools should be installed by executing:
+
+```
+xcode-select --install
+```
+
+### WxPython
+WxPython is the Graphical User Interface manager and an installer can be downloaded from [their website](http://www.wxpython.org/download.php). Note that at this point, Wx 2.8 should still be used but support for 2.8 will be dropped soon and the Wx 2.8 library should be replaced by Wx 3.0. You probably need the Cocoa version of Wx.
+
+Note: there is a bug on OS X 10.11 (El Capitan) where the installer gives an error that there is no software available to install. A workaround for this is to install the required files manually. This can be done by opening the `.pkg` file and unzipping the `wxPython3.0-osx-cocoa-py2.7.pax` file. This will create a `usr` directory which should be copied to `/usr`. To link wx, you should run the `postflight.sh` as root.
+
+### M2Crypto
+To install M2Crypto, Openssl has to be installed first. The shipped version of openssl by Apple gives errors when compiling M2Crypto so a self-compiled version should be used. Start by downloading openssl 0.98 from [here](https://www.openssl.org/source/), extract it and install it:
+
+```
+./config --prefix=/usr/local
+make && make test
+sudo make install
+openssl version # this should be 0.98
+```
+
+Also Swig is required for the compilation of the M2Crypto library. The easiest way to install it, it to download Swig from source [here](http://www.swig.org/download.html) and compile it using:
+
+```
+./configure
+make
+sudo make install
+```
+
+Now we can install M2Crypto. First download the [source](http://chandlerproject.org/Projects/MeTooCrypto) and install it:
+
+```
+python setup.py build build_ext --openssl=/usr/local
+sudo python setup.py install build_ext --openssl=/usr/local
+```
+
+Test it out by executing:
+
+```
+python -c "import M2Crypto"
+```
+
+### Apsw
+Apsw can be installed by brew but this does not seem to work to compile the last version (the Clang compiler uses the `sqlite.h` include shipped with Xcode which is outdated). Instead, the source should be downloaded from their [Github repository](https://github.com/rogerbinns/apsw) and compiled using:
+
+```
+sudo python setup.py fetch --all build --enable-all-extensions install test
+```
+
+### Libtorrent
+An essential dependency of Tribler is libtorrent. libtorrent is dependent on Boost, a set of C++ libraries. To function correctly, Boost should be built from source (this will take a while):
+
+```
+brew install --build-from-source boost
+brew install boost-python
+```
+
+Now we can install libtorrent:
+
+```
+brew install libtorrent-rasterbar --with-python
+```
+
+After the installation, brew gives some instructions to finish the installation, something like:
+
+```
+mkdir -p /Users/martijn/Library/Python/2.7/lib/python/site-packages
+  echo 'import site; site.addsitedir("/usr/local/lib/python2.7/site-packages")' >> /Library/Python/2.7/site-packages/homebrew.pth
+```
+
+This command basically adds another location for the Python site-packages (the location where libtorrent-rasterbar is installed). This command should be executed since the location where brew installs the Python packages is not in sys.path. You can test whether libtorrent is correctly installed by executing:
+
+```
+python
+>>> import libtorrent
+```
+
+### Other Packages
+There are a bunch of other packages that can easily be installed using pip and brew:
+
+```
+brew install Pillow
+pip install cherrypy pillow cffi cryptography decorator feedparser gmpy2 idna leveldb netifaces numpy pyasn1 pycparser requests twisted service_identity
+```
+
+If you encounter any error during the installation of Pillow, make sure that libjpeg and zlib are installed. They can be installed using:
+
+```
+brew tap homebrew/dupes
+brew install libjpeg zlib
+brew link --force zlib
+```
+
+Tribler should now be able to startup without warnings by executing this command in the Tribler root directory:
+
+```
+./tribler.sh
+```
+
+If there are any missing packages, they can often be installed by one pip or brew command. If there are any problems with the guide above, please feel free to fix any errors or [create an issue](https://github.com/Tribler/tribler/issues/new) so we can look into it.

--- a/doc/Tribler development on Windows.md
+++ b/doc/Tribler development on Windows.md
@@ -1,0 +1,112 @@
+This page contains information about setting up a Tribler development environment on Windows. Unlike Linux based systems where installing third-party libraries is often a single `apt-get` command, installing and configuring the necessary libraries requires more attention on Windows. Moreover, the Windows environment has different file stuctures. For instance, where Linux is working extensively with .so (shared object) files, Windows uses DLL files.
+
+## Introduction
+In this guide, all required dependencies of Tribler will be explained. It presents how to install these dependencies. Some dependencies have to be built from source whereas other dependencies can be installed using a .msi installer. The guide targets Windows 10, 64-bit systems, however, it is probably not very hard to install 32-bit packages.
+
+First, Python 2.7 should be installed. If you already have a Python version installed, please check whether this version is 64 bit before proceeding.
+
+```
+python -c "import struct;print( 8 * struct.calcsize('P'))"
+```
+
+This outputs whether your current installation is 32 or 64 bit.
+
+Python can be downloaded from the official [Python website](https://www.python.org/downloads/release/python-2710/). You should download the Windows x86-64 MSI Installer which is an executable. During the installation, remember to install pip/setuptools and to add Python to the PATH variable to access Python from the command line. You can verify whether Python is installed correctly by typing `python` in the command line.
+
+If you did not change the default installation location, Python should be located at `C:\Python27\`. The third-party libraries are located in `C:\Python27\Lib\site-packages`.
+
+In order to compile some of the dependencies of Tribler, you will need the Visual C++ tools. Recently, Microsoft started to distribute these tools as stand-alone packages, removing the need to download the whole Visual Studio suite. The Visual C++ tools can be downloaded [here](http://blogs.msdn.com/b/vcblog/archive/2015/11/02/announcing-visual-c-build-tools-2015-standalone-c-tools-for-build-environments.aspx). These tools are still in pre-release.
+
+The tools are also shipped with Visual Studio 2015 which can be downloaded from [here](https://www.visualstudio.com/downloads/download-visual-studio-vs). You should select the community edition. Visual Studio ships with a command line interface that can be used for building some of the Python packages. Moreover, it provides a nice IDE which can be used to work on Python projects. After installation of Visual Studio, you should install the Visual C++ tools. This can be done from within Visual Studio by creating a new Visual C++ project. Visual Studio then gives an option to install the Visual C++ developer tools.
+
+## M2Crypto
+The first package to be installed is M2Crypto which can be installed using pip (the M2Crypto binary is precompiled):
+
+```
+pip install —-egg M2CryptoWin64
+python -c "import M2Crypto" # test whether M2Crypto can be successfully imported
+```
+
+If the second statement does not raise an error, M2Crypto is successfully installed.
+
+## wxPython
+The graphical interface of Tribler is built using wxPython. wxPython can be installed by using the official win64 installer for Python 2.7 from [Sourceforge](http://sourceforge.net/projects/wxpython/files/wxPython). *At the time of writing, wx3 is not supported yet so you should install wx2.8* (make sure to install the unicode version). You can test whether wx can be successfully imported by running:
+
+```
+python -c "import wx"
+```
+
+This statement should proceed without error.
+
+## pyWin32 Tools
+In order to access some of the Windows API functions, pywin32 should be installed. The pywin32 installer can be downloaded from [Sourceforge](http://sourceforge.net/projects/pywin32/files/pywin32/) and make sure to select the amd64 version and the version compatible with Python 2.7.
+
+## apsw
+The apsw (Another Python SQLite Wrapper) installer can be downloaded from [GitHub](https://github.com/rogerbinns/apsw/releases). Again, make sure to select the amd64 version that is compatible with Python 2.7. You can test whether it is installed correctly by running:
+
+```
+python -c "import apsw"
+```
+
+## libtorrent
+This package should be compiled from source. First, install Boost which can be downloaded from [SourceForge](http://sourceforge.net/projects/boost/files/boost-binaries/). Make sure to select the latest version and choose the version is compatible with your version of Visual C++ tools (probably msvc-14).
+
+After installation, you should set an environment variable to let libtorrent know where Boost can be found. You can do this by going to Control Panel > System > Advanced > Environment Variables (more information about setting environment variables can be found [here](http://www.computerhope.com/issues/ch000549.htm)). Now add a variable named BOOST_ROOT and with the value of your Boost location. The default installation location for the Boost libraries is `C:\local\boost_<BOOST VERSION>` where `<BOOST VERSION>` indicates the installed Boost version.
+
+Next, you should build Boost.build. You can do this by opening the Visual Studio command prompt and navigating to your Boost libraries. Navigate to `tools\build` and execute `bootstrap.bat`. This will create the `b2.exe` file. In order to invoke `b2` from anywhere in your command line, you should add the Boost directory to your user PATH environment variable. After modifying your PATH, you should reopen your command prompt.
+
+Now, ownload the libtorrent source code from [GitHub](https://github.com/arvidn/libtorrent/releases) and extract it. Open the Developer Command Prompt shipped with Visual Studio (not the regular command prompt) and navigate to the location where you extracted the libtorrent source. In the directory where the libtorrent source code is located, navigate to `bindings\python` and build libtorrent by executing the following command (this takes a while so make sure to grab a coffee while waiting):
+
+```
+b2 boost=source libtorrent-link=static address-model=64
+```
+
+This command will build a static libtorrent 64-bit debug binary. You can also build a release binary by appending `release` to the command given above. After the build has been completed, the resulting `libtorrent.pyd` can be found in `LIBTORRENT_SOURCE\bindings\python\bin\msvc-14\debug\address-model-64\boost-source\link-static\` where `LIBTORRENT_SOURCE` indicates the directory with the libtorrent source files. Copy `libtorrent.pyd` to your site-packages location (the default location is `C:\Python27\Lib\site-packages`) and test libtorrent by executing:
+
+```
+python -c "import libtorrent"
+```
+
+## libsodium
+Libsodium can be download as precompiled binary from [their website](https://download.libsodium.org/libsodium/releases/). Download the latest version, built with msvc. Extract the archive to any location on your machine. Next, you should add the location of the dynamic library to your `PATH` variables (either as system variable or as user variable). These library files can be found in `LIBSODIUM_ROOT\x64\Release\v140\dynamic\` where `LIBSODIUM_ROOT` is the location of your extracted libsodium files. After modifying your PATH, you should reopen your command prompt. You test whether Python is able to load `libsodium.dll` by executing:
+
+```
+python -c "import ctypes; ctypes.cdll.LoadLibrary('libsodium')"
+```
+
+## LevelDB
+The next dependency to be installed is levelDB. LevelDB is a fast key-value storage written by Google. LevelDB itself is written in C++ but there are several Python wrappers available. In this guide, you will compile plyvel from source. Start by downloading the source code from [GitHub](https://github.com/numion/plyvel) (either clone the repository or download the source code as zip). This repo is a fork of the original plyvel wrapper with added support for Windows compilation. Open the Developer Command Prompt shipped with Visual Studio (not the regular command prompt) and navigate to the location where you extracted plyvel. To build, execute the following commands:
+
+```
+python bootstrap.py
+bin\buildout.exe
+bin\python.exe setup.py bdist_egg
+python setup.py install
+```
+
+This should install the plyvel package. You can now test whether plyvel is working:
+
+```
+python -c "import plyvel"
+```
+
+## VLC
+To install VLC, you can download the official installer from the [VideoLAN website](http://www.videolan.org/vlc/download-windows.html). Make sure to install the 64-bit version of VLC.
+
+## Additional Packages
+There are some additional packages which should be installed. They can easily be installed using pip:
+
+```
+pip install twisted requests pillow cherrypy cryptography decorator netifaces feedparser
+```
+
+## Running Tribler
+You should now be able to run Tribler from command line. Grab a copy of the Tribler source code and navigate in a command line interface to the source code directory. Start Tribler by running:
+
+```
+python Tribler\Main\tribler.py
+```
+
+You might get errors about imports in the Tribler module. To fix this, you should add the location where the Tribler directory is located to the `PYTHONPATH` user environment variables. Information about changing environment variables can be found [here](http://www.computerhope.com/issues/ch000549.htm).
+
+If there are any problems with the guide above, please feel free to fix any errors or [create an issue](https://github.com/Tribler/tribler/issues/new) so we can look into it.


### PR DESCRIPTION
I've written some documentation about installing the required packages on all major platforms Tribler is supporting currently. I've tested the OS X and Windows guide myself. The documentation might still contain some minor errors.

Feel free to try it out and see whether it works for your environment.