### PR TITLE
Refactored checkpointing system

### DIFF
--- a/Tribler/Core/Libtorrent/LibtorrentDownloadImpl.py
+++ b/Tribler/Core/Libtorrent/LibtorrentDownloadImpl.py
@@ -10,7 +10,8 @@ from traceback import print_exc
 
 import libtorrent as lt
 from twisted.internet import defer, reactor
-from twisted.internet.defer import Deferred, CancelledError
+from twisted.internet.defer import Deferred, CancelledError, succeed
+from twisted.internet.task import LoopingCall
 
 from Tribler.Core import NoDispersyRLock
 from Tribler.Core.DownloadConfig import DownloadStartupConfig, DownloadConfigInterface
@@ -19,6 +20,7 @@ from Tribler.Core.Libtorrent import checkHandleAndSynchronize, waitForHandleAndS
 from Tribler.Core.TorrentDef import TorrentDefNoMetainfo, TorrentDef
 from Tribler.Core.Utilities import maketorrent
 from Tribler.Core.Utilities.torrent_utils import get_info_from_handle
+from Tribler.Core.exceptions import SaveResumeDataError
 from Tribler.Core.osutils import fix_filebasename
 from Tribler.Core.simpledefs import (DLSTATUS_WAITING4HASHCHECK, DLSTATUS_HASHCHECKING, DLSTATUS_METADATA,
                                      DLSTATUS_DOWNLOADING, DLSTATUS_SEEDING, DLSTATUS_ALLOCATING_DISKSPACE,
@@ -151,6 +153,9 @@ class LibtorrentDownloadImpl(DownloadConfigInterface, TaskManager):
         self._checkpoint_disabled = False
 
         self.deferreds_resume = []
+        self.deferreds_handle = []
+
+        self.handle_check_lc = self.register_task("handle_check", LoopingCall(self.check_handle))
 
     def __str__(self):
         return "LibtorrentDownloadImpl <name: '%s' hops: %d checkpoint_disabled: %d>" % \
@@ -168,6 +173,27 @@ class LibtorrentDownloadImpl(DownloadConfigInterface, TaskManager):
     def get_checkpoint_disabled(self):
         return self._checkpoint_disabled
 
+    def check_handle(self):
+        """
+        Check whether the handle exists and is valid. If so, stop the looping call and fire the deferreds waiting
+        for the handle.
+        """
+        if self.handle and self.handle.is_valid():
+            self.handle_check_lc.stop()
+            for deferred in self.deferreds_handle:
+                deferred.callback(self.handle)
+
+    def get_handle(self):
+        """
+        Returns a deferred that fires with a valid libtorrent download handle.
+        """
+        if self.handle and self.handle.is_valid():
+            return succeed(self.handle)
+
+        deferred = Deferred()
+        self.deferreds_handle.append(deferred)
+        return deferred
+
     def setup(self, dcfg=None, pstate=None, initialdlstatus=None,
               wrapperDelay=0, share_mode=False, checkpoint_disabled=False):
         """
@@ -179,6 +205,7 @@ class LibtorrentDownloadImpl(DownloadConfigInterface, TaskManager):
         network_create_engine_wrapper.
         """
         # Called by any thread, assume sessionlock is held
+        self.handle_check_lc.start(1, now=False)
         self.set_checkpoint_disabled(checkpoint_disabled)
 
         try:
@@ -338,7 +365,7 @@ class LibtorrentDownloadImpl(DownloadConfigInterface, TaskManager):
             self.cew_scheduled = False
 
             # Return a deferred with the callback already being called
-            return defer.succeed((self, pstate))
+            return defer.succeed(self)
 
     def get_anon_mode(self):
         return self.get_hops() > 0
@@ -496,7 +523,7 @@ class LibtorrentDownloadImpl(DownloadConfigInterface, TaskManager):
 
         alert_types = ('tracker_reply_alert', 'tracker_error_alert', 'tracker_warning_alert', 'metadata_received_alert',
                        'file_renamed_alert', 'performance_alert', 'torrent_checked_alert', 'torrent_finished_alert',
-                       'save_resume_data_alert')
+                       'save_resume_data_alert', 'save_resume_data_failed_alert')
 
         if alert_type in alert_types:
             getattr(self, 'on_' + alert_type)(alert)
@@ -505,15 +532,12 @@ class LibtorrentDownloadImpl(DownloadConfigInterface, TaskManager):
 
     def on_save_resume_data_alert(self, alert):
         """
-        alert to handle save_resume_data_alert
-        it will assign stored resume data in an attribute,
-            and write it to a file
+        Callback for the alert that contains the resume data of a specific download.
+        This resume data will be written to a file on disk.
         """
         resume_data = alert.resume_data
 
-        if not self.pstate_for_restart:
-            self.pstate_for_restart = self.network_get_persistent_state()
-
+        self.pstate_for_restart = self.get_persistent_download_config()
         self.pstate_for_restart.set('state', 'engineresumedata', resume_data)
         self._logger.debug("%s get resume data %s", hexlify(resume_data['info-hash']), resume_data)
 
@@ -528,6 +552,14 @@ class LibtorrentDownloadImpl(DownloadConfigInterface, TaskManager):
         # fire callback for all deferreds_resume
         for deferred_r in self.deferreds_resume:
             deferred_r.callback(resume_data)
+
+        # empties the deferred list
+        self.deferreds_resume = []
+
+    def on_save_resume_data_failed_alert(self, alert):
+        # fire errback for all deferreds_resume
+        for deferred_r in self.deferreds_resume:
+            deferred_r.errback(SaveResumeDataError(alert.msg))
 
         # empties the deferred list
         self.deferreds_resume = []
@@ -796,14 +828,13 @@ class LibtorrentDownloadImpl(DownloadConfigInterface, TaskManager):
         failure.trap(CancelledError)
         self._logger.error("Resume data cancelled")
 
-    @waitForHandleAndSynchronize()
     def save_resume_data(self):
         """
-        method to save resume data.
+        Save the resume data of a download. This method returns a deferred that fires when the resume data is available.
+        Note that this method only calls save_resume_data once on subsequent calls.
         """
-        # only call libtorrent save resume in the first call
         if not self.deferreds_resume:
-            self.handle.save_resume_data()
+            self.get_handle().addCallback(lambda handle: handle.save_resume_data())
 
         defer_resume = Deferred()
         defer_resume.addErrback(self._on_resume_err)
@@ -1018,7 +1049,7 @@ class LibtorrentDownloadImpl(DownloadConfigInterface, TaskManager):
             self._logger.debug("LibtorrentDownloadImpl: network_stop %s", self.tdef.get_name())
             self.cancel_all_pending_tasks()
 
-            pstate = self.network_get_persistent_state()
+            pstate = self.get_persistent_download_config()
             if self.handle is not None:
                 self._logger.debug("LibtorrentDownloadImpl: network_stop: engineresumedata from torrent handle")
                 self.pstate_for_restart = pstate
@@ -1048,11 +1079,8 @@ class LibtorrentDownloadImpl(DownloadConfigInterface, TaskManager):
                     self._logger.debug(
                         "LibtorrentDownloadImpl: network_stop: Could not reuse engineresumedata as pstart_for_restart is None")
 
-            # Offload the removal of the dlcheckpoint to another thread
             if removestate:
                 self.session.lm.remove_pstate(self.tdef.get_infohash())
-
-            return (self.tdef.get_infohash(), pstate)
 
     def get_content_dest(self):
         """ Returns the file to which the downloaded content is saved. """
@@ -1078,7 +1106,7 @@ class LibtorrentDownloadImpl(DownloadConfigInterface, TaskManager):
                     self.cew_scheduled = True
                     create_engine_wrapper_deferred = self.network_create_engine_wrapper(
                         self.pstate_for_restart, initialdlstatus, share_mode=self.get_share_mode())
-                    create_engine_wrapper_deferred.addCallback(self.session.lm.on_download_wrapper_created)
+                    create_engine_wrapper_deferred.addCallback(self.session.lm.on_download_handle_created)
 
                 can_create_engine_deferred = self.can_create_engine_wrapper()
                 can_create_engine_deferred.addCallback(schedule_create_engine)
@@ -1104,33 +1132,19 @@ class LibtorrentDownloadImpl(DownloadConfigInterface, TaskManager):
         return dest_files
 
     def checkpoint(self):
-        """ Called by any thread """
-        if self._checkpoint_disabled:
-            self._logger.warning("Ignoring checkpoint() call as is checkpointing disabled for this download.")
-        else:
-            infohash, pstate = self.network_checkpoint()
-            reactor.callFromThread(self.session.lm.save_download_pstate, infohash, pstate)
+        """
+        Checkpoint this download. Returns a deferred that fires when the checkpointing is completed.
+        """
+        if self._checkpoint_disabled or not self.handle or not self.handle.is_valid():
+            self._logger.warning("Ignoring checkpoint() call as checkpointing is disabled for this download "
+                                 "or the handle is not ready.")
+            return succeed(None)
 
-    def network_checkpoint(self):
-        """ Called by network thread """
-        with self.dllock:
-            pstate = self.network_get_persistent_state()
-            resdata = None
-            if self.handle is None:
-                if self.pstate_for_restart is not None:
-                    resdata = self.pstate_for_restart.get('state', 'engineresumedata')
-            elif isinstance(self.tdef, TorrentDef):
-                self.save_resume_data()
+        return self.save_resume_data()
 
-            pstate.set('state', 'engineresumedata', resdata)
-            return (self.tdef.get_infohash(), pstate)
-
-    def network_get_persistent_state(self):
-        # Assume sessionlock is held
-
+    def get_persistent_download_config(self):
         pstate = self.dlconfig.copy()
 
-        # Reset unpicklable params
         pstate.set('downloadconfig', 'mode', DLMODE_NORMAL)
 
         # Add state stuff

--- a/Tribler/Core/Libtorrent/__init__.py
+++ b/Tribler/Core/Libtorrent/__init__.py
@@ -1,13 +1,14 @@
 # Written by Egbert Bouman
 
-'''
+"""
 The Libtorrent package contains code to manage the torrent library.
-'''
-import random
-from twisted.internet import reactor
+"""
 
 
 def checkHandleAndSynchronize(default=None):
+    """
+    Return the libtorrent handle if it's available, else return the default value
+    """
     def wrap(f):
         def invoke_func(*args, **kwargs):
             download = args[0]
@@ -16,22 +17,4 @@ def checkHandleAndSynchronize(default=None):
                     return f(*args, **kwargs)
             return default
         return invoke_func
-    return wrap
-
-
-def waitForHandleAndSynchronize(default=None):
-    def wrap(f):
-        def invoke_func(*args, **kwargs):
-            download = args[0]
-            with download.dllock:
-                if download.handle and download.handle.is_valid():
-                    return f(*args, **kwargs)
-                elif not download.session.lm.shutdownstarttime:
-                    lambda_f = lambda a = args, kwa = kwargs: invoke_func(*a, **kwa)
-                    random_id = ''.join(random.choice('0123456789abcdef') for _ in xrange(30))
-                    reactor.callFromThread(
-                        lambda: download.register_task("check_handle_%s" % random_id, reactor.callLater(1, lambda_f)))
-                return default
-        return invoke_func
-
     return wrap

--- a/Tribler/Core/Modules/restapi/settings_endpoint.py
+++ b/Tribler/Core/Modules/restapi/settings_endpoint.py
@@ -95,7 +95,7 @@ class SettingsEndpoint(resource.Resource):
         """
         settings_dict = json.loads(request.content.read())
         self.parse_settings_dict(settings_dict)
-        self.session.save_pstate_sessconfig()
+        self.session.save_session_config()
 
         return json.dumps({"modified": True})
 

--- a/Tribler/Core/Session.py
+++ b/Tribler/Core/Session.py
@@ -176,7 +176,7 @@ class Session(SessionConfigInterface):
         self.notifier = Notifier(use_pool=True)
 
         # Checkpoint startup config
-        self.save_pstate_sessconfig()
+        self.save_session_config()
 
         self.sqlite_db = None
         self.dispersy_member = None
@@ -527,43 +527,42 @@ class Session(SessionConfigInterface):
 
         self.lm.load_checkpoint(initialdlstatus_dict=initialdlstatus_dict)
 
-    def checkpoint(self):
-        """ Saves the internal session state to the Session's state dir. """
-        # Called by any thread
-        self.checkpoint_shutdown(stop=False, checkpoint=True, gracetime=None, hacksessconfcheckpoint=False)
-
     @blocking_call_on_reactor_thread
     def start(self):
-        """ Create the LaunchManyCore instance and start it"""
-
-        # Create engine with network thread
+        """
+        Start a Tribler session by initializing the LaunchManyCore class.
+        Returns a deferred that fires when the Tribler session is ready for use.
+        """
         startup_deferred = self.lm.register(self, self.sesslock)
 
-        if self.get_libtorrent():
-            self.load_checkpoint()
+        def load_checkpoint(_):
+            if self.get_libtorrent():
+                self.load_checkpoint()
 
         self.sessconfig.set_callback(self.lm.sessconfig_changed_callback)
 
-        return startup_deferred
+        return startup_deferred.addCallback(load_checkpoint)
 
     @blocking_call_on_reactor_thread
-    def shutdown(self, checkpoint=True, gracetime=2.0, hacksessconfcheckpoint=True):
-        """ Checkpoints the session and closes it, stopping the download engine.
-        @param checkpoint Whether to checkpoint the Session state on shutdown.
-        @param gracetime Time to allow for graceful shutdown + signoff (seconds).
+    def shutdown(self):
         """
-        # Has to be called from the reactor thread
+        Checkpoints the session and closes it, stopping the download engine.
+        This method has to be called from the reactor thread.
+        """
         assert isInIOThread()
 
         @inlineCallbacks
         def on_early_shutdown_complete(_):
             """
-            Callback that gets called when the early shutdown has been compelted.
+            Callback that gets called when the early shutdown has been completed.
             Continues the shutdown procedure that is dependant on the early shutdown.
             :param _: ignored parameter of the Deferred
             """
-            yield self.checkpoint_shutdown(stop=True, checkpoint=checkpoint,
-                                 gracetime=gracetime, hacksessconfcheckpoint=hacksessconfcheckpoint)
+            self.save_session_config()
+            yield self.checkpoint_downloads()
+            self.lm.shutdown_downloads()
+            self.lm.network_shutdown()
+
             if self.sqlite_db:
                 self.sqlite_db.close()
             self.sqlite_db = None
@@ -652,31 +651,13 @@ class Session(SessionConfigInterface):
     #
     # Internal persistence methods
     #
-    def checkpoint_shutdown(self, stop, checkpoint, gracetime, hacksessconfcheckpoint):
-        """ Checkpoints the Session and optionally shuts down the Session.
-        @param stop Whether to shutdown the Session as well.
-        @param checkpoint Whether to checkpoint at all, or just to stop.
-        @param gracetime Time to allow for graceful shutdown + signoff (seconds).
+    def checkpoint_downloads(self):
         """
-        # Called by any thread
-        with self.sesslock:
-            # Arno: Make checkpoint optional on shutdown. At the moment setting
-            # the config at runtime is not possible (see SessionRuntimeConfig)
-            # so this has little use, and interferes with our way of
-            # changing the startup config, which is to write a new
-            # config to disk that will be read at start up.
-            if hacksessconfcheckpoint:
-                try:
-                    self.save_pstate_sessconfig()
-                except Exception as e:
-                    self._logger.error("save_pstate_sessconfig() failed with error: %s", e)
+        Checkpoints the downloads in Tribler.
+        """
+        return self.lm.checkpoint_downloads()
 
-            # Checkpoint all Downloads and stop NetworkThread
-            if stop:
-                self._logger.debug("Session: checkpoint_shutdown")
-            return self.lm.checkpoint(stop=stop, checkpoint=checkpoint, gracetime=gracetime)
-
-    def save_pstate_sessconfig(self):
+    def save_session_config(self):
         """ Save the runtime SessionConfig to disk """
         # Called by any thread
         sscfg = self.get_current_startup_config_copy()

--- a/Tribler/Core/exceptions.py
+++ b/Tribler/Core/exceptions.py
@@ -72,6 +72,13 @@ class DuplicateTorrentFileError(TriblerException):
     pass
 
 
+class SaveResumeDataError(TriblerException):
+
+    """ This error is used when the resume data of a download fails to save. """
+
+    pass
+
+
 class DuplicateDownloadException(TriblerException):
 
     """ The Download already exists in the Session, i.e., a Download for

--- a/Tribler/Policies/BoostingManager.py
+++ b/Tribler/Policies/BoostingManager.py
@@ -440,7 +440,7 @@ class BoostingManager(TaskManager):
         self.session.set_cm_sources(flag_disabled_sources, CONFIG_KEY_DISABLEDLIST)
         self.session.set_cm_sources(archive_sources, CONFIG_KEY_ARCHIVELIST)
 
-        self.session.save_pstate_sessconfig()
+        self.session.save_session_config()
 
     def log_statistics(self):
         """Log transfer statistics"""

--- a/Tribler/Test/Core/Libtorrent/test_libtorrent_download_impl.py
+++ b/Tribler/Test/Core/Libtorrent/test_libtorrent_download_impl.py
@@ -87,8 +87,9 @@ class TestLibtorrentDownloadImpl(TestAsServer):
         tdef = self.create_tdef()
 
         impl = LibtorrentDownloadImpl(self.session, tdef)
-        def callback((ignored, ignored2)):
-            pass
+
+        def callback(_):
+            impl.cancel_all_pending_tasks()
 
         deferred = impl.setup(None, None, None, 0)
         deferred.addCallback(callback)

--- a/Tribler/Test/Core/Libtorrent/test_libtorrent_download_impl.py
+++ b/Tribler/Test/Core/Libtorrent/test_libtorrent_download_impl.py
@@ -1,6 +1,7 @@
 import binascii
 import os
 import libtorrent as lt
+from twisted.internet.defer import Deferred
 
 from Tribler.Core.DownloadConfig import DownloadStartupConfig
 from Tribler.Core.Libtorrent.LibtorrentDownloadImpl import LibtorrentDownloadImpl
@@ -110,6 +111,15 @@ class TestLibtorrentDownloadImpl(TestAsServer):
         impl.dlconfig = DownloadStartupConfig().dlconfig.copy()
         impl.session.lm.on_download_wrapper_created = lambda _: True
         impl.restart()
+
+    @deferred(timeout=20)
+    def test_restart_no_handle(self):
+        test_deferred = Deferred()
+        tdef = self.create_tdef()
+        impl = LibtorrentDownloadImpl(self.session, tdef)
+        impl.session.lm.on_download_handle_created = lambda _: test_deferred.callback(None)
+        impl.restart()
+        return test_deferred
 
     @deferred(timeout=20)
     def test_multifile_torrent(self):

--- a/Tribler/Test/Core/Libtorrent/test_libtorrent_download_impl.py
+++ b/Tribler/Test/Core/Libtorrent/test_libtorrent_download_impl.py
@@ -93,7 +93,7 @@ class TestLibtorrentDownloadImpl(TestAsServer):
 
         deferred = impl.setup(None, None, None, 0)
         deferred.addCallback(callback)
-        return deferred
+        return deferred.addCallback(lambda _: impl.stop())
 
     def test_restart(self):
         tdef = self.create_tdef()
@@ -179,7 +179,7 @@ class TestLibtorrentDownloadImpl(TestAsServer):
         result_deferred = impl.setup(None, None, None, 0)
         result_deferred.addCallback(callback)
 
-        return result_deferred
+        return result_deferred.addCallback(lambda _: impl.stop())
 
 
 class TestLibtorrentDownloadImplNoSession(TriblerCoreTest):

--- a/Tribler/Test/Core/Modules/RestApi/base_api_test.py
+++ b/Tribler/Test/Core/Modules/RestApi/base_api_test.py
@@ -50,8 +50,8 @@ class AbstractBaseApiTest(TestAsServer):
     @blocking_call_on_reactor_thread
     @inlineCallbacks
     def tearDown(self, annotate=True):
-        yield super(AbstractBaseApiTest, self).tearDown(annotate=annotate)
         yield self.close_connections()
+        yield super(AbstractBaseApiTest, self).tearDown(annotate=annotate)
 
     def close_connections(self):
         return self.connection_pool.closeCachedConnections()

--- a/Tribler/Test/Core/Modules/RestApi/base_api_test.py
+++ b/Tribler/Test/Core/Modules/RestApi/base_api_test.py
@@ -6,7 +6,7 @@ from zope.interface import implements
 
 from twisted.internet.defer import succeed, inlineCallbacks
 from twisted.python.threadable import isInIOThread
-from twisted.web.client import Agent, readBody
+from twisted.web.client import Agent, readBody, HTTPConnectionPool
 from twisted.web.http_headers import Headers
 from twisted.web.iweb import IBodyProducer
 
@@ -42,9 +42,19 @@ class AbstractBaseApiTest(TestAsServer):
     @inlineCallbacks
     def setUp(self, autoload_discovery=True):
         yield super(AbstractBaseApiTest, self).setUp(autoload_discovery=autoload_discovery)
+        self.connection_pool = HTTPConnectionPool(reactor, False)
         terms = self.session.lm.category.xxx_filter.xxx_terms
         terms.add("badterm")
         self.session.lm.category.xxx_filter.xxx_terms = terms
+
+    @blocking_call_on_reactor_thread
+    @inlineCallbacks
+    def tearDown(self, annotate=True):
+        yield super(AbstractBaseApiTest, self).tearDown(annotate=annotate)
+        yield self.close_connections()
+
+    def close_connections(self):
+        return self.connection_pool.closeCachedConnections()
 
     @blocking_call_on_reactor_thread
     def setUpPreSession(self):
@@ -59,7 +69,7 @@ class AbstractBaseApiTest(TestAsServer):
         self.config.set_http_api_port(get_random_port(min_port=min_base_port, max_port=min_base_port + 2000))
 
     def do_request(self, endpoint, request_type, post_data, raw_data):
-        agent = Agent(reactor)
+        agent = Agent(reactor, pool=self.connection_pool)
         return agent.request(request_type, 'http://localhost:%s/%s' % (self.session.get_http_api_port(), endpoint),
                              Headers({'User-Agent': ['Tribler ' + version_id]}), POSTDataProducer(post_data, raw_data))
 

--- a/Tribler/Test/Core/Modules/RestApi/test_debug_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_debug_endpoint.py
@@ -1,4 +1,5 @@
 import json
+from twisted.internet.defer import inlineCallbacks
 
 from Tribler.Core.Utilities.twisted_thread import deferred
 from Tribler.Test.Core.Modules.RestApi.base_api_test import AbstractApiTest
@@ -13,8 +14,9 @@ from Tribler.dispersy.util import blocking_call_on_reactor_thread
 class TestCircuitDebugEndpoint(AbstractApiTest):
 
     @blocking_call_on_reactor_thread
+    @inlineCallbacks
     def setUp(self, autoload_discovery=True):
-        super(TestCircuitDebugEndpoint, self).setUp(autoload_discovery=autoload_discovery)
+        yield super(TestCircuitDebugEndpoint, self).setUp(autoload_discovery=autoload_discovery)
 
         self.dispersy = Dispersy(ManualEnpoint(0), self.getStateDir())
         self.dispersy._database.open()

--- a/Tribler/Test/Core/Modules/RestApi/test_downloads_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_downloads_endpoint.py
@@ -155,9 +155,11 @@ class TestDownloadsEndpoint(AbstractApiTest):
         video_tdef, _ = self.create_local_torrent(os.path.join(TESTS_DATA_DIR, 'video.avi'))
         download = self.session.start_download_from_tdef(video_tdef, DownloadStartupConfig())
         infohash = video_tdef.get_infohash().encode('hex')
+        original_stop = download.stop
 
         def mocked_stop():
             download.should_stop = True
+            download.stop = original_stop
 
         def verify_removed(_):
             self.assertEqual(len(self.session.get_downloads()), 1)

--- a/Tribler/Test/Core/Modules/RestApi/test_multichain_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_multichain_endpoint.py
@@ -1,5 +1,6 @@
 import json
 import base64
+from twisted.internet.defer import inlineCallbacks
 
 from Tribler.Core.Utilities.twisted_thread import deferred
 from Tribler.Test.Core.Modules.RestApi.base_api_test import AbstractApiTest
@@ -14,8 +15,9 @@ from Tribler.dispersy.util import blocking_call_on_reactor_thread
 class TestMultichainStatsEndpoint(AbstractApiTest):
 
     @blocking_call_on_reactor_thread
+    @inlineCallbacks
     def setUp(self, autoload_discovery=True):
-        super(TestMultichainStatsEndpoint, self).setUp(autoload_discovery=autoload_discovery)
+        yield super(TestMultichainStatsEndpoint, self).setUp(autoload_discovery=autoload_discovery)
 
         self.dispersy = Dispersy(ManualEnpoint(0), self.getStateDir())
         self.dispersy._database.open()

--- a/Tribler/Test/Core/Modules/RestApi/test_search_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_search_endpoint.py
@@ -1,3 +1,4 @@
+from twisted.internet.defer import inlineCallbacks
 from Tribler.dispersy.util import blocking_call_on_reactor_thread
 from Tribler.Core.Utilities.twisted_thread import deferred
 from Tribler.Core.simpledefs import NTFY_CHANNELCAST, NTFY_TORRENTS, SIGNAL_CHANNEL, SIGNAL_ON_SEARCH_RESULTS, \
@@ -32,8 +33,9 @@ class TestSearchEndpoint(AbstractApiTest):
         self.expected_events_messages = []
 
     @blocking_call_on_reactor_thread
+    @inlineCallbacks
     def setUp(self, autoload_discovery=True):
-        super(TestSearchEndpoint, self).setUp(autoload_discovery)
+        yield super(TestSearchEndpoint, self).setUp(autoload_discovery)
         self.channel_db_handler = self.session.open_dbhandler(NTFY_CHANNELCAST)
         self.channel_db_handler._get_my_dispersy_cid = lambda: "myfakedispersyid"
         self.torrent_db_handler = self.session.open_dbhandler(NTFY_TORRENTS)

--- a/Tribler/Test/test_as_server.py
+++ b/Tribler/Test/test_as_server.py
@@ -85,6 +85,8 @@ class AbstractServer(BaseTestCase):
         from twisted.internet.defer import setDebugging
         setDebugging(True)
 
+    @blocking_call_on_reactor_thread
+    @inlineCallbacks
     def setUp(self, annotate=True):
         self._logger = logging.getLogger(self.__class__.__name__)
 
@@ -95,7 +97,7 @@ class AbstractServer(BaseTestCase):
         defaults.sessdefaults['general']['state_dir'] = self.state_dir
         defaults.dldefaults["downloadconfig"]["saveas"] = self.dest_dir
 
-        self.checkReactor(phase="setUp")
+        yield self.checkReactor(phase="setUp")
 
         self.setUpCleanup()
         os.makedirs(self.session_base_dir)
@@ -158,6 +160,7 @@ class AbstractServer(BaseTestCase):
                                      "Listening ports left on the reactor during %s: %s" % (phase, reader))
 
     @blocking_call_on_reactor_thread
+    @inlineCallbacks
     def tearDown(self, annotate=True):
         self.tearDownCleanup()
         if annotate:
@@ -173,9 +176,9 @@ class AbstractServer(BaseTestCase):
             raise RuntimeError("Couldn't stop the WatchDog")
 
         if self.file_server:
-            return maybeDeferred(self.file_server.stopListening).addCallback(self.checkReactor)
+            yield maybeDeferred(self.file_server.stopListening).addCallback(self.checkReactor)
         else:
-            return self.checkReactor("tearDown")
+            yield self.checkReactor("tearDown")
 
     def tearDownCleanup(self):
         self.setUpCleanup()

--- a/twisted/plugins/tribler_plugin.py
+++ b/twisted/plugins/tribler_plugin.py
@@ -66,16 +66,16 @@ class TriblerServiceMaker(object):
         """
         Main method to startup Tribler.
         """
-        def on_shutdown(_):
+        def on_tribler_shutdown(_):
             msg("Tribler shut down")
-            self.process_checker.remove_lock_file()
             reactor.stop()
+            self.process_checker.remove_lock_file()
 
         def signal_handler(sig, _):
             msg("Received shut down signal %s" % sig)
             if not self._stopping:
                 self._stopping = True
-                self.session.shutdown().addCallback(on_shutdown)
+                self.session.shutdown().addCallback(on_tribler_shutdown)
 
         signal.signal(signal.SIGINT, signal_handler)
         signal.signal(signal.SIGTERM, signal_handler)


### PR DESCRIPTION
I've found out that our resume data is not written away which can be addressed to the checkpointing mechanism and the fact that we are not waiting on our shutdown deferred when closing Tribler from the twistd plugin.

In this PR, I've refactored the complete checkpointing mechanism to make it more simple and so it is using Twisted. Moreover, I've created a `get_handle` method for each download that returns a deferred that fires when the libtorrent handle is available and valid. This allowed me to remove the `waitForHandleAndSynchronized` method which was rather ugly.

Also, various Twisted issues have been fixed, i.e. when we don't wait for a deferred to fire.

Fixes #2531