### PR TITLE
Catch InvalidTag exception.

### DIFF
--- a/Tribler/community/tunnel/tunnel_community.py
+++ b/Tribler/community/tunnel/tunnel_community.py
@@ -1250,9 +1250,18 @@ class TunnelCommunity(Community):
             return self.crypto.encrypt_str(content,
                                            *self.get_session_keys(self.relay_session_keys[circuit_id], ORIGINATOR))
         elif direction == EXIT_NODE:
-            return self.crypto.decrypt_str(content,
-                                           self.relay_session_keys[circuit_id][EXIT_NODE],
-                                           self.relay_session_keys[circuit_id][EXIT_NODE_SALT])
+            try:
+                return self.crypto.decrypt_str(content,
+                                               self.relay_session_keys[circuit_id][EXIT_NODE],
+                                               self.relay_session_keys[circuit_id][EXIT_NODE_SALT])
+            except InvalidTag:
+                self._logger.warning("Could not decrypt message:\n"
+                                     "  direction %s\n"
+                                     "  circuit_id: %r\n"
+                                     "  content: : %r\n"
+                                     "  Possibly corrupt data?",
+                                     direction, circuit_id, content)
+
         raise CryptoException("Direction must be either ORIGINATOR or EXIT_NODE")
 
     def increase_bytes_sent(self, obj, num_bytes):


### PR DESCRIPTION
We don't have integrity checks for the message, so we can't know if it's
corrupted or not.

Closes #1617
Closes #1932