### PR TITLE
Actually check for a dirty reactor

### DIFF
--- a/Tribler/Test/test_as_server.py
+++ b/Tribler/Test/test_as_server.py
@@ -132,7 +132,7 @@ class AbstractServer(BaseTestCase):
         factory = Site(resource)
         self.file_server = reactor.listenTCP(port, factory)
 
-    def checkReactor(self, _):
+    def checkReactor(self, *_):
         delayed_calls = reactor.getDelayedCalls()
         if delayed_calls:
             self._logger.error("The reactor was dirty:")


### PR DESCRIPTION
The dirty reactor check at the end of a test run has been broken for a while now.

Brace yourselves.