### PR TITLE
Fixed segmentation fault when running the GUI tests on Ubuntu

### DIFF
--- a/Tribler/Main/Utility/utility.py
+++ b/Tribler/Main/Utility/utility.py
@@ -2,6 +2,7 @@
 # see LICENSE.txt for license information
 import os
 import sys
+import logging
 from random import gauss
 
 from Tribler.Core.defaults import tribler_defaults
@@ -9,6 +10,8 @@ from Tribler.Core.Utilities.configparser import CallbackConfigParser
 from Tribler.Core.simpledefs import STATEDIR_GUICONFIG
 from Tribler.Core.version import version_id
 from Tribler.Main.globals import DefaultDownloadStartupConfig
+
+logger = logging.getLogger(__name__)
 
 #
 # Generic "glue" class that contains commonly used helper functions
@@ -215,3 +218,16 @@ def size_format(s, truncate=None, stopearly=None, applylabel=True, rawsize=False
         text += u' ' + label
 
     return text
+
+
+def initialize_x11_threads():
+    if sys.platform == 'linux2' and os.environ.get("TRIBLER_INITTHREADS", "true").lower() == "true":
+        try:
+            import ctypes
+            x11 = ctypes.cdll.LoadLibrary('libX11.so.6')
+            x11.XInitThreads()
+            os.environ["TRIBLER_INITTHREADS"] = "False"
+        except OSError as e:
+            logger.debug("Failed to call XInitThreads '%s'", str(e))
+        except:
+            logger.exception('Failed to call xInitThreads')

--- a/Tribler/Main/tribler_main.py
+++ b/Tribler/Main/tribler_main.py
@@ -1044,17 +1044,8 @@ def run(params=[""], autoload_discovery=True, use_torrent_search=True, use_chann
 
             logger.info("Client shutting down. Detected another instance.")
         else:
-
-            if sys.platform == 'linux2' and os.environ.get("TRIBLER_INITTHREADS", "true").lower() == "true":
-                try:
-                    import ctypes
-                    x11 = ctypes.cdll.LoadLibrary('libX11.so.6')
-                    x11.XInitThreads()
-                    os.environ["TRIBLER_INITTHREADS"] = "False"
-                except OSError as e:
-                    logger.debug("Failed to call XInitThreads '%s'", str(e))
-                except:
-                    logger.exception('Failed to call xInitThreads')
+            from Tribler.Main.Utility.utility import initialize_x11_threads
+            initialize_x11_threads()
 
             # Launch first abc single instance
             app = wx.GetApp()

--- a/Tribler/Test/test_as_server.py
+++ b/Tribler/Test/test_as_server.py
@@ -334,6 +334,9 @@ class TestGuiAsServer(TestAsServer):
         self.assertFalse(Session.has_instance(), 'A session instance is already present when setting up the test')
         AbstractServer.setUp(self, annotate=False)
 
+        from Tribler.Main.Utility.utility import initialize_x11_threads
+        initialize_x11_threads()
+
         self.app = wx.GetApp()
         if not self.app:
             from Tribler.Main.tribler_main import TriblerApp


### PR DESCRIPTION
When running the unit tests on Ubuntu, it occasionally gives a segmentation fault when startup up Tribler. Loading the X11 library before the `TriblerApp` object is created should solve this.