### PR TITLE
Moved TriblerApp class to seperate file

### DIFF
--- a/Tribler/Main/tribler_main.py
+++ b/Tribler/Main/tribler_main.py
@@ -23,9 +23,7 @@
 #
 import urllib
 
-
 original_open_https = urllib.URLopener.open_https
-import M2Crypto  # Not a useless import! See above.
 urllib.URLopener.open_https = original_open_https
 
 try:
@@ -75,8 +73,9 @@ from Tribler.Main.Utility.utility import Utility
 from Tribler.Main.globals import DefaultDownloadStartupConfig
 from Tribler.Main.vwxGUI.GuiImageManager import GuiImageManager
 from Tribler.Main.vwxGUI.GuiUtility import GUIUtility, forceWxThread
-from Tribler.Main.vwxGUI.MainFrame import FileDropTarget, MainFrame
+from Tribler.Main.vwxGUI.MainFrame import MainFrame
 from Tribler.Main.vwxGUI.MainVideoFrame import VideoDummyFrame
+from Tribler.Main.vwxGUI.TriblerApp import TriblerApp
 from Tribler.Main.vwxGUI.TriblerUpgradeDialog import TriblerUpgradeDialog
 from Tribler.Main.vwxGUI.gaugesplash import GaugeSplash
 from Tribler.Utilities.Instance2Instance import Instance2InstanceClient, Instance2InstanceServer
@@ -962,22 +961,6 @@ class ABCApp(object):
                 self.guiUtility.ShowPage('my_files')
 
             wx.CallAfter(start_asked_download)
-
-
-class TriblerApp(wx.App):
-
-    def __init__(self, *args, **kwargs):
-        wx.App.__init__(self, *args, **kwargs)
-        self._logger = logging.getLogger(self.__class__.__name__)
-        self._abcapp = None
-
-    def set_abcapp(self, abcapp):
-        self._abcapp = abcapp
-
-    def MacOpenFile(self, filename):
-        self._logger.info(repr(filename))
-        target = FileDropTarget(self._abcapp.frame)
-        target.OnDropFiles(None, None, [filename])
 
 
 #

--- a/Tribler/Main/vwxGUI/TriblerApp.py
+++ b/Tribler/Main/vwxGUI/TriblerApp.py
@@ -1,0 +1,19 @@
+import logging
+import wx
+from Tribler.Main.vwxGUI.MainFrame import FileDropTarget
+
+
+class TriblerApp(wx.App):
+
+    def __init__(self, *args, **kwargs):
+        wx.App.__init__(self, *args, **kwargs)
+        self._logger = logging.getLogger(self.__class__.__name__)
+        self._abcapp = None
+
+    def set_abcapp(self, abcapp):
+        self._abcapp = abcapp
+
+    def MacOpenFile(self, filename):
+        self._logger.info(repr(filename))
+        target = FileDropTarget(self._abcapp.frame)
+        target.OnDropFiles(None, None, [filename])

--- a/Tribler/Test/test_as_server.py
+++ b/Tribler/Test/test_as_server.py
@@ -339,7 +339,7 @@ class TestGuiAsServer(TestAsServer):
 
         self.app = wx.GetApp()
         if not self.app:
-            from Tribler.Main.tribler_main import TriblerApp
+            from Tribler.Main.vwxGUI.TriblerApp import TriblerApp
             self.app = TriblerApp(redirect=False)
 
         self.guiUtility = None


### PR DESCRIPTION
The TriblerApp class is part of the GUI so it is better to move it to the `vwxGUI` directory.