### PR TITLE
WIP: Fix creditmining test handle check

### DIFF
--- a/Tribler/Core/Libtorrent/LibtorrentDownloadImpl.py
+++ b/Tribler/Core/Libtorrent/LibtorrentDownloadImpl.py
@@ -761,7 +761,7 @@ class LibtorrentDownloadImpl(DownloadConfigInterface):
         failure.trap(CancelledError)
         self._logger.error("Resume data cancelled")
 
-    @waitForHandleAndSynchronize()
+    @checkHandleAndSynchronize(default=Deferred().callback(None))
     def save_resume_data(self):
         """
         method to save resume data.
@@ -1173,7 +1173,7 @@ class LibtorrentDownloadImpl(DownloadConfigInterface):
     def get_share_mode(self):
         return self.handle.status().share_mode
 
-    @waitForHandleAndSynchronize(True)
+    @checkHandleAndSynchronize()
     def set_share_mode(self, share_mode):
         self.handle.set_share_mode(share_mode)
 

--- a/Tribler/Test/Core/CreditMining/test_creditmining.py
+++ b/Tribler/Test/Core/CreditMining/test_creditmining.py
@@ -8,7 +8,6 @@ Written by Mihai Capotă and Ardhi Putra Pratama H
 import binascii
 import random
 import re
-from unittest import skip
 
 import Tribler.Policies.BoostingManager as bm
 from Tribler.Core.DownloadConfig import DefaultDownloadStartupConfig
@@ -23,7 +22,6 @@ from Tribler.Test.Core.CreditMining.mock_creditmining import MockMeta, MockLtPee
 from Tribler.Test.test_as_server import TestAsServer
 
 
-@skip("Disabled credit mining tests until they are stable again")
 class TestBoostingManagerPolicies(TestAsServer):
     """
     The class to test core function of credit mining policies
@@ -98,7 +96,6 @@ class TestBoostingManagerPolicies(TestAsServer):
         self.assertEqual(ids_stop, [5, 3, 1])
 
 
-@skip("Disabled credit mining tests until they are stable again")
 class TestBoostingManagerUtilities(TestAsServer):
     """
     Test several utilities used in credit mining
@@ -347,7 +344,6 @@ class TestBoostingManagerUtilities(TestAsServer):
         boost_man.cancel_all_pending_tasks()
 
 
-@skip("Disabled credit mining tests until they are stable again")
 class TestBoostingManagerError(TestAsServer):
     """
     Class to test a bunch of credit mining error handle

--- a/Tribler/Test/Core/CreditMining/test_creditmining_sys.py
+++ b/Tribler/Test/Core/CreditMining/test_creditmining_sys.py
@@ -7,7 +7,6 @@ Written by Ardhi Putra Pratama H
 import binascii
 import os
 import shutil
-from unittest import skip
 
 from twisted.internet import defer
 from twisted.web.server import Site
@@ -31,7 +30,6 @@ from Tribler.dispersy.member import DummyMember
 from Tribler.dispersy.util import blocking_call_on_reactor_thread
 
 
-@skip("Disabled credit mining tests until they are stable again")
 class TestBoostingManagerSys(TestAsServer):
     """
     base class to test base credit mining function
@@ -136,7 +134,6 @@ class TestBoostingManagerSys(TestAsServer):
         return defer_param
 
 
-@skip("Disabled credit mining tests until they are stable again")
 class TestBoostingManagerSysRSS(TestBoostingManagerSys):
     """
     testing class for RSS (dummy) source
@@ -220,7 +217,6 @@ class TestBoostingManagerSysRSS(TestBoostingManagerSys):
         return defer_err_rss
 
 
-@skip("Disabled credit mining tests until they are stable again")
 class TestBoostingManagerSysDir(TestBoostingManagerSys):
     """
     testing class for directory source
@@ -269,7 +265,6 @@ class TestBoostingManagerSysDir(TestBoostingManagerSys):
         return d
 
 
-@skip("Disabled credit mining tests until they are stable again")
 class TestBoostingManagerSysChannel(TestBoostingManagerSys):
     """
     testing class for channel source


### PR DESCRIPTION
As part of PR #2399. This will solve issue #2378. Related to #2303.

Some of the decorator is wrong. This may cause race condition when threadpool is already shutting down. This PR will solve those issue. Also, provided correct default value on decorator