### PR TITLE
Typo in Linux build instructions

### DIFF
--- a/doc/development/development_on_linux.rst
+++ b/doc/development/development_on_linux.rst
@@ -7,7 +7,7 @@ First, install the required dependencies by executing the following command in y
 
 .. code-block:: none
 
-    sudo apt-get install libav-tools libsodium13 libx11-6 python-apsw python-cherrypy3 python-crypto python-cryptography python-feedparser python-leveldb python-libtorrent python-m2crypto python-netifaces python-pil python-pyasn1 python-twisted python2.7 vlc python-pip python-chardet python-configobj python-pyqt5, python-pyqt5.qtsvg
+    sudo apt-get install libav-tools libsodium13 libx11-6 python-apsw python-cherrypy3 python-crypto python-cryptography python-feedparser python-leveldb python-libtorrent python-m2crypto python-netifaces python-pil python-pyasn1 python-twisted python2.7 vlc python-pip python-chardet python-configobj python-pyqt5 python-pyqt5.qtsvg
     sudo pip install decorator libnacl
 
 Next, download the latest .deb file from `here <https://jenkins.tribler.org/job/Build-Tribler_Ubuntu-64_devel/lastStableBuild/>`_.


### PR DESCRIPTION
Another note: `libsodium13` (1.0.3) does not exist on Ubuntu 1604, so I installed `libsodium18` (1.0.11) instead and tribler starts fine (I haven't tested all the functionalities). Perhaps it's useful to comment on this in the instructions too?