### PR TITLE
Fixed parameter type passed to _test_port

### DIFF
--- a/Tribler/Core/Utilities/network_utils.py
+++ b/Tribler/Core/Utilities/network_utils.py
@@ -60,7 +60,7 @@ def check_random_port(port, socket_type="all"):
         if _test_port(_family, socket.SOCK_DGRAM, port):
             is_port_working = _test_port(_family, socket.SOCK_STREAM, port)
     else:
-        is_port_working = _test_port(_family, socket_type, port)
+        is_port_working = _test_port(_family, _sock_type, port)
 
     return is_port_working
 


### PR DESCRIPTION
Currently when the socket type is hard-coded (for instance, `tcp` or `udp`), a string is being passed to the `_test_port` method, triggering the assertion which expects something else. Instead, the `_sock_type` parameter should be passed.