### PR TITLE
WIP: Callback when Tribler started is now from reactor

### DIFF
--- a/Tribler/Core/APIImplementation/LaunchManyCore.py
+++ b/Tribler/Core/APIImplementation/LaunchManyCore.py
@@ -186,7 +186,7 @@ class TriblerLaunchMany(TaskManager):
         return self.startup_deferred
 
     def on_tribler_started(self, subject, changetype, objectID, *args):
-        self.startup_deferred.callback(None)
+        reactor.callFromThread(self.startup_deferred.callback, None)
 
     def init(self):
         if self.dispersy:


### PR DESCRIPTION
We should schedule notifications created by our notifier system on the reactor thread anyway (#2597).