### PR TITLE
Fix creditmining test randomness

### DIFF
--- a/Tribler/Test/Core/CreditMining/test_creditmining.py
+++ b/Tribler/Test/Core/CreditMining/test_creditmining.py
@@ -33,7 +33,6 @@ class TestBoostingManagerPolicies(TestAsServer):
     def setUp(self, autoload_discovery=True):
         super(TestBoostingManagerPolicies, self).setUp()
         self.session.get_download = lambda x: x % 2
-        random.seed(0)
         self.torrents = dict()
         for i in xrange(1, 11):
             mock_metainfo = MockMeta(i)
@@ -45,6 +44,7 @@ class TestBoostingManagerPolicies(TestAsServer):
         """
         testing random policy
         """
+        random.seed(0)
         policy = RandomPolicy(self.session)
         torrents_start, torrents_stop = policy.apply(self.torrents, 6, force=True)
         ids_start = [torrent["metainfo"].get_infohash() for torrent in
@@ -75,6 +75,7 @@ class TestBoostingManagerPolicies(TestAsServer):
             self.torrents[i] = {"metainfo": mock_metainfo, "num_seeders": -i,
                                 "num_leechers": -i, "creation_date": i}
 
+        random.seed(0)
         policy = SeederRatioPolicy(self.session)
         torrents_start, torrents_stop = policy.apply(self.torrents, 6)
         ids_start = [torrent["metainfo"].get_infohash() for torrent in

--- a/Tribler/Test/Core/CreditMining/test_creditmining.py
+++ b/Tribler/Test/Core/CreditMining/test_creditmining.py
@@ -8,7 +8,6 @@ Written by Mihai Capotă and Ardhi Putra Pratama H
 import binascii
 import random
 import re
-from unittest import skip
 
 import Tribler.Policies.BoostingManager as bm
 from Tribler.Core.DownloadConfig import DefaultDownloadStartupConfig
@@ -23,7 +22,6 @@ from Tribler.Test.Core.CreditMining.mock_creditmining import MockMeta, MockLtPee
 from Tribler.Test.test_as_server import TestAsServer
 
 
-@skip("Disabled credit mining tests until they are stable again")
 class TestBoostingManagerPolicies(TestAsServer):
     """
     The class to test core function of credit mining policies
@@ -98,7 +96,6 @@ class TestBoostingManagerPolicies(TestAsServer):
         self.assertEqual(ids_stop, [5, 3, 1])
 
 
-@skip("Disabled credit mining tests until they are stable again")
 class TestBoostingManagerUtilities(TestAsServer):
     """
     Test several utilities used in credit mining
@@ -347,7 +344,6 @@ class TestBoostingManagerUtilities(TestAsServer):
         boost_man.cancel_all_pending_tasks()
 
 
-@skip("Disabled credit mining tests until they are stable again")
 class TestBoostingManagerError(TestAsServer):
     """
     Class to test a bunch of credit mining error handle

--- a/Tribler/Test/Core/CreditMining/test_creditmining_sys.py
+++ b/Tribler/Test/Core/CreditMining/test_creditmining_sys.py
@@ -7,7 +7,6 @@ Written by Ardhi Putra Pratama H
 import binascii
 import os
 import shutil
-from unittest import skip
 
 from twisted.internet import defer
 from twisted.web.server import Site
@@ -31,7 +30,6 @@ from Tribler.dispersy.member import DummyMember
 from Tribler.dispersy.util import blocking_call_on_reactor_thread
 
 
-@skip("Disabled credit mining tests until they are stable again")
 class TestBoostingManagerSys(TestAsServer):
     """
     base class to test base credit mining function
@@ -136,7 +134,6 @@ class TestBoostingManagerSys(TestAsServer):
         return defer_param
 
 
-@skip("Disabled credit mining tests until they are stable again")
 class TestBoostingManagerSysRSS(TestBoostingManagerSys):
     """
     testing class for RSS (dummy) source
@@ -220,7 +217,6 @@ class TestBoostingManagerSysRSS(TestBoostingManagerSys):
         return defer_err_rss
 
 
-@skip("Disabled credit mining tests until they are stable again")
 class TestBoostingManagerSysDir(TestBoostingManagerSys):
     """
     testing class for directory source
@@ -269,7 +265,6 @@ class TestBoostingManagerSysDir(TestBoostingManagerSys):
         return d
 
 
-@skip("Disabled credit mining tests until they are stable again")
 class TestBoostingManagerSysChannel(TestBoostingManagerSys):
     """
     testing class for channel source


### PR DESCRIPTION
As part of PR #2399. This will solve issue #2365.

Sometime the random value cannot be determined although start at the same seed. Use `random.seed` inside of the test hopefully solve this issue.