### PR TITLE
Fixes and changes to the Windows package script

### DIFF
--- a/Tribler/Main/Build/Win/tribler.nsi
+++ b/Tribler/Main/Build/Win/tribler.nsi
@@ -1,14 +1,14 @@
 !define PRODUCT "Tribler"
-; The __GIT__ string will be replaced by update_version_from_git.py
+; Laurens, 2016-03-14: The __GIT__ string will be replaced by update_version_from_git.py
 !define VERSION "__GIT__"
-; The _x86 will be replaced by _x64 if needed in update_version_from_git.py
+; Laurens, 2016-03-14: The _x86 will be replaced by _x64 if needed in update_version_from_git.py
 !define BITVERSION "_x86"
 
 !include "MUI.nsh"
 !include "UAC.nsh"
 !include "FileFunc.nsh"
 
-; Laurens, 2016-03-14: In order to use the UAC plugin we are required to set RequestExecutionLevel to user.
+; In order to use the UAC plugin we are required to set RequestExecutionLevel to user.
 RequestExecutionLevel user
 
 ;--------------------------------
@@ -334,22 +334,27 @@ Function .onInit
   StrCmp $R0 0 +3
 
   MessageBox MB_OK "The installer is already running."
-
   Abort
 
-  ReadRegStr $R0 HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT}" "UninstallString"
-  StrCmp $R0 "" done
-  IfFileExists $R0 +1 done
-
-  MessageBox MB_OKCANCEL|MB_ICONEXCLAMATION "${PRODUCT} is already installed. $\n$\nClick `OK` to remove the previous version or `Cancel` to cancel this upgrade." /SD IDOK IDOK uninst
+  FindWindow $0 "" "${PRODUCT}"
+  StrCmp $0 0 notRunning
+  MessageBox MB_OK|MB_ICONEXCLAMATION "${PRODUCT} is running. Please close it first." /SD IDOK
   Abort
+  notRunning:
 
-  uninst:
-    ClearErrors
-    ExecWait '$R0 _?=$INSTDIR' ;Do not copy the uninstaller to a temp file
     ReadRegStr $R0 HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT}" "UninstallString"
     StrCmp $R0 "" done
+    IfFileExists $R0 +1 done
+
+    MessageBox MB_OKCANCEL|MB_ICONEXCLAMATION "${PRODUCT} is already installed. $\n$\nClick `OK` to remove the previous version or `Cancel` to cancel this upgrade." /SD IDOK IDOK uninst
     Abort
+
+    uninst:
+      ClearErrors
+      ExecWait '$R0 _?=$INSTDIR' ;Do not copy the uninstaller to a temp file
+      ReadRegStr $R0 HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT}" "UninstallString"
+      StrCmp $R0 "" done
+      Abort
   done:
 
 FunctionEnd

--- a/Tribler/Main/Build/Win/tribler.nsi
+++ b/Tribler/Main/Build/Win/tribler.nsi
@@ -1,11 +1,14 @@
 !define PRODUCT "Tribler"
+; The __GIT__ string will be replaced by update_version_from_git.py
 !define VERSION "__GIT__"
+; The _x86 will be replaced by _x64 if needed in update_version_from_git.py
+!define BITVERSION "_x86"
 
 !include "MUI.nsh"
 !include "UAC.nsh"
 !include "FileFunc.nsh"
 
-; In order to use the UAC plugin we are required to set RequestExecutionLevel to user.
+; Laurens, 2016-03-14: In order to use the UAC plugin we are required to set RequestExecutionLevel to user.
 RequestExecutionLevel user
 
 ;--------------------------------
@@ -13,9 +16,10 @@ RequestExecutionLevel user
 
 ;General
 Name "${PRODUCT} ${VERSION}"
-OutFile "${PRODUCT}_${VERSION}.exe"
+OutFile "${PRODUCT}_${VERSION}_{$BITVERSION}.exe"
 
-;Folder selection page
+;Folder selection page. 
+; Laurens, 2016-03-14: Note that $PROGRAMFILES will be replaced by $PROGRAMFILES64 if needed from update_version_from_git.py.
 InstallDir "$PROGRAMFILES\${PRODUCT}"
 
 ;Remember install folder

--- a/Tribler/Main/Build/Win/tribler.nsi
+++ b/Tribler/Main/Build/Win/tribler.nsi
@@ -39,7 +39,7 @@ SetCompressor "lzma"
 ;
 ;SetCompress "off"
 
-CompletedText "Installation completed. Thank you for choosing ${PRODUCT}"
+CompletedText "Installation completed. Thank you for choosing ${PRODUCT}."
 
 BrandingText "${PRODUCT}"
 
@@ -76,13 +76,6 @@ BrandingText "${PRODUCT}"
 !define MUI_LICENSEPAGE_RADIOBUTTONS_TEXT_ACCEPT "I accept"
 !define MUI_LICENSEPAGE_RADIOBUTTONS_TEXT_DECLINE "I decline"
 
-; Arno, 2010-02-09: On Vista+Win7 the default value for RequestExecutionLevel
-; is auto, so this installer will be run as Administrator. Hence also the
-; Tribler.exe that is launched by FINISHPAGE_RUN will be launched as that user.
-; This is not what we want. We do want an admin-level install, in particular
-; for configuring the Windows firewall automatically. Alternative is the
-; UAC plugin (http://nsis.sourceforge.net/UAC_plug-in) but that's still beta.
-; Bouman, 2012-04-13: Now using the UAC plugin.
 !define MUI_FINISHPAGE_RUN
 !define MUI_FINISHPAGE_RUN_FUNCTION PageFinishRun
 
@@ -118,8 +111,8 @@ LangString DESC_SecDefaultMagnet ${LANG_ENGLISH} "Associate magnet links with ${
 
 Section "!Main EXE" SecMain
  SectionIn RO
-	; Check if tribler is not running when trying to install because files will be in use when cleaning the isntall dir.
-	Call checkrunning
+ ; Check if tribler is not running when trying to install because files will be in use when cleaning the isntall dir.
+ Call checkrunning
 
  ; Boudewijn, need to remove stuff from previously installed version
  RMDir /r "$INSTDIR"

--- a/Tribler/Main/Build/update_version_from_git.py
+++ b/Tribler/Main/Build/update_version_from_git.py
@@ -3,7 +3,7 @@
 from subprocess import Popen, PIPE
 from time import ctime
 from os import path, linesep
-from sys import platform
+import sys
 import logging
 
 logger = logging.getLogger(__name__)
@@ -39,12 +39,21 @@ if __name__ == '__main__':
     f.write(version_id)
     f.close()
 
-    if platform == 'linux2':
+    if sys.platform == 'linux2':
         runCommand('dch -v {} New upstream release.'.format(version_id).split())
-    elif platform == 'win32':
+    elif sys.platform == 'win32':
         logger.info('Replacing NSI string.')
         f = open(path.join('Tribler', 'Main', 'Build', 'Win', 'tribler.nsi'), 'r+')
-        content = f.read().replace('__GIT__', version_id)
+        content = f.read()
+
+        # Replace the __GIT__ string with the version id.
+        content = content.replace('__GIT__', version_id)
+
+        # Check if we are building 64 bit, replace the install dir and bit version accordingly.
+        if len(sys.argv) > 0 and sys.argv[1] == "64":
+            content = content.replace('_x86', '_x64')
+            content = content.replace('$PROGRAMFILES', '$PROGRAMFILES64')
+
         f.seek(0)
         f.write(content)
         f.close()

--- a/Tribler/Main/Build/update_version_from_git.py
+++ b/Tribler/Main/Build/update_version_from_git.py
@@ -51,7 +51,7 @@ if __name__ == '__main__':
 
         # Check if we are building 64 bit, replace the install dir and bit version accordingly.
         if len(sys.argv) > 0 and sys.argv[1] == "64":
-            content = content.replace('_x86', '_x64')
+            content = content.replace('x86', 'x64')
             content = content.replace('$PROGRAMFILES', '$PROGRAMFILES64')
 
         f.seek(0)


### PR DESCRIPTION
Fixes #2014, #1943, #1878

- The 64 bit will now have a `_x64` suffix and the 32 bit a `_x86`.
- Will now check if Tribler is running when installer or uninstalling
- Now installs in `Program files` when 64 bit rather than `Program files (x86)`
- Misc. improvements in strings and formatting.