### PR TITLE
Refactored copy_shallow_candidate

### DIFF
--- a/Tribler/Test/Community/Tunnel/test_tunnelcommunity.py
+++ b/Tribler/Test/Community/Tunnel/test_tunnelcommunity.py
@@ -178,7 +178,7 @@ class TestTunnelCommunity(AbstractTestTunnelCommunity):
         hop = Hop(tunnel_crypto.generate_key(u"curve25519").pub())
         circuit.add_hop(hop)
         # Register the first hop with dispersy and the community
-        self.tunnel_community.dispersy.get_member(public_key=hop.node_public_key)
+        circuit.mid = self.tunnel_community.dispersy.get_member(public_key=hop.node_public_key).mid.encode("HEX")
         self.tunnel_community.create_or_update_walkcandidate(circuit.first_hop, circuit.first_hop, circuit.first_hop,
                                                              True, u'unknown')
         self.tunnel_community.circuits[42] = circuit

--- a/Tribler/community/tunnel/hidden_community.py
+++ b/Tribler/community/tunnel/hidden_community.py
@@ -582,8 +582,10 @@ class HiddenTunnelCommunity(TunnelCommunity):
 
             self.send_cell([message.candidate], u"linked-e2e", (circuit.circuit_id, message.payload.identifier))
 
-            self.relay_from_to[circuit.circuit_id] = RelayRoute(relay_circuit.circuit_id, relay_circuit.sock_addr, True)
-            self.relay_from_to[relay_circuit.circuit_id] = RelayRoute(circuit.circuit_id, circuit.sock_addr, True)
+            self.relay_from_to[circuit.circuit_id] = RelayRoute(relay_circuit.circuit_id, relay_circuit.sock_addr, True,
+                                                                mid=relay_circuit.mid)
+            self.relay_from_to[relay_circuit.circuit_id] = RelayRoute(circuit.circuit_id, circuit.sock_addr, True,
+                                                                      mid=circuit.mid)
 
     def check_linked_e2e(self, messages):
         for message in messages:


### PR DESCRIPTION
Fixes #2713
- Fixed anon-circuit request-cache with an extension mid of 0
- Fixed RelayRoutes created in hidden_tunnelcommunity without mid
- Refactored copy_shallow_candidate so the `mid` value is used for Circuits, RelayRoutes and TunnelExitSockets alike