### PR TITLE
Fix NSIS running twice

### DIFF
--- a/Tribler/Main/Build/Win/tribler.nsi
+++ b/Tribler/Main/Build/Win/tribler.nsi
@@ -1,5 +1,6 @@
 !define PRODUCT "Tribler"
-; Laurens, 2016-03-14: The __GIT__ string will be replaced by update_version_from_git.py with the current version of the build.
+; Laurens, 2016-03-14: The __GIT__ string will be replaced by update_version_from_git.py 
+; with the current version of the build.
 !define VERSION "__GIT__"
 ; Laurens, 2016-03-14: The _x86 will be replaced by _x64 if needed in update_version_from_git.py
 !define BITVERSION "x86"
@@ -8,6 +9,8 @@
 !include "FileFunc.nsh"
 !include "nsProcess.nsh"
 
+; Laurens, 2016-04-06: We are going to possibly touch the C:/ drive (by default we do) and it's restricted areas,
+; so we need admin permission to do so (for most devices).
 RequestExecutionLevel admin
 
 ;--------------------------------
@@ -18,10 +21,12 @@ Name "${PRODUCT} ${VERSION}"
 OutFile "${PRODUCT}_${VERSION}_${BITVERSION}.exe"
 
 ;Folder selection page. 
-; Laurens, 2016-03-14: Note that $PROGRAMFILES will be replaced by $PROGRAMFILES64 if needed from update_version_from_git.py.
+; Laurens, 2016-03-14: Note that $PROGRAMFILES will be replaced by $PROGRAMFILES64 
+; if the 64 bit argument is passed to update_version_from_git.py.
 InstallDir "$PROGRAMFILES\${PRODUCT}"
 
-; Laurens, 2016-03-15: No silent mode for the installer and uninstaller because this will disbale the init functions being called.
+; Laurens, 2016-03-15: No silent mode for the installer and uninstaller because 
+; this will disbale the init functions being called.
 SilentInstall normal
 SilentUnInstall normal
 
@@ -45,14 +50,14 @@ BrandingText "${PRODUCT}"
 ; Tribler running check - shared function
 !macro RUNMACRO un
   Function ${un}checkrunning
-	DetailPrint "Checking if Tribler is not running..."
-	checkRunning:
-		${nsProcess::FindProcess} "tribler.exe" $r0
-    		StrCmp $r0 0 0 notRunning
-    		MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION "${PRODUCT} is running, please close it so the (un)installation can proceed." /SD IDCANCEL IDRETRY checkRunning
-    		Abort
+     DetailPrint "Checking if Tribler is not running..."
+     checkRunning:
+          ${nsProcess::FindProcess} "tribler.exe" $r0
+                StrCmp $r0 0 0 notRunning
+                MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION "${PRODUCT} is running, please close it so the (un)installation can proceed." /SD IDCANCEL IDRETRY checkRunning
+                Abort
 
-  	notRunning:
+        notRunning:
   FunctionEnd
 !macroend
  
@@ -105,180 +110,175 @@ LangString DESC_SecDefaultMagnet ${LANG_ENGLISH} "Associate magnet links with ${
 ;Installer Sections
 
 Section "!Main EXE" SecMain
-	MessageBox MB_OK "In Section !Main EXE"
- SectionIn RO
- ; Check if tribler is not running when trying to install because files will be in use when cleaning the isntall dir.
- Call checkrunning
+    SectionIn RO
+    ; Check if tribler is not running when trying to install because files will be in use when cleaning the isntall dir.
+    Call checkrunning
 
- ; Boudewijn, need to remove stuff from previously installed version
- RMDir /r "$INSTDIR"
+    ; Boudewijn, need to remove stuff from previously installed version
+    RMDir /r "$INSTDIR"
 
- ; Install Tribler stuff
- SetOutPath "$INSTDIR"
- File /r Microsoft.VC90.CRT
- File /r *
- File *.txt
- ; Arno: Appears to be for CRT v6?
- ; File tribler.exe.manifest
- File logger.conf
- File tribler.exe
- File ffmpeg.exe
- File /r vlc
- File tools\*.bat
- Delete "$INSTDIR\*.pyd"
- File *.pyd
- Delete "$INSTDIR\python*.dll"
- Delete "$INSTDIR\wx*.dll"
- File *.dll
- CreateDirectory "$INSTDIR\Tribler"
- SetOutPath "$INSTDIR\Tribler"
- File Tribler\*.sql
- CreateDirectory "$INSTDIR\Tribler\Core"
+    ; Install Tribler stuff
+    SetOutPath "$INSTDIR"
+    File /r Microsoft.VC90.CRT
+    File /r *
+    File *.txt
+    File logger.conf
+    File tribler.exe
+    File ffmpeg.exe
+    File /r vlc
+    File tools\*.bat
+    Delete "$INSTDIR\*.pyd"
+    File *.pyd
+    Delete "$INSTDIR\python*.dll"
+    Delete "$INSTDIR\wx*.dll"
+    File *.dll
+    CreateDirectory "$INSTDIR\Tribler"
+    SetOutPath "$INSTDIR\Tribler"
+    File Tribler\*.sql
+    CreateDirectory "$INSTDIR\Tribler\Core"
 
-  ; Main client specific
- CreateDirectory "$INSTDIR\Tribler"
- CreateDirectory "$INSTDIR\Tribler\Main\vwxGUI"
- CreateDirectory "$INSTDIR\Tribler\Main\vwxGUI\images"
- CreateDirectory "$INSTDIR\Tribler\Main\vwxGUI\images\default"
- CreateDirectory "$INSTDIR\Tribler\Main\vwxGUI\images\flags"
- SetOutPath "$INSTDIR\Tribler\Main\vwxGUI\images"
- File Tribler\Main\vwxGUI\images\*
- SetOutPath "$INSTDIR\Tribler\Main\vwxGUI\images\default"
- File Tribler\Main\vwxGUI\images\default\*
- SetOutPath "$INSTDIR\Tribler\Main\vwxGUI\images\flags"
- File Tribler\Main\vwxGUI\images\flags\*
+    ; Main client specific
+    CreateDirectory "$INSTDIR\Tribler"
+    CreateDirectory "$INSTDIR\Tribler\Main\vwxGUI"
+    CreateDirectory "$INSTDIR\Tribler\Main\vwxGUI\images"
+    CreateDirectory "$INSTDIR\Tribler\Main\vwxGUI\images\default"
+    CreateDirectory "$INSTDIR\Tribler\Main\vwxGUI\images\flags"
+    SetOutPath "$INSTDIR\Tribler\Main\vwxGUI\images"
+    File Tribler\Main\vwxGUI\images\*
+    SetOutPath "$INSTDIR\Tribler\Main\vwxGUI\images\default"
+    File Tribler\Main\vwxGUI\images\default\*
+    SetOutPath "$INSTDIR\Tribler\Main\vwxGUI\images\flags"
+    File Tribler\Main\vwxGUI\images\flags\*
 
- CreateDirectory "$INSTDIR\Tribler\Main\webUI"
- CreateDirectory "$INSTDIR\Tribler\Main\webUI\static"
- CreateDirectory "$INSTDIR\Tribler\Main\webUI\static\images"
- CreateDirectory "$INSTDIR\Tribler\Main\webUI\static\lang"
- SetOutPath "$INSTDIR\Tribler\Main\webUI\static"
- File Tribler\Main\webUI\static\*.*
- SetOutPath "$INSTDIR\Tribler\Main\webUI\static\images"
- File Tribler\Main\webUI\static\images\*.*
- SetOutPath "$INSTDIR\Tribler\Main\webUI\static\lang"
- File Tribler\Main\webUI\static\lang\*.*
+    CreateDirectory "$INSTDIR\Tribler\Main\webUI"
+    CreateDirectory "$INSTDIR\Tribler\Main\webUI\static"
+    CreateDirectory "$INSTDIR\Tribler\Main\webUI\static\images"
+    CreateDirectory "$INSTDIR\Tribler\Main\webUI\static\lang"
+    SetOutPath "$INSTDIR\Tribler\Main\webUI\static"
+    File Tribler\Main\webUI\static\*.*
+    SetOutPath "$INSTDIR\Tribler\Main\webUI\static\images"
+    File Tribler\Main\webUI\static\images\*.*
+    SetOutPath "$INSTDIR\Tribler\Main\webUI\static\lang"
+    File Tribler\Main\webUI\static\lang\*.*
 
- ; Categories
- CreateDirectory "$INSTDIR\Tribler\Category"
- SetOutPath "$INSTDIR\Tribler\Category"
- File Tribler\Category\*.conf
- File Tribler\Category\*.filter
+    ; Categories
+    CreateDirectory "$INSTDIR\Tribler\Category"
+    SetOutPath "$INSTDIR\Tribler\Category"
+    File Tribler\Category\*.conf
+    File Tribler\Category\*.filter
 
- ; Arno, 2012-05-25: data files for pymdht
- CreateDirectory "$INSTDIR\Tribler\Core\DecentralizedTracking"
- CreateDirectory "$INSTDIR\Tribler\Core\DecentralizedTracking\pymdht"
- CreateDirectory "$INSTDIR\Tribler\Core\DecentralizedTracking\pymdht\core"
- SetOutPath "$INSTDIR\Tribler\Core\DecentralizedTracking\pymdht\core"
- File Tribler\Core\DecentralizedTracking\pymdht\core\bootstrap_stable
- File Tribler\Core\DecentralizedTracking\pymdht\core\bootstrap_unstable
+    ; Arno, 2012-05-25: data files for pymdht
+    CreateDirectory "$INSTDIR\Tribler\Core\DecentralizedTracking"
+    CreateDirectory "$INSTDIR\Tribler\Core\DecentralizedTracking\pymdht"
+    CreateDirectory "$INSTDIR\Tribler\Core\DecentralizedTracking\pymdht\core"
+    SetOutPath "$INSTDIR\Tribler\Core\DecentralizedTracking\pymdht\core"
+    File Tribler\Core\DecentralizedTracking\pymdht\core\bootstrap_stable
+    File Tribler\Core\DecentralizedTracking\pymdht\core\bootstrap_unstable
 
- ; Install MSVCR 2008, 2010, 2012
- SetOutPath "$INSTDIR"
+    ; Install MSVCR 2008, 2010, 2012
+    SetOutPath "$INSTDIR"
 
- ; Libraries dependant on 2008 are: Python, APSW
- File vc_redist_90.exe
- ExecWait "$INSTDIR\vc_redist_90.exe /q /norestart"
+    ; Libraries dependant on 2008 are: Python, APSW
+    File vc_redist_90.exe
+    ExecWait "$INSTDIR\vc_redist_90.exe /q /norestart"
 
- ; Libraries dependant on 2010 are:M2Crypto, netifaces
- File vc_redist_100.exe
- ExecWait "$INSTDIR\vc_redist_100.exe /q /norestart"
+    ; Libraries dependant on 2010 are:M2Crypto, netifaces
+    File vc_redist_100.exe
+    ExecWait "$INSTDIR\vc_redist_100.exe /q /norestart"
 
- ; Libraries dependant on 2012 are: LevelDB, LibTorrent
- File vc_redist_110.exe
- ExecWait "$INSTDIR\vc_redist_110.exe /q /norestart"
+    ; Libraries dependant on 2012 are: LevelDB, LibTorrent
+    File vc_redist_110.exe
+    ExecWait "$INSTDIR\vc_redist_110.exe /q /norestart"
 
-FileOpen $9 "$INSTDIR\tribler.exe.log" w
-FileWrite $9 ""
-FileClose $9
-AccessControl::GrantOnFile "$INSTDIR\tribler.exe.log" "(BU)" "FullAccess"
-AccessControl::GrantOnFile "$INSTDIR\tribler.exe.log" "(S-1-5-32-545)" "FullAccess"
+    FileOpen $9 "$INSTDIR\tribler.exe.log" w
+    FileWrite $9 ""
+    FileClose $9
+    AccessControl::GrantOnFile "$INSTDIR\tribler.exe.log" "(BU)" "FullAccess"
+    AccessControl::GrantOnFile "$INSTDIR\tribler.exe.log" "(S-1-5-32-545)" "FullAccess"
 
- ; End
- SetOutPath "$INSTDIR"
- WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT}" "DisplayName" "${PRODUCT}"
- WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT}" "NoModify" 1
- WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT}" "NoRepair" 1
- WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT}" "UninstallString" "$INSTDIR\Uninstall.exe"
- WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT}" "InstallLocation" "$INSTDIR"
- WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT}" "DisplayVersion" '${VERSION}'
- WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT}" "DisplayIcon" "$INSTDIR\${PRODUCT}.exe,0"
- WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT}" "Publisher" "The Tribler Team"
- WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT}" "HelpLink" 'http://forum.tribler.org'
- WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT}" "URLInfoAbout" 'http://www.tribler.org'
- WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT}" "URLUpdateInfo" 'http://www.tribler.org/trac/wiki/Download'
- ${GetSize} "$INSTDIR" "/S=0K" $0 $1 $2
- IntFmt $0 "0x%08X" $0
- WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT}" "EstimatedSize" "$0"
+    ; End
+    SetOutPath "$INSTDIR"
+    WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT}" "DisplayName" "${PRODUCT}"
+    WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT}" "NoModify" 1
+    WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT}" "NoRepair" 1
+    WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT}" "UninstallString" "$INSTDIR\Uninstall.exe"
+    WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT}" "InstallLocation" "$INSTDIR"
+    WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT}" "DisplayVersion" '${VERSION}'
+    WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT}" "DisplayIcon" "$INSTDIR\${PRODUCT}.exe,0"
+    WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT}" "Publisher" "The Tribler Team"
+    WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT}" "HelpLink" 'http://forum.tribler.org'
+    WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT}" "URLInfoAbout" 'http://www.tribler.org'
+    WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT}" "URLUpdateInfo" 'http://www.tribler.org/trac/wiki/Download'
+    ${GetSize} "$INSTDIR" "/S=0K" $0 $1 $2
+    IntFmt $0 "0x%08X" $0
+    WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT}" "EstimatedSize" "$0"
 
- ; Now writing to KHEY_LOCAL_MACHINE only -- remove references to uninstall from current user
- DeleteRegKey HKEY_CURRENT_USER "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT}"
- ; Remove old error log if present
- Delete "$INSTDIR\tribler.exe.log"
+    ; Now writing to KHEY_LOCAL_MACHINE only -- remove references to uninstall from current user
+    DeleteRegKey HKEY_CURRENT_USER "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT}"
+    ; Remove old error log if present
+    Delete "$INSTDIR\tribler.exe.log"
 
- WriteUninstaller "$INSTDIR\Uninstall.exe"
+    WriteUninstaller "$INSTDIR\Uninstall.exe"
 
- ; Add an application to the firewall exception list - All Networks - All IP Version - Enabled
- SimpleFC::AddApplication "Tribler" "$INSTDIR\${PRODUCT}.exe" 0 2 "" 1
- ; Pop $0 ; return error(1)/success(0)
-
+    ; Add an application to the firewall exception list - All Networks - All IP Version - Enabled
+    SimpleFC::AddApplication "Tribler" "$INSTDIR\${PRODUCT}.exe" 0 2 "" 1
 SectionEnd
 
 
 Section "Desktop Icons" SecDesk
-   CreateShortCut "$DESKTOP\${PRODUCT}.lnk" "$INSTDIR\${PRODUCT}.exe" ""
+    CreateShortCut "$DESKTOP\${PRODUCT}.lnk" "$INSTDIR\${PRODUCT}.exe" ""
 SectionEnd
 
 
 Section "Startmenu Icons" SecStart
-   CreateDirectory "$SMPROGRAMS\${PRODUCT}"
-   CreateShortCut "$SMPROGRAMS\${PRODUCT}\Uninstall ${PRODUCT}.lnk" "$INSTDIR\Uninstall.exe"
-   CreateShortCut "$SMPROGRAMS\${PRODUCT}\${PRODUCT}.lnk" "$INSTDIR\${PRODUCT}.exe"
+    CreateDirectory "$SMPROGRAMS\${PRODUCT}"
+    CreateShortCut "$SMPROGRAMS\${PRODUCT}\Uninstall ${PRODUCT}.lnk" "$INSTDIR\Uninstall.exe"
+    CreateShortCut "$SMPROGRAMS\${PRODUCT}\${PRODUCT}.lnk" "$INSTDIR\${PRODUCT}.exe"
 SectionEnd
 
 
 Section "Make Default For .torrent" SecDefaultTorrent
-   ; Delete ddeexec key if it exists
-   DeleteRegKey HKCR "bittorrent\shell\open\ddeexec"
-   WriteRegStr HKCR .torrent "" bittorrent
-   WriteRegStr HKCR .torrent "Content Type" application/x-bittorrent
-   WriteRegStr HKCR "MIME\Database\Content Type\application/x-bittorrent" Extension .torrent
-   WriteRegStr HKCR bittorrent "" "TORRENT File"
-   WriteRegBin HKCR bittorrent EditFlags 00000100
-   WriteRegStr HKCR "bittorrent\shell" "" open
-   WriteRegStr HKCR "bittorrent\shell\open\command" "" '"$INSTDIR\${PRODUCT}.exe" "%1"'
-   WriteRegStr HKCR "bittorrent\DefaultIcon" "" "$INSTDIR\Tribler\Main\vwxGUI\images\torrenticon.ico"
+    ; Delete ddeexec key if it exists
+    DeleteRegKey HKCR "bittorrent\shell\open\ddeexec"
+    WriteRegStr HKCR .torrent "" bittorrent
+    WriteRegStr HKCR .torrent "Content Type" application/x-bittorrent
+    WriteRegStr HKCR "MIME\Database\Content Type\application/x-bittorrent" Extension .torrent
+    WriteRegStr HKCR bittorrent "" "TORRENT File"
+    WriteRegBin HKCR bittorrent EditFlags 00000100
+    WriteRegStr HKCR "bittorrent\shell" "" open
+    WriteRegStr HKCR "bittorrent\shell\open\command" "" '"$INSTDIR\${PRODUCT}.exe" "%1"'
+    WriteRegStr HKCR "bittorrent\DefaultIcon" "" "$INSTDIR\Tribler\Main\vwxGUI\images\torrenticon.ico"
 SectionEnd
 
 
 Section "Make Default For .tstream" SecDefaultTStream
-   ; Arno: Poor man's attempt to check if already registered
-   ReadRegStr $0 HKCR .tstream ""
-   ReadRegStr $1 HKCR "tstream\shell\open\command" ""
-   StrCpy $2 $1 -4
-   StrCmp $0 "" 0 +2
-      return
-   MessageBox MB_YESNO ".tstream already registered to $2. Overwrite?" IDYES +2 IDNO 0
-      Return
-   DetailPrint "Arno registering .tstream: $0 $1 $2"
+    ; Arno: Poor man's attempt to check if already registered
+    ReadRegStr $0 HKCR .tstream ""
+    ReadRegStr $1 HKCR "tstream\shell\open\command" ""
+    StrCpy $2 $1 -4
+    StrCmp $0 "" 0 +2
+    return
+    MessageBox MB_YESNO ".tstream already registered to $2. Overwrite?" IDYES +2 IDNO 0
+    Return
+    DetailPrint "Arno registering .tstream: $0 $1 $2"
 
-   ; Register
-   WriteRegStr HKCR .tstream "" tstream
-   WriteRegStr HKCR .tstream "Content Type" application/x-tribler-stream
-   WriteRegStr HKCR "MIME\Database\Content Type\application/x-tribler-stream" Extension .tstream
-   WriteRegStr HKCR tstream "" "TSTREAM File"
-   WriteRegBin HKCR tstream EditFlags 00000100
-   WriteRegStr HKCR "tstream\shell" "" open
-   WriteRegStr HKCR "tstream\shell\open\command" "" '"$INSTDIR\${PRODUCT}.exe" "%1"'
-   WriteRegStr HKCR "tstream\DefaultIcon" "" "$INSTDIR\Tribler\Main\vwxGUI\images\torrenticon.ico"
+    ; Register
+    WriteRegStr HKCR .tstream "" tstream
+    WriteRegStr HKCR .tstream "Content Type" application/x-tribler-stream
+    WriteRegStr HKCR "MIME\Database\Content Type\application/x-tribler-stream" Extension .tstream
+    WriteRegStr HKCR tstream "" "TSTREAM File"
+    WriteRegBin HKCR tstream EditFlags 00000100
+    WriteRegStr HKCR "tstream\shell" "" open
+    WriteRegStr HKCR "tstream\shell\open\command" "" '"$INSTDIR\${PRODUCT}.exe" "%1"'
+    WriteRegStr HKCR "tstream\DefaultIcon" "" "$INSTDIR\Tribler\Main\vwxGUI\images\torrenticon.ico"
 SectionEnd
 
 Section "Make Default For magnet://" SecDefaultMagnet
-   WriteRegStr HKCR "magnet" "" "URL: Magnet Link Protocol"
-   WriteRegStr HKCR "magnet" "URL Protocol" ""
-   WriteRegStr HKCR "magnet\DefaultIcon" "" "$INSTDIR\Tribler\Main\vwxGUI\images\torrenticon.ico"
-   WriteRegStr HKCR "magnet\shell\open\command" "" '"$INSTDIR\${PRODUCT}.exe" "%1"'
-   WriteRegStr HKLM "SOFTWARE\Classes\magnet\shell\open\command" "" '"$INSTDIR\${PRODUCT}.exe" "%1"'
+    WriteRegStr HKCR "magnet" "" "URL: Magnet Link Protocol"
+    WriteRegStr HKCR "magnet" "URL Protocol" ""
+    WriteRegStr HKCR "magnet\DefaultIcon" "" "$INSTDIR\Tribler\Main\vwxGUI\images\torrenticon.ico"
+    WriteRegStr HKCR "magnet\shell\open\command" "" '"$INSTDIR\${PRODUCT}.exe" "%1"'
+    WriteRegStr HKLM "SOFTWARE\Classes\magnet\shell\open\command" "" '"$INSTDIR\${PRODUCT}.exe" "%1"'
 SectionEnd
 
 ;--------------------------------
@@ -288,7 +288,6 @@ SectionEnd
 !insertmacro MUI_DESCRIPTION_TEXT ${SecMain} $(DESC_SecMain)
 !insertmacro MUI_DESCRIPTION_TEXT ${SecDesk} $(DESC_SecDesk)
 !insertmacro MUI_DESCRIPTION_TEXT ${SecStart} $(DESC_SecStart)
-;!insertmacro MUI_DESCRIPTION_TEXT ${SecLang} $(DESC_SecLang)
 !insertmacro MUI_DESCRIPTION_TEXT ${SecDefaultTorrent} $(DESC_SecDefaultTorrent)
 !insertmacro MUI_DESCRIPTION_TEXT ${SecDefaultTStream} $(DESC_SecDefaultTStream)
 !insertmacro MUI_DESCRIPTION_TEXT ${SecDefaultMagnet} $(DESC_SecDefaultMagnet)
@@ -299,7 +298,6 @@ SectionEnd
 ;Uninstaller Section
 
 Section "Uninstall"
-    MessageBox MB_OK "In Uninstall section"
     ; Check if tribler is not running when trying to uninstall because files will be in use then.
     Call un.checkrunning
     RMDir /r "$INSTDIR"
@@ -315,43 +313,40 @@ Section "Uninstall"
 
     ; Remove an application from the firewall exception list
     SimpleFC::RemoveApplication "$INSTDIR\${PRODUCT}.exe"
-    ; Pop $0 ; return error(1)/success(0)
 SectionEnd
 
 ;--------------------------------
 ;Macros and Functions Section
 
 Function .onInit
-	MessageBox MB_OK "In .onInit"
+    System::Call 'kernel32::CreateMutexA(i 0, i 0, t "Tribler") i .r1 ?e'
 
-  System::Call 'kernel32::CreateMutexA(i 0, i 0, t "Tribler") i .r1 ?e'
+    Pop $R0
+    StrCmp $R0 0 checkinst
 
-  Pop $R0
-  StrCmp $R0 0 checkinst
-
-  MessageBox MB_OK "The installer is already running."
-  Abort
-
-  checkinst:
-  ReadRegStr $R0 HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT}" "UninstallString"
-  StrCmp $R0 "" done
-  IfFileExists $R0 showuninstdialog done
-
-  showuninstdialog:
-  MessageBox MB_OKCANCEL|MB_ICONEXCLAMATION "${PRODUCT} is already installed. $\n$\nClick `OK` to remove the previous version or `Cancel` to cancel this upgrade." /SD IDCANCEL IDOK uninst
-  Abort
-
-  uninst:
-    ClearErrors
-    ; Laurens (2016-03-29): Retrieve the uninstallString stored in the register. Do NOT use $INSTDIR as this points to the current $INSTDIR var of the INSTALLER, 
-    ; which is the default location at this point.
-    ReadRegStr $R0 HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT}" "UninstallString"
- MessageBox MB_OK "$R0"
-    ExecWait '"$R0" _?=$INSTDIR'
-    ReadRegStr $R0 HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT}" "UninstallString"
-    StrCmp $R0 "" done
+    MessageBox MB_OK "The installer is already running."
     Abort
-  done:
+
+    checkinst:
+        ReadRegStr $R0 HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT}" "UninstallString"
+        StrCmp $R0 "" done
+        IfFileExists $R0 showuninstdialog done
+
+    showuninstdialog:
+        MessageBox MB_OKCANCEL|MB_ICONEXCLAMATION "${PRODUCT} is already installed. $\n$\nClick `OK` to remove the previous version or `Cancel` to cancel this upgrade." /SD IDCANCEL IDOK uninst
+        Abort
+
+    uninst:
+        ClearErrors
+        ; Laurens (2016-03-29): Retrieve the uninstallString stored in the register. 
+		; Do NOT use $INSTDIR as this points to the current $INSTDIR var of the INSTALLER, 
+        ; which is the default location at this point.
+        ReadRegStr $R0 HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT}" "UninstallString"
+        ExecWait '"$R0" _?=$INSTDIR' ; This prevents the installer from being ran in a tmp directory, causing execwait not to wait.
+        ReadRegStr $R0 HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT}" "UninstallString"
+        StrCmp $R0 "" done
+        Abort
+    done:
 
 FunctionEnd
 

--- a/Tribler/Main/Build/Win/tribler.nsi
+++ b/Tribler/Main/Build/Win/tribler.nsi
@@ -182,10 +182,6 @@ Section "!Main EXE" SecMain
     File vc_redist_90.exe
     ExecWait "$INSTDIR\vc_redist_90.exe /q /norestart"
 
-    ; Libraries dependant on 2010 are:M2Crypto, netifaces
-    File vc_redist_100.exe
-    ExecWait "$INSTDIR\vc_redist_100.exe /q /norestart"
-
     ; Libraries dependant on 2012 are: LevelDB, LibTorrent
     File vc_redist_110.exe
     ExecWait "$INSTDIR\vc_redist_110.exe /q /norestart"


### PR DESCRIPTION
So after quite a while I managed to get rid of the double running problem. The problem was in the UAC plugin and after having a nice chat with the author Anders (nice guy by the way :D) he told me to sacrifice the check box at the last page and get rid of the UAC plugin.

So I got rid of the UAC and kept the check box anyway that now calls the desktop shortcut that is created during installation and works perfect. Tested on proxmox 144 and works splendid.
While I was at it, I formatted the file because it was 2, 3 and 4 space indented mixed with tabs.
Also added a bit of comments to let future generations know why decisions were made and what it does.

Oh... ignore most fixup commits as they feature tries by me to either identify the root cause of this bug, get to know how stuff works, debug items or simply to test things.

Fixes **1** blocker bug
Comments and formatting improved (enhancement)
Got rid of UAC plugin (enhancement)

Fixes #2110 
