### PR TITLE
Removed try/except block around sys.getfilesystemencoding call

### DIFF
--- a/Tribler/Core/TorrentDef.py
+++ b/Tribler/Core/TorrentDef.py
@@ -51,10 +51,7 @@ class TorrentDef(object):
         self.input = {}  # fields added by user, waiting to be turned into torrent file
         # Define the built-in default here
         self.input.update(TDEF_DEFAULTS)
-        try:
-            self.input['encoding'] = sys.getfilesystemencoding()
-        except:
-            self.input['encoding'] = sys.getdefaultencoding()
+        self.input['encoding'] = sys.getfilesystemencoding()
 
         self.input['files'] = []
 


### PR DESCRIPTION
According to the Python docs, the call to `sys.getfilesystemencoding()` does not raise any exception.