### PR TITLE
Removed unused assignment

### DIFF
--- a/Tribler/Main/tribler_main.py
+++ b/Tribler/Main/tribler_main.py
@@ -203,9 +203,6 @@ class ABCApp(object):
             # Counter to suppress some event from occurring
             self.ratestatecallbackcount = 0
 
-            # So we know if we asked for peer details last cycle
-            self.lastwantpeers = []
-
             maxup = self.utility.read_config('maxuploadrate')
             maxdown = self.utility.read_config('maxdownloadrate')
             # set speed limits using LibtorrentMgr
@@ -654,7 +651,6 @@ class ABCApp(object):
         except:
             print_exc()
 
-        self.lastwantpeers = wantpeers
         return 1.0, wantpeers
 
     def loadSessionCheckpoint(self):


### PR DESCRIPTION
The `self.lastwantpeers` variable is not used anywhere in the `tribler_main` script so the assignment is redundant.