### PR TITLE
Lower "cannot exit data" log entry.

### DIFF
--- a/Tribler/community/tunnel/tunnel_community.py
+++ b/Tribler/community/tunnel/tunnel_community.py
@@ -1092,7 +1092,7 @@ class TunnelCommunity(Community):
                 if destination != ('0.0.0.0', 0):
                     self.exit_data(circuit_id, sock_addr, destination, data)
                 else:
-                    self.tunnel_logger.error("cannot exit data, destination is 0.0.0.0:0")
+                    self.tunnel_logger.warning("cannot exit data, destination is 0.0.0.0:0")
 
     def on_ping(self, messages):
         for message in messages:


### PR DESCRIPTION
It's on release code and Tribler keeps telling the user that errors
occurred.