### PR TITLE
Fix tribler.conf Tribler section.

### DIFF
--- a/Tribler/Main/Utility/utility.py
+++ b/Tribler/Main/Utility/utility.py
@@ -36,7 +36,7 @@ class Utility(object):
 
     def setupConfig(self):
         self.configfilepath = os.path.join(self.getConfigPath(), STATEDIR_GUICONFIG)
-        self.config = CallbackConfigParser(tribler_defaults)
+        self.config = CallbackConfigParser()
 
         # Load the config file.
         if os.path.exists(self.configfilepath):


### PR DESCRIPTION
Turns out RawConfigParser constructor doesn't understand sections on the
defaults dict and makes a mess of the config file.