### PR TITLE
Fixed tribler.sh startup script on OS X

### DIFF
--- a/tribler.sh
+++ b/tribler.sh
@@ -10,6 +10,9 @@ else
     TRIBLER_SCRIPT=Tribler/Main/tribler_profiler.py
 fi
 
+PYTHONPATH=.:"$PYTHONPATH"
+export PYTHONPATH
+
 if [ "$UNAME" = "Linux" ]; then
     # Find the Tribler dir
     TRIBLER_DIR="$(dirname "$(readlink -f "$0")")"
@@ -22,10 +25,6 @@ if [ "$UNAME" = "Linux" ]; then
         echo "Couldn't cd to $TRIBLER_DIR. Check permissions."
         exit 1
     }
-
-    PYTHONPATH=.:"$PYTHONPATH"
-
-    export PYTHONPATH
 
     python2.7 $TRIBLER_SCRIPT
 


### PR DESCRIPTION
To run Tribler from the Tribler.sh script, we first have to add the current working directory to the `PYTHONPATH` variable. Otherwise, the Tribler modules cannot be found.