### PR TITLE
Remove multichain dispersy timeout test

### DIFF
--- a/Tribler/Test/test_multichain_community.py
+++ b/Tribler/Test/test_multichain_community.py
@@ -282,22 +282,6 @@ class TestMultiChainCommunity(AbstractServer, DispersyTestFunc):
         # Assert
         self.assertEqual((10, 5), node.call(node.community._get_next_total, 0, 0))
 
-    def test_signature_request_timeout(self):
-        """"
-        Test the community to timeout on a signature request message.
-        """
-        # Arrange
-        node, other = self.create_nodes(2)
-        other.send_identity(node)
-        target_other = self._create_target(node, other)
-        # Act
-        node.call(node.community.publish_signature_request_message, target_other, 5, 5)
-        # Wait for the timeout.
-        time.sleep(10 + 2)  # 10 seconds is the default timeout for a signature request in dispersy
-        # Assert
-        self.assertBlocksInDatabase(node, 1)
-        self.assertBlocksInDatabase(other, 0)
-
     def test_request_block_latest(self):
         """
         Test the crawler to request the latest block.


### PR DESCRIPTION
This removes a timeout listed in https://github.com/Tribler/tribler/issues/2130

Now that multichain no longer uses a custom timeout, this is basically just a dispersy test now, which should be tested elsewhere.