### PR TITLE
Added function to check libtorrent version

### DIFF
--- a/Tribler/Core/Libtorrent/LibtorrentMgr.py
+++ b/Tribler/Core/Libtorrent/LibtorrentMgr.py
@@ -590,6 +590,18 @@ class LibtorrentMgr(TaskManager):
 
         return result
 
+    def get_libtorrent_version(self):
+        """
+        This method returns the version of the used libtorrent
+        library and is required for compatibility purposes
+        """
+        if hasattr(lt, '__version__'):
+            return lt.__version__
+        else:
+            # libtorrent.version is deprecated starting from 1.0
+            return lt.version
+
+
 def encode_atp(atp):
     for k, v in atp.iteritems():
         if isinstance(v, unicode):

--- a/Tribler/Policies/BoostingManager.py
+++ b/Tribler/Policies/BoostingManager.py
@@ -455,7 +455,7 @@ class BoostingManager(TaskManager):
                                    lt_torrent.max_uploads(), lt_torrent.max_connections())
 
                 # piece_priorities will fail in libtorrent 1.0.9
-                if lt.__version__ == '1.0.9.0':
+                if self.session.lm.ltmgr.get_libtorrent_version() == '1.0.9.0':
                     continue
                 else:
                     non_zero_values = []

--- a/Tribler/Test/Core/CreditMining/mock_creditmining.py
+++ b/Tribler/Test/Core/CreditMining/mock_creditmining.py
@@ -147,6 +147,9 @@ class MockLtSession(object):
 
         self.add_observer = lambda *_: None
 
+    def get_libtorrent_version(self):
+        return '0'
+
     def get_session(self):
         """
         supposed to get libtorrent session


### PR DESCRIPTION
This PR will add a function to check libtorrent version. On old version of libtorrent, we can call this by `libtorrent.version`. However, starting from version RC_1_0, that will be deprecated and replaced by `libtorrent.__version__` (which more python-like).

Relevant : https://github.com/arvidn/libtorrent/blob/master/bindings/python/src/version.cpp

This should close issue #2676 if merged.