### PR TITLE
WIP: Notifier callback is now on reactor thread

### DIFF
--- a/Tribler/Core/CacheDB/Notifier.py
+++ b/Tribler/Core/CacheDB/Notifier.py
@@ -25,10 +25,8 @@ class Notifier(object):
                 SIGNAL_SEARCH_COMMUNITY, SIGNAL_TORRENT, NTFY_WATCH_FOLDER_CORRUPT_TORRENT, NTFY_NEW_VERSION,
                 NTFY_TRIBLER, NTFY_UPGRADER_TICK, NTFY_TORRENT, NTFY_CHANNEL]
 
-    def __init__(self, use_pool):
+    def __init__(self):
         self._logger = logging.getLogger(self.__class__.__name__)
-
-        self.use_pool = use_pool
 
         self.observers = []
         self.observerscache = {}
@@ -104,10 +102,7 @@ class Notifier(object):
                                 self.observerLock.release()
 
                                 if events:
-                                    if self.use_pool:
-                                        callInThreadPool(ofunc, events)
-                                    else:
-                                        ofunc(events)
+                                    ofunc(events)
 
                             t = threading.Timer(cache, doQueue, (ofunc,))
                             t.setName("Notifier-timer-%s" % subject)
@@ -122,7 +117,4 @@ class Notifier(object):
 
         self.observerLock.release()
         for task in tasks:
-            if self.use_pool:
-                callInThreadPool(task, *args)
-            else:
-                task(*args)  # call observer function in this thread
+            task(*args)  # call observer function in this thread

--- a/Tribler/Core/Session.py
+++ b/Tribler/Core/Session.py
@@ -177,7 +177,7 @@ class Session(SessionConfigInterface):
 
         # Create handler for calling back the user via separate threads
         self.lm = TriblerLaunchMany()
-        self.notifier = Notifier(use_pool=True)
+        self.notifier = Notifier()
 
         # Checkpoint startup config
         self.save_session_config()

--- a/Tribler/Test/Core/Libtorrent/test_libtorrent_mgr.py
+++ b/Tribler/Test/Core/Libtorrent/test_libtorrent_mgr.py
@@ -15,7 +15,7 @@ from Tribler.dispersy.util import blocking_call_on_reactor_thread
 class FakeTriblerSession:
 
     def __init__(self, state_dir):
-        self.notifier = Notifier(False)
+        self.notifier = Notifier()
         self.state_dir = state_dir
 
     def get_libtorrent_utp(self):

--- a/Tribler/Test/Core/Modules/RestApi/test_events_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_events_endpoint.py
@@ -47,7 +47,6 @@ class TestEventsEndpoint(AbstractApiTest):
         self.connection_pool = HTTPConnectionPool(reactor, False)
         self.socket_open_deferred = self.tribler_started_deferred.addCallback(self.open_events_socket)
         self.messages_to_wait_for = 0
-        self.session.notifier.use_pool = False
 
     @blocking_call_on_reactor_thread
     @inlineCallbacks

--- a/Tribler/Test/Core/Modules/RestApi/test_search_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_search_endpoint.py
@@ -40,7 +40,6 @@ class TestSearchEndpoint(AbstractApiTest):
         self.channel_db_handler._get_my_dispersy_cid = lambda: "myfakedispersyid"
         self.torrent_db_handler = self.session.open_dbhandler(NTFY_TORRENTS)
 
-        self.session.notifier.use_pool = False
         self.session.add_observer(self.on_search_results_channels, SIGNAL_CHANNEL, [SIGNAL_ON_SEARCH_RESULTS])
         self.session.add_observer(self.on_search_results_torrents, SIGNAL_TORRENT, [SIGNAL_ON_SEARCH_RESULTS])
 

--- a/Tribler/Test/Core/test_notifier.py
+++ b/Tribler/Test/Core/test_notifier.py
@@ -23,50 +23,50 @@ class TriblerCoreTestNotifier(TriblerCoreTest):
             counter += 1
 
     def test_notifier_no_threadpool(self):
-        notifier = Notifier(False)
+        notifier = Notifier()
         notifier.add_observer(self.callback_func, NTFY_TORRENTS, [NTFY_STARTED])
         notifier.notify(NTFY_TORRENTS, NTFY_STARTED, None)
         self.wait_for_callback()
         notifier.remove_observer(self.called_callback)
 
     def test_notifier_threadpool(self):
-        notifier = Notifier(True)
+        notifier = Notifier()
         notifier.add_observer(self.callback_func, NTFY_TORRENTS, [NTFY_STARTED])
         notifier.notify(NTFY_TORRENTS, NTFY_STARTED, None)
         self.wait_for_callback()
 
     def test_notifier_remove_observers(self):
-        notifier = Notifier(False)
+        notifier = Notifier()
         notifier.add_observer(self.callback_func, NTFY_TORRENTS, [NTFY_STARTED])
         notifier.remove_observers()
         self.assertTrue(len(notifier.observers) == 0)
 
     def test_notifier_no_observers(self):
-        notifier = Notifier(False)
+        notifier = Notifier()
         notifier.notify(NTFY_TORRENTS, NTFY_STARTED, None)
         self.assertFalse(self.called_callback)
 
     def test_notifier_wrong_changetype(self):
-        notifier = Notifier(False)
+        notifier = Notifier()
         notifier.add_observer(self.callback_func, NTFY_TORRENTS, [NTFY_STARTED])
         notifier.notify(NTFY_TORRENTS, NTFY_FINISHED, None)
         self.assertFalse(self.called_callback)
 
     def test_notifier_cache(self):
-        notifier = Notifier(False)
+        notifier = Notifier()
         notifier.add_observer(self.cache_callback_func, NTFY_TORRENTS, [NTFY_STARTED], cache=0.1)
         notifier.notify(NTFY_TORRENTS, NTFY_STARTED, None)
         self.wait_for_callback()
 
     def test_notifier_cache_notify_twice(self):
-        notifier = Notifier(False)
+        notifier = Notifier()
         notifier.add_observer(self.cache_callback_func, NTFY_TORRENTS, [NTFY_STARTED], cache=0.1)
         notifier.notify(NTFY_TORRENTS, NTFY_STARTED, None)
         notifier.notify(NTFY_TORRENTS, NTFY_STARTED, None)
         self.wait_for_callback()
 
     def test_notifier_cache_remove_observers(self):
-        notifier = Notifier(False)
+        notifier = Notifier()
         notifier.add_observer(self.cache_callback_func, NTFY_TORRENTS, [NTFY_STARTED], cache=10)
         notifier.notify(NTFY_TORRENTS, NTFY_STARTED, None)
         notifier.remove_observers()


### PR DESCRIPTION
When the wx GUI was active, we used to have the notifier callback on the threadpool. Now that we are not having multiple threads anymore, we should have this callback being invoked on the reactor thread. This might also solve some race conditions we are experiencing and avoids having to write code to delegate logic in the callback method to the reactor thread.

Fixes #2597 