### PR TITLE
WIP: Excluded pyqt5 from build

### DIFF
--- a/Tribler/Main/Build/Mac/setuptriblermac_64bit.py
+++ b/Tribler/Main/Build/Mac/setuptriblermac_64bit.py
@@ -215,7 +215,7 @@ setup(
     options={'py2app': {
         'argv_emulation': True,
         'includes': includeModules,
-        'excludes': ["Tkinter", "Tkconstants", "tcl"],
+        'excludes': ["Tkinter", "Tkconstants", "tcl", "PyQt5"],
         'iconfile': LIBRARYNAME + '/Main/Build/Mac/tribler.icns',
         'plist': Plist.fromFile(LIBRARYNAME + '/Main/Build/Mac/Info.plist'),
         'optimize': 0 if __debug__ else 2,


### PR DESCRIPTION
This will reduce the size of Tribler.app from around 231mb to 100.5mb 👍 

Py2app somehow manages to include pyqt5 in the app bundle. The problem is that I cannot remove pyqt5 from the site packages, otherwise my new GUI won't work anymore on the builder.

Hopefully we can switch to PyInstaller soon!