### PR TITLE
url-list with type string in torrent metainfo is now supported

### DIFF
--- a/Tribler/Core/Utilities/utilities.py
+++ b/Tribler/Core/Utilities/utilities.py
@@ -142,8 +142,11 @@ def validTorrentFile(metainfo):
             del metainfo['url-list']
             logger.warn("Warning: Only single-file mode supported with HTTP seeding. HTTP seeding disabled")
         elif not isinstance(metainfo['url-list'], ListType):
-            del metainfo['url-list']
-            logger.warn("Warning: url-list is not of type list. HTTP seeding disabled")
+            if isinstance(metainfo['url-list'], StringType):
+                metainfo['url-list'] = [metainfo['url-list']]
+            else:
+                del metainfo['url-list']
+                logger.warn("Warning: url-list is not of type list/string. HTTP seeding disabled")
         else:
             for url in metainfo['url-list']:
                 if not isValidURL(url):

--- a/Tribler/Test/Core/test_utilities.py
+++ b/Tribler/Test/Core/test_utilities.py
@@ -166,6 +166,10 @@ class TriblerCoreTestUtilities(TriblerCoreTest):
         validTorrentFile({"info": {"name": "my_torrent", "piece length": 12345, "pieces": "12345678901234567890",
                                    "files": [{"length": 42, "path": ["/foo/bar"]}]}, "url-list": []})
 
+    def test_valid_torrent_file_url_list_string(self):
+        validTorrentFile({"info": {"name": "my_torrent", "piece length": 12345, "pieces": "12345678901234567890",
+                                   "length": 42}, "url-list": "http://google.com"})
+
     def test_valid_torrent_file_url_list_wrong_type(self):
         validTorrentFile({"info": {"name": "my_torrent", "piece length": 12345, "pieces": "12345678901234567890",
                                    "length": 42}, "url-list": ()})


### PR DESCRIPTION
As described in #2002, web seeds are not working when downloading torrents with Tribler that contains a `url-list` metainfo key. The reason for this is that we only accept `url-list` arguments as a list, however, the  `mktorrent` tool creates the `url-list` value as a string if only one web seed is given. I've added some code to convert a string to a single-item list.