### PR TITLE
Changed height of expanding panel below button

### DIFF
--- a/Tribler/Main/vwxGUI/list_details.py
+++ b/Tribler/Main/vwxGUI/list_details.py
@@ -2391,7 +2391,7 @@ class VideoplayerExpandedPanel(wx.lib.scrolledpanel.ScrolledPanel):
     def OnChange(self):
         self.Freeze()
 
-        max_height = self.guiutility.frame.actlist.GetSize().y - self.GetParent().GetPosition()[1] * 1.25 - 4
+        max_height = self.guiutility.frame.actlist.GetSize().y - self.GetParent().GetPosition()[1] * 1.25 - 16
         virtual_height = sum([link.text.GetSize()[1]
                              for link in self.links]) if self.links else (30 if self.message else 0)
         best_height = min(max_height, virtual_height)


### PR DESCRIPTION
We noticed an assertion during the test runs where an assertion came up after starting to stream a video file. This was due to the panel below the video player button in the left menu which was too high. The height of this panel caused the popup that shows up when adding a torrent to be squashed, resulting in an assertion.