### PR TITLE
Fixed observer changetype of the upgrader event

### DIFF
--- a/Tribler/Main/tribler_main.py
+++ b/Tribler/Main/tribler_main.py
@@ -355,7 +355,7 @@ class ABCApp(object):
             self.sconfig.set_enable_channel_search(False)
 
         session = Session(self.sconfig, autoload_discovery=autoload_discovery)
-        session.add_observer(self.show_upgrade_dialog, NTFY_UPGRADER, [NTFY_FINISHED])
+        session.add_observer(self.show_upgrade_dialog, NTFY_UPGRADER, [NTFY_STARTED])
         self.upgrader = session.prestart()
 
         return session


### PR DESCRIPTION
The upgrader splash was still a very short time visible for me in the latest checkout of `level`.

Fixes #1733