### PR TITLE
Nsis fix uninstall location

### DIFF
--- a/Tribler/Main/Build/Win/tribler.nsi
+++ b/Tribler/Main/Build/Win/tribler.nsi
@@ -365,7 +365,8 @@ Function .onInit
 
   uninst:
     ClearErrors
-    ExecWait '$R0 _?=$INSTDIR' ;Do not copy the uninstaller to a temp file
+    ReadRegStr $UNINSTDIR HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT}" "UninstallString"
+    ExecWait '$R0 _?=$UNINSTDIR' ;Do not copy the uninstaller to a temp file
     ReadRegStr $R0 HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT}" "UninstallString"
     StrCmp $R0 "" done
     Abort

--- a/Tribler/Main/Build/Win/tribler.nsi
+++ b/Tribler/Main/Build/Win/tribler.nsi
@@ -367,8 +367,8 @@ Function .onInit
     ClearErrors
     ; Laurens (2016-03-29): Retrieve the uninstallString stored in the register. Do NOT use $INSTDIR as this points to the current $INSTDIR var of the INSTALLER, 
     ; which is the default location at this point.
-    ReadRegStr $UNINSTDIR HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT}" "UninstallString"
-    ExecWait '$R0 _?=$UNINSTDIR' ;Do not copy the uninstaller to a temp file
+    ReadRegStr $R0 HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT}" "UninstallString"
+    ExecWait '"$R0"' ;Do not copy the uninstaller to a temp file
     ReadRegStr $R0 HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT}" "UninstallString"
     StrCmp $R0 "" done
     Abort

--- a/Tribler/Main/Build/Win/tribler.nsi
+++ b/Tribler/Main/Build/Win/tribler.nsi
@@ -365,6 +365,8 @@ Function .onInit
 
   uninst:
     ClearErrors
+    ; Laurens (2016-03-29): Retrieve the uninstallString stored in the register. Do NOT use $INSTDIR as this points to the current $INSTDIR var of the INSTALLER, 
+    ; which is the default location at this point.
     ReadRegStr $UNINSTDIR HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT}" "UninstallString"
     ExecWait '$R0 _?=$UNINSTDIR' ;Do not copy the uninstaller to a temp file
     ReadRegStr $R0 HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT}" "UninstallString"


### PR DESCRIPTION
Will now read the uninstallstring in the register on windows and use that location, rather than the $INSTDIR of the installer which is always the default location at that point.

Fixes #1664 