### PR TITLE
Implement a win32 env var setter

### DIFF
--- a/Tribler/Main/tribler.py
+++ b/Tribler/Main/tribler.py
@@ -14,6 +14,11 @@ LOGGER_CONF = os.path.join(TRIBLER_ROOT, "logger.conf")
 if TRIBLER_ROOT not in sys.path:
     sys.path.insert(0, TRIBLER_ROOT)
 
+# tribler_exe.py: does this for windows in an uglier way.
+if sys.platform != 'win32':
+    # Make sure the installation dir is on the PATH
+    os.environ['PATH'] = os.path.abspath(TRIBLER_ROOT) + os.pathsep + os.environ['PATH']
+
 try:
     logging.config.fileConfig(LOGGER_CONF)
 except Exception as e:

--- a/Tribler/Main/tribler_exe.py
+++ b/Tribler/Main/tribler_exe.py
@@ -46,6 +46,7 @@ import os
 import sys
 
 
+# TODO(emilon): remove this when Tribler gets migrated to python 3.
 # From: https://measureofchaos.wordpress.com/2011/03/04/python-on-windows-unicode-environment-variables/
 def getEnvironmentVariable(name):
     """Get the unicode version of the value of an environment variable
@@ -56,6 +57,12 @@ def getEnvironmentVariable(name):
     buf = ctypes.create_unicode_buffer(u'\0' * n)
     ctypes.windll.kernel32.GetEnvironmentVariableW(name, buf, n)
     return buf.value
+
+def setEnvironmentVariable(name, value):
+    """Unicode compatible environment variable setter
+    """
+    if ctypes.windll.kernel32.SetEnvironmentVariableW(name, None) == 0:
+        raise RuntimeError("Failed to set env. variable '%s' to '%s" % (repr(name), repr(value)))
 
 LOG_PATH = os.path.join(getEnvironmentVariable(u"APPDATA"), u"Tribler.exe.log")
 OLD_LOG_PATH = os.path.join(getEnvironmentVariable(u"APPDATA"), u"Tribler.exe.old.log")
@@ -76,6 +83,8 @@ INSTALL_DIR = os.path.abspath(os.path.dirname(sys.argv[0]))
 
 if INSTALL_DIR not in sys.path:
     sys.path.append(INSTALL_DIR)
+
+setEnvironmentVariable("PATH", os.path.abspath(INSTALL_DIR) + os.pathsep + getEnvironmentVariable(u"PATH"))
 
 from Tribler.Main.tribler import __main__
 

--- a/Tribler/Main/tribler_main.py
+++ b/Tribler/Main/tribler_main.py
@@ -310,9 +310,6 @@ class ABCApp(object):
         """ Stage 1 start: pre-start the session to handle upgrade.
         """
 
-        # Make sure the installation dir is on the PATH
-        os.environ['PATH'] += os.pathsep + os.path.abspath(installdir)
-
         self.gui_image_manager = GuiImageManager.getInstance(installdir)
 
         # Start Tribler Session


### PR DESCRIPTION
To fix the case where the users' PATH env. var. contains non-ASCII
characters on windows.

I've moved the multiplatform version to tribler.py and skipped it in
case we are running windows too.