### PR TITLE
WIP: Replace fetching of remote torrents with the usage of local ones

### DIFF
--- a/Tribler/Test/test_gui_dialogs.py
+++ b/Tribler/Test/test_gui_dialogs.py
@@ -10,6 +10,7 @@ from traceback import print_exc
 
 # Import WX after selecting the version
 from Tribler.Test.test_as_server import TestGuiAsServer, TESTS_DATA_DIR, wx
+from Tribler.Test.test_libtorrent_download import TORRENT_VIDEO_FILE
 
 from Tribler.Main.Dialogs.ConfirmationDialog import ConfirmationDialog
 from Tribler.Main.Dialogs.AddTorrent import AddTorrent
@@ -96,7 +97,7 @@ class TestGuiDialogs(TestGuiAsServer):
             self.assert_(isinstance(dialog, AddTorrent), 'could not find AddTorrent')
 
             self.callLater(1, lambda: do_assert(dialog))
-            dialog.magnet.SetValue(r'http://torrent.fedoraproject.org/torrents/Fedora-20-i386-DVD.torrent')
+            dialog.magnet.SetValue('file:' + TORRENT_VIDEO_FILE)
             dialog.OnAdd(None)
 
         def do_add_dialog():

--- a/Tribler/Test/test_libtorrent_download.py
+++ b/Tribler/Test/test_libtorrent_download.py
@@ -9,12 +9,12 @@ from Tribler.Test.test_as_server import TestGuiAsServer, TESTS_DATA_DIR
 from Tribler.Core.simpledefs import DOWNLOAD
 
 
-TORRENT_R = r'http://torrent.fedoraproject.org/torrents/Fedora-Live-Workstation-x86_64-21.torrent'
-TORRENT_INFOHASH = binascii.unhexlify('89f0835dc2def218ec4bac73da6be6b8c20534ea')
+TORRENT_R = r'http://torrent.ubuntu.com/releases/wily/release/server/ubuntu-15.10-server-ppc64el.iso.torrent'
+TORRENT_INFOHASH = binascii.unhexlify('9874df3783f8de52f944032b9affe4a5c88bc9fe')
 TORRENT_FILE = os.path.join(TESTS_DATA_DIR, "ubuntu-15.04-desktop-amd64.iso.torrent")
 TORRENT_FILE_INFOHASH = binascii.unhexlify("fc8a15a2faf2734dbb1dc5f7afdc5c9beaeb1f59")
 TORRENT_VIDEO_FILE = os.path.join(TESTS_DATA_DIR, "Night.Of.The.Living.Dead_1080p_archive.torrent")
-TORRENT_VIDEO_FILE_INFOHASH = binascii.unhexlify("0d6bbc31db060e7082f85a87194d4273aea9924c")
+TORRENT_VIDEO_FILE_INFOHASH = binascii.unhexlify("90ed3962785c52a774e89706fb4f811a468e6c05")
 TORRENT_VIDEO_FILE_SELECTED_FILE = os.path.join('NightOfTheLivingDead_1080p.ogv',)
 
 
@@ -120,7 +120,7 @@ class TestLibtorrentDownload(TestGuiAsServer):
         self.startTest(do_downloadfrommagnet)
 
     def test_stopresumedelete(self):
-        infohash = TORRENT_INFOHASH
+        infohash = TORRENT_VIDEO_FILE_INFOHASH
 
         def do_final():
             self.screenshot('After deleting a libtorrent download')
@@ -160,7 +160,7 @@ class TestLibtorrentDownload(TestGuiAsServer):
 
         def do_start():
             self.guiUtility.showLibrary()
-            self.frame.startDownloadFromArg(TORRENT_R, self.getDestDir())
+            self.frame.startDownloadFromArg('file:' + TORRENT_VIDEO_FILE, self.getDestDir())
             self.CallConditional(60, lambda: self.session.get_download(infohash), download_object_ready,
                                  'do_start() failed')
 

--- a/Tribler/Test/test_my_channel.py
+++ b/Tribler/Test/test_my_channel.py
@@ -5,6 +5,7 @@ from binascii import hexlify
 import os
 
 from Tribler.Test.common import UBUNTU_1504_INFOHASH
+from Tribler.Test.test_libtorrent_download import TORRENT_R
 from Tribler.Test.test_as_server import TestGuiAsServer, TESTS_DATA_DIR
 
 from Tribler.Core.TorrentDef import TorrentDef
@@ -31,7 +32,7 @@ class TestMyChannel(TestGuiAsServer):
                 60, lambda: len(managefiles.GetItems()) > 0, do_files_check, 'Channel did not have torrents')
 
         def do_rss():
-            self.managechannel.rss_url.SetValue(r'http://torrent.fedoraproject.org/rss20.xml')
+            self.managechannel.rss_url.SetValue(os.path.join(TESTS_DATA_DIR, 'test_rss.xml'))
             self.managechannel.OnAddRss()
 
             # switch to manage tab
@@ -93,8 +94,7 @@ class TestMyChannel(TestGuiAsServer):
             managefiles = self.managechannel.fileslist
             manager = managefiles.GetManager()
             manager.startDownload(torrentfilename, fixtorrent=True)
-            manager.startDownloadFromUrl(
-                r'http://torrent.fedoraproject.org/torrents/Fedora-20-i386-DVD.torrent', fixtorrent=True)
+            manager.startDownloadFromUrl(TORRENT_R, fixtorrent=True)
             manager.startDownloadFromMagnet(
                 r'magnet:?xt=urn:btih:%s&dn=ubuntu-14.04.2-desktop-amd64.iso' % hexlify(UBUNTU_1504_INFOHASH), fixtorrent=True)
 


### PR DESCRIPTION
Very dangerous to be depending on the internet since our used torrent is not working anymore: http://torrent.fedoraproject.org/torrents/Fedora-20-i386-DVD.torrent.