### PR TITLE
READY: absolute path for android

### DIFF
--- a/Tribler/Core/SessionConfig.py
+++ b/Tribler/Core/SessionConfig.py
@@ -80,7 +80,7 @@ class SessionConfigInterface(object):
         else:
             ffmpegname = u"ffmpeg"
 
-        ffmpegpath = find_executable(ffmpegname, path_env)
+        ffmpegpath = os.path.abspath(find_executable(ffmpegname, path_env))
 
         if ffmpegpath is None:
             if sys.platform == 'darwin':


### PR DESCRIPTION
find_executable relies on the executable to be on the path, but on android it is in the current folder and not on the path