### PR TITLE
Disabled select all functionalities on wx versions older than 3

### DIFF
--- a/Tribler/Main/vwxGUI/list_body.py
+++ b/Tribler/Main/vwxGUI/list_body.py
@@ -1436,7 +1436,11 @@ class ListBody(AbstractListBody, scrolled.ScrolledPanel):
         accelerators.append((wx.ACCEL_NORMAL, wx.WXK_DOWN, adownId))
         accelerators.append((wx.ACCEL_NORMAL, wx.WXK_DELETE, deleteId))
         accelerators.append((wx.ACCEL_NORMAL, wx.WXK_BACK, backId))
-        accelerators.append((wx.ACCEL_RAW_CTRL, ord('a'), ctrlaId))
+
+        # wx.ACCEL_RAW_CTRL is not available in versions < wx3 so disable select all functionality on these versions.
+        if hasattr(wx, 'ACCEL_RAW_CTRL'):
+            accelerators.append((wx.ACCEL_RAW_CTRL, ord('a'), ctrlaId))
+
         self.SetAcceleratorTable(wx.AcceleratorTable(accelerators))
 
         self.SetForegroundColour(parent.GetForegroundColour())


### PR DESCRIPTION
`wx.ACCEL_RAW_CTRL` is not implemented in wx2.8. We should still support wx2.8 so users on Ubuntu 14.04 and older can Tribler.