### PR TITLE
Temporarily disable broken tunnel tests

### DIFF
--- a/Tribler/Test/test_hidden_community.py
+++ b/Tribler/Test/test_hidden_community.py
@@ -9,9 +9,12 @@ from Tribler.Core.DecentralizedTracking.pymdht.core.identifier import Id
 from Tribler.community.tunnel import CIRCUIT_ID_PORT
 from Tribler.community.tunnel.hidden_community import HiddenTunnelCommunity
 
+from unittest.case import skip
 
 class TestHiddenCommunity(TestTunnelBase):
 
+    # TODO(emilon): Fix this test!
+    @skip("This test fails most of the time. Temporalily disabled it until somebody has time to fix it")
     def test_hidden_services(self):
         def take_second_screenshot():
             self.screenshot('Network graph after libtorrent download over hidden services')
@@ -86,6 +89,8 @@ class TestHiddenCommunity(TestTunnelBase):
 
         self.startTest(setup_seeder, bypass_dht=True)
 
+    # TODO(emilon): Fix this test!
+    @skip("This test fails most of the time. Temporalily disabled it until somebody has time to fix it")
     def test_hidden_services_with_exit_nodes(self):
         def take_second_screenshot():
             self.screenshot('Network graph after libtorrent download with hidden services over exitnodes')

--- a/Tribler/Test/test_libtorrent_download.py
+++ b/Tribler/Test/test_libtorrent_download.py
@@ -13,9 +13,9 @@ TORRENT_R = r'http://torrent.fedoraproject.org/torrents/Fedora-Live-Workstation-
 TORRENT_INFOHASH = binascii.unhexlify('89f0835dc2def218ec4bac73da6be6b8c20534ea')
 TORRENT_FILE = os.path.join(TESTS_DATA_DIR, "ubuntu-15.04-desktop-amd64.iso.torrent")
 TORRENT_FILE_INFOHASH = binascii.unhexlify("fc8a15a2faf2734dbb1dc5f7afdc5c9beaeb1f59")
-TORRENT_VIDEO_FILE = os.path.join(TESTS_DATA_DIR, "Pioneer.One.S01E01.REDUX.720p.x264-VODO.torrent")
+TORRENT_VIDEO_FILE = os.path.join(TESTS_DATA_DIR, "Night.Of.The.Living.Dead_1080p_archive.torrent")
 TORRENT_VIDEO_FILE_INFOHASH = binascii.unhexlify("0d6bbc31db060e7082f85a87194d4273aea9924c")
-TORRENT_VIDEO_FILE_SELECTED_FILE = os.path.join('Sample', 'Pioneer.One.S01E01.REDUX.720p.x264.Sample-VODO.mkv')
+TORRENT_VIDEO_FILE_SELECTED_FILE = os.path.join('NightOfTheLivingDead_1080p.ogv',)
 
 
 class TestLibtorrentDownload(TestGuiAsServer):


### PR DESCRIPTION
It doesn't make sense to waste so much time re-running broken tests. 
When somebody gets around fixing the tunnel community and its tests, they can be enabled again.

Pioneer one torrent is dying and it takes a long time to start downloading, so switching to a different torrent for the test.