### PR TITLE
READY: Added some dlls to the exclude list when building Tribler on Windows

### DIFF
--- a/Tribler/Main/Build/Win/setuptribler.py
+++ b/Tribler/Main/Build/Win/setuptribler.py
@@ -6,6 +6,7 @@ import os
 try:
     import py2exe.mf as modulefinder
     import win32com
+
     for p in win32com.__path__[1:]:
         modulefinder.AddPackagePath("win32com", p)
     for extra in ["win32com.shell"]:
@@ -15,7 +16,6 @@ try:
             modulefinder.AddPackagePath(extra, p)
 except ImportError:
     pass
-
 
 from distutils.core import setup
 import py2exe
@@ -48,25 +48,29 @@ includePanels = [
 ]
 
 # packages = ["Tribler.Core","encodings"] + ["Tribler.Main.vwxGUI.%s" % x for x in includePanels]
-packages = ["encodings"] + ["Tribler.Main.vwxGUI.%s" % x for x in includePanels] +\
-    ["Tribler.Core.DecentralizedTracking.pymdht.core",
-     "Tribler.Main.tribler_main", "win32com.shell", "win32api",
-     "netifaces", "cherrypy", "feedparser", "pycparser", "pyasn1",
-     "twisted", "apsw", "libtorrent", "M2Crypto", "cryptography", "libnacl", "cffi",
-     "zope.interface", "PIL.Image", "requests", "leveldb", "decorator"]
+PACKAGES = ["encodings"] + ["Tribler.Main.vwxGUI.%s" % x for x in includePanels] + \
+           ["Tribler.Core.DecentralizedTracking.pymdht.core",
+            "Tribler.Main.tribler_main", "win32com.shell", "win32api",
+            "netifaces", "cherrypy", "feedparser", "pycparser", "pyasn1",
+            "twisted", "apsw", "libtorrent", "M2Crypto", "cryptography", "libnacl", "cffi",
+            "zope.interface", "PIL.Image", "requests", "leveldb", "decorator"]
 
 setup(
     # (Disabling bundle_files for now -- apparently causes some issues with Win98)
     # options = {"py2exe": {"bundle_files": 1}},
     # zipfile = None,
-    options={"py2exe": {"packages": packages,
+    # py2exe includes some dlls which it should not see:
+    # http://stackoverflow.com/questions/20930173/how-to-include-components-of-psutil-in-py2exe-that-py2exe-cant-find
+    #  https://github.com/Tribler/tribler/issues/2056 was our issue.
+    # Py2exe packs certain dlls: http://www.py2exe.org/index.cgi/OverridingCriteraForIncludingDlls
+    options={"py2exe": {"packages": PACKAGES,
                         "optimize": 2,
                         "skip_archive": True,
                         "dist_dir": os.path.join("dist", "installdir"),
-                        "dll_excludes": ["mswsock.dll", 
-										"MSVCR90.DLL"]
-						}
-			},
-	data_files=[(".", [r"C:\build\libsodium.dll"])],
+                        "dll_excludes": ["mswsock.dll", "MSVCR90.dll", "msvcr71.dll",
+                                         "IPHLPAPI.dll", "NSI.dll", "WINNSI.dll", "WTSAPI32.dll"]
+                       }
+            },
+    data_files=[(".", [r"C:\build\libsodium.dll"])],
     windows=[target],
 )


### PR DESCRIPTION
Most likely fixes the case of #2056. I have tested the installation on proxmox 144 and tribler starts with no (visible) problems.

based on: http://stackoverflow.com/questions/20930173/how-to-include-components-of-psutil-in-py2exe-that-py2exe-cant-find

Fixes **1** bug.