### PR TITLE
Implemented the watch folder functionality

### DIFF
--- a/Tribler/Core/CacheDB/Notifier.py
+++ b/Tribler/Core/CacheDB/Notifier.py
@@ -11,7 +11,8 @@ from Tribler.Core.simpledefs import (NTFY_TORRENTS, NTFY_PLAYLISTS, NTFY_COMMENT
                                      NTFY_TRACKERINFO, NTFY_UPDATE, NTFY_INSERT, NTFY_DELETE, NTFY_TUNNEL,
                                      NTFY_STARTUP_TICK, NTFY_CLOSE_TICK,NTFY_UPGRADER,
                                      SIGNAL_ALLCHANNEL_COMMUNITY, SIGNAL_SEARCH_COMMUNITY, SIGNAL_TORRENT,
-                                     SIGNAL_CHANNEL, SIGNAL_CHANNEL_COMMUNITY, SIGNAL_RSS_FEED)
+                                     SIGNAL_CHANNEL, SIGNAL_CHANNEL_COMMUNITY, SIGNAL_RSS_FEED,
+                                     NTFY_WATCH_CORRUPT_FOLDER)
 
 
 class Notifier(object):
@@ -20,7 +21,7 @@ class Notifier(object):
                 NTFY_MYPREFERENCES, NTFY_ACTIVITIES, NTFY_REACHABLE, NTFY_CHANNELCAST, NTFY_CLOSE_TICK, NTFY_DISPERSY,
                 NTFY_STARTUP_TICK, NTFY_TRACKERINFO, NTFY_TUNNEL, NTFY_UPGRADER, NTFY_VOTECAST,
                 SIGNAL_ALLCHANNEL_COMMUNITY, SIGNAL_CHANNEL, SIGNAL_CHANNEL_COMMUNITY, SIGNAL_RSS_FEED,
-                SIGNAL_SEARCH_COMMUNITY, SIGNAL_TORRENT]
+                SIGNAL_SEARCH_COMMUNITY, SIGNAL_TORRENT, NTFY_WATCH_CORRUPT_FOLDER]
 
     def __init__(self, use_pool):
         self._logger = logging.getLogger(self.__class__.__name__)

--- a/Tribler/Core/Modules/watch_folder.py
+++ b/Tribler/Core/Modules/watch_folder.py
@@ -1,0 +1,44 @@
+import logging
+import os
+from twisted.internet.task import LoopingCall
+from Tribler.Core.TorrentDef import TorrentDef
+from Tribler.Core.Utilities.utilities import fix_torrent
+from Tribler.dispersy.taskmanager import TaskManager
+
+
+WATCH_FOLDER_CHECK_INTERVAL = 10
+
+
+class WatchFolder(TaskManager):
+
+    def __init__(self, session):
+        super(WatchFolder, self).__init__()
+
+        self._logger = logging.getLogger(self.__class__.__name__)
+        self.session = session
+
+    def start(self):
+        self.register_task("check watch dir", LoopingCall(self.check_watch_folder)).start(WATCH_FOLDER_CHECK_INTERVAL)
+
+    def stop(self):
+        self.cancel_all_pending_tasks()
+
+    def check_watch_folder(self):
+        if not os.path.isdir(self.session.get_watch_folder_path()):
+            return
+
+        for root, _, files in os.walk(self.session.get_watch_folder_path()):
+            for name in files:
+                if not name.endswith(u".torrent"):
+                    continue
+
+                torrent_data = fix_torrent(os.path.join(root, name))
+                if not torrent_data:  # torrent appears to be corrupt
+                    continue
+
+                tdef = TorrentDef.load_from_memory(torrent_data)
+                infohash = tdef.get_infohash()
+
+                if not self.session.has_download(infohash):
+                    self._logger.info("Starting download from torrent file %s", name)
+                    self.session.lm.ltmgr.start_download(tdef=tdef)

--- a/Tribler/Core/SessionConfig.py
+++ b/Tribler/Core/SessionConfig.py
@@ -686,6 +686,35 @@ class SessionConfigInterface(object):
         return self.sessconfig.get(u'upgrader', u'enabled')
 
     #
+    # Watch folder
+    #
+    def set_watch_folder_enabled(self, watch_folder_enabled):
+        """
+        Sets if the watch folder is enabled.
+        :param watch_folder_enabled: True or False.
+        """
+        return self.sessconfig.set(u'watch_folder', u'enabled', watch_folder_enabled)
+
+    def get_watch_folder_enabled(self):
+        """
+        Returns if the watch folder is enabled.
+        :return: A boolean indicating if the watch folder is enabled.
+        """
+        return self.sessconfig.get(u'watch_folder', u'enabled')
+
+    def set_watch_folder_path(self, value):
+        """ Set the location of the watch folder
+        @param value An absolute path.
+        """
+        self.sessconfig.set(u'watch_folder', u'watch_folder_dir', value)
+
+    def get_watch_folder_path(self):
+        """ Get the path to the watch folder directory.
+        @return An absolute path.
+        """
+        return self.sessconfig.get(u'watch_folder', u'watch_folder_dir')
+
+    #
     # Static methods
     #
     @staticmethod

--- a/Tribler/Core/defaults.py
+++ b/Tribler/Core/defaults.py
@@ -35,9 +35,10 @@ DEFAULTPORT = 7760
 #  Version 4: remove swift
 #  Version 7: exitnode optin switch added
 #  Version 10: BarterCommunity settings added (disabled by default)
-# Version 11: Added a default whether we should upgrade or not.
+#  Version 11: Added a default whether we should upgrade or not.
+#  Version 12: Added watch folder options.
 
-SESSDEFAULTS_VERSION = 11
+SESSDEFAULTS_VERSION = 12
 sessdefaults = OrderedDict()
 
 # General Tribler settings
@@ -137,6 +138,10 @@ sessdefaults['video']['preferredmode'] = PLAYBACKMODE_INTERNAL
 sessdefaults['upgrader'] = OrderedDict()
 sessdefaults['upgrader']['enabled'] = True
 
+# Watch folder config
+sessdefaults['watch_folder'] = OrderedDict()
+sessdefaults['watch_folder']['enabled'] = False
+sessdefaults['watch_folder']['watch_folder_dir'] = None
 
 #
 # BT per download opts

--- a/Tribler/Core/simpledefs.py
+++ b/Tribler/Core/simpledefs.py
@@ -87,6 +87,7 @@ NTFY_CLOSE_TICK = 'closetick'
 NTFY_ACTIVITIES = 'activities'  # an activity was set (peer met/dns resolved)
 NTFY_REACHABLE = 'reachable'  # the Session is reachable from the Internet
 NTFY_DISPERSY = 'dispersy'  # an notification regarding dispersy
+NTFY_WATCH_CORRUPT_FOLDER = 'corrupt_torrent'  # a corrupt torrent has been found in the watch folder
 
 # changeTypes
 NTFY_UPDATE = 'update'  # data is updated

--- a/Tribler/Main/tribler_main.py
+++ b/Tribler/Main/tribler_main.py
@@ -308,7 +308,10 @@ class ABCApp(object):
         self.sconfig.set_install_dir(self.installdir)
 
         if not self.sconfig.get_watch_folder_path():
-            self.sconfig.set_watch_folder_path(os.path.join(get_home_dir(), u'Downloads', u'TriblerWatchFolder'))
+            default_watch_folder_dir = os.path.join(get_home_dir(), u'Downloads', u'TriblerWatchFolder')
+            self.sconfig.set_watch_folder_path(default_watch_folder_dir)
+            if not os.path.exists(default_watch_folder_dir):
+                os.makedirs(default_watch_folder_dir)
 
         # TODO(emilon): Do we still want to force limit this? With the new
         # torrent store it should be pretty fast even with more that that.

--- a/Tribler/Main/tribler_main.py
+++ b/Tribler/Main/tribler_main.py
@@ -46,7 +46,7 @@ from Tribler.Core.simpledefs import (DLSTATUS_DOWNLOADING, DLSTATUS_SEEDING, DLS
                                      NTFY_MODERATIONS, NTFY_MODIFICATIONS, NTFY_MODIFIED, NTFY_MYPREFERENCES,
                                      NTFY_PLAYLISTS, NTFY_REACHABLE, NTFY_STARTED, NTFY_STATE, NTFY_TORRENTS,
                                      NTFY_UPDATE, NTFY_VOTECAST, UPLOAD, dlstatus_strings, STATEDIR_GUICONFIG,
-                                     NTFY_STARTUP_TICK, NTFY_CLOSE_TICK, NTFY_UPGRADER)
+                                     NTFY_STARTUP_TICK, NTFY_CLOSE_TICK, NTFY_UPGRADER, NTFY_WATCH_CORRUPT_FOLDER)
 from Tribler.Core.version import commit_id, version_id
 from Tribler.Main.Dialogs.FeedbackWindow import FeedbackWindow
 from Tribler.Main.Utility.GuiDBHandler import GUIDBProducer, startWorker
@@ -406,6 +406,7 @@ class ABCApp(object):
         s.add_observer(self.sesscb_ntfy_torrentfinished, NTFY_TORRENTS, [NTFY_FINISHED])
         s.add_observer(self.sesscb_ntfy_magnet,
                        NTFY_TORRENTS, [NTFY_MAGNET_GOT_PEERS, NTFY_MAGNET_STARTED, NTFY_MAGNET_CLOSE])
+        s.add_observer(self.sesscb_ntfy_corrupt_torrent, NTFY_WATCH_CORRUPT_FOLDER, [NTFY_INSERT])
 
         # TODO(emilon): Use the LogObserver I already implemented
         # self.dispersy.callback.attach_exception_handler(self.frame.exceptionHandler)
@@ -790,6 +791,15 @@ class ABCApp(object):
             self.guiUtility.library_manager.magnet_got_peers(objectID, args[0])
         elif changetype == NTFY_MAGNET_CLOSE:
             self.guiUtility.library_manager.magnet_close(objectID)
+
+    @forceWxThread
+    def sesscb_ntfy_corrupt_torrent(self, subject, changetype, objectID, *args):
+        dlg = wx.MessageDialog(self.frame,
+                               "Unable to add corrupt torrent in watch folder to downloads: %s" % args[0],
+                               "Corrupt torrent",
+                               wx.OK | wx.ICON_ERROR)
+        dlg.ShowModal()
+        dlg.Destroy()
 
     @forceWxThread
     def sesscb_ntfy_playlistupdates(self, subject, changeType, objectID, *args):

--- a/Tribler/Main/tribler_main.py
+++ b/Tribler/Main/tribler_main.py
@@ -38,7 +38,7 @@ from Tribler.Core.DownloadConfig import get_default_dest_dir, get_default_dscfg_
 from Tribler.Core.Session import Session
 from Tribler.Core.SessionConfig import SessionStartupConfig
 from Tribler.Core.Video.VideoPlayer import PLAYBACKMODE_INTERNAL, return_feasible_playback_modes
-from Tribler.Core.osutils import get_free_space
+from Tribler.Core.osutils import get_free_space, get_home_dir
 from Tribler.Core.simpledefs import (DLSTATUS_DOWNLOADING, DLSTATUS_SEEDING, DLSTATUS_STOPPED,
                                      DLSTATUS_STOPPED_ON_ERROR, DOWNLOAD, NTFY_ACTIVITIES, NTFY_CHANNELCAST,
                                      NTFY_COMMENTS, NTFY_CREATE, NTFY_DELETE, NTFY_DISPERSY, NTFY_FINISHED, NTFY_INSERT,
@@ -306,6 +306,9 @@ class ABCApp(object):
                 self.sconfig.set_state_dir(state_dir)
 
         self.sconfig.set_install_dir(self.installdir)
+
+        if not self.sconfig.get_watch_folder_path():
+            self.sconfig.set_watch_folder_path(os.path.join(get_home_dir(), u'Downloads', u'TriblerWatchFolder'))
 
         # TODO(emilon): Do we still want to force limit this? With the new
         # torrent store it should be pretty fast even with more that that.

--- a/Tribler/Test/Core/Modules/__init__.py
+++ b/Tribler/Test/Core/Modules/__init__.py
@@ -1,0 +1,3 @@
+"""
+This testing package contains tests for the various modules that can be found in Tribler.
+"""

--- a/Tribler/Test/Core/Modules/test_watch_folder.py
+++ b/Tribler/Test/Core/Modules/test_watch_folder.py
@@ -1,0 +1,38 @@
+import os
+import shutil
+from Tribler.Test.test_as_server import TestAsServer, TESTS_DATA_DIR
+from Tribler.Test.test_libtorrent_download import TORRENT_FILE
+
+
+class TestWatchFolder(TestAsServer):
+
+    def setUpPreSession(self):
+        super(TestWatchFolder, self).setUpPreSession()
+        self.config.set_libtorrent(True)
+        self.config.set_watch_folder_enabled(True)
+
+        self.watch_dir = os.path.join(self.session_base_dir, 'watch')
+        os.mkdir(self.watch_dir)
+
+        self.config.set_watch_folder_path(self.watch_dir)
+
+    def test_watchfolder_no_files(self):
+        self.session.lm.watch_folder.check_watch_folder()
+        self.assertEqual(len(self.session.get_downloads()), 0)
+
+    def test_watchfolder_no_torrent_file(self):
+        shutil.copyfile(TORRENT_FILE, os.path.join(self.watch_dir, "test.txt"))
+        self.session.lm.watch_folder.check_watch_folder()
+        self.assertEqual(len(self.session.get_downloads()), 0)
+
+    def test_watchfolder_invalid_dir(self):
+        shutil.copyfile(TORRENT_FILE, os.path.join(self.watch_dir, "test.txt"))
+        self.session.set_watch_folder_path(os.path.join(self.watch_dir, "test.txt"))
+        self.session.lm.watch_folder.check_watch_folder()
+        self.assertEqual(len(self.session.get_downloads()), 0)
+
+    def test_watchfolder_torrent_file_one_corrupt(self):
+        shutil.copyfile(TORRENT_FILE, os.path.join(self.watch_dir, "test.torrent"))
+        shutil.copyfile(os.path.join(TESTS_DATA_DIR, 'test_rss.xml'), os.path.join(self.watch_dir, "test2.torrent"))
+        self.session.lm.watch_folder.check_watch_folder()
+        self.assertEqual(len(self.session.get_downloads()), 1)

--- a/Tribler/Test/Core/Modules/test_watch_folder.py
+++ b/Tribler/Test/Core/Modules/test_watch_folder.py
@@ -36,3 +36,4 @@ class TestWatchFolder(TestAsServer):
         shutil.copyfile(os.path.join(TESTS_DATA_DIR, 'test_rss.xml'), os.path.join(self.watch_dir, "test2.torrent"))
         self.session.lm.watch_folder.check_watch_folder()
         self.assertEqual(len(self.session.get_downloads()), 1)
+        self.assertTrue(os.path.isfile(os.path.join(self.watch_dir, "test2.torrent.corrupt")))

--- a/Tribler/Test/test_as_server.py
+++ b/Tribler/Test/test_as_server.py
@@ -227,9 +227,6 @@ class TestAsServer(AbstractServer):
             self._shutdown_session(self.session)
             Session.del_instance()
 
-        time.sleep(10)
-        gc.collect()
-
         ts = enumerate_threads()
         self._logger.debug("test_as_server: Number of threads still running %d", len(ts))
         for t in ts:


### PR DESCRIPTION
As requested in #1038, I've implemented the watch folder functionality.

I've created a separate subclass of `TaskManager` that polls the watch folder functionality every two minutes and adds downloads of (new) torrent files it finds in this directory. I'm aware that there are several directory watching libraries available in Python (for instance, [watchdog](https://pypi.python.org/pypi/watchdog)) but I don't want to add another dependency to Tribler (but this is open for discussion).

The watch folder can be enabled in settings -> general and the path of the watch directory can be adjusted.