### PR TITLE
Tooltip of tray icon now contains upload/download speeds

### DIFF
--- a/Tribler/Main/Dialogs/systray.py
+++ b/Tribler/Main/Dialogs/systray.py
@@ -2,6 +2,7 @@
 # see LICENSE.txt for license information
 import wx
 from traceback import print_exc
+from Tribler.Main.Utility.utility import speed_format
 
 try:
     import win32gui  # , win32con
@@ -31,6 +32,12 @@ class ABCTaskBarIcon(wx.TaskBarIcon):
         self.Bind(wx.EVT_MENU, parent.onTaskBarActivate, id=wx.NewId())
 
         self.updateIcon(False)
+
+    def updateTooltip(self, download_speed=0, upload_speed=0):
+        if not WIN32:
+            return
+        self.tooltip = "Down: %s, Up: %s" % (speed_format(download_speed), speed_format(upload_speed))
+        self.SetIcon(self.icon, self.tooltip)
 
     def updateIcon(self, iconifying=False):
         remove = True

--- a/Tribler/Main/Utility/utility.py
+++ b/Tribler/Main/Utility/utility.py
@@ -7,7 +7,7 @@ from random import gauss
 
 from Tribler.Core.defaults import tribler_defaults
 from Tribler.Core.Utilities.configparser import CallbackConfigParser
-from Tribler.Core.simpledefs import STATEDIR_GUICONFIG
+from Tribler.Core.simpledefs import STATEDIR_GUICONFIG, UPLOAD, DOWNLOAD
 from Tribler.Core.version import version_id
 from Tribler.Main.globals import DefaultDownloadStartupConfig
 
@@ -218,6 +218,14 @@ def size_format(s, truncate=None, stopearly=None, applylabel=True, rawsize=False
         text += u' ' + label
 
     return text
+
+
+def get_download_upload_speed(dslist):
+    total_down, total_up = 0.0, 0.0
+    for ds in dslist:
+        total_down += ds.get_current_speed(DOWNLOAD)
+        total_up += ds.get_current_speed(UPLOAD)
+    return total_down, total_up
 
 
 def initialize_x11_threads():

--- a/Tribler/Main/tribler_main.py
+++ b/Tribler/Main/tribler_main.py
@@ -53,7 +53,7 @@ from Tribler.Main.Utility.GuiDBHandler import GUIDBProducer, startWorker
 from Tribler.Main.Utility.compat import (convertDefaultDownloadConfig, convertDownloadCheckpoints, convertMainConfig,
                                          convertSessionConfig)
 from Tribler.Core.Utilities.install_dir import determine_install_dir
-from Tribler.Main.Utility.utility import Utility
+from Tribler.Main.Utility.utility import Utility, get_download_upload_speed
 from Tribler.Main.globals import DefaultDownloadStartupConfig
 from Tribler.Main.vwxGUI.GuiImageManager import GuiImageManager
 from Tribler.Main.vwxGUI.GuiUtility import GUIUtility, forceWxThread
@@ -525,6 +525,11 @@ class ABCApp(object):
     def sesscb_states_callback(self, dslist):
         if not self.ready:
             return 5.0, []
+
+        # update tray icon
+        total_download, total_upload = get_download_upload_speed(dslist)
+        if self.frame and self.frame.tbicon:
+            self.frame.tbicon.updateTooltip(total_download, total_upload)
 
         wantpeers = []
         self.ratestatecallbackcount += 1

--- a/Tribler/Main/vwxGUI/SRstatusbar.py
+++ b/Tribler/Main/vwxGUI/SRstatusbar.py
@@ -8,7 +8,7 @@ from Tribler.Main.vwxGUI.GuiUtility import GUIUtility
 from Tribler.Main.vwxGUI.GuiImageManager import GuiImageManager
 from Tribler.Main.vwxGUI.widgets import HorizontalGauge, ActionButton
 
-from Tribler.Main.Utility.utility import size_format, round_range, speed_format
+from Tribler.Main.Utility.utility import size_format, round_range, speed_format, get_download_upload_speed
 
 from Tribler.community.bartercast4.statistics import BartercastStatisticTypes, _barter_statistics
 
@@ -83,7 +83,7 @@ class SRstatusbar(wx.StatusBar):
         self.SetStatusWidths([field[0] for field in self.fields])
         self.SetStatusStyles([field[1] for field in self.fields])
 
-        self.SetTransferSpeeds(0, 0)
+        self.SetTransferSpeeds(speed_format(0), speed_format(0))
         self.Bind(wx.EVT_SIZE, self.OnSize)
         self.library_manager.add_download_state_callback(self.RefreshTransferSpeed)
 
@@ -123,16 +123,13 @@ class SRstatusbar(wx.StatusBar):
             return
 
         self.UpdateTunnelContrib()
-        total_down, total_up = 0.0, 0.0
-        for ds in dslist:
-            total_down += ds.get_current_speed(DOWNLOAD)
-            total_up += ds.get_current_speed(UPLOAD)
-        self.SetTransferSpeeds(total_down, total_up)
+        total_down, total_up = get_download_upload_speed(dslist)
+        self.SetTransferSpeeds(speed_format(total_down), speed_format(total_up))
 
     @warnWxThread
     def SetTransferSpeeds(self, down, up):
-        self.speed_down.SetLabel(speed_format(down))
-        self.speed_up.SetLabel(speed_format(up))
+        self.speed_down.SetLabel(down)
+        self.speed_up.SetLabel(up)
         self.Reposition()
 
     def SetGlobalMaxSpeed(self, direction, value):


### PR DESCRIPTION
The tooltip of Tribler on Unix and Windows now show the download/upload speeds of all active downloads in the library as requested by #1650.