### PR TITLE
Free space actually deletes items

### DIFF
--- a/Tribler/Core/CacheDB/sqlitecachedb.py
+++ b/Tribler/Core/CacheDB/sqlitecachedb.py
@@ -69,6 +69,14 @@ class SQLiteCacheDB(TaskManager):
         """The version of this database."""
         return self._version
 
+    @property
+    def connection(self):
+        """
+        Returns the connection of the database, which may be None if not initialized or closed.
+        :return: The connection object of the database
+        """
+        return self._connection
+
     @blocking_call_on_reactor_thread
     def initialize(self):
         """ Initializes the database. If the database doesn't exist, we create a new one. Otherwise, we check the
@@ -80,6 +88,9 @@ class SQLiteCacheDB(TaskManager):
 
     @blocking_call_on_reactor_thread
     def close(self):
+        """
+        Cancels all pending tasks and closes all cursors. Then, it closes the connection.
+        """
         self.cancel_all_pending_tasks()
         with self._cursor_lock:
             for cursor in self._cursor_table.itervalues():

--- a/Tribler/Core/Session.py
+++ b/Tribler/Core/Session.py
@@ -601,6 +601,16 @@ class Session(SessionConfigInterface):
             raise OperationNotEnabledByConfigurationException("torrent_store is not enabled")
         self.lm.torrent_store.put(hexlify(infohash), data)
 
+    def delete_collected_torrent(self, infohash):
+        """
+        Deletes the given torrent from the torrent_store database.
+        :param infohash: The given infohash binary.
+        """
+        if not self.get_torrent_store():
+            raise OperationNotEnabledByConfigurationException("torrent_store is not enabled")
+
+        del self.lm.torrent_store[hexlify(infohash)]
+
     def search_remote_torrents(self, keywords):
         """
         Searches for remote torrents through SearchCommunity with the given keywords.

--- a/Tribler/Test/Core/test_session.py
+++ b/Tribler/Test/Core/test_session.py
@@ -1,0 +1,41 @@
+from binascii import hexlify
+
+from nose.tools import raises
+
+from Tribler.Core.Session import Session
+from Tribler.Core.SessionConfig import SessionStartupConfig
+from Tribler.Core.exceptions import OperationNotEnabledByConfigurationException
+from Tribler.Core.leveldbstore import LevelDbStore
+from Tribler.Test.Core.base_test import TriblerCoreTest
+
+
+class testSession(TriblerCoreTest):
+
+    @raises(OperationNotEnabledByConfigurationException)
+    def test_torrent_store_not_enabled(self):
+        config = SessionStartupConfig()
+        config.set_torrent_store(False)
+        session = Session(config, ignore_singleton=True)
+        session.delete_collected_torrent(None)
+
+    def test_torrent_store_delete(self):
+        config = SessionStartupConfig()
+        config.set_torrent_store(True)
+        session = Session(config, ignore_singleton=True)
+        # Manually set the torrent store as we don't want to start the session.
+        session.lm.torrent_store = LevelDbStore(session.get_torrent_store_dir())
+        session.lm.torrent_store[hexlify("fakehash")] = "Something"
+        self.assertEqual("Something", session.lm.torrent_store[hexlify("fakehash")])
+        session.delete_collected_torrent("fakehash")
+
+        raised_key_error = False
+        # This structure is needed because if we add a @raises above the test, we cannot close the DB
+        # resulting in a dirty reactor.
+        try:
+            self.assertRaises(KeyError,session.lm.torrent_store[hexlify("fakehash")])
+        except KeyError:
+            raised_key_error = True
+        finally:
+            session.lm.torrent_store.close()
+
+        self.assertTrue(raised_key_error)


### PR DESCRIPTION
This PR fixes the bug where the freespace method does not delete anything. 


Fixes **1** bug
Added **1** (property) method for lint issues (enhancement). This can be used by other classes also accessing the protected member `_connection`.
Adds **2**  and modifies **1** tests.