### PR TITLE
Changed parameters of channel search test + removed blocking call to lookup trackers

### DIFF
--- a/Tribler/Core/Utilities/tracker_utils.py
+++ b/Tribler/Core/Utilities/tracker_utils.py
@@ -112,10 +112,4 @@ def parse_tracker_url(tracker_url):
     else:
         raise RuntimeError(u'No port number for UDP tracker URL.')
 
-    # TODO(emilon): A URL parser shoudn't have a blocking host resolution on it.
-    try:
-        hostname = socket.gethostbyname(hostname)
-    except:
-        raise RuntimeError(u'Cannot resolve tracker URL.')
-
     return tracker_type, (hostname, port), announce_page

--- a/Tribler/Test/Core/test_tracker_utils.py
+++ b/Tribler/Test/Core/test_tracker_utils.py
@@ -66,6 +66,3 @@ class TriblerCoreTestTrackerUtils(TriblerCoreTest):
     def test_parse_tracker_url_wrong_type_4(self):
         parse_tracker_url("http://tracker.openbittorrent.com:abc/announce")
 
-    @raises(RuntimeError)
-    def test_parse_tracker_url_no_resolve(self):
-        parse_tracker_url("http://notexistingexample123.com:80/announce")

--- a/Tribler/Test/test_remote_search.py
+++ b/Tribler/Test/test_remote_search.py
@@ -19,8 +19,8 @@ class BaseRemoteTest(TestGuiAsServer):
         else:
             def wait_for_chansearch():
                 self._logger.debug("Frame ready, starting to wait for channelsearch to be ready")
-                self.CallConditional(300, lambda: self.frame.SRstatusbar.GetChannelConnections() > 10, callback,
-                                     'did not connect to more than 10 peers within 300s',
+                self.CallConditional(300, lambda: self.frame.SRstatusbar.GetChannelConnections() > 16, callback,
+                                     'did not connect to more than 16 peers within 300s',
                                      assert_callback=lambda *argv, **kwarg: callback())
             super(BaseRemoteTest, self).startTest(wait_for_chansearch,
                                                   use_torrent_search=use_torrent_search,
@@ -79,7 +79,7 @@ class TestRemoteChannelSearch(BaseRemoteTest):
         def do_search():
             self.guiUtility.toggleFamilyFilter(newState=False, setCheck=True)
             self.guiUtility.dosearch(u'de')
-            self.callLater(15, do_doubleclick)
+            self.callLater(20, do_doubleclick)
 
         self.startTest(do_search, search_community=False, use_torrent_search=False, use_channel_search=True)
 


### PR DESCRIPTION
The channel search test is still failing because it cannot find channels (though a lot less than before). I increased the number of peers to have before the search can be executed. I also increased the callback time for the check whether there are channel results.

Still, these GUI tests needs a major refactoring but that's something for the longer term. Hopefully this change will increase the stability of the channel search test.