### PR TITLE
Conditional Wx3 import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /.coverage
 /.dir-locals.el
 /.gdb_history
+/.idea/
 /.noseids
 /.project
 /.pydevproject

--- a/Tribler/Main/tribler.py
+++ b/Tribler/Main/tribler.py
@@ -47,7 +47,10 @@ try:
     # in the windows and mac distribution, there may be no version available.
     # so select a version only when there is any available.
     if wxversion.getInstalled():
-        wxversion.select("2.8-unicode")
+        if wxversion.checkInstalled("3.0-unicode"):
+            wxversion.select("3.0-unicode")
+        else:
+            wxversion.select("2.8-unicode")
 except wxversion.VersionError:
     logger.exception("Unable to use wxversion installed wxversions: %s", repr(wxversion.getInstalled()))
 

--- a/Tribler/Main/vwxGUI/list_body.py
+++ b/Tribler/Main/vwxGUI/list_body.py
@@ -89,7 +89,7 @@ class ListItem(wx.Panel):
 
                         control = StaticText(
                             self,
-                            style=self.columns[i].get('style', 0) | wx.ST_NO_AUTORESIZE | wx.ST_DOTS_END,
+                            style=self.columns[i].get('style', 0) | wx.ST_NO_AUTORESIZE,
                             size=size)
 
                         fontWeight = self.columns[i].get('fontWeight', wx.FONTWEIGHT_NORMAL)
@@ -107,7 +107,7 @@ class ListItem(wx.Panel):
                         if addColumnname:
                             control = StaticText(
                                 self, -1, self.columns[i]['name'] + ": ",
-                                style=self.columns[i].get('style', 0) | wx.ST_NO_AUTORESIZE | wx.ST_DOTS_END)
+                                style=self.columns[i].get('style', 0) | wx.ST_NO_AUTORESIZE)
                             self._add_control(control, -1, 0, 0)
                             remaining_width -= control.GetSize()[0]
                     control = method_control or control

--- a/Tribler/Main/vwxGUI/list_details.py
+++ b/Tribler/Main/vwxGUI/list_details.py
@@ -1480,8 +1480,6 @@ class ChannelDetails(AbstractDetails):
         self.detailsTab.SetBackgroundColour(wx.WHITE)
 
         fgSizer = wx.FlexGridSizer(0, 2, 3, 10)
-        fgSizer.AddGrowableCol(1)
-        fgSizer.AddGrowableRow(6)
 
         titles = ['Name', 'Description', 'Torrents', 'Latest update', 'Favorite votes']
         for title in titles:
@@ -1490,6 +1488,8 @@ class ChannelDetails(AbstractDetails):
             control2_name = title.lower().replace(' ', '')
             setattr(self, control1_name, control1)
             setattr(self, control2_name, control2)
+        
+        fgSizer.AddGrowableCol(1)
 
         self.detailsSizer.Add(fgSizer, 1, wx.EXPAND)
         self.detailsTab.Layout()
@@ -1571,8 +1571,6 @@ class PlaylistDetails(AbstractDetails):
         self.detailsTab.SetBackgroundColour(wx.WHITE)
 
         fgSizer = wx.FlexGridSizer(0, 2, 3, 10)
-        fgSizer.AddGrowableCol(1)
-        fgSizer.AddGrowableRow(6)
 
         titles = ['Name', 'Description', 'Torrents']
         for title in titles:
@@ -1601,6 +1599,9 @@ class PlaylistDetails(AbstractDetails):
         tSizer.Add(self.thumbnails, 0, wx.ALIGN_RIGHT | wx.ALIGN_TOP | wx.EXPAND)
         self.detailsSizer.Add(tSizer, 1, wx.EXPAND)
         self.thumbnails.Show(False)
+        
+        fgSizer.AddGrowableCol(1)
+
         self.detailsTab.Layout()
 
         self.Thaw()

--- a/Tribler/Main/vwxGUI/list_header.py
+++ b/Tribler/Main/vwxGUI/list_header.py
@@ -129,7 +129,7 @@ class ListHeader(wx.Panel):
                     label.SetToolTipString('Click to sort table by %s.' % columns[i]['name'])
                     label.SetBackgroundColour(self.GetBackgroundColour())
                     label.column = i
-                    label.Bind(wx.EVT_LEFT_UP, self.OnClick)
+                    label.Bind(wx.EVT_LEFT_DOWN, self.OnClick)
 
                     if i == 0:
                         sizer.Add(label, 0, wx.ALIGN_CENTER_VERTICAL | wx.TOP | wx.BOTTOM, 3)
@@ -567,11 +567,11 @@ class TorrentFilter(BaseFilter):
 
         self.sortby_icon = wx.StaticBitmap(panel, -1, self.icon_right)
         self.sortby = LinkStaticText(panel, 'Sort by', None, font_colour=wx.BLACK)
-        self.sortby.Bind(wx.EVT_LEFT_UP, self.OnPopupSort)
+        self.sortby.Bind(wx.EVT_LEFT_DOWN, self.OnPopupSort)
 
         self.filetype_icon = wx.StaticBitmap(panel, -1, self.icon_right)
         self.filetype = LinkStaticText(panel, 'File type', None, font_colour=wx.BLACK)
-        self.filetype.Bind(wx.EVT_LEFT_UP, self.OnPopupFileType)
+        self.filetype.Bind(wx.EVT_LEFT_DOWN, self.OnPopupFileType)
 
         self.filesize_str = StaticText(panel, -1, 'File size:')
         self.filesize = MinMaxSlider(panel, -1)
@@ -828,11 +828,11 @@ class ChannelFilter(BaseFilter):
 
         self.sortby_icon = wx.StaticBitmap(panel, -1, self.icon_right)
         self.sortby = LinkStaticText(panel, 'Sort by', None, font_colour=wx.BLACK)
-        self.sortby.Bind(wx.EVT_LEFT_UP, self.OnPopupSort)
+        self.sortby.Bind(wx.EVT_LEFT_DOWN, self.OnPopupSort)
 
         self.channeltype_icon = wx.StaticBitmap(panel, -1, self.icon_right)
         self.channeltype = LinkStaticText(panel, 'Channel type', None, font_colour=wx.BLACK)
-        self.channeltype.Bind(wx.EVT_LEFT_UP, self.OnPopupChannelType)
+        self.channeltype.Bind(wx.EVT_LEFT_DOWN, self.OnPopupChannelType)
 
         self.search = wx.SearchCtrl(panel)
         self.search.SetDescriptiveText('Filter channels')
@@ -987,7 +987,7 @@ class DownloadFilter(BaseFilter):
 
         self.sortby_icon = wx.StaticBitmap(panel, -1, self.icon_right)
         self.sortby = LinkStaticText(panel, 'Sort by', None, font_colour=wx.BLACK)
-        self.sortby.Bind(wx.EVT_LEFT_UP, self.OnPopupSort)
+        self.sortby.Bind(wx.EVT_LEFT_DOWN, self.OnPopupSort)
 
         self.filesize_str = StaticText(panel, -1, 'File size:')
         self.filesize = MinMaxSlider(panel, -1)
@@ -995,7 +995,7 @@ class DownloadFilter(BaseFilter):
 
         self.state_icon = wx.StaticBitmap(panel, -1, self.icon_right)
         self.state = LinkStaticText(panel, 'Download state', None, font_colour=wx.BLACK)
-        self.state.Bind(wx.EVT_LEFT_UP, self.OnPopupState)
+        self.state.Bind(wx.EVT_LEFT_DOWN, self.OnPopupState)
 
         self.search = wx.SearchCtrl(panel)
         self.search.SetDescriptiveText('Filter downloads')

--- a/Tribler/Test/test_as_server.py
+++ b/Tribler/Test/test_as_server.py
@@ -4,7 +4,10 @@
 
 # set wxpython version before importing wx or anything from Tribler
 import wxversion
-wxversion.select("2.8-unicode")
+if wxversion.checkInstalled("3.0-unicode"):
+    wxversion.select("3.0-unicode")
+else:
+    wxversion.select("2.8-unicode")
 
 # Make sure the in thread reactor is installed.
 from Tribler.Core.Utilities.twisted_thread import reactor

--- a/tribler.sh
+++ b/tribler.sh
@@ -41,7 +41,7 @@ else
         fi
 
         PYTHONVER=2.7
-        PYTHON="arch -i386 /usr/bin/python$PYTHONVER"
+        PYTHON="/usr/bin/python$PYTHONVER"
 
         $PYTHON $TRIBLER_SCRIPT
     fi


### PR DESCRIPTION
This PR contains some fixes for Wx3.

The most important change is an conditional check in the `tribler.py` file that checks whether Wx3 is installed on the users' system. If so, it uses Wx3. If not, it fallbacks to Wx2.8. In some sense, we now have an experimental version of Wx3 in Tribler.

I've tested manually on Windows, Ubuntu and OS X and everything still seems to work ok. Wx3 on OS X is quite stable currently with some minor issues left.