### PR TITLE
The requests library does not throw URLError

### DIFF
--- a/Tribler/Core/TorrentDef.py
+++ b/Tribler/Core/TorrentDef.py
@@ -6,7 +6,7 @@ import os
 import logging
 from hashlib import sha1
 from types import StringType, ListType, IntType, LongType
-from urllib2 import URLError
+from requests.exceptions import InvalidSchema
 from libtorrent import bencode, bdecode
 import requests
 
@@ -137,7 +137,7 @@ class TorrentDef(object):
             if response.ok:
                 return TorrentDef.load_from_memory(response.content)
 
-        except URLError:
+        except InvalidSchema:
             pass
 
     @staticmethod


### PR DESCRIPTION
`urllib` does however but we are not using that. We probably used that library before but forgot to change the exception being catched.