### PR TITLE
Put entire message payload info in torrent discovered event

### DIFF
--- a/Tribler/Core/Modules/restapi/events_endpoint.py
+++ b/Tribler/Core/Modules/restapi/events_endpoint.py
@@ -32,8 +32,8 @@ class EventsEndpoint(resource.Resource):
     - tribler_started: An indicator that Tribler has completed the startup procedure and is ready to use.
     - channel_discovered: An indicator that Tribler has discovered a new channel. The event contains the name,
       description and dispersy community id of the discovered channel.
-    - torrent_discovered: An indicator that Tribler has discovered a new torrent. The event contains the name and the
-      dispersy community id of the discovered torrent.
+    - torrent_discovered: An indicator that Tribler has discovered a new torrent. The event contains the infohash, name,
+      list of trackers, list of files with name and size, and the dispersy community id of the discovered torrent.
     - torrent_finished: A specific torrent has finished downloading. The event includes the infohash and name of the
       torrent that has finished downloading.
     - torrent_error: An error has occurred during the download process of a specific torrent. The event includes the

--- a/Tribler/community/channel/community.py
+++ b/Tribler/community/channel/community.py
@@ -415,7 +415,11 @@ class ChannelCommunity(Community):
                 self._logger.debug("torrent received: %s on channel: %s", hexlify(message.payload.infohash), self._master_member)
 
                 self.tribler_session.notifier.notify(NTFY_TORRENT, NTFY_DISCOVERED, None,
-                                                     {"name": message.payload.name,
+                                                     {"infohash": hexlify(message.payload.infohash),
+                                                      "timestamp": message.payload.timestamp,
+                                                      "name": message.payload.name,
+                                                      "files": message.payload.files,
+                                                      "trackers": message.payload.trackers,
                                                       "dispersy_cid": self._cid.encode("hex")})
 
                 if message.candidate and message.candidate.sock_addr:


### PR DESCRIPTION
The infohash is needed on the client and available on the server. Why not send all potentially relevant information along?