### PR TITLE
Removed hide from string definition of LibtorrentDownloadImpl

### DIFF
--- a/Tribler/Core/Libtorrent/LibtorrentDownloadImpl.py
+++ b/Tribler/Core/Libtorrent/LibtorrentDownloadImpl.py
@@ -145,7 +145,7 @@ class LibtorrentDownloadImpl(DownloadConfigInterface):
         self.correctedinfoname = u""
 
     def __str__(self):
-        return "LibtorrentDownloadImpl <name: '%s' hops: %d hide: %d>" % (self.correctedinfoname, self.get_hops(), self.hide)
+        return "LibtorrentDownloadImpl <name: '%s' hops: %d>" % (self.correctedinfoname, self.get_hops())
 
     def __repr__(self):
         return self.__str__()

--- a/Tribler/Test/API/test_download.py
+++ b/Tribler/Test/API/test_download.py
@@ -34,18 +34,21 @@ class TestDownload(TestAsServer):
 
     def test_download_torrent_from_url(self):
         d = self.session.start_download_from_uri(TORRENT_R)
+        self._logger.debug("Download started: %s", d)
         d.set_state_callback(self.downloader_state_callback)
         assert self.downloading_event.wait(60)
 
     def test_download_torrent_from_magnet(self):
         magnet_link = 'magnet:?xt=urn:btih:%s' % hexlify(UBUNTU_1504_INFOHASH)
         d = self.session.start_download_from_uri(magnet_link)
+        self._logger.debug("Download started: %s", d)
         d.set_state_callback(self.downloader_state_callback)
         assert self.downloading_event.wait(60)
 
     def test_download_torrent_from_file(self):
         from urllib import pathname2url
         d = self.session.start_download_from_uri('file:' + pathname2url(TORRENT_FILE))
+        self._logger.debug("Download started: %s", d)
         d.set_state_callback(self.downloader_state_callback)
         assert self.downloading_event.wait(60)
 


### PR DESCRIPTION
The `hide` attribute does not exist anymore in `LibtorrentDownloadImpl`.