### PR TITLE
ON HOLD: Refactor general excepts

### DIFF
--- a/Tribler/Category/Category.py
+++ b/Tribler/Category/Category.py
@@ -4,6 +4,7 @@
 import os
 import re
 import logging
+from ConfigParser import MissingSectionHeaderError, ParsingError
 
 from Tribler import LIBRARYNAME
 from Tribler.Category.init_category import getCategoryInfo
@@ -31,7 +32,7 @@ class Category(object):
         try:
             self.category_info = getCategoryInfo(filename)
             self.category_info.sort(cmp_rank)
-        except:
+        except (MissingSectionHeaderError, ParsingError, IOError):
             self.category_info = []
             self._logger.critical('', exc_info=True)
 
@@ -89,14 +90,8 @@ class Category(object):
         return self.calculateCategoryNonDict(files_list, display_name, tracker, comment)
 
     def calculateCategoryNonDict(self, files_list, display_name, tracker, comment):
-        # Check xxx
-        try:
-
-            if self.xxx_filter.isXXXTorrent(files_list, display_name, tracker, comment):
-                return 'xxx'
-        except:
-            self._logger.critical(
-                'Category: Exception in explicit terms filter in torrent: %s', display_name, exc_info=True)
+        if self.xxx_filter.isXXXTorrent(files_list, display_name, tracker, comment):
+            return 'xxx'
 
         torrent_category = None
         # filename_list ready
@@ -125,7 +120,7 @@ class Category(object):
             try:
                 fileKeywords.index(ikeywords)
                 factor *= 1 - category['keywords'][ikeywords]
-            except:
+            except ValueError:
                 pass
         if (1 - factor) > 0.5:
             if 'strength' in category:
@@ -161,7 +156,7 @@ class Category(object):
                     fileKeywords.index(ikeywords)
                     # print ikeywords
                     factor *= 1 - category['keywords'][ikeywords]
-                except:
+                except ValueError:
                     pass
             if factor < 0.5:
                 matchSize += length

--- a/Tribler/Category/FamilyFilter.py
+++ b/Tribler/Category/FamilyFilter.py
@@ -33,8 +33,8 @@ class XXXFilter(object):
                 else:
                     terms.add(line)
             f.close()
-        except:
-            self._logger.exception(u"Failed to init terms.")
+        except IOError:
+            self._logger.exception(u"Could not open %s, initTerms failed.", filename)
 
         self._logger.debug('Read %d XXX terms from file %s', len(terms) + len(searchterms), filename)
         return terms, searchterms

--- a/Tribler/Core/DownloadConfig.py
+++ b/Tribler/Core/DownloadConfig.py
@@ -14,6 +14,7 @@
 #
 
 import os
+from ConfigParser import ParsingError
 from types import StringType
 
 from Tribler.Core.Utilities.configparser import CallbackConfigParser
@@ -191,8 +192,8 @@ class DownloadStartupConfig(DownloadConfigInterface):
         dlconfig = CallbackConfigParser()
         try:
             dlconfig.read_file(filename)
-        except:
-            raise IOError, "Failed to open download config file"
+        except (ParsingError, IOError):
+            raise IOError, "Failed to open download config file: %s" % filename
 
         return DownloadStartupConfig(dlconfig)
 

--- a/Tribler/Core/Libtorrent/LibtorrentDownloadImpl.py
+++ b/Tribler/Core/Libtorrent/LibtorrentDownloadImpl.py
@@ -27,7 +27,7 @@ from Tribler.Core.simpledefs import (DLSTATUS_WAITING4HASHCHECK, DLSTATUS_HASHCH
 if sys.platform == "win32":
     try:
         import ctypes
-    except:
+    except ImportError:
         pass
 
 
@@ -635,7 +635,7 @@ class LibtorrentDownloadImpl(DownloadConfigInterface):
                             if sys.platform == "win32":
                                 ctypes.windll.kernel32.SetFileAttributesW(
                                     unwanteddir_abs, 2)  # 2 = FILE_ATTRIBUTE_HIDDEN
-                        except:
+                        except OSError:
                             self._logger.error("LibtorrentDownloadImpl: could not create %s" % unwanteddir_abs)
                             # Note: If the destination directory can't be accessed, libtorrent will not be able to store the files.
                             # This will result in a DLSTATUS_STOPPED_ON_ERROR.

--- a/Tribler/Core/Modules/tracker_manager.py
+++ b/Tribler/Core/Modules/tracker_manager.py
@@ -88,7 +88,6 @@ class TrackerManager(object):
         sanitized_tracker_url = get_uniformed_tracker_url(tracker_url)
         return self._tracker_dict.get(sanitized_tracker_url)
 
-    @call_on_reactor_thread
     def update_tracker_info(self, tracker_url, is_successful):
         """
         Updates a tracker information.

--- a/Tribler/Core/Utilities/network_utils.py
+++ b/Tribler/Core/Utilities/network_utils.py
@@ -102,7 +102,7 @@ def autodetect_socket_style():
             dual_socket_style = int(f.read())
             f.close()
             return int(not dual_socket_style)
-        except:
+        except (IOError, ValueError):
             return 0
 
 

--- a/Tribler/Core/Utilities/tracker_utils.py
+++ b/Tribler/Core/Utilities/tracker_utils.py
@@ -60,7 +60,7 @@ def get_uniformed_tracker_url(tracker_url):
 
     try:
         port = int(port)
-    except:
+    except ValueError:
         return
 
     page = page_part
@@ -102,10 +102,7 @@ def parse_tracker_url(tracker_url):
     # get port number if exists, otherwise, use HTTP default 80
     if hostname_part.find(u':') != -1:
         hostname, port = hostname_part.split(u':', 1)
-        try:
-            port = int(port)
-        except:
-            raise RuntimeError(u'Invalid port number.')
+        port = int(port)
     elif tracker_type == u'HTTP':
         hostname = hostname_part
         port = 80

--- a/Tribler/Core/Utilities/utilities.py
+++ b/Tribler/Core/Utilities/utilities.py
@@ -170,8 +170,8 @@ def isValidTorrentFile(metainfo):
     try:
         validTorrentFile(metainfo)
         return True
-    except:
-        print_exc()
+    except ValueError:
+        logger.exception("Could not check torrentfile: a ValueError was thrown")
         return False
 
 

--- a/Tribler/Core/Video/VideoPlayer.py
+++ b/Tribler/Core/Video/VideoPlayer.py
@@ -159,8 +159,8 @@ class VideoPlayer(object):
             # Launch an external player. Play URL from network or disk.
             try:
                 self.player_out, self.player_in = os.popen2(cmd, 'b')
-            except:
-                print_exc()
+            except OSError:
+                self._logger.exception("An OSError was thrown, could not launch video player")
 
     def get_video_player(self, ext, videourl):
         if self.playbackmode == PLAYBACKMODE_INTERNAL:

--- a/Tribler/Main/Dialogs/SaveAs.py
+++ b/Tribler/Main/Dialogs/SaveAs.py
@@ -33,7 +33,7 @@ class SaveAs(wx.Dialog):
         self.filehistory = []
         try:
             self.filehistory = json.loads(self.utility.read_config("recent_download_history", literal_eval=False))
-        except:
+        except (ValueError, TypeError):
             pass
 
         self.defaultdir = defaultdir

--- a/Tribler/Main/Dialogs/systray.py
+++ b/Tribler/Main/Dialogs/systray.py
@@ -7,7 +7,7 @@ from Tribler.Main.Utility.utility import speed_format
 try:
     import win32gui  # , win32con
     WIN32 = True
-except:
+except ImportError:
     WIN32 = False
 
 #

--- a/Tribler/Main/Utility/GuiDBHandler.py
+++ b/Tribler/Main/Utility/GuiDBHandler.py
@@ -307,7 +307,7 @@ def startWorker(
                 filename, line, function, _ = extract_stack(limit=2)[0]
                 _, filename = os.path.split(filename)
                 jobID = u"%s:%s (%s)" % (filename, line, function)
-            except:
+            except ZeroDivisionError:
                 pass
 
     result = ASyncDelayedResult(jobID)

--- a/Tribler/Test/Category/test_category.py
+++ b/Tribler/Test/Category/test_category.py
@@ -1,7 +1,8 @@
 import os
 from nose.tools import raises
 from Tribler.Category.Category import Category, cmp_rank
-from Tribler.Test.test_as_server import BaseTestCase, AbstractServer
+from Tribler.Test.test_as_server import AbstractServer
+from Tribler.Category import Category as category
 
 
 class TriblerCategoryTest(AbstractServer):
@@ -11,6 +12,7 @@ class TriblerCategoryTest(AbstractServer):
 
     def tearDown(self):
         Category.delInstance()
+        category.CATEGORY_CONFIG_FILE = "category.conf"
 
     @raises(RuntimeError)
     def test_category_singleton(self):
@@ -53,3 +55,8 @@ class TriblerCategoryTest(AbstractServer):
     def test_cmp_rank(self):
         self.assertEquals(cmp_rank({'bla': 3}, {'bla': 4}), 1)
         self.assertEquals(cmp_rank({'rank': 3}, {'bla': 4}), -1)
+
+    def test_conf_not_found(self):
+        category.CATEGORY_CONFIG_FILE = "nonexistant"
+        cat = Category.getInstance(install_dir=self.CATEGORY_TEST_DATA_DIR)
+        self.assertEquals(cat.category_info, [])

--- a/Tribler/Test/Category/test_family_filter.py
+++ b/Tribler/Test/Category/test_family_filter.py
@@ -1,4 +1,7 @@
 import os
+
+from nose.tools import raises
+
 from Tribler.Category.FamilyFilter import XXXFilter
 from Tribler.Test.test_as_server import AbstractServer
 
@@ -26,3 +29,10 @@ class TriblerCategoryTestFamilyFilter(AbstractServer):
         self.assertFalse(family_filter.isXXXTerm("term0es"))
         self.assertTrue(family_filter.isXXXTerm("term1s"))
         self.assertFalse(family_filter.isXXXTerm("term0n"))
+
+    def test_invalid_filename_exception(self):
+        family_filter = XXXFilter(self.CATEGORY_TEST_DATA_DIR)
+        terms, searchterms = family_filter.initTerms("thisfiledoesnotexist.txt")
+        self.assertEqual(len(terms), 0)
+        self.assertEqual(len(searchterms), 0)
+

--- a/Tribler/Test/Community/Channel/__init__.py
+++ b/Tribler/Test/Community/Channel/__init__.py
@@ -1,0 +1,3 @@
+"""
+This package contains various unit tests to test the channel community
+"""

--- a/Tribler/Test/Community/Channel/test_channel_base.py
+++ b/Tribler/Test/Community/Channel/test_channel_base.py
@@ -1,0 +1,23 @@
+from Tribler.community.channel.community import ChannelCommunity
+
+from Tribler.Test.test_as_server import AbstractServer
+from Tribler.dispersy.dispersy import Dispersy
+from Tribler.dispersy.endpoint import ManualEnpoint
+from Tribler.dispersy.member import DummyMember
+from Tribler.dispersy.requestcache import RequestCache
+from Tribler.dispersy.util import blocking_call_on_reactor_thread
+
+
+class AbstractTestChannelCommunity(AbstractServer):
+
+    # We have to initialize Dispersy and the channel community on the reactor thread
+    @blocking_call_on_reactor_thread
+    def setUp(self):
+        super(AbstractTestChannelCommunity, self).setUp()
+
+        self.dispersy = Dispersy(ManualEnpoint(0), self.getStateDir())
+        self.dispersy._database.open()
+        self.master_member = DummyMember(self.dispersy, 1, "a" * 20)
+        self.member = self.dispersy.get_new_member(u"curve25519")
+        self.channel_community = ChannelCommunity(self.dispersy, self.master_member, self.member)
+        self.channel_community._request_cache = RequestCache()

--- a/Tribler/Test/Community/Channel/test_channelcommunity.py
+++ b/Tribler/Test/Community/Channel/test_channelcommunity.py
@@ -1,0 +1,44 @@
+from Tribler.Test.Community.Channel.test_channel_base import AbstractTestChannelCommunity
+from Tribler.dispersy.exception import MetaNotFoundException
+from Tribler.dispersy.util import blocking_call_on_reactor_thread
+
+
+class TestTunnelCommunity(AbstractTestChannelCommunity):
+
+    def raiseRuntimeErorr(self):
+        raise RuntimeError("Unit-testing")
+
+    def raiseMetaNotFoundException(self):
+        raise MetaNotFoundException("Unit-testing")
+
+    @blocking_call_on_reactor_thread
+    def test_initialize_error_runtimeError(self):
+        """
+        Tests whether the channel community can handle the _get_latest_channel_message throwing
+        a RuntimeError.
+        """
+        self.channel_community._get_latest_channel_message = self.raiseRuntimeErorr
+        self.channel_community.initialize()
+
+    @blocking_call_on_reactor_thread
+    def test_initialize_error_metanotfoundexception(self):
+        """
+        Tests whether the channel community can handle the _get_latest_channel_message throwing
+        a raiseMetaNotFoundException
+        """
+        self.channel_community._get_latest_channel_message = self.raiseMetaNotFoundException
+        self.channel_community.initialize()
+
+    @blocking_call_on_reactor_thread
+    def test_initialize_runs_ok(self):
+        """
+        Tests whether the channel community can initialize fine without a Tribler session.
+        """
+        self.channel_community.initialize()
+
+
+    def test_dispersy_sync_response_limit(self):
+        self.assertEqual(self.channel_community.dispersy_sync_response_limit, 25 * 1024)
+
+    def test_get_channel_id_none(self):
+        self.assertIsNone(self.channel_community.get_channel_id())

--- a/Tribler/Test/Core/test_tracker_utils.py
+++ b/Tribler/Test/Core/test_tracker_utils.py
@@ -62,7 +62,7 @@ class TriblerCoreTestTrackerUtils(TriblerCoreTest):
     def test_parse_tracker_url_wrong_type_3(self):
         parse_tracker_url("http://tracker.openbittorrent.com:80")
 
-    @raises(RuntimeError)
+    @raises(ValueError)
     def test_parse_tracker_url_wrong_type_4(self):
         parse_tracker_url("http://tracker.openbittorrent.com:abc/announce")
 

--- a/Tribler/community/channel/community.py
+++ b/Tribler/community/channel/community.py
@@ -716,7 +716,7 @@ class ChannelCommunity(Community):
                 try:
                     data = json.loads(message.payload.modification_value)
                     thumbnail_hash = data[u'thumb_hash'].decode('hex')
-                except:
+                except ValueError:
                     yield DropMessage(message, "Not compatible json format")
                     continue
                 else:

--- a/Tribler/community/channel/community.py
+++ b/Tribler/community/channel/community.py
@@ -15,6 +15,7 @@ from Tribler.dispersy.community import Community
 from Tribler.dispersy.conversion import DefaultConversion
 from Tribler.dispersy.destination import CandidateDestination, CommunityDestination
 from Tribler.dispersy.distribution import FullSyncDistribution, DirectDistribution
+from Tribler.dispersy.exception import MetaNotFoundException
 from Tribler.dispersy.message import BatchConfiguration, Message, DropMessage, DelayMessageByProof
 from Tribler.dispersy.resolution import LinearResolution, PublicResolution, DynamicResolution
 from Tribler.dispersy.util import call_on_reactor_thread
@@ -87,7 +88,7 @@ class ChannelCommunity(Community):
                 message = self._get_latest_channel_message()
                 if message:
                     self._channel_id = self.cid
-            except:
+            except (MetaNotFoundException, RuntimeError):
                 pass
 
             from Tribler.community.allchannel.community import AllChannelCommunity


### PR DESCRIPTION
A lot of general try excepts are in the wx code which I will not trace because 1. this will be deleted soon 2. most of them are impossible to find qua what they can raise.

Some code chunks are too big or calling C libraries for which no doc is enclosed.

Also note that a lot of general excepts are in the submodules which this PR will not cover.

Contributes, but probably does not fix #1823

Fixes #2183 - **1** bug
Adds **6** tests
Makes sure no bugs under the carpet are swallowed (enhancement)