### PR TITLE
Added a version check manager

### DIFF
--- a/Tribler/Core/APIImplementation/LaunchManyCore.py
+++ b/Tribler/Core/APIImplementation/LaunchManyCore.py
@@ -17,6 +17,7 @@ from Tribler.Core.APIImplementation.threadpoolmanager import ThreadPoolManager
 from Tribler.Core.CacheDB.sqlitecachedb import forceDBThread
 from Tribler.Core.DownloadConfig import DownloadStartupConfig
 from Tribler.Core.Modules.search_manager import SearchManager
+from Tribler.Core.Modules.versioncheck_manager import VersionCheckManager
 from Tribler.Core.Modules.watch_folder import WatchFolder
 from Tribler.Core.TorrentDef import TorrentDef, TorrentDefNoMetainfo
 from Tribler.Core.Utilities.configparser import CallbackConfigParser
@@ -71,6 +72,7 @@ class TriblerLaunchMany(TaskManager):
         self.rtorrent_handler = None
         self.tftp_handler = None
         self.watch_folder = None
+        self.version_check_manager = None
 
         self.cat = None
         self.peer_db = None
@@ -249,6 +251,8 @@ class TriblerLaunchMany(TaskManager):
         if self.session.get_watch_folder_enabled():
             self.watch_folder = WatchFolder(self.session)
             self.watch_folder.start()
+
+        self.version_check_manager = VersionCheckManager(self.session)
 
         self.initComplete = True
 
@@ -616,6 +620,9 @@ class TriblerLaunchMany(TaskManager):
         if self.videoplayer:
             self.videoplayer.shutdown()
             self.videoplayer = None
+
+        self.version_check_manager.stop()
+        self.version_check_manager = None
 
         if self.tracker_manager:
             self.tracker_manager.shutdown()

--- a/Tribler/Core/CacheDB/Notifier.py
+++ b/Tribler/Core/CacheDB/Notifier.py
@@ -12,7 +12,7 @@ from Tribler.Core.simpledefs import (NTFY_TORRENTS, NTFY_PLAYLISTS, NTFY_COMMENT
                                      NTFY_STARTUP_TICK, NTFY_CLOSE_TICK,NTFY_UPGRADER,
                                      SIGNAL_ALLCHANNEL_COMMUNITY, SIGNAL_SEARCH_COMMUNITY, SIGNAL_TORRENT,
                                      SIGNAL_CHANNEL, SIGNAL_CHANNEL_COMMUNITY, SIGNAL_RSS_FEED,
-                                     NTFY_WATCH_CORRUPT_FOLDER)
+                                     NTFY_WATCH_CORRUPT_FOLDER, NTFY_NEW_VERSION)
 
 
 class Notifier(object):
@@ -21,7 +21,7 @@ class Notifier(object):
                 NTFY_MYPREFERENCES, NTFY_ACTIVITIES, NTFY_REACHABLE, NTFY_CHANNELCAST, NTFY_CLOSE_TICK, NTFY_DISPERSY,
                 NTFY_STARTUP_TICK, NTFY_TRACKERINFO, NTFY_TUNNEL, NTFY_UPGRADER, NTFY_VOTECAST,
                 SIGNAL_ALLCHANNEL_COMMUNITY, SIGNAL_CHANNEL, SIGNAL_CHANNEL_COMMUNITY, SIGNAL_RSS_FEED,
-                SIGNAL_SEARCH_COMMUNITY, SIGNAL_TORRENT, NTFY_WATCH_CORRUPT_FOLDER]
+                SIGNAL_SEARCH_COMMUNITY, SIGNAL_TORRENT, NTFY_WATCH_CORRUPT_FOLDER, NTFY_NEW_VERSION]
 
     def __init__(self, use_pool):
         self._logger = logging.getLogger(self.__class__.__name__)

--- a/Tribler/Core/Modules/versioncheck_manager.py
+++ b/Tribler/Core/Modules/versioncheck_manager.py
@@ -1,0 +1,53 @@
+from distutils.version import LooseVersion
+import json
+import logging
+from twisted.internet.error import ConnectError, DNSLookupError
+from twisted.internet.task import LoopingCall
+from twisted.web.client import Agent, readBody
+from twisted.web.error import SchemeNotSupported
+from twisted.web.http_headers import Headers
+from Tribler.Core.Utilities.twisted_thread import reactor
+from Tribler.Core.simpledefs import NTFY_INSERT, NTFY_NEW_VERSION
+from Tribler.Core.version import version_id
+from Tribler.dispersy.taskmanager import TaskManager
+
+
+VERSION_CHECK_URL = 'https://api.github.com/repos/tribler/tribler/releases/latest'
+
+
+class VersionCheckManager(TaskManager):
+
+    def __init__(self, session):
+        super(VersionCheckManager, self).__init__()
+
+        self._logger = logging.getLogger(self.__class__.__name__)
+        self.session = session
+
+    def start(self, interval):
+        self.register_task("tribler version check", LoopingCall(self.check_new_version)).start(interval)
+
+    def stop(self):
+        self.cancel_all_pending_tasks()
+
+    def check_new_version(self):
+
+        def parse_body(body):
+            if body is None:
+                return
+            version = json.loads(body)['name'][1:]
+            if LooseVersion(version) > LooseVersion(version_id):
+                self.session.notifier.notify(NTFY_NEW_VERSION, NTFY_INSERT, None, version)
+
+        def on_request_error(error):
+            error.trap(SchemeNotSupported, ConnectError, DNSLookupError)
+            self._logger.error("Error when performing version check request: %s", error)
+
+        def parse_response(response):
+            if response.code == 200:
+                return readBody(response)
+            else:
+                self._logger.warning("Got response code %s when performing version check request", response.code)
+
+        agent = Agent(reactor)
+        return agent.request('GET', VERSION_CHECK_URL, Headers({'User-Agent': ['Tribler ' + version_id]}), None)\
+            .addCallback(parse_response).addCallback(parse_body).addErrback(on_request_error)

--- a/Tribler/Core/defaults.py
+++ b/Tribler/Core/defaults.py
@@ -206,8 +206,6 @@ tribler_defaults['Tribler']['confirmonclose'] = 1
 # RateLimitPanel
 tribler_defaults['Tribler']['maxuploadrate'] = 0
 tribler_defaults['Tribler']['maxdownloadrate'] = 0
-# Misc
-tribler_defaults['Tribler']['torrentassociationwarned'] = 0
 # Anon tunnel
 tribler_defaults['Tribler']['default_number_hops'] = 1
 tribler_defaults['Tribler']['default_anonymity_enabled'] = True
@@ -228,8 +226,10 @@ tribler_defaults['Tribler']['emc_ip'] = '127.0.0.1'
 tribler_defaults['Tribler']['emc_port'] = '8332'
 tribler_defaults['Tribler']['emc_username'] = 'tribler'
 tribler_defaults['Tribler']['emc_password'] = 'tribler'
+# Misc
 tribler_defaults['Tribler']['showsaveas'] = 1
 tribler_defaults['Tribler']['i2ilistenport'] = 57891
 tribler_defaults['Tribler']['mintray'] = 2 if sys.platform == 'win32' else 0
 tribler_defaults['Tribler']['free_space_threshold'] = 100 * 1024 * 1024
 tribler_defaults['Tribler']['version_info'] = {}
+tribler_defaults['Tribler']['last_reported_version'] = None

--- a/Tribler/Core/simpledefs.py
+++ b/Tribler/Core/simpledefs.py
@@ -88,6 +88,7 @@ NTFY_ACTIVITIES = 'activities'  # an activity was set (peer met/dns resolved)
 NTFY_REACHABLE = 'reachable'  # the Session is reachable from the Internet
 NTFY_DISPERSY = 'dispersy'  # an notification regarding dispersy
 NTFY_WATCH_CORRUPT_FOLDER = 'corrupt_torrent'  # a corrupt torrent has been found in the watch folder
+NTFY_NEW_VERSION = 'newversion' # a new version of Tribler is available
 
 # changeTypes
 NTFY_UPDATE = 'update'  # data is updated

--- a/Tribler/Main/Dialogs/NewVersionDialog.py
+++ b/Tribler/Main/Dialogs/NewVersionDialog.py
@@ -1,0 +1,58 @@
+import wx
+from Tribler.Main.vwxGUI.GuiUtility import GUIUtility
+from Tribler.Main.vwxGUI.widgets import _set_font
+
+
+class NewVersionDialog(wx.Dialog):
+
+    def __init__(self, version, parent, name, msg_bold='', msg='', title='', center_on_frame=True):
+        wx.Dialog.__init__(self, parent=parent, size=(475, 210), name=name)
+
+        self.version = version
+        self.SetTitle(title)
+        messageSizer = wx.BoxSizer(wx.VERTICAL)
+
+        if msg_bold:
+            messageText1 = wx.StaticText(self, label=msg_bold)
+            _set_font(messageText1, fontweight=wx.FONTWEIGHT_BOLD)
+            messageSizer.Add(messageText1, 1, wx.EXPAND)
+        if msg:
+            messageText2 = wx.StaticText(self, label=msg)
+            messageSizer.Add(messageText2, 1, wx.EXPAND | wx.TOP, 10 if msg_bold else 0)
+
+        bodySizer = wx.BoxSizer(wx.HORIZONTAL)
+        bodySizer.Add(wx.StaticBitmap(self, -1, wx.ArtProvider.GetBitmap(
+            wx.ART_INFORMATION, wx.ART_CMN_DIALOG)), 0, wx.ALIGN_TOP | wx.RIGHT, 25)
+        bodySizer.Add(messageSizer, 1, wx.EXPAND)
+
+        buttonSizer = wx.StdDialogButtonSizer()
+        okButton = wx.Button(self, wx.ID_OK, label='Ok')
+        okButton.Bind(wx.EVT_BUTTON, self.OnOk)
+        laterButton = wx.Button(self, id=wx.ID_CANCEL, label='Later')
+        laterButton.Bind(wx.EVT_BUTTON, self.OnLater)
+        ignoreButton = wx.Button(self, id=wx.ID_IGNORE, label='Ignore')
+        ignoreButton.Bind(wx.EVT_BUTTON, self.OnIgnore)
+        buttonSizer.Add(ignoreButton)
+        buttonSizer.Add(laterButton)
+        buttonSizer.Add(okButton)
+        buttonSizer.Realize()
+
+        mainSizer = wx.BoxSizer(wx.VERTICAL)
+        mainSizer.Add(bodySizer, 1, wx.EXPAND | wx.ALL, 10)
+        mainSizer.Add(buttonSizer, 0, wx.ALIGN_RIGHT | wx.ALL, 10)
+        self.SetSizerAndFit(mainSizer)
+        if center_on_frame:
+            x, y, w, h = GUIUtility.getInstance().frame.GetScreenRect()
+            self.SetPosition((x + ((w - self.GetSize().x) / 2), y + ((h - self.GetSize().y) / 2)))
+
+    def OnOk(self, event):
+        import webbrowser
+        webbrowser.open("https://tribler.org")
+        self.EndModal(wx.ID_OK)
+
+    def OnLater(self, event):
+        self.EndModal(wx.ID_CANCEL)
+
+    def OnIgnore(self, event):
+        GUIUtility.getInstance().utility.write_config('last_reported_version', str(self.version))
+        self.EndModal(wx.ID_IGNORE)

--- a/Tribler/Main/tribler_main.py
+++ b/Tribler/Main/tribler_main.py
@@ -8,7 +8,7 @@
 #
 # see LICENSE.txt for license information
 #
-
+from Tribler.Main.Dialogs.NewVersionDialog import NewVersionDialog
 
 try:
     import prctl
@@ -46,7 +46,8 @@ from Tribler.Core.simpledefs import (DLSTATUS_DOWNLOADING, DLSTATUS_SEEDING, DLS
                                      NTFY_MODERATIONS, NTFY_MODIFICATIONS, NTFY_MODIFIED, NTFY_MYPREFERENCES,
                                      NTFY_PLAYLISTS, NTFY_REACHABLE, NTFY_STARTED, NTFY_STATE, NTFY_TORRENTS,
                                      NTFY_UPDATE, NTFY_VOTECAST, UPLOAD, dlstatus_strings, STATEDIR_GUICONFIG,
-                                     NTFY_STARTUP_TICK, NTFY_CLOSE_TICK, NTFY_UPGRADER, NTFY_WATCH_CORRUPT_FOLDER)
+                                     NTFY_STARTUP_TICK, NTFY_CLOSE_TICK, NTFY_UPGRADER, NTFY_WATCH_CORRUPT_FOLDER,
+                                     NTFY_NEW_VERSION)
 from Tribler.Core.version import commit_id, version_id
 from Tribler.Main.Dialogs.FeedbackWindow import FeedbackWindow
 from Tribler.Main.Utility.GuiDBHandler import GUIDBProducer, startWorker
@@ -407,6 +408,10 @@ class ABCApp(object):
         s.add_observer(self.sesscb_ntfy_magnet,
                        NTFY_TORRENTS, [NTFY_MAGNET_GOT_PEERS, NTFY_MAGNET_STARTED, NTFY_MAGNET_CLOSE])
         s.add_observer(self.sesscb_ntfy_corrupt_torrent, NTFY_WATCH_CORRUPT_FOLDER, [NTFY_INSERT])
+        s.add_observer(self.sesscb_ntfy_newversion, NTFY_NEW_VERSION, [NTFY_INSERT])
+
+        # Check for a new version
+        s.lm.version_check_manager.start(24 * 3600)
 
         # TODO(emilon): Use the LogObserver I already implemented
         # self.dispersy.callback.attach_exception_handler(self.frame.exceptionHandler)
@@ -783,6 +788,19 @@ class ABCApp(object):
             infohash = objectID
             torrent = self.guiUtility.torrentsearch_manager.getTorrentByInfohash(infohash)
             self.guiUtility.library_manager.addDownloadState(torrent)
+
+    @forceWxThread
+    def sesscb_ntfy_newversion(self, subject, changeType, objectID, *args):
+        if str(self.utility.read_config('last_reported_version')) == args[0]:
+            return
+
+        new_version_dialog = NewVersionDialog(args[0], self.frame, 'new_version_dialog', 'New version available',
+                                              title='New version',
+                                              msg="Version %s of Tribler is available. "
+                                                  "Do you want to visit the website to download the newest version?"
+                                                  % args[0])
+        new_version_dialog.ShowModal()
+        new_version_dialog.Destroy()
 
     def sesscb_ntfy_magnet(self, subject, changetype, objectID, *args):
         if changetype == NTFY_MAGNET_STARTED:

--- a/Tribler/Test/Core/Modules/test_versioncheck.py
+++ b/Tribler/Test/Core/Modules/test_versioncheck.py
@@ -1,0 +1,72 @@
+import json
+from twisted.internet.defer import Deferred, maybeDeferred
+from twisted.web import server, resource
+from Tribler.Core.Modules import versioncheck_manager
+from Tribler.Core.Utilities.network_utils import get_random_port
+from Tribler.Core.Utilities.twisted_thread import reactor, deferred
+from Tribler.Test.test_as_server import TestAsServer
+from Tribler.dispersy.util import call_on_reactor_thread
+
+
+class VersionResource(resource.Resource):
+
+    isLeaf = True
+
+    def __init__(self, response, response_code):
+        resource.Resource.__init__(self)
+        self.response = response
+        self.response_code = response_code
+
+    def render_GET(self, request):
+        request.setResponseCode(self.response_code)
+        return self.response
+
+
+class TestVersionCheck(TestAsServer):
+
+    def setUp(self):
+        self.port = get_random_port()
+        self.server = None
+        self.should_call_new_version_callback = False
+        self.new_version_called = False
+        versioncheck_manager.VERSION_CHECK_URL = 'http://localhost:%s' % self.port
+        super(TestVersionCheck, self).setUp()
+
+        self.session.notifier.notify = self.notifier_callback
+
+    def notifier_callback(self, subject, changeType, obj_id, *args):
+        self.new_version_called = True
+
+    @call_on_reactor_thread
+    def setup_version_server(self, response, response_code=200):
+        site = server.Site(VersionResource(response, response_code))
+        self.server = reactor.listenTCP(self.port, site)
+
+    def assert_new_version_called(self, _):
+        self.assertTrue(self.new_version_called == self.should_call_new_version_callback)
+        return maybeDeferred(self.server.stopListening)
+
+    def check_version(self):
+        return self.session.lm.version_check_manager.check_new_version().addCallback(self.assert_new_version_called)
+
+    @deferred(timeout=10)
+    def test_old_version(self):
+        self.setup_version_server(json.dumps({'name': 'v1.0'}))
+        return self.check_version()
+
+    @deferred(timeout=10)
+    def test_new_version(self):
+        self.should_call_new_version_callback = True
+        self.setup_version_server(json.dumps({'name': 'v1337.0'}))
+        return self.check_version()
+
+    @deferred(timeout=10)
+    def test_bad_request(self):
+        self.setup_version_server(json.dumps({'name': 'v1.0'}), response_code=500)
+        return self.check_version()
+
+    @deferred(timeout=10)
+    def test_connection_error(self):
+        self.setup_version_server(json.dumps({'name': 'v1.0'}))
+        versioncheck_manager.VERSION_CHECK_URL = "http://this.will.not.exist"
+        return self.check_version()


### PR DESCRIPTION
Github has a nice API endpoint that can be used to fetch the latest release: `https://api.github.com/repos/tribler/tribler/releases`. This gives the latest stable release.

I propose to add a version check manager that can schedule version checks in the future. This can for instance be called when the GUI starts.

I'm not really sure about the best way to integrate this into the GUI but we can discuss this. This is just a quick implementation of a version check manager that should replace `version_check.py` in `Main/Utility`.

This PR contains work on #14.