### PR TITLE
DO NOT MERGE: Stabilizing credit mining test

### DIFF
--- a/Tribler/Core/Libtorrent/LibtorrentDownloadImpl.py
+++ b/Tribler/Core/Libtorrent/LibtorrentDownloadImpl.py
@@ -761,7 +761,7 @@ class LibtorrentDownloadImpl(DownloadConfigInterface):
         failure.trap(CancelledError)
         self._logger.error("Resume data cancelled")
 
-    @waitForHandleAndSynchronize()
+    @checkHandleAndSynchronize(default=Deferred().callback(None))
     def save_resume_data(self):
         """
         method to save resume data.
@@ -1169,11 +1169,11 @@ class LibtorrentDownloadImpl(DownloadConfigInterface):
             return False
         return True
 
-    @checkHandleAndSynchronize
+    @checkHandleAndSynchronize()
     def get_share_mode(self):
         return self.handle.status().share_mode
 
-    @waitForHandleAndSynchronize(True)
+    @checkHandleAndSynchronize()
     def set_share_mode(self, share_mode):
         self.handle.set_share_mode(share_mode)
 

--- a/Tribler/Test/Core/CreditMining/test_creditmining.py
+++ b/Tribler/Test/Core/CreditMining/test_creditmining.py
@@ -33,7 +33,6 @@ class TestBoostingManagerPolicies(TestAsServer):
     def setUp(self, autoload_discovery=True):
         super(TestBoostingManagerPolicies, self).setUp()
         self.session.get_download = lambda x: x % 2
-        random.seed(0)
         self.torrents = dict()
         for i in xrange(1, 11):
             mock_metainfo = MockMeta(i)
@@ -45,6 +44,7 @@ class TestBoostingManagerPolicies(TestAsServer):
         """
         testing random policy
         """
+        random.seed(0)
         policy = RandomPolicy(self.session)
         torrents_start, torrents_stop = policy.apply(self.torrents, 6, force=True)
         ids_start = [torrent["metainfo"].get_infohash() for torrent in
@@ -75,6 +75,7 @@ class TestBoostingManagerPolicies(TestAsServer):
             self.torrents[i] = {"metainfo": mock_metainfo, "num_seeders": -i,
                                 "num_leechers": -i, "creation_date": i}
 
+        random.seed(0)
         policy = SeederRatioPolicy(self.session)
         torrents_start, torrents_stop = policy.apply(self.torrents, 6)
         ids_start = [torrent["metainfo"].get_infohash() for torrent in

--- a/Tribler/Test/Core/CreditMining/test_creditmining_sys.py
+++ b/Tribler/Test/Core/CreditMining/test_creditmining_sys.py
@@ -92,7 +92,7 @@ class TestBoostingManagerSys(TestAsServer):
             defer_param = defer.Deferred()
 
         src_obj = self.boosting_manager.get_source_object(src)
-        if len(src_obj.torrents) < target:
+        if src_obj is None or len(src_obj.torrents) < target:
             reactor.callLater(1, self.check_torrents, src, defer_param, target=target)
         else:
             # notify torrent (emulate scraping)


### PR DESCRIPTION
This PR will fix credit mining testcase issues. Known issues so far : 

- [x] #2378. Threadpool race condition (`exceptions.AttributeError: 'NoneType' object has no attribute 'add_task'). Related to #2303
- [ ] #2363. Win32 reader/writers left. In linux ([this](https://jenkins.tribler.org/job/GH_Tribler_PR_tests_linux/2324/testReport/junit/Tribler.Test.Core.CreditMining.test_creditmining_sys/TestBoostingManagerSysRSS/test_rss/)). Both in `test_rss`
- [x] #2365. Test random policy. work in PR #2461
- [x] Cannot find object in `check_torrents`. [Link](https://github.com/Tribler/tribler/pull/2399#issuecomment-230398652)

All together should close issue #2378
