### PR TITLE
Refactor tunnel code

### DIFF
--- a/Tribler/Test/test_tunnel_community_positive.py
+++ b/Tribler/Test/test_tunnel_community_positive.py
@@ -24,7 +24,8 @@ class TestTunnelCommunityPositive(TestTunnelBase):
             self.assert_(data == "42", "Data is not 42, it is '%s'" % data.encode("HEX"))
             self.assert_(destination == ("127.0.0.1", 12345), "Destination is not 127.0.0.1:12345, it is '%s:%d'" %
                          (destination[0], destination[1]))
-            community.tunnel_data_to_origin(circuit_id, sock_addr, ("127.0.0.1", 12345), "4242")
+
+            community.exit_sockets[circuit_id].tunnel_data(("127.0.0.1", 12345), "4242")
 
         def start_test(tunnel_communities):
             # assuming that the last tunnel community is that loaded by the tribler gui

--- a/Tribler/community/tunnel/crypto/tunnelcrypto.py
+++ b/Tribler/community/tunnel/crypto/tunnelcrypto.py
@@ -80,13 +80,6 @@ class TunnelCrypto(ECCrypto):
                         ).decryptor()
         return cipher.update(content[24:]) + cipher.finalize()
 
-    def ec_encrypt_str(self, key, content):
-        raise RuntimeError('no more')
-
-    def ec_decrypt_str(self, key, content):
-        raise RuntimeError('no more')
-
-
 class NoTunnelCrypto(TunnelCrypto):
 
     def initialize(self, community):


### PR DESCRIPTION
Overal cleanup of the code. Biggest changed:
* Removed retrying for circuits
* Fixed Extended message (the created message was actually forwarded back to the origin, instead of the last hop). Causing the Extended message never to be created :smile: 
* Tried to simply the crypto stuffs, but failed
* Removed the tunnel_to_end methods

For now I left on all the debug logging. Laurens, have a look at the number of (very small) packets being sent to the same ip/ports during a libtorrent download (e.g. the test_hidden_community). I think adding a buffer, and batch sending those will substantially improve download speeds.