### PR TITLE
Fixed wrong status when downloading

### DIFF
--- a/Tribler/Core/Libtorrent/LibtorrentDownloadImpl.py
+++ b/Tribler/Core/Libtorrent/LibtorrentDownloadImpl.py
@@ -122,7 +122,6 @@ class LibtorrentDownloadImpl(DownloadConfigInterface):
         self.dlstate = DLSTATUS_WAITING4HASHCHECK
         self.length = 0
         self.progress = 0.0
-        self.bufferprogress = 0.0
         self.curspeeds = {DOWNLOAD: 0.0, UPLOAD: 0.0}  # bytes/s
         self.all_time_upload = 0.0
         self.all_time_download = 0.0

--- a/Tribler/Main/vwxGUI/SearchGridManager.py
+++ b/Tribler/Main/vwxGUI/SearchGridManager.py
@@ -579,6 +579,7 @@ class LibraryManager(object):
         return self.wantpeers
 
     def magnet_started(self, infohash):
+        # [time, amount of peers, ????]
         self.magnetlist[infohash] = [long(time()), 0, 0]
 
     def magnet_got_peers(self, infohash, total_peers):
@@ -612,6 +613,12 @@ class LibraryManager(object):
             self.gui_callback.remove(callback)
 
     def set_want_peers(self, hashes, enable=True):
+        """
+        Sets whether or now we want hashes, appending or removing them
+        from the wantpeers list.
+        :param hashes: A list of hashes we want to add or remove from the wantpeers list
+        :param enable: A boolean indicating if they should be removed or added
+        """
         if not enable:
             for h in hashes:
                 if h in self.wantpeers:
@@ -631,10 +638,7 @@ class LibraryManager(object):
 
     def addDownloadStates(self, torrentlist):
         for torrent in torrentlist:
-            for ds in self.dslist:
-                torrent.addDs(ds)
-            if torrent.infohash in self.magnetlist:
-                torrent.magnetstatus = self.magnetlist[torrent.infohash]
+            self.addDownloadState(torrent)
         return torrentlist
 
     def startLastVODTorrent(self):

--- a/Tribler/Main/vwxGUI/list_item.py
+++ b/Tribler/Main/vwxGUI/list_item.py
@@ -602,7 +602,6 @@ class TorrentListItem(DoubleLineListItemWithButtons):
             # remote channel link to force reload
             for torrent in added:
                 del torrent.channel
-                torrent.channel
 
             if len(added) == 1:
                 def gui_call():
@@ -623,7 +622,6 @@ class TorrentListItem(DoubleLineListItemWithButtons):
     def OnExplore(self, event):
         torrents = self.guiutility.frame.top_bg.GetSelectedTorrents()
         for torrent in torrents:
-            path = None
             if torrent.ds:
                 download = torrent.ds.get_download()
                 if isinstance(download.get_def(), TorrentDef):


### PR DESCRIPTION
The problem is that `self.torrent.magnetstatus` will always be **not** None when adding from a magnet link, even when the .torrent has been downloaded. This will trigger the first if statement and set the status wrong. So now the DL status takes priority over the magnetstatus.

I also tried removing the `if self.torrent.magnetstatus` check which seems to work, but as I do not understand the logic behind [this undocumented function](https://github.com/Tribler/tribler/blob/devel/Tribler/Main/Utility/GuiDBTuples.py#L215) I decided to go with the current approach. Confirmed by removing + data and readding. Now changes immediately.

# edit
Thinking about it, it makes no sense. It switched to seeding just fine but it should not if that magnetstatus list is not None. I'll delete this magnetstatus object from the if statement as I observed no issue with removing it.

Fixes #1702, Fixes #2089 
Fixes **2** bugs
Removed some duplicate code and unused variables (enhancement)