### PR TITLE
READY: Remove on_tunnel_remove notifier on multichain community unload

### DIFF
--- a/Tribler/community/multichain/community.py
+++ b/Tribler/community/multichain/community.py
@@ -385,6 +385,7 @@ class MultiChainCommunity(Community):
 
     def unload_community(self):
         self.logger.debug("Unloading the MultiChain Community.")
+        self.notifier.remove_observer(self.on_tunnel_remove)
         super(MultiChainCommunity, self).unload_community()
         # Close the persistence layer
         self.persistence.close()


### PR DESCRIPTION
Issues #2327 and #2313 seem to be caused by tunnel notifications happening when the multichain community has already unloaded. This should fix those issues.