### PR TITLE
fix typo includeDispsersy to includeDispersy

### DIFF
--- a/Tribler/Core/CacheDB/SqliteCacheDBHandler.py
+++ b/Tribler/Core/CacheDB/SqliteCacheDBHandler.py
@@ -2257,11 +2257,11 @@ ORDER BY CMD.time_stamp DESC LIMIT ?;
               "FROM Channels ORDER BY nr_favorite DESC, modified DESC LIMIT ?"
         return self._getChannels(sql, (max_nr,), includeSpam=False)
 
-    def getMySubscribedChannels(self, includeDispsersy=False):
+    def getMySubscribedChannels(self, include_dispersy=False):
         sql = "SELECT id, name, description, dispersy_cid, modified, nr_torrents, nr_favorite, nr_spam " + \
               "FROM Channels, ChannelVotes " + \
               "WHERE Channels.id = ChannelVotes.channel_id AND voter_id ISNULL AND vote == 2"
-        if not includeDispsersy:
+        if not include_dispersy:
             sql += " AND dispersy_cid == -1"
 
         return self._getChannels(sql)

--- a/Tribler/Core/Modules/restapi/channels_endpoint.py
+++ b/Tribler/Core/Modules/restapi/channels_endpoint.py
@@ -56,7 +56,7 @@ class ChannelsSubscribedEndpoint(BaseChannelsEndpoint):
     """
 
     def render_GET(self, request):
-        subscribed_channels_db = self.channel_db_handler.getMySubscribedChannels(includeDispsersy=True)
+        subscribed_channels_db = self.channel_db_handler.getMySubscribedChannels(include_dispersy=True)
         results_json = [self.convert_db_channel_to_json(channel) for channel in subscribed_channels_db]
         return json.dumps({"subscribed": results_json})
 

--- a/Tribler/Main/vwxGUI/SearchGridManager.py
+++ b/Tribler/Main/vwxGUI/SearchGridManager.py
@@ -1005,7 +1005,7 @@ class ChannelManager(object):
         return self._createChannels(allchannels)
 
     def getMySubscriptions(self):
-        subscriptions = self.channelcast_db.getMySubscribedChannels(includeDispsersy=True)
+        subscriptions = self.channelcast_db.getMySubscribedChannels(include_dispersy=True)
         return self._createChannels(subscriptions)
 
     def getPopularChannels(self):

--- a/Tribler/Test/Core/test_sqlitecachedbhandler_channels.py
+++ b/Tribler/Test/Core/test_sqlitecachedbhandler_channels.py
@@ -70,7 +70,7 @@ class TestChannelDBHandler(AbstractDB):
         self.assertEqual(res[2][0], 8)
 
     def test_get_my_subscribed_channels(self):
-        res = self.cdb.getMySubscribedChannels(includeDispsersy=True)
+        res = self.cdb.getMySubscribedChannels(include_dispersy=True)
         self.assertEqual(len(res), 1)
         res = self.cdb.getMySubscribedChannels()
         self.assertEqual(len(res), 0)


### PR DESCRIPTION
Bugs me for a while. This fixes the typo in those which affected. Is there any other place using this method?