### PR TITLE
Fixed flags when adding a torrent file

### DIFF
--- a/Tribler/Core/Libtorrent/LibtorrentDownloadImpl.py
+++ b/Tribler/Core/Libtorrent/LibtorrentDownloadImpl.py
@@ -225,10 +225,9 @@ class LibtorrentDownloadImpl(DownloadConfigInterface):
         atp = {}
         atp["save_path"] = os.path.abspath(self.get_dest_dir())
         atp["storage_mode"] = lt.storage_mode_t.storage_mode_sparse
-        atp["paused"] = True
-        atp["auto_managed"] = False
-        atp["duplicate_is_error"] = True
         atp["hops"] = self.get_hops()
+        atp["flags"] = (lt.add_torrent_params_flags_t.flag_paused |
+                        lt.add_torrent_params_flags_t.flag_duplicate_is_error)
 
         resume_data = pstate.get('state', 'engineresumedata') if pstate else None
         if not isinstance(self.tdef, TorrentDefNoMetainfo):

--- a/Tribler/Core/Libtorrent/LibtorrentMgr.py
+++ b/Tribler/Core/Libtorrent/LibtorrentMgr.py
@@ -344,8 +344,9 @@ class LibtorrentMgr(TaskManager):
 
             elif infohash not in self.metainfo_requests:
                 # Flags = 4 (upload mode), should prevent libtorrent from creating files
-                atp = {'save_path': self.metadata_tmpdir, 'duplicate_is_error': True, 'paused': False,
-                       'auto_managed': False, 'upload_mode': True}
+                atp = {'save_path': self.metadata_tmpdir,
+                       'flags': (lt.add_torrent_params_flags_t.flag_duplicate_is_error |
+                                 lt.add_torrent_params_flags_t.flag_upload_mode)}
                 if magnet:
                     atp['url'] = magnet
                 else:


### PR DESCRIPTION
When adding or loading a torrent file in Tribler, the `auto_managed` settings (and some other settings) were not automatically set in a libtorrent without deprecated methods, making it behave very weird when trying to pause or resume a torrent. This PR should fix this.