### PR TITLE
Tunnel extension counted bytes on a non-existant tunnel

### DIFF
--- a/Tribler/community/tunnel/tunnel_community.py
+++ b/Tribler/community/tunnel/tunnel_community.py
@@ -1121,12 +1121,11 @@ class TunnelCommunity(Community):
                                                       candidate.sock_addr, candidate_mid,
                                                       extend_candidate.sock_addr, extend_candidate_mid))
 
-
-            self.increase_bytes_sent(to_circuit_id, self.send_cell([extend_candidate],
-                                                                    u"create", (to_circuit_id,
-                                                                                message.payload.node_id,
-                                                                                message.payload.node_public_key,
-                                                                                message.payload.key)))
+            self.send_cell([extend_candidate],
+                           u"create", (to_circuit_id,
+                                       message.payload.node_id,
+                                       message.payload.node_public_key,
+                                       message.payload.key))
 
     def on_extended(self, messages):
         for message in messages:


### PR DESCRIPTION
Fixes #2352. The circuit object has not been constructed at this time, so we cannot account bytes up/down on it yet. Since this is only a few bytes of control traffic at every tunnel creation, we can safely ignore the stats count on this packet.