### PR TITLE
Created unit tests for the Category package, decoupled Session and Category

### DIFF
--- a/Tribler/Category/Category.py
+++ b/Tribler/Category/Category.py
@@ -8,6 +8,7 @@ import logging
 from Tribler import LIBRARYNAME
 from Tribler.Category.init_category import getCategoryInfo
 from Tribler.Category.FamilyFilter import XXXFilter
+from Tribler.Core.Utilities.install_dir import determine_install_dir
 
 CATEGORY_CONFIG_FILE = "category.conf"
 
@@ -18,13 +19,14 @@ class Category(object):
     __single = None
     __size_change = 1024 * 1024
 
-    def __init__(self, session, ffEnabled=False):
+    def __init__(self, install_dir=determine_install_dir(), ffEnabled=False):
         self._logger = logging.getLogger(self.__class__.__name__)
-        self._session = session
+
+        self.install_dir = install_dir
 
         if Category.__single:
             raise RuntimeError("Category is singleton")
-        filename = os.path.join(self._session.get_install_dir(), LIBRARYNAME, u'Category', CATEGORY_CONFIG_FILE)
+        filename = os.path.join(self.install_dir, LIBRARYNAME, u'Category', CATEGORY_CONFIG_FILE)
         Category.__single = self
         try:
             self.category_info = getCategoryInfo(filename)
@@ -33,7 +35,7 @@ class Category(object):
             self.category_info = []
             self._logger.critical('', exc_info=True)
 
-        self.xxx_filter = XXXFilter(self._session.get_install_dir())
+        self.xxx_filter = XXXFilter(self.install_dir)
 
         self._logger.debug("category: Categories defined by user: %s", self.getCategoryNames())
 

--- a/Tribler/Core/APIImplementation/LaunchManyCore.py
+++ b/Tribler/Core/APIImplementation/LaunchManyCore.py
@@ -117,7 +117,7 @@ class TriblerLaunchMany(TaskManager):
 
                 self._logger.debug('tlm: Reading Session state from %s', self.session.get_state_dir())
 
-                self.cat = Category.getInstance(self.session)
+                self.cat = Category.getInstance()
 
                 # create DBHandlers
                 self.peer_db = PeerDBHandler(self.session)

--- a/Tribler/Core/Upgrade/db_upgrader.py
+++ b/Tribler/Core/Upgrade/db_upgrader.py
@@ -523,7 +523,7 @@ DROP TABLE IF EXISTS MetaDataTypes;
         self.status_update_func("Opening TorrentDBHandler...")
         # TODO(emilon): That's a freakishly ugly hack.
         torrent_db_handler = TorrentDBHandler(self.session)
-        torrent_db_handler.category = Category.getInstance(self.session)
+        torrent_db_handler.category = Category.getInstance()
 
         # TODO(emilon): It would be nice to drop the corrupted torrent data from the store as a bonus.
         self.status_update_func("Registering recovered torrents...")

--- a/Tribler/Main/tribler_main.py
+++ b/Tribler/Main/tribler_main.py
@@ -159,7 +159,7 @@ class ABCApp(object):
 
             session.notifier.notify(NTFY_STARTUP_TICK, NTFY_INSERT, None, 'Initializing Family Filter')
             wx.Yield()
-            cat = Category.getInstance(session)
+            cat = Category.getInstance()
 
             state = self.utility.read_config('family_filter')
             if state in (1, 0):

--- a/Tribler/Test/Category/__init__.py
+++ b/Tribler/Test/Category/__init__.py
@@ -1,0 +1,3 @@
+"""
+This package contains unit tests to test the Category package in Tribler.
+"""

--- a/Tribler/Test/Category/data/Tribler/Category/category.conf
+++ b/Tribler/Test/Category/data/Tribler/Category/category.conf
@@ -13,7 +13,7 @@ matchpercentage = 0.0
 
 
 [unknown]
-rank = 9
+rank = -1
 displayname = Unknown
 matchpercentage = 0.0
 

--- a/Tribler/Test/Category/data/Tribler/Category/filter_terms.filter
+++ b/Tribler/Test/Category/data/Tribler/Category/filter_terms.filter
@@ -1,0 +1,3 @@
+term1
+term2
+*term3

--- a/Tribler/Test/Category/data/category.conf
+++ b/Tribler/Test/Category/data/category.conf
@@ -1,0 +1,74 @@
+[xxx]
+rank = 10
+displayname = XXX
+matchpercentage = 0.001
+strength = 1.1
+# Keywords are in seperate file: filter_content.filter
+
+
+[other]
+rank = 8
+displayname = Other
+matchpercentage = 0.0
+
+
+[unknown]
+rank = 9
+displayname = Unknown
+matchpercentage = 0.0
+
+
+[Video]
+rank = 1
+displayname = Video Files
+suffix = asf, asp, avi, flc, fli, flic, mkv, mov, movie, mpeg, mpg, qicktime, ram, rm, rmvb, rpm, vob, wma, wmv
+minfilesize = 50
+maxfilesize = 10000000
+matchpercentage = 0.5
+
+*divx = 1
+*xvid = 1
+*rmvb = 1
+
+[VideoClips]
+rank = 2
+displayname = Video Clips
+suffix = asf, asp, avi, flc, fli, flic, mkv, mov, movie, mpeg, mpg, qicktime, ram, rm, rmvb, rpm, vob, wma, wmv, mp4, flv
+minfilesize = 0
+maxfilesize = 50
+matchpercentage = 0.5
+
+[Audio]
+rank = 3
+displayname = Audio
+suffix = cda, flac, m3u, mp2, mp3, vorbis, wav, wma, ogg, ape
+matchpercentage = 0.8
+
+[Document]
+rank = 5
+displayname = Documents
+suffix = doc, pdf, ppt, ps, tex, txt, vsd
+matchpercentage = 0.8
+
+[Compressed]
+rank = 4
+displayname = Compressed
+suffix = ace, bin, bwt, cab, ccd, cdi, cue, gzip, iso, jar, mdf, mds, nrg, rar, tar, vcd, z, zip
+matchpercentage = 0.8
+
+*.r0 = 1
+*.r1 = 1
+*.r2 = 1
+*.r3 = 1
+*.r4 = 1
+*.r5 = 1
+*.r6 = 1
+*.r7 = 1
+*.r8 = 1
+*.r9 = 1
+
+[Picture]
+rank = 6
+displayname = Pictures
+suffix = bmp, dib, dwg, gif, ico, jpeg, jpg, pic, png, swf, tif, tiff
+matchpercentage = 0.8

--- a/Tribler/Test/Category/test_category.py
+++ b/Tribler/Test/Category/test_category.py
@@ -1,0 +1,55 @@
+import os
+from nose.tools import raises
+from Tribler.Category.Category import Category, cmp_rank
+from Tribler.Test.test_as_server import BaseTestCase
+
+
+class TriblerCategoryTest(BaseTestCase):
+
+    FILE_DIR = os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
+    CATEGORY_TEST_DATA_DIR = os.path.abspath(os.path.join(FILE_DIR, u"data/"))
+
+    def tearDown(self):
+        Category.delInstance()
+
+    @raises(RuntimeError)
+    def test_category_singleton(self):
+        cat = Category(install_dir=self.CATEGORY_TEST_DATA_DIR)
+        next_cat = Category(install_dir=self.CATEGORY_TEST_DATA_DIR)
+
+    def test_category_names_none_names(self):
+        cat = Category.getInstance(install_dir=self.CATEGORY_TEST_DATA_DIR)
+        cat.category_info = None
+        self.assertFalse(cat.getCategoryNames())
+
+    def test_get_category_names(self):
+        cat = Category.getInstance(install_dir=self.CATEGORY_TEST_DATA_DIR)
+        self.assertEquals(len(cat.category_info), 9)
+
+    def test_calculate_category_multi_file(self):
+        cat = Category.getInstance(install_dir=self.CATEGORY_TEST_DATA_DIR)
+        torrent_info = {"info": {"files": [{"path": "/my/path/video.avi", "length": 1234}]},
+                        "announce": "http://tracker.org", "comment": "lorem ipsum"}
+        self.assertEquals(cat.calculateCategory(torrent_info, "my torrent"), 'other')
+
+    def test_calculate_category_single_file(self):
+        cat = Category.getInstance(install_dir=self.CATEGORY_TEST_DATA_DIR)
+        torrent_info = {"info": {"name": "my_torrent", "length": 1234},
+                        "announce-list": ["http://tracker.org"], "comment": "lorem ipsum"}
+        self.assertEquals(cat.calculateCategory(torrent_info, "my torrent"), 'other')
+
+    def test_calculate_category_xxx(self):
+        cat = Category.getInstance(install_dir=self.CATEGORY_TEST_DATA_DIR)
+        torrent_info = {"info": {"name": "term1", "length": 1234},
+                        "announce-list": ["http://tracker.org"], "comment": "lorem ipsum"}
+        self.assertEquals(cat.calculateCategory(torrent_info, "my torrent"), 'xxx')
+
+    def test_get_family_filter_sql(self):
+        cat = Category.getInstance(install_dir=self.CATEGORY_TEST_DATA_DIR)
+        self.assertFalse(cat.get_family_filter_sql())
+        cat.set_family_filter(b=True)
+        self.assertTrue(cat.get_family_filter_sql())
+
+    def test_cmp_rank(self):
+        self.assertEquals(cmp_rank({'bla': 3}, {'bla': 4}), 1)
+        self.assertEquals(cmp_rank({'rank': 3}, {'bla': 4}), -1)

--- a/Tribler/Test/Category/test_family_filter.py
+++ b/Tribler/Test/Category/test_family_filter.py
@@ -1,0 +1,29 @@
+import os
+import Tribler
+from Tribler.Category.FamilyFilter import XXXFilter
+from Tribler.Test.test_as_server import BaseTestCase
+
+
+class TriblerCategoryTestFamilyFilter(BaseTestCase):
+
+    FILE_DIR = os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
+    CATEGORY_TEST_DATA_DIR = os.path.abspath(os.path.join(FILE_DIR, u"data/"))
+
+    def test_filter_torrent(self):
+        family_filter = XXXFilter(self.CATEGORY_TEST_DATA_DIR)
+        self.assertFalse(family_filter.isXXXTorrent(["file1.txt"], "mytorrent", "http://tracker.org"))
+        self.assertFalse(family_filter.isXXXTorrent(["file1.txt"], "mytorrent", ""))
+        self.assertTrue(family_filter.isXXXTorrent(["term1.txt"], "term2", ""))
+
+    def test_is_xxx(self):
+        family_filter = XXXFilter(self.CATEGORY_TEST_DATA_DIR)
+        self.assertTrue(family_filter.isXXX("term1"))
+        self.assertFalse(family_filter.isXXX("term0"))
+        self.assertTrue(family_filter.isXXX("term3"))
+
+    def test_is_xxx_term(self):
+        family_filter = XXXFilter(self.CATEGORY_TEST_DATA_DIR)
+        self.assertTrue(family_filter.isXXXTerm("term1es"))
+        self.assertFalse(family_filter.isXXXTerm("term0es"))
+        self.assertTrue(family_filter.isXXXTerm("term1s"))
+        self.assertFalse(family_filter.isXXXTerm("term0n"))

--- a/Tribler/Test/Category/test_init_category.py
+++ b/Tribler/Test/Category/test_init_category.py
@@ -1,0 +1,20 @@
+import os
+from Tribler.Category.init_category import INIT_FUNC_DICT, getCategoryInfo
+from Tribler.Test.test_as_server import BaseTestCase
+
+
+class TriblerCategoryTestInit(BaseTestCase):
+
+    FILE_DIR = os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
+    CATEGORY_TEST_DATA_DIR = os.path.abspath(os.path.join(FILE_DIR, u"data/"))
+
+    def test_split_list(self):
+        string = "foo ,bar,  moo  "
+        self.assertEquals(INIT_FUNC_DICT["suffix"](string), ["foo", "bar", "moo"])
+
+    def test_get_category_info(self):
+        category_info = getCategoryInfo(os.path.join(self.CATEGORY_TEST_DATA_DIR, "category.conf"))
+        self.assertEquals(len(category_info), 9)
+        self.assertEquals(category_info[0]['name'], 'xxx')
+        self.assertEquals(category_info[0]['strength'], 1.1)
+        self.assertFalse(category_info[0]['keywords'])

--- a/Tribler/Test/Category/test_init_category.py
+++ b/Tribler/Test/Category/test_init_category.py
@@ -6,7 +6,7 @@ from Tribler.Test.test_as_server import BaseTestCase
 class TriblerCategoryTestInit(BaseTestCase):
 
     FILE_DIR = os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
-    CATEGORY_TEST_DATA_DIR = os.path.abspath(os.path.join(FILE_DIR, u"data/"))
+    CATEGORY_TEST_DATA_DIR = os.path.abspath(os.path.join(FILE_DIR, u"data/Tribler/Category/"))
 
     def test_split_list(self):
         string = "foo ,bar,  moo  "

--- a/Tribler/Test/test_sqlitecachedbhandler.py
+++ b/Tribler/Test/test_sqlitecachedbhandler.py
@@ -172,7 +172,7 @@ class TestTorrentDBHandler(AbstractDB):
         self.session.lm.tracker_manager.initialize()
         self.tdb = TorrentDBHandler(self.session)
         self.tdb.torrent_dir = TESTS_DATA_DIR
-        self.tdb.category = Category.getInstance(self.session)
+        self.tdb.category = Category.getInstance()
         self.tdb.mypref_db = MyPreferenceDBHandler(self.session)
 
     @blocking_call_on_reactor_thread


### PR DESCRIPTION
Contained in this PR:
-unit tests for the Category package. The code coverage of `Tribler.Category` is 91% after running these tests.
-custom `filter_terms.py` and `category.con` files that are used for testing purposes.
-refactored `Category.py` a bit. The `session` parameter now does not have to be passed anymore to the constructor of `Category`. For testing purposes, I've added an optional parameter to override the location of the `category.conf` file. Fixes #1986 