### PR TITLE
Removed readme from OS X builder

### DIFF
--- a/Tribler/Main/Build/Mac/setuptriblermac_64bit.py
+++ b/Tribler/Main/Build/Mac/setuptriblermac_64bit.py
@@ -225,7 +225,6 @@ setup(
               [LIBRARYNAME + "/Core/DecentralizedTracking/pymdht/core/bootstrap_stable"]),
              (LIBRARYNAME + "/Core/DecentralizedTracking/pymdht/core",
               [LIBRARYNAME + "/Core/DecentralizedTracking/pymdht/core/bootstrap_unstable"]),
-             LIBRARYNAME + "/readme.txt",
              LIBRARYNAME + "/Main/Build/Mac/TriblerDoc.icns",
              ]
             + ["/Users/tribler/Documents/workspace/install/libsodium.dylib"]


### PR DESCRIPTION
This fixes the OS X builder. The readme.txt file has been removed a while ago.