### PR TITLE
Test improvements

### DIFF
--- a/Tribler/Test/API/test_download.py
+++ b/Tribler/Test/API/test_download.py
@@ -1,7 +1,7 @@
 from binascii import hexlify
 import logging
 import threading
-from Tribler.Core.simpledefs import dlstatus_strings
+from Tribler.Core.simpledefs import dlstatus_strings, DLSTATUS_DOWNLOADING
 from Tribler.Test.common import UBUNTU_1504_INFOHASH
 from Tribler.Test.test_as_server import TestAsServer
 from Tribler.Test.test_libtorrent_download import TORRENT_FILE, TORRENT_R
@@ -56,7 +56,7 @@ class TestDownload(TestAsServer):
                            dlstatus_strings[ds.get_status()],
                            ds.get_progress())
 
-        if ds.get_progress() > 0:
+        if ds.get_status() == DLSTATUS_DOWNLOADING:
             self.downloading_event.set()
 
         return 1.0, False

--- a/Tribler/Test/test_remote_search.py
+++ b/Tribler/Test/test_remote_search.py
@@ -61,10 +61,10 @@ class TestRemoteChannelSearch(BaseRemoteTest):
             self.quit()
 
         def do_doubleclick():
-            self.assert_(self.frame.searchlist.GetNrChannels() > 0, 'no channels matching tv',
+            self.assert_(self.frame.searchlist.GetNrChannels() > 0, 'no channels matching de',
                          tribler_session=self.guiUtility.utility.session, dump_statistics=True)
 
-            self.screenshot('After doing tv search, got %d results' % self.frame.searchlist.GetNrResults())
+            self.screenshot('After doing de search, got %d results' % self.frame.searchlist.GetNrResults())
             items = self.frame.searchlist.GetItems()
             for _, item in items.iteritems():
                 if isinstance(item, ChannelListItem):
@@ -78,7 +78,7 @@ class TestRemoteChannelSearch(BaseRemoteTest):
 
         def do_search():
             self.guiUtility.toggleFamilyFilter(newState=False, setCheck=True)
-            self.guiUtility.dosearch(u'tv')
+            self.guiUtility.dosearch(u'de')
             self.callLater(15, do_doubleclick)
 
         self.startTest(do_search, search_community=False, use_torrent_search=False, use_channel_search=True)


### PR DESCRIPTION
I made two improvements to the test suite:
-changed the keyword for the channel search to `de`. This is way more common than `tv` (I checked this in my own local Tribler database - `tv` has 25 hits where `de` has 300 hits). I've performed this test several times on my machine and I didn't have a single failure.
-the test that starts a download using the `start_download_from_uri` method in session now only checks whether a download has started.