### PR TITLE
LibtorrentMgr and channel_rss import the correct reactor

### DIFF
--- a/Tribler/Core/Libtorrent/LibtorrentMgr.py
+++ b/Tribler/Core/Libtorrent/LibtorrentMgr.py
@@ -1,6 +1,5 @@
 # Written by Egbert Bouman
 import binascii
-import os
 import logging
 import tempfile
 import threading
@@ -10,9 +9,9 @@ from binascii import hexlify
 from copy import deepcopy
 from shutil import rmtree
 
+from twisted.internet import reactor
 import libtorrent as lt
 
-from Tribler.Core.Utilities.twisted_thread import reactor
 from Tribler.Core.Utilities.utilities import parse_magnetlink
 from Tribler.Core.exceptions import DuplicateDownloadException
 from Tribler.Core.simpledefs import (NTFY_INSERT, NTFY_MAGNET_CLOSE, NTFY_MAGNET_GOT_PEERS, NTFY_MAGNET_STARTED,

--- a/Tribler/Core/Modules/channel/channel_rss.py
+++ b/Tribler/Core/Modules/channel/channel_rss.py
@@ -8,6 +8,7 @@ import os
 import re
 import feedparser
 
+from twisted.internet import reactor
 from twisted.web.client import getPage
 
 from Tribler.dispersy.taskmanager import TaskManager
@@ -17,7 +18,6 @@ from Tribler.Core.simpledefs import (SIGNAL_CHANNEL_COMMUNITY, SIGNAL_ON_TORRENT
                                      SIGNAL_ON_UPDATED)
 from Tribler.Core.TorrentDef import TorrentDef
 from Tribler.Core.Modules.channel.cache import SimpleCache
-from Tribler.Core.Utilities.twisted_thread import reactor
 
 DEFAULT_CHECK_INTERVAL = 1800  # half an hour
 


### PR DESCRIPTION
The LibtorrentMgr.py imported the incorrect reactor. This caused exceptions in gumby experiments that use the full tribler core as dispersy source. I searched for other uses of the twisted_thread, and found and fixed another one that is probably wrong.