### PR TITLE
Written some more unit tests for the configuration files

### DIFF
--- a/Tribler/Test/Core/base_test.py
+++ b/Tribler/Test/Core/base_test.py
@@ -1,5 +1,14 @@
+from tempfile import mkdtemp
+
+import shutil
+
 from Tribler.Test.test_as_server import BaseTestCase
 
 
 class TriblerCoreTest(BaseTestCase):
-    pass
+
+    def setUp(self):
+        self.temp_dir = mkdtemp(suffix="_tribler_test_session")
+
+    def tearDown(self):
+        shutil.rmtree(unicode(self.temp_dir), ignore_errors=True)

--- a/Tribler/Test/Core/data/config_files/config1.conf
+++ b/Tribler/Test/Core/data/config_files/config1.conf
@@ -1,0 +1,78 @@
+[general]
+version = 11
+state_dir = None
+install_dir = /Users/tribler/Documents/tribler
+ip = 0.0.0.0
+minport = 7760
+maxport = 7760
+bind = []
+ipv6_enabled = 0
+ipv6_binds_v4 = 1
+timeout = 300.0
+timeout_check_interval = 60.0
+eckeypairfilename = /Users/tribler/.Tribler/ec.pem
+megacache = True
+nickname = Tribler User
+mugshot = None
+videoanalyserpath = vlc/ffmpeg
+peer_icon_path = /Users/tribler/.Tribler/icons
+live_aux_seeders = []
+
+[allchannel_community]
+enabled = True
+
+[search_community]
+enabled = True
+
+[tunnel_community]
+socks5_listen_ports = [-1, -1, -1, -1, -1]
+exitnode_enabled = False
+
+[barter_community]
+enabled = False
+
+[metadata]
+enabled = True
+store_dir = /Users/tribler/.Tribler/collected_metadata
+
+[mainline_dht]
+enabled = True
+mainline_dht_port = -1
+
+[torrent_checking]
+enabled = 1
+
+[torrent_store]
+enabled = True
+dir = /Users/tribler/.Tribler/collected_torrents
+
+[torrent_collecting]
+enabled = True
+dht_torrent_collecting = True
+torrent_collecting_max_torrents = 50000
+torrent_collecting_dir = None
+stop_collecting_threshold = 200
+
+[libtorrent]
+enabled = True
+lt_proxytype = 0
+lt_proxyserver = None
+lt_proxyauth = None
+utp = True
+anon_listen_port = -1
+anon_proxytype = 0
+anon_proxyserver = None
+anon_proxyauth = None
+
+[dispersy]
+enabled = True
+dispersy_port = 7759
+
+[video]
+enabled = True
+path = /Applications/VLC.app
+port = -1
+preferredmode = 0
+
+[upgrader]
+enabled = True

--- a/Tribler/Test/Core/data/config_files/corrupt_download_config.conf
+++ b/Tribler/Test/Core/data/config_files/corrupt_download_config.conf
@@ -1,0 +1,13 @@
+downloadconfig]
+version = 15
+saveas = None
+max_upload_rate = 0
+max_download_rate = 0
+mode = 0
+hops = 0
+selected_files = []
+correctedfilename = None
+safe_seeding = True
+seeding_mode = ratio
+seeding_ratio = 2.0
+seeding_time = 60

--- a/Tribler/Test/Core/data/config_files/corrupt_session_config.conf
+++ b/Tribler/Test/Core/data/config_files/corrupt_session_config.conf
@@ -1,0 +1,2 @@
+[upgrader
+enabled = True

--- a/Tribler/Test/Core/test_configparser.py
+++ b/Tribler/Test/Core/test_configparser.py
@@ -1,0 +1,92 @@
+import os
+from ConfigParser import DEFAULTSECT
+from tempfile import mkdtemp
+
+import shutil
+from nose.tools import raises
+
+from Tribler.Core.Utilities.configparser import CallbackConfigParser
+from Tribler.Core.exceptions import OperationNotPossibleAtRuntimeException
+from Tribler.Test.Core.base_test import TriblerCoreTest
+
+
+class TestConfigParser(TriblerCoreTest):
+
+    FILE_DIR = os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
+    CONFIG_FILES_DIR = os.path.abspath(os.path.join(FILE_DIR, u"data/config_files/"))
+
+    def test_configparser_config1(self):
+        ccp = CallbackConfigParser()
+        ccp.read_file(os.path.join(self.CONFIG_FILES_DIR, 'config1.conf'))
+
+        self.assertEqual(ccp.get('general', 'version'), 11)
+        self.assertTrue(ccp.get('search_community', 'enabled'))
+        self.assertIsInstance(ccp.get('tunnel_community', 'socks5_listen_ports'), list)
+        self.assertFalse(ccp.get('foo', 'bar'))
+
+    def test_configparser_copy(self):
+        ccp = CallbackConfigParser()
+        ccp.read_file(os.path.join(self.CONFIG_FILES_DIR, 'config1.conf'))
+
+        copy_ccp = ccp.copy()
+        self.assertEqual(copy_ccp.get('general', 'version'), 11)
+        self.assertTrue(copy_ccp.get('search_community', 'enabled'))
+
+    def test_configparser_set_callback(self):
+
+        def parser_callback(section, option, old_value, new_value):
+            return True
+
+        ccp = CallbackConfigParser()
+        ccp.set_callback(parser_callback)
+        ccp.read_file(os.path.join(self.CONFIG_FILES_DIR, 'config1.conf'))
+
+        ccp.set('search_community', 'enabled', False)
+        ccp.set('search_community', 'bar', 42)
+
+        self.assertFalse(ccp.get('search_community', 'enabled'))
+        self.assertEquals(ccp.get('search_community', 'bar'), 42)
+
+    @raises(OperationNotPossibleAtRuntimeException)
+    def test_configparser_false_callback(self):
+
+        def parser_callback(section, option, old_value, new_value):
+            return False
+
+        ccp = CallbackConfigParser()
+        ccp.read_file(os.path.join(self.CONFIG_FILES_DIR, 'config1.conf'))
+        ccp.set_callback(parser_callback)
+        ccp.set('search_community', 'enabled', False)
+
+    def test_configparser_write_file(self):
+
+        temp_dir = mkdtemp(suffix="_tribler_test_session")
+        ccp = CallbackConfigParser()
+        ccp.read_file(os.path.join(self.CONFIG_FILES_DIR, 'config1.conf'))
+
+        new_path = os.path.join(temp_dir, 'config_new.conf')
+        ccp.write_file(new_path)
+
+        self.assertTrue(os.path.isfile(new_path))
+        ccp.read_file(new_path)
+
+        self.assertEqual(ccp.get('general', 'version'), 11)
+        self.assertTrue(ccp.get('search_community', 'enabled'))
+        self.assertIsInstance(ccp.get('tunnel_community', 'socks5_listen_ports'), list)
+        self.assertFalse(ccp.get('foo', 'bar'))
+
+        shutil.rmtree(unicode(temp_dir), ignore_errors=True)
+
+    def test_configparser_write_file_defaults(self):
+
+        temp_dir = mkdtemp(suffix="_tribler_test_session")
+        ccp = CallbackConfigParser(defaults={'foo': 'bar'})
+
+        new_path = os.path.join(temp_dir, 'config_new.conf')
+        ccp.write_file(new_path)
+
+        self.assertTrue(os.path.isfile(new_path))
+        ccp.read_file(new_path)
+        self.assertEqual(ccp.get('DEFAULT', 'foo'), 'bar')
+
+        shutil.rmtree(unicode(temp_dir), ignore_errors=True)

--- a/Tribler/Test/Core/test_configparser.py
+++ b/Tribler/Test/Core/test_configparser.py
@@ -1,8 +1,5 @@
 import os
-from ConfigParser import DEFAULTSECT
-from tempfile import mkdtemp
 
-import shutil
 from nose.tools import raises
 
 from Tribler.Core.Utilities.configparser import CallbackConfigParser
@@ -49,7 +46,6 @@ class TestConfigParser(TriblerCoreTest):
 
     @raises(OperationNotPossibleAtRuntimeException)
     def test_configparser_false_callback(self):
-
         def parser_callback(section, option, old_value, new_value):
             return False
 
@@ -59,12 +55,10 @@ class TestConfigParser(TriblerCoreTest):
         ccp.set('search_community', 'enabled', False)
 
     def test_configparser_write_file(self):
-
-        temp_dir = mkdtemp(suffix="_tribler_test_session")
         ccp = CallbackConfigParser()
         ccp.read_file(os.path.join(self.CONFIG_FILES_DIR, 'config1.conf'))
 
-        new_path = os.path.join(temp_dir, 'config_new.conf')
+        new_path = os.path.join(self.temp_dir, 'config_new.conf')
         ccp.write_file(new_path)
 
         self.assertTrue(os.path.isfile(new_path))
@@ -75,18 +69,12 @@ class TestConfigParser(TriblerCoreTest):
         self.assertIsInstance(ccp.get('tunnel_community', 'socks5_listen_ports'), list)
         self.assertFalse(ccp.get('foo', 'bar'))
 
-        shutil.rmtree(unicode(temp_dir), ignore_errors=True)
-
     def test_configparser_write_file_defaults(self):
-
-        temp_dir = mkdtemp(suffix="_tribler_test_session")
         ccp = CallbackConfigParser(defaults={'foo': 'bar'})
 
-        new_path = os.path.join(temp_dir, 'config_new.conf')
+        new_path = os.path.join(self.temp_dir, 'config_new.conf')
         ccp.write_file(new_path)
 
         self.assertTrue(os.path.isfile(new_path))
         ccp.read_file(new_path)
         self.assertEqual(ccp.get('DEFAULT', 'foo'), 'bar')
-
-        shutil.rmtree(unicode(temp_dir), ignore_errors=True)

--- a/Tribler/Test/Core/test_downloadconfig.py
+++ b/Tribler/Test/Core/test_downloadconfig.py
@@ -1,0 +1,84 @@
+import os
+from tempfile import mkdtemp
+
+import shutil
+from nose.tools import raises
+
+from Tribler.Core.DownloadConfig import DownloadConfigInterface, DownloadStartupConfig, get_default_dest_dir, \
+    get_default_dscfg_filename
+from Tribler.Core.Utilities.configparser import CallbackConfigParser
+from Tribler.Core.simpledefs import DLMODE_VOD, UPLOAD, DOWNLOAD
+from Tribler.Test.Core.base_test import TriblerCoreTest
+
+
+class TestConfigParser(TriblerCoreTest):
+
+    FILE_DIR = os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
+    CONFIG_FILES_DIR = os.path.abspath(os.path.join(FILE_DIR, u"data/config_files/"))
+
+    def test_downloadconfig(self):
+        dlconf = CallbackConfigParser()
+        dlconf.add_section('downloadconfig')
+        dlconf.set('downloadconfig', 'hops', 5)
+        dlcfg = DownloadConfigInterface(dlconf)
+
+        temp_dir = mkdtemp(suffix="_tribler_test_session")
+        self.assertIsInstance(dlcfg.get_dest_dir(), unicode)
+        dlcfg.set_dest_dir(temp_dir)
+        self.assertEqual(dlcfg.get_dest_dir(), temp_dir)
+
+        dlcfg.set_corrected_filename("foobar")
+        self.assertEqual(dlcfg.get_corrected_filename(), "foobar")
+
+        dlcfg.set_mode(1)
+        self.assertEqual(dlcfg.get_mode(), 1)
+
+        dlcfg.set_hops(4)
+        self.assertEqual(dlcfg.get_hops(), 4)
+
+        dlcfg.set_safe_seeding(False)
+        self.assertFalse(dlcfg.get_safe_seeding())
+
+        dlcfg.set_selected_files("foo.bar")
+        self.assertEqual(dlcfg.get_selected_files(), ["foo.bar"])
+
+        dlcfg.set_max_speed(UPLOAD, 1337)
+        dlcfg.set_max_speed(DOWNLOAD, 1338)
+        self.assertEqual(dlcfg.get_max_speed(UPLOAD), 1337)
+        self.assertEqual(dlcfg.get_max_speed(DOWNLOAD), 1338)
+
+    @raises(ValueError)
+    def test_downloadconfig_set_vod_multiple_files(self):
+        dlcfg = DownloadConfigInterface()
+        dlcfg.set_mode(DLMODE_VOD)
+        dlcfg.set_selected_files(["foo.txt", "bar.txt"])
+
+    def test_downloadconfig_copy(self):
+        dlcfg = DownloadConfigInterface()
+        dlcfg_copy = dlcfg.copy()
+
+        self.assertEqual(dlcfg_copy.get_hops(), 0)
+
+    def test_downloadstartupconfig_copy(self):
+        dlcfg = DownloadStartupConfig()
+        dlcfg_copy = dlcfg.copy()
+
+        self.assertEqual(dlcfg_copy.get_hops(), 0)
+
+    def test_startup_download_save_load(self):
+        temp_dir = mkdtemp(suffix="_tribler_test_session")
+        dlcfg = DownloadStartupConfig()
+        file_path = os.path.join(temp_dir, "downloadconfig.conf")
+        dlcfg.save(file_path)
+        dlcfg.load(file_path)
+
+        shutil.rmtree(unicode(temp_dir), ignore_errors=True)
+
+    @raises(IOError)
+    def test_startup_download_load_corrupt(self):
+        dlcfg = DownloadStartupConfig()
+        dlcfg.load(os.path.join(self.CONFIG_FILES_DIR, "corrupt_download_config.conf"))
+
+    def test_get_default_dest_dir(self):
+        self.assertIsInstance(get_default_dest_dir(), unicode)
+        self.assertIsInstance(get_default_dscfg_filename(""), str)

--- a/Tribler/Test/Core/test_downloadconfig.py
+++ b/Tribler/Test/Core/test_downloadconfig.py
@@ -1,7 +1,5 @@
 import os
-from tempfile import mkdtemp
 
-import shutil
 from nose.tools import raises
 
 from Tribler.Core.DownloadConfig import DownloadConfigInterface, DownloadStartupConfig, get_default_dest_dir, \
@@ -22,10 +20,9 @@ class TestConfigParser(TriblerCoreTest):
         dlconf.set('downloadconfig', 'hops', 5)
         dlcfg = DownloadConfigInterface(dlconf)
 
-        temp_dir = mkdtemp(suffix="_tribler_test_session")
         self.assertIsInstance(dlcfg.get_dest_dir(), unicode)
-        dlcfg.set_dest_dir(temp_dir)
-        self.assertEqual(dlcfg.get_dest_dir(), temp_dir)
+        dlcfg.set_dest_dir(self.temp_dir)
+        self.assertEqual(dlcfg.get_dest_dir(), self.temp_dir)
 
         dlcfg.set_corrected_filename("foobar")
         self.assertEqual(dlcfg.get_corrected_filename(), "foobar")
@@ -66,13 +63,10 @@ class TestConfigParser(TriblerCoreTest):
         self.assertEqual(dlcfg_copy.get_hops(), 0)
 
     def test_startup_download_save_load(self):
-        temp_dir = mkdtemp(suffix="_tribler_test_session")
         dlcfg = DownloadStartupConfig()
-        file_path = os.path.join(temp_dir, "downloadconfig.conf")
+        file_path = os.path.join(self.temp_dir, "downloadconfig.conf")
         dlcfg.save(file_path)
         dlcfg.load(file_path)
-
-        shutil.rmtree(unicode(temp_dir), ignore_errors=True)
 
     @raises(IOError)
     def test_startup_download_load_corrupt(self):

--- a/Tribler/Test/Core/test_network_utils.py
+++ b/Tribler/Test/Core/test_network_utils.py
@@ -16,10 +16,10 @@ class TriblerCoreTestNetworkUtils(TriblerCoreTest):
         self.assertTrue(random_port)
 
     def test_get_random_port_tcp(self):
-        reactor.listenTCP(9283, Factory())
+        listenport = reactor.listenTCP(9283, Factory())
         random_port = get_random_port(socket_type='tcp', min_port=9283, max_port=9283)
         self.assertEqual(random_port, 9284)
-        reactor.stop()
+        listenport.stopListening()
 
     def test_get_random_port_udp(self):
         random_port = get_random_port(socket_type='udp')

--- a/Tribler/Test/Core/test_sessionconfig.py
+++ b/Tribler/Test/Core/test_sessionconfig.py
@@ -1,7 +1,4 @@
 import os
-from tempfile import mkdtemp
-
-import shutil
 
 from nose.tools import raises
 
@@ -26,9 +23,8 @@ class TestSessionConfig(TriblerCoreTest):
         self.assertIsInstance(sci.get_mainline_dht_listen_port(), int)
         self.assertIsInstance(sci.get_default_state_dir(), unicode)
 
-        temp_dir = mkdtemp(suffix="_tribler_test_session")
-        sci.set_state_dir(temp_dir)
-        self.assertEqual(sci.get_state_dir(), temp_dir)
+        sci.set_state_dir(self.temp_dir)
+        self.assertEqual(sci.get_state_dir(), self.temp_dir)
 
         self.assertIsInstance(sci.get_install_dir(), str)
         self.assertIsInstance(sci.get_permid_keypair_filename(), str)
@@ -59,8 +55,8 @@ class TestSessionConfig(TriblerCoreTest):
         sci.set_torrent_store(False)
         self.assertFalse(sci.get_torrent_store())
 
-        sci.set_torrent_store_dir(temp_dir)
-        self.assertEqual(sci.get_torrent_store_dir(), temp_dir)
+        sci.set_torrent_store_dir(self.temp_dir)
+        self.assertEqual(sci.get_torrent_store_dir(), self.temp_dir)
 
         sci.set_torrent_collecting(False)
         self.assertFalse(sci.get_torrent_collecting())
@@ -71,8 +67,8 @@ class TestSessionConfig(TriblerCoreTest):
         sci.set_torrent_collecting_max_torrents(1337)
         self.assertEqual(sci.get_torrent_collecting_max_torrents(), 1337)
 
-        sci.set_torrent_collecting_dir(temp_dir)
-        self.assertEqual(sci.get_torrent_collecting_dir(), temp_dir)
+        sci.set_torrent_collecting_dir(self.temp_dir)
+        self.assertEqual(sci.get_torrent_collecting_dir(), self.temp_dir)
 
         sci.set_torrent_checking(False)
         self.assertFalse(sci.get_torrent_checking())
@@ -87,11 +83,11 @@ class TestSessionConfig(TriblerCoreTest):
         sci.set_mugshot("myimage", mime="image/png")
         self.assertEqual(sci.get_mugshot(), ("image/png", "myimage"))
 
-        sci.set_peer_icon_path(temp_dir)
-        self.assertEqual(sci.get_peer_icon_path(), temp_dir)
+        sci.set_peer_icon_path(self.temp_dir)
+        self.assertEqual(sci.get_peer_icon_path(), self.temp_dir)
 
-        sci.set_video_analyser_path(temp_dir)
-        self.assertEqual(sci.get_video_analyser_path(), temp_dir)
+        sci.set_video_analyser_path(self.temp_dir)
+        self.assertEqual(sci.get_video_analyser_path(), self.temp_dir)
 
         sci.set_mainline_dht(False)
         self.assertFalse(sci.get_mainline_dht())
@@ -112,8 +108,8 @@ class TestSessionConfig(TriblerCoreTest):
         sci.set_videoplayer(False)
         self.assertFalse(sci.get_videoplayer())
 
-        sci.set_videoplayer_path(temp_dir)
-        self.assertEqual(sci.get_videoplayer_path(), temp_dir)
+        sci.set_videoplayer_path(self.temp_dir)
+        self.assertEqual(sci.get_videoplayer_path(), self.temp_dir)
 
         sci.set_videoplayer_port(1337)
         self.assertIsInstance(sci.get_videoplayer_port(), int)
@@ -131,26 +127,20 @@ class TestSessionConfig(TriblerCoreTest):
         sci.set_enable_metadata(False)
         self.assertFalse(sci.get_enable_metadata())
 
-        sci.set_metadata_store_dir(temp_dir)
-        self.assertEqual(sci.get_metadata_store_dir(), temp_dir)
+        sci.set_metadata_store_dir(self.temp_dir)
+        self.assertEqual(sci.get_metadata_store_dir(), self.temp_dir)
 
         sci.set_upgrader_enabled(False)
         self.assertFalse(sci.get_upgrader_enabled())
 
-        self.assertIsInstance(sci.get_default_config_filename(temp_dir), str)
-
-        shutil.rmtree(unicode(temp_dir), ignore_errors=True)
+        self.assertIsInstance(sci.get_default_config_filename(self.temp_dir), str)
 
     def test_startup_session_save_load(self):
-        temp_dir = mkdtemp(suffix="_tribler_test_session")
-
         sci = SessionStartupConfig(CallbackConfigParser())
-        file_path = os.path.join(temp_dir, "startupconfig.conf")
+        file_path = os.path.join(self.temp_dir, "startupconfig.conf")
         sci.save(file_path)
 
         sci.load(file_path)
-
-        shutil.rmtree(unicode(temp_dir), ignore_errors=True)
 
     @raises(IOError)
     def test_startup_session_load_corrupt(self):

--- a/Tribler/Test/Core/test_sessionconfig.py
+++ b/Tribler/Test/Core/test_sessionconfig.py
@@ -1,0 +1,163 @@
+import os
+from tempfile import mkdtemp
+
+import shutil
+
+from nose.tools import raises
+
+from Tribler.Core.SessionConfig import SessionConfigInterface, SessionStartupConfig
+from Tribler.Core.Utilities.configparser import CallbackConfigParser
+from Tribler.Test.Core.base_test import TriblerCoreTest
+
+
+class TestSessionConfig(TriblerCoreTest):
+
+    FILE_DIR = os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
+    CONFIG_FILES_DIR = os.path.abspath(os.path.join(FILE_DIR, u"data/config_files/"))
+
+    def test_session_config_init(self):
+        sessconf = CallbackConfigParser()
+        sessconf.add_section('mainline_dht')
+        sessconf.set('mainline_dht', 'mainline_dht_port', 1234)
+        sci = SessionConfigInterface(sessconf)
+        self.assertTrue(sci)
+
+        self.assertIsInstance(sci.get_listen_port(), int)
+        self.assertIsInstance(sci.get_mainline_dht_listen_port(), int)
+        self.assertIsInstance(sci.get_default_state_dir(), unicode)
+
+        temp_dir = mkdtemp(suffix="_tribler_test_session")
+        sci.set_state_dir(temp_dir)
+        self.assertEqual(sci.get_state_dir(), temp_dir)
+
+        self.assertIsInstance(sci.get_install_dir(), str)
+        self.assertIsInstance(sci.get_permid_keypair_filename(), str)
+
+        sci.set_listen_port(1337)
+        self.assertEqual(sci.sessconfig.get('general', 'minport'), 1337)
+        self.assertEqual(sci.sessconfig.get('general', 'maxport'), 1337)
+
+        self.assertIsInstance(sci.get_tunnel_community_socks5_listen_ports(), list)
+        self.assertFalse(sci.get_tunnel_community_exitnode_enabled())
+        self.assertFalse(sci.get_barter_community_enabled())
+
+        sci.set_megacache(False)
+        self.assertFalse(sci.get_megacache())
+
+        sci.set_libtorrent(False)
+        self.assertFalse(sci.get_libtorrent())
+
+        sci.set_libtorrent_proxy_settings(3, ("127.0.0.1", 1337), ("foo", "bar"))
+        self.assertEqual(sci.get_libtorrent_proxy_settings(), (3, ("127.0.0.1", 1337), ("foo", "bar")))
+
+        sci.set_anon_proxy_settings(5, ("127.0.0.1", 1337), ("foo", "bar"))
+        self.assertEqual(sci.get_anon_proxy_settings(), (5, ("127.0.0.1", 1337), ("foo", "bar")))
+
+        sci.set_libtorrent_utp(False)
+        self.assertFalse(sci.get_libtorrent_utp())
+
+        sci.set_torrent_store(False)
+        self.assertFalse(sci.get_torrent_store())
+
+        sci.set_torrent_store_dir(temp_dir)
+        self.assertEqual(sci.get_torrent_store_dir(), temp_dir)
+
+        sci.set_torrent_collecting(False)
+        self.assertFalse(sci.get_torrent_collecting())
+
+        sci.set_dht_torrent_collecting(False)
+        self.assertFalse(sci.get_dht_torrent_collecting())
+
+        sci.set_torrent_collecting_max_torrents(1337)
+        self.assertEqual(sci.get_torrent_collecting_max_torrents(), 1337)
+
+        sci.set_torrent_collecting_dir(temp_dir)
+        self.assertEqual(sci.get_torrent_collecting_dir(), temp_dir)
+
+        sci.set_torrent_checking(False)
+        self.assertFalse(sci.get_torrent_checking())
+
+        sci.set_stop_collecting_threshold(1337)
+        self.assertEqual(sci.get_stop_collecting_threshold(), 1337)
+
+        sci.set_nickname("foobar")
+        self.assertEqual(sci.get_nickname(), "foobar")
+
+        self.assertEqual(sci.get_mugshot(), (None, None))
+        sci.set_mugshot("myimage", mime="image/png")
+        self.assertEqual(sci.get_mugshot(), ("image/png", "myimage"))
+
+        sci.set_peer_icon_path(temp_dir)
+        self.assertEqual(sci.get_peer_icon_path(), temp_dir)
+
+        sci.set_video_analyser_path(temp_dir)
+        self.assertEqual(sci.get_video_analyser_path(), temp_dir)
+
+        sci.set_mainline_dht(False)
+        self.assertFalse(sci.get_mainline_dht())
+
+        sci.set_mainline_dht_listen_port(1337)
+        self.assertEqual(sci.sessconfig.get('mainline_dht', 'mainline_dht_port'), 1337)
+
+        sci.set_multicast_local_peer_discovery(False)
+        self.assertFalse(sci.get_multicast_local_peer_discovery())
+
+        sci.set_dispersy(False)
+        self.assertFalse(sci.get_dispersy())
+
+        sci.set_dispersy_port(1337)
+        self.assertIsInstance(sci.get_dispersy_port(), int)
+        self.assertEqual(sci.sessconfig.get('dispersy', 'dispersy_port'), 1337)
+
+        sci.set_videoplayer(False)
+        self.assertFalse(sci.get_videoplayer())
+
+        sci.set_videoplayer_path(temp_dir)
+        self.assertEqual(sci.get_videoplayer_path(), temp_dir)
+
+        sci.set_videoplayer_port(1337)
+        self.assertIsInstance(sci.get_videoplayer_port(), int)
+        self.assertEqual(sci.sessconfig.get('video', 'port'), 1337)
+
+        sci.set_preferred_playback_mode(5)
+        self.assertEqual(sci.get_preferred_playback_mode(), 5)
+
+        sci.set_enable_torrent_search(False)
+        self.assertFalse(sci.get_enable_torrent_search())
+
+        sci.set_enable_channel_search(False)
+        self.assertFalse(sci.get_enable_channel_search())
+
+        sci.set_enable_metadata(False)
+        self.assertFalse(sci.get_enable_metadata())
+
+        sci.set_metadata_store_dir(temp_dir)
+        self.assertEqual(sci.get_metadata_store_dir(), temp_dir)
+
+        sci.set_upgrader_enabled(False)
+        self.assertFalse(sci.get_upgrader_enabled())
+
+        self.assertIsInstance(sci.get_default_config_filename(temp_dir), str)
+
+        shutil.rmtree(unicode(temp_dir), ignore_errors=True)
+
+    def test_startup_session_save_load(self):
+        temp_dir = mkdtemp(suffix="_tribler_test_session")
+
+        sci = SessionStartupConfig(CallbackConfigParser())
+        file_path = os.path.join(temp_dir, "startupconfig.conf")
+        sci.save(file_path)
+
+        sci.load(file_path)
+
+        shutil.rmtree(unicode(temp_dir), ignore_errors=True)
+
+    @raises(IOError)
+    def test_startup_session_load_corrupt(self):
+        sci = SessionStartupConfig()
+        sci.load(os.path.join(self.CONFIG_FILES_DIR, "corrupt_session_config.conf"))
+
+    def test_startup_session_load_no_filename(self):
+        sci = SessionStartupConfig()
+        sci.load()
+        self.assertTrue(sci)


### PR DESCRIPTION
Tribler is using various kinds of configuration files. I've written some basic unit tests for the general configuration file parser, the session configuration file and the download configuration file. Each of the tested files now has a coverage of > 90%.