### PR TITLE
 Avoid 2 unnecessary dependecies.

### DIFF
--- a/Tribler/Core/osutils.py
+++ b/Tribler/Core/osutils.py
@@ -21,24 +21,14 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def get_android_api_version():
-    """
-    :return: integer Runtime API version or None.
-    """
-    try:
-        from android import api_version
-        return api_version
-    except ImportError:
-        return None
-
-
 def is_android():
     """
-    This functions checks whether Tribler is running on Android or not, using the Android runtime API version.
+    This functions checks whether Tribler is running on Android or not,
+    using the system platform name and OS environment variable ANDROID_PRIVATE
 
     :return: boolean True if running on Android. False otherwise.
     """
-    return get_android_api_version() is not None
+    return sys.platform.startswith('linux') and 'ANDROID_PRIVATE' in os.environ
 
 
 if sys.platform == "win32":

--- a/Tribler/Test/Core/test_osutils.py
+++ b/Tribler/Test/Core/test_osutils.py
@@ -7,8 +7,8 @@ if os.path.exists('test_osutils.py'):
 elif os.path.exists('LICENSE.txt'):
     BASE_DIR = '.'
 
-from Tribler.Core.osutils import (fix_filebasename, get_android_api_version, is_android,
-                                  get_home_dir, get_appstate_dir, get_picture_dir, get_desktop_dir)
+from Tribler.Core.osutils import (fix_filebasename, is_android, get_home_dir, get_appstate_dir, get_picture_dir,
+                                  get_desktop_dir)
 from Tribler.Test.test_as_server import BaseTestCase
 
 
@@ -60,15 +60,6 @@ class Test_OsUtils(BaseTestCase):
         for name in name_table:
             fixedname = fix_filebasename(name)
             assert fixedname == name_table[name], (fixedname, name_table[name])
-
-    def test_get_android_api_version(self):
-        if sys.platform.startswith('linux') and 'ANDROID_PRIVATE' in os.environ:
-            version = get_android_api_version()
-            self.assertIsInstance(version, int)
-            self.assertGreater(version, 0)
-            self.assertLess(version, 50)
-        else:
-            self.assertIsNone(get_android_api_version())
 
     def test_is_android(self):
         if sys.platform.startswith('linux') and 'ANDROID_PRIVATE' in os.environ:


### PR DESCRIPTION
Triblerd running as a service does not need to know the api version.