### PR TITLE
re-Disabled credit mining tests

### DIFF
--- a/Tribler/Test/Core/CreditMining/test_creditmining.py
+++ b/Tribler/Test/Core/CreditMining/test_creditmining.py
@@ -8,6 +8,7 @@ Written by Mihai Capotă and Ardhi Putra Pratama H
 import binascii
 import random
 import re
+from unittest import skip
 
 import Tribler.Policies.BoostingManager as bm
 from Tribler.Core.DownloadConfig import DefaultDownloadStartupConfig
@@ -22,6 +23,7 @@ from Tribler.Test.Core.CreditMining.mock_creditmining import MockMeta, MockLtPee
 from Tribler.Test.test_as_server import TestAsServer
 
 
+@skip("Disabled credit mining tests until they are stable again")
 class TestBoostingManagerPolicies(TestAsServer):
     """
     The class to test core function of credit mining policies
@@ -97,6 +99,7 @@ class TestBoostingManagerPolicies(TestAsServer):
         self.assertEqual(ids_stop, [5, 3, 1])
 
 
+@skip("Disabled credit mining tests until they are stable again")
 class TestBoostingManagerUtilities(TestAsServer):
     """
     Test several utilities used in credit mining
@@ -345,6 +348,7 @@ class TestBoostingManagerUtilities(TestAsServer):
         boost_man.cancel_all_pending_tasks()
 
 
+@skip("Disabled credit mining tests until they are stable again")
 class TestBoostingManagerError(TestAsServer):
     """
     Class to test a bunch of credit mining error handle

--- a/Tribler/Test/Core/CreditMining/test_creditmining_sys.py
+++ b/Tribler/Test/Core/CreditMining/test_creditmining_sys.py
@@ -7,6 +7,7 @@ Written by Ardhi Putra Pratama H
 import binascii
 import os
 import shutil
+from unittest import skip
 
 from twisted.internet import defer
 from twisted.web.server import Site
@@ -30,6 +31,7 @@ from Tribler.dispersy.member import DummyMember
 from Tribler.dispersy.util import blocking_call_on_reactor_thread
 
 
+@skip("Disabled credit mining tests until they are stable again")
 class TestBoostingManagerSys(TestAsServer):
     """
     base class to test base credit mining function
@@ -134,6 +136,7 @@ class TestBoostingManagerSys(TestAsServer):
         return defer_param
 
 
+@skip("Disabled credit mining tests until they are stable again")
 class TestBoostingManagerSysRSS(TestBoostingManagerSys):
     """
     testing class for RSS (dummy) source
@@ -217,6 +220,7 @@ class TestBoostingManagerSysRSS(TestBoostingManagerSys):
         return defer_err_rss
 
 
+@skip("Disabled credit mining tests until they are stable again")
 class TestBoostingManagerSysDir(TestBoostingManagerSys):
     """
     testing class for directory source
@@ -265,6 +269,7 @@ class TestBoostingManagerSysDir(TestBoostingManagerSys):
         return d
 
 
+@skip("Disabled credit mining tests until they are stable again")
 class TestBoostingManagerSysChannel(TestBoostingManagerSys):
     """
     testing class for channel source


### PR DESCRIPTION
This PR reverts commit aa47be891d7ea8cdd5565e9a22a7ec0c2c3ea9af, which reverts the disabling of credit mining test.