### PR TITLE
Ready: Created the HTTP API classes and written a first endpoint to fetch information about your channel

### DIFF
--- a/Tribler/Core/Modules/restapi/__init__.py
+++ b/Tribler/Core/Modules/restapi/__init__.py
@@ -1,0 +1,3 @@
+"""
+This package contains code for the Tribler HTTP API.
+"""

--- a/Tribler/Core/Modules/restapi/my_channel_endpoint.py
+++ b/Tribler/Core/Modules/restapi/my_channel_endpoint.py
@@ -1,0 +1,57 @@
+import json
+from twisted.web import server, resource
+from Tribler.Core.simpledefs import NTFY_CHANNELCAST
+
+
+class MyChannelEndpoint(resource.Resource):
+    """
+    This endpoint is reponsible for handing all requests regarding your channel such as getting and updating
+    torrents, playlists and rss-feeds.
+    """
+
+    def __init__(self, session):
+        resource.Resource.__init__(self)
+        self.session = session
+
+    def getChild(self, path, request):
+        if path == "overview":
+            return MyChannelOverviewEndpoint(self.session)
+
+
+class MyChannelOverviewEndpoint(resource.Resource):
+    """
+    This endpoint returns a 404 HTTP response if you have not created a channel (yet).
+    Otherwise, it returns the name, description and identifier of your channel.
+
+    Example response:
+    {
+        "overview": {
+            "name": "My Tribler channel",
+            "description": "A great collection of open-source movies",
+            "identifier": "4a9cfc7ca9d15617765f4151dd9fae94c8f3ba11"
+        }
+    }
+    """
+
+    def __init__(self, session):
+        resource.Resource.__init__(self)
+        self.session = session
+        self.channel_db_handler = self.session.open_dbhandler(NTFY_CHANNELCAST)
+
+    def return_404(self, request):
+        """
+        Returns a 404 response code if your channel has not been created.
+        """
+        request.setResponseCode(404)
+        request.finish()
+
+    def render_GET(self, request):
+        my_channel_id = self.channel_db_handler.getMyChannelId()
+        if my_channel_id is None:
+            self.return_404(request)
+            return server.NOT_DONE_YET
+
+        my_channel = self.channel_db_handler.getChannel(my_channel_id)
+        request.setHeader('Content-Type', 'text/json')
+        return json.dumps({'overview': {'identifier': my_channel[1].encode('hex'), 'name': my_channel[2],
+                                        'description': my_channel[3]}})

--- a/Tribler/Core/Modules/restapi/rest_manager.py
+++ b/Tribler/Core/Modules/restapi/rest_manager.py
@@ -1,0 +1,31 @@
+import logging
+from twisted.internet.defer import maybeDeferred
+from twisted.web import server
+from Tribler.Core.Modules.restapi.root_endpoint import RootEndpoint
+from Tribler.Core.Utilities.twisted_thread import reactor
+from Tribler.dispersy.taskmanager import TaskManager
+
+
+class RESTManager(TaskManager):
+    """
+    This class is responsible for managing the startup and closing of the Tribler HTTP API.
+    """
+
+    def __init__(self, session):
+        super(RESTManager, self).__init__()
+        self._logger = logging.getLogger(self.__class__.__name__)
+        self.session = session
+        self.site = None
+
+    def start(self):
+        """
+        Starts the HTTP API with the listen port as specified in the session configuration.
+        """
+        self.site = reactor.listenTCP(self.session.get_http_api_port(),
+                                      server.Site(RootEndpoint(self.session)))
+
+    def stop(self):
+        """
+        Stop the HTTP API and return a deferred that fires when the server has shut down.
+        """
+        return maybeDeferred(self.site.stopListening)

--- a/Tribler/Core/Modules/restapi/root_endpoint.py
+++ b/Tribler/Core/Modules/restapi/root_endpoint.py
@@ -1,0 +1,16 @@
+from twisted.web import resource
+from Tribler.Core.Modules.restapi.my_channel_endpoint import MyChannelEndpoint
+
+
+class RootEndpoint(resource.Resource):
+    """
+    The root endpoint of the Tribler HTTP API is the root resource in the request tree.
+    It will dispatch requests regarding torrents, channels, settings etc to the right child endpoint.
+    """
+
+    def __init__(self, session):
+        resource.Resource.__init__(self)
+        self.session = session
+
+        self.my_channel_endpoint = MyChannelEndpoint(self.session)
+        self.putChild("mychannel", self.my_channel_endpoint)

--- a/Tribler/Core/SessionConfig.py
+++ b/Tribler/Core/SessionConfig.py
@@ -730,6 +730,37 @@ class SessionConfigInterface(object):
         return self.sessconfig.get(u'watch_folder', u'watch_folder_dir')
 
     #
+    # API
+    #
+    def set_http_api_enabled(self, http_api_enabled):
+        """
+        Sets whether the HTTP API is enabled.
+        :param http_api_enabled: True or False.
+        """
+        return self.sessconfig.set(u'http_api', u'enabled', http_api_enabled)
+
+    def get_http_api_enabled(self):
+        """
+        Returns whether the HTTP API is enabled.
+        :return: A boolean indicating whether the HTTP API is enabled.
+        """
+        return self.sessconfig.get(u'http_api', u'enabled')
+
+    def set_http_api_port(self, http_api_port):
+        """
+        Sets the HTTP API listen port.
+        :param http_api_port: An integer, indicating the port where the HTTP API should listen on.
+        """
+        return self.sessconfig.set(u'http_api', u'port', http_api_port)
+
+    def get_http_api_port(self):
+        """
+        Returns the HTTP API listen port.
+        :return: An integer indicating the port where the HTPT API listens on.
+        """
+        return self._obtain_port(u'http_api', u'port')
+
+    #
     # Static methods
     #
     @staticmethod

--- a/Tribler/Core/defaults.py
+++ b/Tribler/Core/defaults.py
@@ -37,8 +37,9 @@ DEFAULTPORT = 7760
 #  Version 10: BarterCommunity settings added (disabled by default)
 #  Version 11: Added a default whether we should upgrade or not.
 #  Version 12: Added watch folder options.
+#  Version 13: Added HTTP API options.
 
-SESSDEFAULTS_VERSION = 12
+SESSDEFAULTS_VERSION = 13
 sessdefaults = OrderedDict()
 
 # General Tribler settings
@@ -146,6 +147,11 @@ sessdefaults['upgrader']['enabled'] = True
 sessdefaults['watch_folder'] = OrderedDict()
 sessdefaults['watch_folder']['enabled'] = False
 sessdefaults['watch_folder']['watch_folder_dir'] = None
+
+# HTTP API config
+sessdefaults['http_api'] = OrderedDict()
+sessdefaults['http_api']['enabled'] = False
+sessdefaults['http_api']['port'] = -1
 
 #
 # BT per download opts

--- a/Tribler/Test/Core/Modules/RestApi/__init__.py
+++ b/Tribler/Test/Core/Modules/RestApi/__init__.py
@@ -1,0 +1,3 @@
+"""
+This module contains tests for the endpoints of the Tribler HTTP API.
+"""

--- a/Tribler/Test/Core/Modules/RestApi/base_api_test.py
+++ b/Tribler/Test/Core/Modules/RestApi/base_api_test.py
@@ -1,0 +1,45 @@
+import json
+from twisted.internet.defer import succeed
+from twisted.web.client import Agent, readBody
+from twisted.web.http_headers import Headers
+from Tribler.Core.Utilities.twisted_thread import reactor
+from Tribler.Core.version import version_id
+from Tribler.Test.test_as_server import TestAsServer
+
+
+class AbstractApiTest(TestAsServer):
+    """
+    Tests for the Tribler HTTP API should create a subclass of this class.
+    This class contains some auxiliary methods to perform requests and to check the right response code/
+    response json returned.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(AbstractApiTest, self).__init__(*args, **kwargs)
+        self.expected_response_code = 200
+        self.expected_response_json = None
+
+    def setUpPreSession(self):
+        super(AbstractApiTest, self).setUpPreSession()
+        self.config.set_http_api_enabled(True)
+        self.config.set_megacache(True)
+
+    def parse_body(self, body):
+        if body is not None:
+            self.assertDictEqual(json.loads(body), self.expected_response_json)
+
+    def parse_response(self, response):
+        self.assertEqual(response.code, self.expected_response_code)
+        if response.code == 200:
+            return readBody(response)
+        else:
+            return succeed(None)
+
+    def do_request(self, endpoint, expected_code=200, expected_json=None):
+        self.expected_response_code = expected_code
+        self.expected_response_json = expected_json
+
+        agent = Agent(reactor)
+        return agent.request('GET', 'http://localhost:%s/%s' % (self.session.get_http_api_port(), endpoint),
+                             Headers({'User-Agent': ['Tribler ' + version_id]}), None)\
+            .addCallback(self.parse_response).addCallback(self.parse_body)

--- a/Tribler/Test/Core/Modules/RestApi/test_my_channel_endpoints.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_my_channel_endpoints.py
@@ -1,0 +1,29 @@
+from Tribler.Core.Utilities.twisted_thread import deferred
+from Tribler.Core.simpledefs import NTFY_CHANNELCAST
+from Tribler.Test.Core.Modules.RestApi.base_api_test import AbstractApiTest
+
+
+class TestMyChannelEndpoints(AbstractApiTest):
+
+    @deferred(timeout=10)
+    def test_my_channel_overview_endpoint_no_my_channel(self):
+        """
+        Testing whether the API returns response code 404 if no channel has been created
+        """
+        return self.do_request('mychannel/overview', expected_code=404)
+
+    @deferred(timeout=10)
+    def test_my_channel_overview_endpoint_with_channel(self):
+        """
+        Testing whether the API returns the right JSON data if a channel overview is requested
+        """
+        channel_db_handler = self.session.open_dbhandler(NTFY_CHANNELCAST)
+
+        channel_json = {u'overview': {u'name': u'testname', u'description': u'testdescription',
+                                      u'identifier': 'fakedispersyid'.encode('hex')}}
+        channel_db_handler._get_my_dispersy_cid = lambda: "myfakedispersyid"
+        channel_db_handler.on_channel_from_dispersy('fakedispersyid', None,
+                                                         channel_json['overview']['name'],
+                                                         channel_json['overview']['description'])
+
+        return self.do_request('mychannel/overview', expected_code=200, expected_json=channel_json)

--- a/Tribler/Test/Core/test_sessionconfig.py
+++ b/Tribler/Test/Core/test_sessionconfig.py
@@ -133,6 +133,12 @@ class TestSessionConfig(TriblerCoreTest):
         sci.set_upgrader_enabled(False)
         self.assertFalse(sci.get_upgrader_enabled())
 
+        sci.set_http_api_enabled(True)
+        self.assertTrue(sci.get_http_api_enabled())
+
+        sci.set_http_api_port(1337)
+        self.assertEqual(sci.sessconfig.get('http_api', 'port'), 1337)
+
         self.assertIsInstance(sci.get_default_config_filename(self.session_base_dir), str)
 
     def test_startup_session_save_load(self):

--- a/Tribler/Test/test_as_server.py
+++ b/Tribler/Test/test_as_server.py
@@ -260,6 +260,7 @@ class TestAsServer(AbstractServer):
         self.config.set_videoplayer(False)
         self.config.set_enable_metadata(False)
         self.config.set_upgrader_enabled(False)
+        self.config.set_http_api_enabled(False)
 
     def tearDown(self):
         self.annotate(self._testMethodName, start=False)

--- a/doc/Tribler REST API.md
+++ b/doc/Tribler REST API.md
@@ -1,0 +1,31 @@
+# Tribler REST API
+
+## Overview
+The Tribler REST API allows you to create your own applications with the channels, torrents and other data that can be found in Tribler. Moreover, you can control Tribler and add data to Tribler using various endpoints. This documentation explains the format and structure of the endpoints that can be found in this API. *Note that this API is currently under development and more endpoints will be added over time*.
+
+## Making requests
+The API has been built using [Twisted Web](http://twistedmatrix.com/trac/wiki/TwistedWeb). Requests go over HTTP where GET requests should be used when data is fetched from the Tribler core and POST requests should be used if data in the core is manipulated (such as adding a torrent or removing a download). Responses of the requests are in JSON format.
+
+## Endpoints
+
+### My Channel
+
+| Endpoint | Description |
+| ---- | --------------- |
+| [GET /mychannel/overview](/v3_resources/blocks.md#get-usersloginblocks) | Get the name, description and identifier of your channel |
+
+## `GET /mychannel/overview`
+
+Returns an overview of the channel of the user. This includes the name, description and identifier of the channel.
+
+### Example response
+
+```json
+{
+    "overview": {
+        "name": "My Tribler channel",
+        "description": "A great collection of open-source movies",
+        "identifier": "4a9cfc7ca9d15617765f4151dd9fae94c8f3ba11"
+    }
+}
+```

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
         'Tribler.Core.Libtorrent',
         'Tribler.Core.Modules',
         'Tribler.Core.Modules.channel',
+        'Tribler.Core.Modules.restapi',
         'Tribler.Core.TFTP',
         'Tribler.Core.TorrentChecker',
         'Tribler.Core.Upgrade',


### PR DESCRIPTION
In this PR, I created the classes that are setting up the Tribler HTTP API. The API can be enabled or disabled by using the session configuration file. Also, changing the port is possible. By default, the API listens on port 8085 (we should fix this port so the new Qt GUI knows which port to use) but it's also possible to assign a random port to the API as I do in the unit tests.

The first endpoint of the API is to fetch the overview of your channel. This returns the name, identifier (hex-encoded) and description of your channel. The API will be gradually improved and expanded in separate PRs after this one has been merged. I will first focus on the endpoints related to your channel (getting/adding torrents, playlists and rss-feeds) as requested by @brussee.

I've also written a document describing the API and available endpoints in more detail. This document might grow over time so at one point, we might have to split it into separate files. The structure of the API documentations resembles the [Twitch API documentation](https://github.com/justintv/Twitch-API) which I think has a clear structure.

I've added docstrings where I think they might increase the understandability of the code.

Also, this PR got a little larger than I initially hoped but I think it's very hard to split this since everything I did is necessary to create the base for the API.