### PR TITLE
Hack quotes in the nickname config.

### DIFF
--- a/Tribler/Core/SessionConfig.py
+++ b/Tribler/Core/SessionConfig.py
@@ -447,12 +447,17 @@ class SessionConfigInterface(object):
         """ The nickname you want to show to others.
         @param value A Unicode string.
         """
-        self.sessconfig.set(u'general', u'nickname', value)
+        # TODO(emilon): ugly hack to work around the fact that Tribler's config
+        # system is really, really bad and can't deal with unicode strings by
+        # itself. Fixing that at the ConfigParser level would break too many
+        # things, so let's stick with this until we can throw the whole thing
+        # away and use ConfigObj instead.
+        self.sessconfig.set(u'general', u'nickname', u'"%s"' % value.strip('"'))
 
     def get_nickname(self):
         """ Returns the set nickname.
         @return A Unicode string. """
-        return unicode(self.sessconfig.get(u'general', u'nickname'))
+        return self.sessconfig.get(u'general', u'nickname')
 
     def set_mugshot(self, value, mime='image/jpeg'):
         """ The picture of yourself you want to show to others.

--- a/Tribler/Core/Utilities/configparser.py
+++ b/Tribler/Core/Utilities/configparser.py
@@ -43,6 +43,8 @@ class CallbackConfigParser(RawConfigParser):
                     value = ast.literal_eval(value)
                 except:
                     pass
+            if isinstance(value, str):
+                value = value.decode('utf-8')
             return value
 
     def copy(self):


### PR DESCRIPTION
So a non-ASCII one can be decoded correctly by the config parser.

Fixes #2093