### PR TITLE
Refactored a callback to deferred in libtorrentdownloadmanagerimpl

### DIFF
--- a/Tribler/Core/APIImplementation/LaunchManyCore.py
+++ b/Tribler/Core/APIImplementation/LaunchManyCore.py
@@ -270,8 +270,8 @@ class TriblerLaunchMany(TaskManager):
 
             # Store in list of Downloads, always.
             self.downloads[infohash] = d
-            d.setup(dscfg, pstate, initialdlstatus, self.network_engine_wrapper_created_callback,
-                    wrapperDelay=setupDelay)
+            setup_deferred = d.setup(dscfg, pstate, initialdlstatus, wrapperDelay=setupDelay)
+            setup_deferred.addCallback(self.on_download_wrapper_created)
 
         if d and not hidden and self.session.get_megacache():
             @forceDBThread
@@ -292,7 +292,7 @@ class TriblerLaunchMany(TaskManager):
 
         return d
 
-    def network_engine_wrapper_created_callback(self, d, pstate):
+    def on_download_wrapper_created(self, (d, pstate)):
         """ Called by network thread """
         try:
             if pstate is None:

--- a/Tribler/Test/Core/test_libtorrent_download_impl.py
+++ b/Tribler/Test/Core/test_libtorrent_download_impl.py
@@ -1,0 +1,142 @@
+import os
+
+from Tribler.Core.DownloadConfig import DownloadStartupConfig
+from Tribler.Core.Libtorrent.LibtorrentDownloadImpl import LibtorrentDownloadImpl
+from Tribler.Core.SessionConfig import SessionStartupConfig
+from Tribler.Core.TorrentDef import TorrentDef
+from Tribler.Core.Utilities.configparser import CallbackConfigParser
+from Tribler.Core.Utilities.twisted_thread import deferred, reactor
+from Tribler.Test.test_as_server import TestAsServer, TESTS_DATA_DIR
+
+
+class TestLibtorrentDownloadImpl(TestAsServer):
+    """
+    This class provides unit tests tha tes tthe LibtorrentDownloadImpl class.
+    """
+
+    def setUpPreSession(self):
+        super(TestLibtorrentDownloadImpl, self).setUpPreSession()
+        self.config = SessionStartupConfig()
+        self.config.set_state_dir(self.getStateDir())
+        self.config.set_torrent_checking(False)
+        self.config.set_multicast_local_peer_discovery(False)
+        self.config.set_megacache(True)
+        self.config.set_dispersy(True)
+        self.config.set_mainline_dht(False)
+        self.config.set_torrent_collecting(True)
+        self.config.set_libtorrent(True)
+        self.config.set_dht_torrent_collecting(False)
+        self.config.set_videoplayer(False)
+        self.config.set_torrent_collecting_dir(os.path.join(self.session_base_dir, 'torrent_collecting_dir'))
+
+    @deferred(timeout=10)
+    def test_can_create_engine_wrapper(self):
+        impl = LibtorrentDownloadImpl(self.session, None)
+        impl.cew_scheduled = False
+        self.session.lm.ltmgr.is_dht_ready = lambda: True
+        return impl.can_create_engine_wrapper()
+
+    @deferred(timeout=15)
+    def test_can_create_engine_wrapper_retry(self):
+        impl = LibtorrentDownloadImpl(self.session, None)
+        impl.cew_scheduled = True
+        def set_cew_false():
+            self.session.lm.ltmgr.is_dht_ready = lambda: True
+            impl.cew_scheduled = False
+
+        # Simulate Tribler changing the cew, the calllater should have fired by now
+        # and before it executed the cew is false, firing the deferred.
+        reactor.callLater(2, set_cew_false)
+        return impl.can_create_engine_wrapper()
+
+    def test_get_magnet_link_none(self):
+        tdef = TorrentDef()
+        sourcefn = os.path.join(TESTS_DATA_DIR, 'video.avi')
+        tdef.add_content(sourcefn)
+        tdef.set_tracker("http://localhost/announce")
+        tdef.finalize()
+
+        torrentfn = os.path.join(self.session.get_state_dir(), "gen.torrent")
+        tdef.save(torrentfn)
+
+        impl = LibtorrentDownloadImpl(self.session, tdef)
+        link = impl.get_magnet_link()
+        self.assertEqual(None, link, "Magnet link was not none while it should be!")
+
+    def test_get_tdef(self):
+        tdef = TorrentDef()
+        sourcefn = os.path.join(TESTS_DATA_DIR, 'video.avi')
+        tdef.add_content(sourcefn)
+        tdef.set_tracker("http://localhost/announce")
+        tdef.finalize()
+
+        torrentfn = os.path.join(self.session.get_state_dir(), "gen.torrent")
+        tdef.save(torrentfn)
+
+        impl = LibtorrentDownloadImpl(self.session, None)
+        impl.set_def(tdef)
+        self.assertEqual(impl.tdef, tdef, "Torrent definitions were not equal!")
+
+    @deferred(timeout=20)
+    def test_setup(self):
+        tdef = TorrentDef()
+        sourcefn = os.path.join(TESTS_DATA_DIR, 'video.avi')
+        tdef.add_content(sourcefn)
+        tdef.set_tracker("http://localhost/announce")
+        tdef.finalize()
+
+        torrentfn = os.path.join(self.session.get_state_dir(), "gen.torrent")
+        tdef.save(torrentfn)
+
+        impl = LibtorrentDownloadImpl(self.session, tdef)
+        def callback((ignored, ignored2)):
+            pass
+
+        deferred = impl.setup(None, None, None, 0)
+        deferred.addCallback(callback)
+        return deferred
+
+    def test_restart(self):
+        tdef = TorrentDef()
+        sourcefn = os.path.join(TESTS_DATA_DIR, 'video.avi')
+        tdef.add_content(sourcefn)
+        tdef.set_tracker("http://localhost/announce")
+
+        tdef.finalize()
+
+        torrentfn = os.path.join(self.session.get_state_dir(), "gen.torrent")
+        tdef.save(torrentfn)
+
+        impl = LibtorrentDownloadImpl(self.session, tdef)
+        impl.handle = None
+        # Create a dummy download config
+        impl.dlconfig = DownloadStartupConfig().dlconfig.copy()
+        impl.session.lm.on_download_wrapper_created = lambda _: True
+        impl.restart()
+
+    @deferred(timeout=20)
+    def test_multifile_torrent(self):
+        t = TorrentDef()
+
+        dn = os.path.join(TESTS_DATA_DIR, "contentdir")
+        t.add_content(dn, "dirintorrent")
+
+        fn = os.path.join(TESTS_DATA_DIR, "video.avi")
+        t.add_content(fn, os.path.join("dirintorrent", "video.avi"))
+
+        t.set_tracker("http://tribler.org/announce")
+        t.finalize()
+
+        impl = LibtorrentDownloadImpl(self.session, t)
+        # Override the addtorrent because it will be called
+        impl.ltmgr = self.session.lm.ltmgr
+        impl.ltmgr.add_torrent = lambda ignored, ignored2: False
+        # Create a dummy download config
+        impl.dlconfig = DownloadStartupConfig().dlconfig.copy()
+        # Create a dummy pstate
+        pstate = CallbackConfigParser()
+        pstate.add_section("state")
+        test_dict = dict()
+        test_dict["a"] = "b"
+        pstate.set("state", "engineresumedata", test_dict)
+        return impl.network_create_engine_wrapper(pstate)


### PR DESCRIPTION
Removed a callback being passed to two functions in libtorrentdownloadimpl, refactored one of them and let the other return a deferred instead.

Fixes #2032

Fixes **1** PEP8 violation in launchmanycores (enchancement)
Removes several callbacks to use deferreds instead (code complexity/quality enchancement)
Adds **7** tests that cover the libtorrentdownloadmanagerimpl
**improves** responsiveness by making use of asynchronous callbacks. 