### PR TITLE
Changed the way the old builder adds the license to the .dmg file

### DIFF
--- a/Tribler/Main/Build/license.txt
+++ b/Tribler/Main/Build/license.txt
@@ -1,0 +1,1 @@
+This software is released under the LGPL license by Delft University of Technology. Included third party libraries and software modules may have different licences. For details see the included file in Tribler/LICENSE.txt or https://raw.githubusercontent.com/Tribler/tribler/devel/Tribler/LICENSE.txt.

--- a/mac/makedistmac.sh
+++ b/mac/makedistmac.sh
@@ -121,10 +121,7 @@ hdiutil convert dist/temp/rw.dmg -format UDZO -imagekey zlib-level=9 -o dist/$AP
 rm -f dist/temp/rw.dmg
 
 # add EULA
-hdiutil unflatten dist/$APPNAME.dmg
-DeRez -useDF $LIBRARYNAME/Main/Build/Mac/SLAResources.rsrc > dist/temp/sla.r
-Rez -a dist/temp/sla.r -o dist/$APPNAME.dmg
-hdiutil flatten dist/$APPNAME.dmg
+eulagise --license $LIBRARYNAME/Main/Build/license.txt --target dist/$APPNAME.dmg
 
 if [ ! -z "$DMGNAME" ]; then
     mv dist/$APPNAME.dmg dist/$DMGNAME.dmg


### PR DESCRIPTION
We're now adding the EULA to the .dmg file using the `eulagise` script. I've installed this script on the old OS X builder. I've tested this script using the new Mac Mini. I'm pull requesting this against next so we can use this new EULA for the 6.5 release.