### PR TITLE
WIP: Refactored the download mechanism to make it more simple

### DIFF
--- a/Tribler/Core/Libtorrent/__init__.py
+++ b/Tribler/Core/Libtorrent/__init__.py
@@ -1,10 +1,15 @@
 # Written by Egbert Bouman
 
-'''
+"""
 The Libtorrent package contains code to manage the torrent library.
-'''
+"""
 
-def checkHandleAndSynchronize(default=None):
+
+def check_handle_and_synchronize(default=None):
+    """
+    This method can be used as decorator and checks whether the download handler is valid.
+    If so, it executes the function. Else, it returns the default value passed.
+    """
     def wrap(f):
         def invoke_func(*args, **kwargs):
             download = args[0]
@@ -16,7 +21,10 @@ def checkHandleAndSynchronize(default=None):
     return wrap
 
 
-def waitForHandleAndSynchronize(default=None):
+def wait_for_handle_and_synchronize(default=None):
+    """
+    This method can be used as decorator and waits until the download handler is available.
+    """
     def wrap(f):
         def invoke_func(*args, **kwargs):
             download = args[0]
@@ -28,5 +36,4 @@ def waitForHandleAndSynchronize(default=None):
                     download.session.lm.threadpool.add_task(lambda_f, 1)
                     return default
         return invoke_func
-
     return wrap

--- a/Tribler/Policies/BoostingManager.py
+++ b/Tribler/Policies/BoostingManager.py
@@ -440,7 +440,7 @@ class BoostingManager(TaskManager):
         self.session.set_cm_sources(flag_disabled_sources, CONFIG_KEY_DISABLEDLIST)
         self.session.set_cm_sources(archive_sources, CONFIG_KEY_ARCHIVELIST)
 
-        self.session.save_pstate_sessconfig()
+        self.session.save_session_config()
 
     def log_statistics(self):
         """Log transfer statistics"""

--- a/Tribler/Test/Core/Libtorrent/test_libtorrent_download_impl.py
+++ b/Tribler/Test/Core/Libtorrent/test_libtorrent_download_impl.py
@@ -52,7 +52,7 @@ class TestLibtorrentDownloadImpl(TestAsServer):
         impl = LibtorrentDownloadImpl(self.session, None)
         impl.cew_scheduled = False
         self.session.lm.ltmgr.is_dht_ready = lambda: True
-        return impl.can_create_engine_wrapper()
+        return impl.can_create_handle()
 
     @deferred(timeout=15)
     def test_can_create_engine_wrapper_retry(self):
@@ -65,7 +65,7 @@ class TestLibtorrentDownloadImpl(TestAsServer):
         # Simulate Tribler changing the cew, the calllater should have fired by now
         # and before it executed the cew is false, firing the deferred.
         reactor.callLater(2, set_cew_false)
-        return impl.can_create_engine_wrapper()
+        return impl.can_create_handle()
 
     def test_get_magnet_link_none(self):
         tdef = self.create_tdef()
@@ -106,7 +106,7 @@ class TestLibtorrentDownloadImpl(TestAsServer):
         fake_status.share_mode = False
         # Create a dummy download config
         impl.dlconfig = DownloadStartupConfig().dlconfig.copy()
-        impl.session.lm.on_download_wrapper_created = lambda _: True
+        impl.session.lm.on_download_handle_created = lambda _: True
         impl.restart()
 
     @deferred(timeout=20)
@@ -143,7 +143,7 @@ class TestLibtorrentDownloadImpl(TestAsServer):
         test_dict = dict()
         test_dict["a"] = "b"
         pstate.set("state", "engineresumedata", test_dict)
-        return impl.network_create_engine_wrapper(pstate)
+        return impl.create_download_handle(pstate)
 
     @deferred(timeout=10)
     def test_save_resume(self):

--- a/Tribler/Test/test_as_server.py
+++ b/Tribler/Test/test_as_server.py
@@ -215,8 +215,8 @@ class TestAsServer(AbstractServer):
 
         self.hisport = self.session.get_listen_port()
 
-        while not self.session.lm.initComplete:
-            time.sleep(1)
+        while not self.session.lm.init_complete:
+            time.sleep(0.1)
 
         self.annotate(self._testMethodName, start=True)
 


### PR DESCRIPTION
My initial idea with this PR was to only refactor the checkpoint mechanism, however, it seems that I'm ending up with a complete overhaul of the download mechanism.

The current checkpoint mechanism has a grace time parameter in there, probably because we had to wait for the GUI to be stopped. This leads to checkpoints being scheduled on the tread pool around 1.5 seconds after shutdown! Moreover, the checkpointing was combined with stopping the downloads on shutdown which is a complicated design and prone to errors.

I refactored the checkpoint mechanism so it is better streamlined in our current code. This fixes a bug where the thread pool is `None`. Also, it speeds up our test execution time tremendously: a small test reduced the average runtime of REST API tests (where a complete session is started) **from 2.3 seconds to 1.3 seconds**.