### PR TITLE
Fix double starting reactor

### DIFF
--- a/Tribler/Core/Utilities/twisted_thread.py
+++ b/Tribler/Core/Utilities/twisted_thread.py
@@ -52,7 +52,8 @@ def threaded_reactor():
 
         def _reactor_runner():
             reactor.suggestThreadPoolSize(1)
-            reactor.run(installSignalHandlers=False)
+            if not reactor.running:
+                reactor.run(installSignalHandlers=False)
 
         _twisted_thread = Thread(target=_reactor_runner, name="Twisted")
         _twisted_thread.setDaemon(True)


### PR DESCRIPTION
In some scenarios the gumby scenario runner already has the reactor running. When a dispersy session gets started through the full tribler core, it would try to start the reactor again, which causes an exception and a stack trace.