### PR TITLE
Created a start_download method in LibtorrentMgr

### DIFF
--- a/Tribler/Core/Libtorrent/LibtorrentMgr.py
+++ b/Tribler/Core/Libtorrent/LibtorrentMgr.py
@@ -504,13 +504,13 @@ class LibtorrentMgr(TaskManager):
         else:
             getattr(self.get_session(hops), funcname)(*args, **kwargs)
 
-    def start_download_from_arg(self, argument):
-        if argument.startswith("http"):
-            return self.start_download_from_url(argument)
-        if argument.startswith("magnet:"):
-            return self.start_download_from_magnet(argument)
-        if argument.startswith("file:"):
-            argument = url2pathname(argument[5:])
+    def start_download_from_uri(self, uri):
+        if uri.startswith("http"):
+            return self.start_download_from_url(uri)
+        if uri.startswith("magnet:"):
+            return self.start_download_from_magnet(uri)
+        if uri.startswith("file:"):
+            argument = url2pathname(uri[5:])
             return self.start_download(torrentfilename=argument)
 
         return None

--- a/Tribler/Core/Libtorrent/LibtorrentMgr.py
+++ b/Tribler/Core/Libtorrent/LibtorrentMgr.py
@@ -12,12 +12,15 @@ from shutil import rmtree
 from twisted.internet import reactor
 import libtorrent as lt
 from Tribler.Core.Utilities.torrent_utils import get_info_from_handle
+from Tribler.Core.TorrentDef import TorrentDef
 
-from Tribler.Core.Utilities.utilities import parse_magnetlink
-from Tribler.Core.exceptions import DuplicateDownloadException
+from Tribler.Core.Utilities.utilities import parse_magnetlink, fix_torrent
+from Tribler.Core.Video.utils import videoextdefaults
+from Tribler.Core.exceptions import DuplicateDownloadException, TorrentFileException
 from Tribler.Core.simpledefs import (NTFY_INSERT, NTFY_MAGNET_CLOSE, NTFY_MAGNET_GOT_PEERS, NTFY_MAGNET_STARTED,
                                      NTFY_REACHABLE, NTFY_TORRENTS)
 from Tribler.Core.version import version_id
+from Tribler.Main.globals import DefaultDownloadStartupConfig
 from Tribler.dispersy.taskmanager import LoopingCall, TaskManager
 from Tribler.dispersy.util import blocking_call_on_reactor_thread, call_on_reactor_thread
 
@@ -499,6 +502,62 @@ class LibtorrentMgr(TaskManager):
                 getattr(session, funcname)(*args, **kwargs)
         else:
             getattr(self.get_session(hops), funcname)(*args, **kwargs)
+
+    def start_download(self, torrentfilename=None, destdir=None, infohash=None, tdef=None):
+        self._logger.debug(u"starting download: filename: %s, dest dir: %s, torrent def: %s",
+                           torrentfilename, destdir, tdef)
+
+        if infohash is not None:
+            assert isinstance(infohash, str), "infohash type: %s" % type(infohash)
+            assert len(infohash) == 20, "infohash length is not 20: %s, %s" % (len(infohash), infohash)
+
+        # the priority of the parameters is: (1) tdef, (2) infohash, (3) torrent_file.
+        # so if we have tdef, infohash and torrent_file will be ignored, and so on.
+        if tdef is None:
+            if infohash is not None:
+                # try to get the torrent from torrent_store if the infohash is provided
+                torrent_data = self.trsession.get_collected_torrent(infohash)
+                if torrent_data is not None:
+                    # use this torrent data for downloading
+                    tdef = TorrentDef.load_from_memory(torrent_data)
+
+            if tdef is None:
+                assert torrentfilename is not None, "torrent file must be provided if tdef and infohash are not given"
+                # try to get the torrent from the given torrent file
+                torrent_data = fix_torrent(torrentfilename)
+                if torrent_data is None:
+                    raise TorrentFileException()
+
+                tdef = TorrentDef.load_from_memory(torrent_data)
+
+        assert tdef is not None, "tdef MUST not be None after loading torrent"
+
+        d = self.trsession.get_download(tdef.get_infohash())
+        if d:
+            new_trackers = list(set(tdef.get_trackers_as_single_tuple()) - set(
+                d.get_def().get_trackers_as_single_tuple()))
+            if not new_trackers:
+                raise DuplicateDownloadException()
+
+            else:
+                self.trsession.update_trackers(tdef.get_infohash(), new_trackers)
+            return
+
+        defaultDLConfig = DefaultDownloadStartupConfig.getInstance()
+        dscfg = defaultDLConfig.copy()
+
+        # TODO martijn: for now, we are always using the default settings, which means that we bypass
+        # the screen to select torrent files/adjust the anonymity level.
+        dscfg.set_hops(0) # TODO martijn: hard-coded for now
+        dscfg.set_safe_seeding(False) # TODO martijn: hard-coded for now
+
+        if destdir is not None:
+            dscfg.set_dest_dir(destdir)
+
+        self._logger.info('start_download: Starting in VOD mode')
+        result = self.trsession.start_download_from_tdef(tdef, dscfg)
+
+        return result
 
 def encode_atp(atp):
     for k, v in atp.iteritems():

--- a/Tribler/Core/Libtorrent/LibtorrentMgr.py
+++ b/Tribler/Core/Libtorrent/LibtorrentMgr.py
@@ -1,6 +1,7 @@
 # Written by Egbert Bouman
 import binascii
 import logging
+from urllib import url2pathname
 import tempfile
 import threading
 import os
@@ -508,6 +509,9 @@ class LibtorrentMgr(TaskManager):
             return self.start_download_from_url(argument)
         if argument.startswith("magnet:"):
             return self.start_download_from_magnet(argument)
+        if argument.startswith("file:"):
+            argument = url2pathname(argument[5:])
+            return self.start_download(torrentfilename=argument)
 
         return None
 

--- a/Tribler/Core/Libtorrent/LibtorrentMgr.py
+++ b/Tribler/Core/Libtorrent/LibtorrentMgr.py
@@ -503,6 +503,20 @@ class LibtorrentMgr(TaskManager):
         else:
             getattr(self.get_session(hops), funcname)(*args, **kwargs)
 
+    def start_download_from_arg(self, argument):
+        if argument.startswith("http"):
+            return self.start_download_from_url(argument)
+
+        return None
+
+    def start_download_from_url(self, url):
+        try:
+            tdef = TorrentDef.load_from_url(url)
+            if tdef:
+                return self.start_download(tdef=tdef)
+        except:
+            return None
+
     def start_download(self, torrentfilename=None, destdir=None, infohash=None, tdef=None):
         self._logger.debug(u"starting download: filename: %s, dest dir: %s, torrent def: %s",
                            torrentfilename, destdir, tdef)

--- a/Tribler/Core/Session.py
+++ b/Tribler/Core/Session.py
@@ -187,7 +187,7 @@ class Session(SessionConfigInterface):
     #
     # Public methods
     #
-    def start_download_from_arg(self, argument):
+    def start_download_from_uri(self, uri):
         """
         Start a download from an argument. This argument can be of the following type:
         -http: Start a download from a torrent file at the given url.
@@ -198,7 +198,7 @@ class Session(SessionConfigInterface):
         if an error occurred during the start of the download.
         """
         if self.get_libtorrent():
-            return self.lm.ltmgr.start_download_from_arg(argument)
+            return self.lm.ltmgr.start_download_from_uri(uri)
         raise OperationNotEnabledByConfigurationException()
 
     def start_download_from_tdef(self, tdef, dcfg=None, initialdlstatus=None, hidden=False):

--- a/Tribler/Core/Session.py
+++ b/Tribler/Core/Session.py
@@ -187,7 +187,7 @@ class Session(SessionConfigInterface):
     #
     # Public methods
     #
-    def start_download(self, tdef, dcfg=None, initialdlstatus=None, hidden=False):
+    def start_download_from_tdef(self, tdef, dcfg=None, initialdlstatus=None, hidden=False):
         """
         Creates a Download object and adds it to the session. The passed
         ContentDef and DownloadStartupConfig are copied into the new Download

--- a/Tribler/Core/Session.py
+++ b/Tribler/Core/Session.py
@@ -187,6 +187,20 @@ class Session(SessionConfigInterface):
     #
     # Public methods
     #
+    def start_download_from_arg(self, argument):
+        """
+        Start a download from an argument. This argument can be of the following type:
+        -http: Start a download from a torrent file at the given url.
+        -magnet: Start a download from a torrent file by using a magnet link.
+        -file: Start a download from a torrent file at given location.
+        :param argument: The argument that specifies the location of the torrent to be downloaded
+        :return: A LibtorrentDownloadImpl object that represents the new download. Can return none
+        if an error occurred during the start of the download.
+        """
+        if self.get_libtorrent():
+            return self.lm.ltmgr.start_download_from_arg(argument)
+        raise OperationNotEnabledByConfigurationException()
+
     def start_download_from_tdef(self, tdef, dcfg=None, initialdlstatus=None, hidden=False):
         """
         Creates a Download object and adds it to the session. The passed

--- a/Tribler/Core/exceptions.py
+++ b/Tribler/Core/exceptions.py
@@ -64,3 +64,10 @@ class TorrentDefNotFinalizedException(TriblerException):
 
     def __init__(self, msg=None):
         TriblerException.__init__(self, msg)
+
+class TorrentFileException(TriblerException):
+
+    """ The torrent file that is used is corrupt or cannot be read. """
+
+    def __init__(self, msg=None):
+        TriblerException.__init__(self, msg)

--- a/Tribler/Main/Utility/version_check.py
+++ b/Tribler/Main/Utility/version_check.py
@@ -126,7 +126,7 @@ def _upgradeVersion(self, my_version, latest_version, info):
 
         # start download
         try:
-            download = self.utility.session.start_download(tdef)
+            download = self.utility.session.start_download_from_tdef(tdef)
 
         except DuplicateDownloadException:
             self._logger.error("-- Duplicate download")

--- a/Tribler/Main/tribler_main.py
+++ b/Tribler/Main/tribler_main.py
@@ -608,7 +608,7 @@ class ABCApp(object):
                         # that removing a torrent is racy.
                         self.utility.session.lm.threadpool.call(0.5,
                                                                 reactor.callInThread,
-                                                                self.utility.session.start_download,
+                                                                self.utility.session.start_download_from_tdef,
                                                                 tdef, dscfg)
 
             self.prevActiveDownloads = newActiveDownloads

--- a/Tribler/Main/vwxGUI/MainFrame.py
+++ b/Tribler/Main/vwxGUI/MainFrame.py
@@ -578,7 +578,7 @@ class MainFrame(wx.Frame):
 
                 if vodmode:
                     self._logger.info('MainFrame: startDownload: Starting in VOD mode')
-                    result = self.utility.session.start_download(tdef, dscfg)
+                    result = self.utility.session.start_download_from_tdef(tdef, dscfg)
                     self.guiUtility.library_manager.playTorrent(
                         tdef.get_infohash(), videofiles[0] if len(videofiles) == 1 else None)
 
@@ -587,7 +587,7 @@ class MainFrame(wx.Frame):
                         dscfg.set_selected_files(selectedFiles)
 
                     self._logger.debug('MainFrame: startDownload: Starting in DL mode')
-                    result = self.utility.session.start_download(tdef, dscfg, hidden=hidden)
+                    result = self.utility.session.start_download_from_tdef(tdef, dscfg, hidden=hidden)
 
                 if result and not hidden:
                     self.show_saved(tdef)

--- a/Tribler/Test/API/test_download.py
+++ b/Tribler/Test/API/test_download.py
@@ -33,19 +33,19 @@ class TestDownload(TestAsServer):
         pass
 
     def test_download_torrent_from_url(self):
-        d = self.session.start_download_from_arg(TORRENT_R)
+        d = self.session.start_download_from_uri(TORRENT_R)
         d.set_state_callback(self.downloader_state_callback)
         assert self.downloading_event.wait(60)
 
     def test_download_torrent_from_magnet(self):
         magnet_link = 'magnet:?xt=urn:btih:%s' % hexlify(UBUNTU_1504_INFOHASH)
-        d = self.session.start_download_from_arg(magnet_link)
+        d = self.session.start_download_from_uri(magnet_link)
         d.set_state_callback(self.downloader_state_callback)
         assert self.downloading_event.wait(60)
 
     def test_download_torrent_from_file(self):
         from urllib import pathname2url
-        d = self.session.start_download_from_arg('file:' + pathname2url(TORRENT_FILE))
+        d = self.session.start_download_from_uri('file:' + pathname2url(TORRENT_FILE))
         d.set_state_callback(self.downloader_state_callback)
         assert self.downloading_event.wait(60)
 

--- a/Tribler/Test/API/test_download.py
+++ b/Tribler/Test/API/test_download.py
@@ -1,0 +1,62 @@
+from binascii import hexlify
+import logging
+import threading
+from Tribler.Core.simpledefs import dlstatus_strings
+from Tribler.Test.common import UBUNTU_1504_INFOHASH
+from Tribler.Test.test_as_server import TestAsServer
+from Tribler.Test.test_libtorrent_download import TORRENT_FILE, TORRENT_R
+
+
+class TestDownload(TestAsServer):
+
+    """
+    Testing of a torrent download via new tribler API:
+    """
+
+    def __init__(self, *argv, **kwargs):
+        super(TestDownload, self).__init__(*argv, **kwargs)
+        self._logger = logging.getLogger(self.__class__.__name__)
+
+    def setUp(self):
+        """ override TestAsServer """
+        super(TestDownload, self).setUp()
+
+        self.downloading_event = threading.Event()
+
+    def setUpPreSession(self):
+        """ override TestAsServer """
+        super(TestDownload, self).setUpPreSession()
+
+        self.config.set_libtorrent(True)
+
+    def setUpPostSession(self):
+        pass
+
+    def test_download_torrent_from_url(self):
+        d = self.session.start_download_from_arg(TORRENT_R)
+        d.set_state_callback(self.downloader_state_callback)
+        assert self.downloading_event.wait(60)
+
+    def test_download_torrent_from_magnet(self):
+        magnet_link = 'magnet:?xt=urn:btih:%s' % hexlify(UBUNTU_1504_INFOHASH)
+        d = self.session.start_download_from_arg(magnet_link)
+        d.set_state_callback(self.downloader_state_callback)
+        assert self.downloading_event.wait(60)
+
+    def test_download_torrent_from_file(self):
+        from urllib import pathname2url
+        d = self.session.start_download_from_arg('file:' + pathname2url(TORRENT_FILE))
+        d.set_state_callback(self.downloader_state_callback)
+        assert self.downloading_event.wait(60)
+
+    def downloader_state_callback(self, ds):
+        d = ds.get_download()
+        self._logger.debug("download status: %s %s %s",
+                           repr(d.get_def().get_name()),
+                           dlstatus_strings[ds.get_status()],
+                           ds.get_progress())
+
+        if ds.get_progress() > 0:
+            self.downloading_event.set()
+
+        return 1.0, False

--- a/Tribler/Test/API/test_seeding.py
+++ b/Tribler/Test/API/test_seeding.py
@@ -73,7 +73,7 @@ class TestSeeding(TestAsServer):
 
         self.dscfg = DownloadStartupConfig()
         self.dscfg.set_dest_dir(TESTS_API_DIR)  # basedir of the file we are seeding
-        d = self.session.start_download(self.tdef, self.dscfg)
+        d = self.session.start_download_from_tdef(self.tdef, self.dscfg)
         d.set_state_callback(self.seeder_state_callback)
 
         self._logger.debug("starting to wait for download to reach seeding state")
@@ -125,7 +125,7 @@ class TestSeeding(TestAsServer):
 
         tdef2 = TorrentDef.load(self.torrentfn)
 
-        d = self.session2.start_download(tdef2, self.dscfg2)
+        d = self.session2.start_download_from_tdef(tdef2, self.dscfg2)
         d.set_state_callback(self.downloader_state_callback)
 
         time.sleep(5)

--- a/Tribler/Test/test_magnetlink.py
+++ b/Tribler/Test/test_magnetlink.py
@@ -282,7 +282,7 @@ class TestMetadataFakePeer(TestAsServer, MagnetHelpers):
 
         self.dscfg = DownloadStartupConfig()
         self.dscfg.set_dest_dir(TESTS_API_DIR)
-        self.download = self.session.start_download(self.tdef, self.dscfg)
+        self.download = self.session.start_download_from_tdef(self.tdef, self.dscfg)
         self.download.set_state_callback(self.seeder_state_callback)
 
         assert self.seeder_setup_complete.wait(30)

--- a/Tribler/Test/test_tunnel_base.py
+++ b/Tribler/Test/test_tunnel_base.py
@@ -138,7 +138,7 @@ class TestTunnelBase(TestGuiAsServer):
         dscfg = DownloadStartupConfig()
         dscfg.set_dest_dir(TESTS_DATA_DIR)  # basedir of the file we are seeding
         dscfg.set_hops(hops)
-        d = session.start_download(tdef, dscfg)
+        d = session.start_download_from_tdef(tdef, dscfg)
         d.set_state_callback(self.seeder_state_callback)
 
         return torrentfn

--- a/Tribler/Test/test_video_server.py
+++ b/Tribler/Test/test_video_server.py
@@ -68,7 +68,7 @@ class TestVideoHTTPServer(TestAsServer):
         dscfg = DownloadStartupConfig()
         dscfg.set_dest_dir(os.path.dirname(self.sourcefn))
 
-        download = self.session.start_download(self.tdef, dscfg)
+        download = self.session.start_download_from_tdef(self.tdef, dscfg)
         while not download.handle:
             time.sleep(1)
 

--- a/Tribler/Test/test_vod.py
+++ b/Tribler/Test/test_vod.py
@@ -55,7 +55,7 @@ class TestVideoOnDemand(TestAsServer):
         dscfg.set_dest_dir(destdir)
         dscfg.set_mode(DLMODE_VOD)
 
-        download = self.session.start_download(self.tdef, dscfg)
+        download = self.session.start_download_from_tdef(self.tdef, dscfg)
         download.set_state_callback(self.state_callback)
 
         self.session.set_download_states_callback(self.states_callback)

--- a/Tribler/community/tunnel/main.py
+++ b/Tribler/community/tunnel/main.py
@@ -287,7 +287,7 @@ class LineHandler(LineReceiver):
             dscfg.set_hops(1)
             dscfg.set_dest_dir(cur_path)
 
-            anon_tunnel.session.lm.threadpool.call(0, anon_tunnel.session.start_download, tdef, dscfg)
+            anon_tunnel.session.lm.threadpool.call(0, anon_tunnel.session.start_download_from_tdef, tdef, dscfg)
         elif line.startswith('i'):
             # Introduce dispersy port from other main peer to this peer
             line_split = line.split(' ')
@@ -317,7 +317,7 @@ class LineHandler(LineReceiver):
                                  sum(ds.get_num_seeds_peers()),
                                  sum(1 for _ in anon_tunnel.community.dispersy_yield_verified_candidates())))
                     return 1.0, False
-                download = anon_tunnel.session.start_download(tdef, dscfg)
+                download = anon_tunnel.session.start_download_from_tdef(tdef, dscfg)
                 download.set_state_callback(cb, delay=1)
 
             anon_tunnel.session.lm.threadpool.call(0, start_download)


### PR DESCRIPTION
Currently, the method to start a download using a file url, http url, magnet link or emercoin download, is located inside `MainFrame` which is part of the GUI. Eventually, `libtribler` should contain an endpoint to start a download. This PR creates a GUI-independent implementation of methods to start a download inside `LibtorrentMgr` (since that class is responsible for managing libtorrent downloads).

For now, the emercoin download is not supported since that requires porting of some emercoin functionality to the core (for instance, the `EmercoinMgr` class). Moreover, downloads started with this method do not support anonymity (yet) and uses the default configuration.