### PR TITLE
Refactored str2unicode method

### DIFF
--- a/Tribler/Core/Utilities/unicode.py
+++ b/Tribler/Core/Utilities/unicode.py
@@ -30,22 +30,14 @@ def bin2unicode(bin, possible_encoding='utf_8'):
 
 def str2unicode(s):
     try:
-        s = unicode(s)
-    except:
-        flag = 0
-        for encoding in [sys.getfilesystemencoding(), 'utf_8', 'iso-8859-1', 'unicode-escape']:
+        return unicode(s)
+    except UnicodeDecodeError:
+        for encoding in [sys.getfilesystemencoding(), 'utf_8', 'iso-8859-1']:
             try:
-                s = unicode(s, encoding)
-                flag = 1
-                break
-            except:
+                return unicode(s, encoding)
+            except UnicodeDecodeError:
                 pass
-        if flag == 0:
-            try:
-                s = unicode(s, sys.getdefaultencoding(), errors='replace')
-            except:
-                pass
-    return s
+    return None
 
 
 def dunno2unicode(dunno):


### PR DESCRIPTION
After having a discussion on IRC (#python channel), I got several suggestions about refactoring the `str2unicode ` method so I made the following changes:
1) Catching a more specific exception (`UnicodeDecodeError`)
2) Using True/False values instead of 0/1
3) Removed  `unicode-escape` encoding from the list since `iso-8859-1` will be able to decode any byte string
4) Due to point 3, the `unicode(s, sys.getdefaultencoding(), errors='replace')` statement is not needed anymore.

@whirm we might use Chardet (https://pypi.python.org/pypi/chardet) to do the encoding/decoding of strings?