### PR TITLE
Remove session-registered notification callbacks

### DIFF
--- a/Tribler/Main/tribler_main.py
+++ b/Tribler/Main/tribler_main.py
@@ -830,6 +830,25 @@ class ABCApp(object):
             # Niels: lets add a max waiting time for this session shutdown.
             session_shutdown_start = time()
 
+            # TODO(emilon): probably more notification callbacks should be remmoved
+            # here
+            s = self.utility.session
+            s.remove_observer(self.sesscb_ntfy_newversion)
+            s.remove_observer(self.sesscb_ntfy_corrupt_torrent)
+            s.remove_observer(self.sesscb_ntfy_magnet)
+            s.remove_observer(self.sesscb_ntfy_torrentfinished)
+            s.remove_observer(self.sesscb_ntfy_markingupdates)
+            s.remove_observer(self.sesscb_ntfy_moderationupdats)
+            s.remove_observer(self.sesscb_ntfy_modificationupdates)
+            s.remove_observer(self.sesscb_ntfy_commentupdates)
+            s.remove_observer(self.sesscb_ntfy_playlistupdates)
+            s.remove_observer(self.sesscb_ntfy_torrentupdates)
+            s.remove_observer(self.sesscb_ntfy_myprefupdates)
+            s.remove_observer(self.sesscb_ntfy_channelupdates)
+            s.remove_observer(self.sesscb_ntfy_channelupdates)
+            s.remove_observer(self.sesscb_ntfy_activities)
+            s.remove_observer(self.sesscb_ntfy_reachable)
+
             try:
                 self._logger.info("ONEXIT cleaning database")
                 self.utility.session.notifier.notify(NTFY_CLOSE_TICK, NTFY_INSERT, None, 'Cleaning database')


### PR DESCRIPTION
when shutting down to avoid getting them triggered half way during
shutdown and crashing because the GUI or any other component has been
removed.