### PR TITLE
Fixed a memory issue when running the tunnel helpers

### DIFF
--- a/Tribler/Test/Community/Tunnel/test_tunnelhelper.py
+++ b/Tribler/Test/Community/Tunnel/test_tunnelhelper.py
@@ -1,0 +1,11 @@
+from Tribler.Test.test_as_server import AbstractServer
+from Tribler.community.tunnel.main import Tunnel
+from Tribler.community.tunnel.tunnel_community import TunnelSettings
+
+
+class TestTunnelHelpers(AbstractServer):
+
+    def test_start_stop(self):
+        tunnel = Tunnel(TunnelSettings())
+        tunnel.start(None)
+        tunnel.stop()

--- a/Tribler/community/tunnel/main.py
+++ b/Tribler/community/tunnel/main.py
@@ -11,6 +11,7 @@ from collections import defaultdict, deque
 
 from twisted.internet.task import LoopingCall
 from twisted.internet.stdio import StandardIO
+from twisted.logger import globalLogPublisher
 from twisted.protocols.basic import LineReceiver
 from twisted.internet.threads import blockingCallFromThread
 
@@ -26,6 +27,8 @@ from Tribler.community.tunnel.hidden_community import HiddenTunnelCommunity
 import logging.config
 from Tribler.Core.simpledefs import dlstatus_strings
 from Tribler.dispersy.candidate import Candidate
+from Tribler.dispersy.tool.clean_observers import clean_twisted_observers
+
 logging.config.fileConfig("logger.conf")
 logger = logging.getLogger('TunnelMain')
 
@@ -84,6 +87,8 @@ class Tunnel(object):
         for k in self.crawl_message.keys():
             if now - 3600 > self.crawl_message[k]['time']:
                 self.crawl_message.pop(k)
+
+        clean_twisted_observers(globalLogPublisher)
 
     def build_history(self):
         self.history_stats.append(self.get_stats())

--- a/twisted/twisted/plugins/bartercast_crawler_plugin.py
+++ b/twisted/twisted/plugins/bartercast_crawler_plugin.py
@@ -8,6 +8,8 @@ Temporary approach: all peers will run this service if this works OK. See Github
 import os
 import signal
 
+from twisted.logger import globalLogPublisher
+
 from Tribler.dispersy.crypto import NoVerifyCrypto, NoCrypto
 # from dispersy.discovery.community import DiscoveryCommunity
 from Tribler.dispersy.dispersy import Dispersy
@@ -22,6 +24,10 @@ from twisted.python.log import msg
 from twisted.python.threadable import isInIOThread
 from zope.interface import implements
 from Tribler.community.bartercast4.community import BarterCommunityCrawler
+from Tribler.dispersy.tool.clean_observers import clean_twisted_observers
+
+
+clean_twisted_observers(globalLogPublisher)
 
 
 class BartercastCrawler(Dispersy):


### PR DESCRIPTION
After a day of memory investigation, I found the root cause of the memory usage problem in the tunnel helpers when they are running for a long time.

The problem is that the Twisted log observer is intercepting lower-level Twisted events. When Twisted starts, a `LimitedHistoryLogObserver` is created, however, the name is very misleading since the observed history is not limited at all! An entry is written to the log, every time something interesting happens in the Tunnel community (for instance, the reactor starts or stops listening on a specific port or the `TunnelExitSocket` protocol starts).

Searching on the internet, brought me to this issue: [here](http://twistedmatrix.com/trac/ticket/7841). A workaround has been implemented [here](https://github.com/plq/neurons/blob/417836a729706f2d1449109ccbb7d4a510227050/neurons/daemon/config.py#L623). I basically took their approach with some minor changes. For instance, I don't replay the logs in `LimitedHistoryLogObserver`.

The fact that the memory is increasing faster when the community is running as exit node can easily be explained since we are opening more tunnels thus writing more log entries.

If you’re interested in how I found this exactly, I’ve written a blog post about it [here](http://blog.code-up.nl/finding-python-memory-peaks-using-meliae/).

I also fixed another issue in the tunnel helper main script that prevented the session from closing, fixing #2083.

Fixes #2000, fixes #2083