### PR TITLE
Refactored tracker health check code to become asynchronous. Adjusted a part of the tribler shutdown procedure as a result.

### DIFF
--- a/Tribler/Core/Utilities/encoding.py
+++ b/Tribler/Core/Utilities/encoding.py
@@ -1,4 +1,7 @@
 import logging
+from json import dumps
+from urllib import unquote, urlencode
+from urlparse import urlparse, parse_qsl, ParseResult
 
 logger = logging.getLogger(__name__)
 
@@ -334,3 +337,44 @@ def decode(stream, offset=0):
         return _a_decode_mapping[stream[index]](stream, index + 1, int(stream[offset + 1:index]), _a_decode_mapping)
 
     raise ValueError("Unknown version found")
+
+def add_url_params(url, params):
+    """ Add GET params to provided URL being aware of existing.
+
+    :param url: string of target URL
+    :param params: dict containing requested params to be added
+    :return: string with updated URL
+
+    >> url = 'http://stackoverflow.com/test?answers=true'
+    >> new_params = {'answers': False, 'data': ['some','values']}
+    >> add_url_params(url, new_params)
+    'http://stackoverflow.com/test?data=some&data=values&answers=false'
+    """
+    # Unquoting URL first so we don't loose existing args
+    url = unquote(url)
+    # Extracting url info
+    parsed_url = urlparse(url)
+    # Extracting URL arguments from parsed URL
+    get_args = parsed_url.query
+    # Converting URL arguments to dict
+    parsed_get_args = dict(parse_qsl(get_args))
+    # Merging URL arguments dict with new params
+    parsed_get_args.update(params)
+
+    # Bool and Dict values should be converted to json-friendly values
+    # you may throw this part away if you don't like it :)
+    parsed_get_args.update(
+        {k: dumps(v) for k, v in parsed_get_args.items()
+         if isinstance(v, (bool, dict))}
+    )
+
+    # Converting URL argument to proper query string
+    encoded_get_args = urlencode(parsed_get_args, doseq=True)
+    # Creating new parsed result object based on provided with new
+    # URL arguments. Same thing happens inside of urlparse.
+    new_url = ParseResult(
+        parsed_url.scheme, parsed_url.netloc, parsed_url.path,
+        parsed_url.params, encoded_get_args, parsed_url.fragment
+    ).geturl()
+
+    return new_url

--- a/Tribler/Test/Core/test_torrentchecker.py
+++ b/Tribler/Test/Core/test_torrentchecker.py
@@ -1,0 +1,49 @@
+import time
+
+from Tribler.Core.Modules.tracker_manager import TrackerManager
+from Tribler.Core.TorrentChecker.session import UdpTrackerSession, HttpTrackerSession
+from Tribler.Core.TorrentChecker.torrent_checker import TorrentChecker
+from Tribler.Core.Utilities.twisted_thread import deferred
+from Tribler.Test.test_as_server import TestAsServer
+
+
+class TestTorrentChecker(TestAsServer):
+    """
+       This class contains tests which test the torrentchecker class.
+     """
+
+    @deferred(timeout=20)
+    def test_torrent_checker_session_timout_retry(self):
+        session = UdpTrackerSession("http://localhost/test", ("localhost", 4782), "/test", None)
+        session2 = HttpTrackerSession("http://localhost/test", ("localhost", 8475), "/test", None)
+        session._last_contact = int(time.time()) - (session.retry_interval() + 1)
+        session.create_connection()
+        session2.create_connection()
+        session._is_initiated = True
+        session2._is_initiated = True
+        self.session.lm.tracker_manager = TrackerManager(self.session)
+        self.session.lm.tracker_manager.initialize()
+        self.session.lm.tracker_manager.add_tracker('http://localhost/test')
+        torrent_checker = TorrentChecker(self.session)
+        torrent_checker._session_list.append(session)
+        torrent_checker._session_list.append(session2)
+        torrent_checker.check_sessions()
+        self.assertEqual(session._retries, 1, "Retries was %s while it should've been 1" % session._retries)
+        self.assertEqual(session2._retries, 0, "Retries was not 0")
+        return torrent_checker.shutdown()
+
+    @deferred(timeout=20)
+    def test_torrent_checker_udp_retry(self):
+        session = UdpTrackerSession("http://localhost/test", ("localhost", 4782), "/test", None)
+        session._last_contact = int(time.time()) - (session.retry_interval() + 1)
+        session.infohash_list.append("test")
+        session.create_connection()
+        self.session.lm.tracker_manager = TrackerManager(self.session)
+        self.session.lm.tracker_manager.initialize()
+        self.session.lm.tracker_manager.add_tracker('http://localhost/test')
+        torrent_checker = TorrentChecker(self.session)
+        torrent_checker._session_list.append(session)
+        torrent_checker._pending_response_dict["test"] = dict()
+        torrent_checker.check_timed_out_udp_session([session])
+        self.assertEqual(session._retries, 1, "Retries was %s while it should've been 1" % session._retries)
+        return torrent_checker.shutdown()

--- a/Tribler/Test/Core/test_torrentchecker_session.py
+++ b/Tribler/Test/Core/test_torrentchecker_session.py
@@ -5,6 +5,7 @@ from twisted.internet.task import Clock
 
 from twisted.internet.defer import Deferred, DeferredList
 
+
 from Tribler.Core.TorrentChecker.session import HttpTrackerSession, UDPScraper, UdpTrackerSession
 from Tribler.Core.Utilities.twisted_thread import deferred, reactor
 from Tribler.Test.Core.base_test import TriblerCoreTest
@@ -50,6 +51,14 @@ class TestTorrentCheckerSession(TriblerCoreTest):
     @deferred(timeout=5)
     def test_httpsession_cancel_operation(self):
         session = HttpTrackerSession("127.0.0.1", ("localhost", 8475), "/announce", None)
+        d = Deferred(session._on_cancel)
+        d.addErrback(lambda _ : None)
+        session.result_deferred = d
+        return session.cleanup()
+
+    @deferred(timeout=5)
+    def test_udpsession_cancel_operation(self):
+        session = UdpTrackerSession("127.0.0.1", ("localhost", 8475), "/announce", None)
         d = Deferred(session._on_cancel)
         d.addErrback(lambda _ : None)
         session.result_deferred = d

--- a/Tribler/Test/Core/test_torrentchecker_session.py
+++ b/Tribler/Test/Core/test_torrentchecker_session.py
@@ -1,0 +1,250 @@
+import struct
+from libtorrent import bencode
+
+from twisted.internet.task import Clock
+
+from twisted.internet.defer import Deferred, DeferredList
+
+from Tribler.Core.TorrentChecker.session import HttpTrackerSession, UDPScraper, UdpTrackerSession
+from Tribler.Core.Utilities.twisted_thread import deferred, reactor
+from Tribler.Test.Core.base_test import TriblerCoreTest
+
+
+class ClockedUDPCrawler(UDPScraper):
+    _reactor = Clock()
+
+
+class FakeScraper:
+    def write_data(self, _):
+        pass
+
+class TestTorrentCheckerSession(TriblerCoreTest):
+    def test_httpsession_scrape_no_body(self):
+        session = HttpTrackerSession("localhost", ("localhost", 8475), "/announce", None)
+        session._process_scrape_response(None)
+        session._infohash_list = []
+        self.assertTrue(session.is_failed)
+
+    def test_httpsession_bdecode_fails(self):
+        session = HttpTrackerSession("localhost", ("localhost", 8475), "/announce", None)
+        session._infohash_list = []
+        session._process_scrape_response("test")
+        self.assertTrue(session.is_failed)
+
+    def test_httpsession_code_not_200(self):
+        session = HttpTrackerSession("localhost", ("localhost", 8475), "/announce", None)
+
+        class FakeResponse:
+            code = 201
+            phrase = "unit testing!"
+
+        session.on_response(FakeResponse())
+        self.assertTrue(session.is_failed)
+
+    def test_httpsession_failure_reason_in_dict(self):
+        session = HttpTrackerSession("localhost", ("localhost", 8475), "/announce", None)
+        session._infohash_list = []
+        session._process_scrape_response(bencode({'failure reason': 'test'}))
+        self.assertTrue(session.is_failed)
+
+    @deferred(timeout=5)
+    def test_httpsession_cancel_operation(self):
+        session = HttpTrackerSession("127.0.0.1", ("localhost", 8475), "/announce", None)
+        d = Deferred(session._on_cancel)
+        d.addErrback(lambda _ : None)
+        session.result_deferred = d
+        return session.cleanup()
+
+    def test_udpsession_udp_tracker_timeout(self):
+        session = UdpTrackerSession("localhost", ("localhost", 4782), "/announce", None)
+        scraper = ClockedUDPCrawler(session, "127.0.0.1", 4782)
+        # Advance 16 seconds so the timeout triggered
+        scraper._reactor.advance(scraper.timeout_seconds + 1)
+        self.assertFalse(scraper.timeout.active(), "timeout was active while should've canceled")
+
+    @deferred(timeout=5)
+    def test_udp_scraper_stop_no_connection(self):
+        session = UdpTrackerSession("localhost", ("localhost", 4782), "/announce", None)
+        scraper = UDPScraper(session, "127.0.0.1", 4782)
+        # Stop it manually, so the transport becomes inactive
+        stop_deferred = scraper.stop()
+
+        return DeferredList([stop_deferred, session.cleanup()])
+
+    @deferred(timeout=5)
+    def test_udpsession_udp_tracker_connection_refused(self):
+        session = UdpTrackerSession("localhost", ("localhost", 4782), "/announce", None)
+        scraper = UDPScraper(session, "127.0.0.1", 4782)
+        scraper.connectionRefused()
+        self.assertTrue(session.is_failed, "Session did not fail while it should")
+        return scraper.stop()
+
+    @deferred(timeout=5)
+    def test_udpsession_udp_tracker_stop(self):
+        session = UdpTrackerSession("localhost", ("localhost", 4782), "/announce", None)
+        session.create_connection()
+        scraper = UDPScraper(session, "127.0.0.1", 4782)
+        session.scraper = scraper
+        reactor.listenUDP(0, scraper)
+        stop_deferred = scraper.stop()
+
+        def verify_timeout_stop(_):
+            self.assertFalse(scraper.timeout.active(), "timeout was active while should've fired.")
+
+        stop_deferred.addCallback(verify_timeout_stop)
+        return stop_deferred
+
+    def test_udpsession_handle_response_wrong_len(self):
+        session = UdpTrackerSession("localhost", ("localhost", 4782), "/announce", None)
+        self.assertFalse(session.is_failed)
+        session.handle_connection_response("too short")
+        self.assertTrue(session.is_failed)
+
+    def test_udpsession_handle_connection_wrong_action_transaction(self):
+        session = UdpTrackerSession("localhost", ("localhost", 4782), "/announce", None)
+        self.assertFalse(session.is_failed)
+        packet = struct.pack("!qq4s", 123, 123, "test")
+        session.handle_connection_response(packet)
+        self.assertTrue(session.is_failed)
+
+    def test_udpsession_handle_packet(self):
+        session = UdpTrackerSession("localhost", ("localhost", 4782), "/announce", None)
+        session.scraper = FakeScraper()
+        session._action = 123
+        session._transaction_id = 124
+        self.assertFalse(session.is_failed)
+        packet = struct.pack("!iiq", 123, 124, 126)
+        session.handle_connection_response(packet)
+        self.assertFalse(session.is_failed)
+
+    def test_udpsession_handle_wrong_action_transaction(self):
+        session = UdpTrackerSession("localhost", ("localhost", 4782), "/announce", None)
+        self.assertFalse(session.is_failed)
+        packet = struct.pack("!qq4s", 123, 123, "test")
+        session.handle_connection_response(packet)
+        self.assertTrue(session.is_failed)
+
+    def test_udpsession_mismatch(self):
+        session = UdpTrackerSession("localhost", ("localhost", 4782), "/announce", None)
+        session.scraper = FakeScraper()
+        session._action = 123
+        session._transaction_id = 124
+        session._infohash_list = [1337]
+        self.assertFalse(session.is_failed)
+        packet = struct.pack("!ii", 123, 124)
+        session.handle_response(packet)
+        self.assertTrue(session.is_failed)
+
+    def test_udpsession_response_too_short(self):
+        session = UdpTrackerSession("localhost", ("localhost", 4782), "/announce", None)
+        session.scraper = FakeScraper()
+        self.assertFalse(session.is_failed)
+        packet = struct.pack("!i", 123)
+        session.handle_response(packet)
+        self.assertTrue(session.is_failed)
+
+    def test_udpsession_response_wrong_transaction_id(self):
+        session = UdpTrackerSession("localhost", ("localhost", 4782), "/announce", None)
+        session.scraper = FakeScraper()
+        self.assertFalse(session.is_failed)
+        packet = struct.pack("!ii", 0, 1337)
+        session.handle_response(packet)
+        self.assertTrue(session.is_failed)
+
+    @deferred(timeout=5)
+    def test_udpsession_invalid_url(self):
+        session = UdpTrackerSession("udp://localhost/triblertest", ("blablafakeshizzle.kr", 4782), "/announce", None)
+        result_deferred = session.connect_to_tracker()
+
+        def on_error(_):
+            self.assertTrue(session.is_failed)
+
+        result_deferred.addErrback(on_error)
+
+        return result_deferred
+
+    @deferred(timeout=5)
+    def test_udpsession_cancel_old_deferreds(self):
+        session = UdpTrackerSession("udp://localhost/announce", ("localhost", 13468), "/announce", None)
+        session.create_connection()
+        session.ip_address = "127.0.0.1"
+        fake_func = lambda _: 1 + 1
+        fake_result_deferred = Deferred(fake_func)
+        fake_ip_reoslve_deferred = Deferred(fake_func)
+        session.result_deferred = fake_result_deferred
+        session.result_deferred.addErrback(fake_func)
+        session.ip_resolve_deferred = fake_ip_reoslve_deferred
+        session.ip_resolve_deferred.addErrback(fake_func)
+        result_deferred = session.connect_to_tracker()
+
+        def on_error(_):
+            pass
+
+        result_deferred.addErrback(on_error)
+
+        cleanup_deferred = session.cleanup()
+        return cleanup_deferred
+
+    def test_udpsession_response_list_len_mismatch(self):
+        session = UdpTrackerSession("localhost", ("localhost", 4782), "/announce", None)
+        session.scraper = FakeScraper()
+        session.result_deferred = Deferred()
+
+        def on_error(_):
+            pass
+
+        session.result_deferred.addErrback(on_error)
+        session._action = 123
+        session._transaction_id = 123
+        self.assertFalse(session.is_failed)
+        session._infohash_list = ["test", "test2"]
+        packet = struct.pack("!iiiii", 123, 123, 0, 1, 2)
+        session.handle_response(packet)
+        self.assertTrue(session.is_failed)
+
+    @deferred(timeout=5)
+    def test_udpsession_correct_handle(self):
+        session = UdpTrackerSession("localhost", ("localhost", 4782), "/announce", None)
+        session.create_connection()
+        session.on_ip_address_resolved("127.0.0.1")
+        session.result_deferred = Deferred()
+        self.assertFalse(session.is_failed)
+        session._infohash_list = ["test"]
+        packet = struct.pack("!iiiii", session._action, session._transaction_id, 0, 1, 2)
+        session.handle_response(packet)
+
+        return session.result_deferred
+
+    @deferred(timeout=5)
+    def test_big_correct_run(self):
+        session = UdpTrackerSession("localhost", ("192.168.1.1", 1234), "/announce", None)
+        session.create_connection()
+        session.on_ip_address_resolved("192.168.1.1")
+        session.result_deferred = Deferred()
+        self.assertFalse(session.is_failed)
+        packet = struct.pack("!iiq", session._action, session._transaction_id, 126)
+        session.scraper.datagramReceived(packet, (None, None))
+        session._infohash_list = ["test"]
+        packet = struct.pack("!iiiii", session._action, session._transaction_id, 0, 1, 2)
+        session.scraper.datagramReceived(packet, (None, None))
+
+        return session.result_deferred
+
+    def test_http_unprocessed_infohashes(self):
+        session = HttpTrackerSession("localhost", ("localhost", 8475), "/announce", None)
+        result_deffered = Deferred()
+        session.result_deferred = result_deffered
+        session._infohash_list.append("test")
+        response = bencode(dict())
+        session._process_scrape_response(response)
+        self.assertTrue(session.is_finished)
+
+    @deferred(timeout=5)
+    def test_scraper_stop_old(self):
+        session = UdpTrackerSession("localhost", ("localhost", 4782), "/announce", None)
+        session.create_connection()
+        scraper = UDPScraper(session, "127.0.0.1", 4782)
+        session.scraper = scraper
+        session.on_ip_address_resolved("127.0.0.1")
+        self.assertNotEquals(session.scraper, scraper, "Scrapers are identical while they should not be")
+        return session.cleanup()

--- a/Tribler/Test/Core/test_utilities.py
+++ b/Tribler/Test/Core/test_utilities.py
@@ -1,4 +1,6 @@
 from nose.tools import raises
+
+from Tribler.Core.Utilities.encoding import add_url_params
 from Tribler.Core.Utilities.utilities import validTorrentFile, isValidTorrentFile, parse_magnetlink
 from Tribler.Test.Core.base_test import TriblerCoreTest
 
@@ -216,3 +218,17 @@ class TriblerCoreTestUtilities(TriblerCoreTest):
     def test_parse_magnetlink_nomagnet(self):
         result = parse_magnetlink("http://")
         self.assertEqual(result, (None, None, []))
+
+    def test_add_url_param_some_present(self):
+        url = 'http://stackoverflow.com/test?answers=true'
+        new_params = {'answers': False, 'data': ['some', 'values']}
+        result = add_url_params(url, new_params)
+        self.assertEqual(result, 'http://stackoverflow.com/test?data=some&data=values&answers=false')
+
+    def test_add_url_param_clean(self):
+        url = 'http://stackoverflow.com/test'
+        new_params = {'data': ['some', 'values']}
+        result = add_url_params(url, new_params)
+        self.assertEqual(result, 'http://stackoverflow.com/test?data=some&data=values')
+
+

--- a/Tribler/Test/test_torrent_checking.py
+++ b/Tribler/Test/test_torrent_checking.py
@@ -7,7 +7,6 @@ from Tribler.Test.test_libtorrent_download import TORRENT_FILE
 
 
 class TestTorrentChecking(TestAsServer):
-
     def setUp(self):
         super(TestTorrentChecking, self).setUp()
 
@@ -36,4 +35,22 @@ class TestTorrentChecking(TestAsServer):
 
         num_seeders = torrent['num_seeders']
         num_leechers = torrent['num_leechers']
-        assert num_leechers >= 0 or num_seeders >= 0, "No peers found: leechers: %d seeders: %d" % (num_leechers, num_seeders)
+        assert num_leechers >= 0 or num_seeders >= 0, "No peers found: leechers: %d seeders: %d" % (
+        num_leechers, num_seeders)
+
+    def test_udp_torrent_checking(self):
+        tdef = TorrentDef.load(TORRENT_FILE)
+        tdef.set_tracker("udp://localhost")
+        tdef.metainfo_valid = True
+
+        self.tdb.addExternalTorrent(tdef)
+        self.session.check_torrent_health(tdef.get_infohash())
+        sleep(31)
+
+        torrent = self.tdb.getTorrent(tdef.get_infohash())
+        self._logger.debug('got torrent %s', torrent)
+
+        num_seeders = torrent['num_seeders']
+        num_leechers = torrent['num_leechers']
+        assert num_leechers >= 0 or num_seeders >= 0, \
+            "No peers found: leechers: %d seeders: %d" % (num_leechers, num_seeders)


### PR DESCRIPTION
More deletions than additions while keeping the same functionality (I hope), but much more clean!

- HTTP tracker code now makes use of Twisted's RedirectAgent. This means it will automatically redirect when a 30x code is returned, is asynchronous and has a timeout implemented. 
- The UDP tracker is now asynchronous, has a timeout added and has some bug fixes.
- Shutdown of a UDP connection is now asynchronous, this is propogated in Tribler where it preparations are made for other components to shutdown asynchronous as well by using Deferreds.

Fixes #2035, contributing to #1848

Adds **29** tests
Improves responsiveness a lot, watchdog was tripping with > 10 seconds timeout. Not anymore.
Fixed **2** bugs
Improved redirection by making use of Twisted's redirectAgent
Added lots of documentation for other generations to read (enchancement)
Fixed **50+** pylint style errors
