### PR TITLE
Removed lock in get method of configparser

### DIFF
--- a/Tribler/Core/Utilities/configparser.py
+++ b/Tribler/Core/Utilities/configparser.py
@@ -35,15 +35,14 @@ class CallbackConfigParser(RawConfigParser):
             RawConfigParser.set(self, section, option, new_value)
 
     def get(self, section, option, literal_eval=True):
-        with self.lock:
-            value = RawConfigParser.get(self, section, option) if RawConfigParser.has_option(
-                self, section, option) else None
-            if literal_eval:
-                try:
-                    value = ast.literal_eval(value)
-                except:
-                    pass
-            return value
+        value = RawConfigParser.get(self, section, option) if RawConfigParser.has_option(
+            self, section, option) else None
+        if literal_eval:
+            try:
+                value = ast.literal_eval(value)
+            except (ValueError, SyntaxError):
+                pass
+        return value
 
     def copy(self):
         with self.lock:


### PR DESCRIPTION
The tests in `Tribler/Test/API/test_download.py` occasionally got stuck. It turned out that is caused by locks in the `threading` and `logging` framework which seems to contain a bug (http://bugs.python.org/issue6721).

The location where the tests were hanging is always the `get` method of `configparser.py`. There is a lock here but no thread critical code as far as I can see so I propose to remove the lock. I tested the code below and the tests do not get stuck anymore (been running them for a while in several terminals).

I will run the unit tests several times.