### PR TITLE
READY: Added save_resume_data None case

### DIFF
--- a/Tribler/Core/APIImplementation/LaunchManyCore.py
+++ b/Tribler/Core/APIImplementation/LaunchManyCore.py
@@ -784,9 +784,11 @@ class TriblerLaunchMany(TaskManager):
         """ Called by network thread """
 
         self.downloads[infohash].pstate_for_restart = pstate
+        save_resume_data = self.downloads[infohash].save_resume_data()
 
-        self.register_task("save_pstate %f" % timemod.clock(),
-                           self.downloads[infohash].save_resume_data())
+        if save_resume_data:
+            self.register_task("save_pstate %f" % timemod.clock(),
+                               save_resume_data)
 
     def load_download_pstate(self, filename):
         """ Called by any thread """


### PR DESCRIPTION
This makes sure that when closing Tribler, uninitialized pstates do not cause AssertionErrors.
This fixes #2577 (see for more info).