### PR TITLE
Update required package for building on Debian / Ubuntu

### DIFF
--- a/doc/building/building.rst
+++ b/doc/building/building.rst
@@ -21,7 +21,7 @@ Run the following commands in your terminal:
 
 .. code-block:: none
 
-    sudo apt-get install devscripts
+    sudo apt-get install devscripts python-setuptools
     cd tribler
     Tribler/Main/Build/update_version_from_git.py
     debuild -i -us -uc -b


### PR DESCRIPTION
It appears the changes in setup.py requires an additional package (not installed by default on Ubuntu). This was likely the cause for the failed build 624 on https://jenkins.tribler.org/job/Build-Tribler_Ubuntu-64_devel/624/console