### PR TITLE
READY: Initialized threadpool size in twistd plugin

### DIFF
--- a/twisted/plugins/tribler_plugin.py
+++ b/twisted/plugins/tribler_plugin.py
@@ -115,6 +115,7 @@ class TriblerServiceMaker(object):
             })
             tribler_service.addService(manhole)
 
+        reactor.suggestThreadPoolSize(1)
         reactor.callWhenRunning(self.start_tribler, options)
 
         return tribler_service


### PR DESCRIPTION
If we don't do this, we have no thread pool when running the twistd plugin 👎 . This gave me an error if I tried to start the twistd plugin before the upgrader in Tribler starts.

The reason why it probably worked before, is that the thread pool size was initialized by https://github.com/Tribler/tribler/blob/devel/Tribler/Core/Utilities/twisted_thread.py#L54.