### PR TITLE
Fixed wrong exception for invalid received encryption

### DIFF
--- a/Tribler/community/tunnel/crypto/tunnelcrypto.py
+++ b/Tribler/community/tunnel/crypto/tunnelcrypto.py
@@ -73,6 +73,9 @@ class TunnelCrypto(ECCrypto):
 
     def decrypt_str(self, content, key, salt):
         # content contains the gcm tag and salt_explicit in plaintext
+        if len(content) < 24:
+            raise CryptoException("truncated content")
+
         salt_explicit, gcm_tag = struct.unpack_from('!q16s', content)
         cipher = Cipher(algorithms.AES(key),
                         modes.GCM(initialization_vector=self._bulid_iv(salt, salt_explicit), tag=gcm_tag),


### PR DESCRIPTION
Fixes #2663, contains:
 - Correction of exception thrown by `decrypt_str()`
 - Unit test for this case