### PR TITLE
Enable monkey crypto patch with py2app

### DIFF
--- a/Tribler/Main/hacks.py
+++ b/Tribler/Main/hacks.py
@@ -51,7 +51,8 @@ def patch_crypto_be_discovery():
     """
 
     # Just do the monkeypatching if running on a windows installer version.
-    if sys.platform == 'win32' and sys.argv[0].lower().endswith("tribler.exe"):
+    if (sys.platform == 'win32' and sys.argv[0].lower().endswith("tribler.exe")) \
+            or (sys.platform == 'darwin' and hasattr(sys, 'frozen')):
         from cryptography.hazmat import backends
 
         try:


### PR DESCRIPTION
Anonymous downloads were not working in the bundled version of OS X due to the openssl backend which cannot be found. I've enabled the monkey patch for cryptography on OS X too when we're frozen.

I've tested it and anonymous downloads seems to work correctly now. It's probably not the best fix but it's the best fix I can think of right now.

See https://github.com/pyca/cryptography/issues/2039