### PR TITLE
Update Tribler development on Windows.md

### DIFF
--- a/doc/Tribler development on Windows.md
+++ b/doc/Tribler development on Windows.md
@@ -55,7 +55,7 @@ After installation, you should set an environment variable to let libtorrent kno
 
 Next, you should build Boost.build. You can do this by opening the Visual Studio command prompt and navigating to your Boost libraries. Navigate to `tools\build` and execute `bootstrap.bat`. This will create the `b2.exe` file. In order to invoke `b2` from anywhere in your command line, you should add the Boost directory to your user PATH environment variable. After modifying your PATH, you should reopen your command prompt.
 
-Now, ownload the libtorrent source code from [GitHub](https://github.com/arvidn/libtorrent/releases) and extract it. Open the Developer Command Prompt shipped with Visual Studio (not the regular command prompt) and navigate to the location where you extracted the libtorrent source. In the directory where the libtorrent source code is located, navigate to `bindings\python` and build libtorrent by executing the following command (this takes a while so make sure to grab a coffee while waiting):
+Now, download the libtorrent source code from [GitHub](https://github.com/arvidn/libtorrent/releases) and extract it. Version 1.0.7 of Libtorrent seems to contain a bug when downloading torrents from the DHT so it is recommended to use the source code of version 1.0.6. Open the Developer Command Prompt shipped with Visual Studio (not the regular command prompt) and navigate to the location where you extracted the libtorrent source. In the directory where the libtorrent source code is located, navigate to `bindings\python` and build libtorrent by executing the following command (this takes a while so make sure to grab a coffee while waiting):
 
 ```
 b2 boost=source libtorrent-link=static address-model=64


### PR DESCRIPTION
Added advise to download libtorrent 1.0.6 on Windows instead of the latest version (1.0.7).