### PR TITLE
Alert for resume data

### DIFF
--- a/Tribler/Core/APIImplementation/LaunchManyCore.py
+++ b/Tribler/Core/APIImplementation/LaunchManyCore.py
@@ -761,11 +761,11 @@ class TriblerLaunchMany(TaskManager):
 
     def save_download_pstate(self, infohash, pstate):
         """ Called by network thread """
-        basename = binascii.hexlify(infohash) + '.state'
-        filename = os.path.join(self.session.get_downloads_pstate_dir(), basename)
 
-        self._logger.debug("tlm: network checkpointing: to file %s", filename)
-        pstate.write_file(filename)
+        self.downloads[infohash].pstate_for_restart = pstate
+
+        self.register_task("save_pstate %f" % timemod.clock(),
+                           self.downloads[infohash].save_resume_data())
 
     def load_download_pstate(self, filename):
         """ Called by any thread """


### PR DESCRIPTION
This PR create alert for `save_resume_data`. I used `Deferred` on `resume_data`. This deferred object will call `lm.start_download` as callback (I don't find other use beside this). Resume data will be stored in `LibtorrentDownloadImpl` attribute if available.

The result is, `engineresumedata` is now available in disk-saved state. This to a certain extent, solves #2251. However, I can't get fastresume in libtorrent working, even with my own small program. So #2199 is not solved yet.