### PR TITLE
Fix creditmining test asynchronous issue

### DIFF
--- a/Tribler/Core/Libtorrent/LibtorrentDownloadImpl.py
+++ b/Tribler/Core/Libtorrent/LibtorrentDownloadImpl.py
@@ -761,7 +761,7 @@ class LibtorrentDownloadImpl(DownloadConfigInterface):
         failure.trap(CancelledError)
         self._logger.error("Resume data cancelled")
 
-    @waitForHandleAndSynchronize()
+    @checkHandleAndSynchronize(default=defer.succeed(None))
     def save_resume_data(self):
         """
         method to save resume data.
@@ -1173,7 +1173,7 @@ class LibtorrentDownloadImpl(DownloadConfigInterface):
     def get_share_mode(self):
         return self.handle.status().share_mode
 
-    @waitForHandleAndSynchronize(True)
+    @waitForHandleAndSynchronize()
     def set_share_mode(self, share_mode):
         self.handle.set_share_mode(share_mode)
 

--- a/Tribler/Test/Core/CreditMining/test_creditmining.py
+++ b/Tribler/Test/Core/CreditMining/test_creditmining.py
@@ -8,7 +8,6 @@ Written by Mihai Capotă and Ardhi Putra Pratama H
 import binascii
 import random
 import re
-from unittest import skip
 
 import Tribler.Policies.BoostingManager as bm
 from Tribler.Core.DownloadConfig import DefaultDownloadStartupConfig
@@ -23,7 +22,6 @@ from Tribler.Test.Core.CreditMining.mock_creditmining import MockMeta, MockLtPee
 from Tribler.Test.test_as_server import TestAsServer
 
 
-@skip("Disabled credit mining tests until they are stable again")
 class TestBoostingManagerPolicies(TestAsServer):
     """
     The class to test core function of credit mining policies
@@ -98,7 +96,6 @@ class TestBoostingManagerPolicies(TestAsServer):
         self.assertEqual(ids_stop, [5, 3, 1])
 
 
-@skip("Disabled credit mining tests until they are stable again")
 class TestBoostingManagerUtilities(TestAsServer):
     """
     Test several utilities used in credit mining
@@ -347,7 +344,6 @@ class TestBoostingManagerUtilities(TestAsServer):
         boost_man.cancel_all_pending_tasks()
 
 
-@skip("Disabled credit mining tests until they are stable again")
 class TestBoostingManagerError(TestAsServer):
     """
     Class to test a bunch of credit mining error handle

--- a/Tribler/Test/Core/CreditMining/test_creditmining_sys.py
+++ b/Tribler/Test/Core/CreditMining/test_creditmining_sys.py
@@ -7,7 +7,6 @@ Written by Ardhi Putra Pratama H
 import binascii
 import os
 import shutil
-from unittest import skip
 
 from twisted.internet import defer
 from twisted.web.server import Site
@@ -31,7 +30,6 @@ from Tribler.dispersy.member import DummyMember
 from Tribler.dispersy.util import blocking_call_on_reactor_thread
 
 
-@skip("Disabled credit mining tests until they are stable again")
 class TestBoostingManagerSys(TestAsServer):
     """
     base class to test base credit mining function
@@ -136,7 +134,6 @@ class TestBoostingManagerSys(TestAsServer):
         return defer_param
 
 
-@skip("Disabled credit mining tests until they are stable again")
 class TestBoostingManagerSysRSS(TestBoostingManagerSys):
     """
     testing class for RSS (dummy) source
@@ -220,7 +217,6 @@ class TestBoostingManagerSysRSS(TestBoostingManagerSys):
         return defer_err_rss
 
 
-@skip("Disabled credit mining tests until they are stable again")
 class TestBoostingManagerSysDir(TestBoostingManagerSys):
     """
     testing class for directory source
@@ -269,7 +265,6 @@ class TestBoostingManagerSysDir(TestBoostingManagerSys):
         return d
 
 
-@skip("Disabled credit mining tests until they are stable again")
 class TestBoostingManagerSysChannel(TestBoostingManagerSys):
     """
     testing class for channel source

--- a/Tribler/Test/Core/CreditMining/test_creditmining_sys.py
+++ b/Tribler/Test/Core/CreditMining/test_creditmining_sys.py
@@ -92,7 +92,7 @@ class TestBoostingManagerSys(TestAsServer):
             defer_param = defer.Deferred()
 
         src_obj = self.boosting_manager.get_source_object(src)
-        if len(src_obj.torrents) < target:
+        if src_obj is None or len(src_obj.torrents) < target:
             reactor.callLater(1, self.check_torrents, src, defer_param, target=target)
         else:
             # notify torrent (emulate scraping)
@@ -106,6 +106,7 @@ class TestBoostingManagerSys(TestAsServer):
                         'infohash': src_obj.torrents.keys()[0], 'length': 1150844928, 'last_tracker_check': 10001,
                         'myDownloadHistory': False, 'name': u'ubuntu-15.04-desktop-amd64.iso',
                         'num_leechers': 999, 'num_seeders': 123, 'status': u'unknown', 'tracker_check_retries': 0}
+
             self.boosting_manager.torrent_db.getTorrent = _get_tor_dummy
             self.session.notifier.notify(NTFY_TORRENTS, NTFY_UPDATE, src_obj.torrents.keys()[0])
 
@@ -468,7 +469,6 @@ class TestBoostingManagerSysChannel(TestBoostingManagerSys):
 
             chn_obj.kill_tasks()
 
-
         d = self.check_source(dispersy_cid)
         d.addCallback(clean_community)
         return d
@@ -533,7 +533,7 @@ class TestBoostingManagerSysChannel(TestBoostingManagerSys):
 
             src_obj = self.boosting_manager.get_source_object(src)
             success = True
-            if len(src_obj.unavail_torrent) == 0:
+            if src_obj is not None and len(src_obj.unavail_torrent) == 0:
                 self.assertLessEqual(len(src_obj.torrents), src_obj.max_torrents)
             else:
                 success = False


### PR DESCRIPTION
As part of PR #2399. This will solve issue mentioned in [here](https://github.com/Tribler/tribler/pull/2399#issuecomment-230398652).

Sometime, function called in twisted cannot find the object that should be there. This case is rare, in my opinion. This PR works as a precaution for that, though.

EDIT:
The work is similar with old PR #2462. This will solve issue #2378. Related to #2303. Some of the decorator is wrong. This may cause race condition when threadpool is already shutting down. This PR will solve those issue. Also, provided correct default value on decorator