### PR TITLE
Add Backup + Checkout of Stabilization Branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,17 @@
 
 # How to contribute to the Tribler project? #
 
+## Checking out the Stabilization Branch ##
+The stabilization branch `next` contains the most up to date bugfixes. If your issue cannot be reproduced there, it is most likely already fixed.
+
+To backup your Tribler installation and checkout the latest version of the stabilization branch, please perform the following steps.
+* Copy the `.Tribler` folder to a safe location on your system (for instance the desktop) Make sure to leave the original folder on its original location. This folder is located at `~/.Tribler/` (Linux/OSX) or `%APPDATA\.Tribler` (Windows).
+* Remove the `tribler` installation folder.
+* Go to [the latest tested version of Tribler](https://jenkins.tribler.org/job/Publish_tribler_next/lastStableBuild/) and under 'Build Artifacts', download the package  appropriate to your operating system.
+* Install/unzip this package.
+
+To revert back to your original version of Tribler, [download the installer again](https://github.com/Tribler/tribler/releases) and install it. Afterwards you can restore your backed up Tribler data folder.
+
 ## Reporting bugs ##
 
 * Make sure the issue/feature you want to report doesn't already exist.


### PR DESCRIPTION
Adds step-by-step instructions to backup the Tribler installation and checkout the next branch to reproducde issues before submitting.