### PR TITLE
READY: Now cleaning the reactor after a test has left delayed calls behind

### DIFF
--- a/Tribler/Test/test_as_server.py
+++ b/Tribler/Test/test_as_server.py
@@ -137,6 +137,7 @@ class AbstractServer(BaseTestCase):
             self._logger.error("The reactor was dirty:")
             for dc in delayed_calls:
                 self._logger.error(">     %s" % dc)
+                dc.cancel()
         self.assertFalse(delayed_calls, "The reactor was dirty when tearing down the test")
         self.assertFalse(Session.has_instance(), 'A session instance is still present when tearing down the test')
 


### PR DESCRIPTION
Fixes #2075 

Prevent from cascading delayed calls in other tests (enhancement).
Added a check which tests for left readers/writers in the reactor (enhancement)

@whirm I ran this with the Core tests (unittests) and it seems to work fine, no errors. Should a test be written for this case? It's hard because you are in the teardown after all.