### PR TITLE
Added missing TunnelExitSocket mid assignment

### DIFF
--- a/Tribler/community/tunnel/tunnel_community.py
+++ b/Tribler/community/tunnel/tunnel_community.py
@@ -1089,7 +1089,7 @@ class TunnelCommunity(Community):
             if candidate.get_member() is not None:
                 candidate_mid = candidate.get_member().mid.encode('hex')
             else:
-                self.dispersy.get_member(public_key=message.payload.node_public_key)
+                candidate_mid = self.dispersy.get_member(public_key=message.payload.node_public_key).mid.encode('hex')
             self.exit_sockets[circuit_id] = TunnelExitSocket(circuit_id, self, candidate.sock_addr, candidate_mid)
 
             if self.notifier:


### PR DESCRIPTION
Added missing mid assignment for TunnelExitSockets, as shown by 1 hour run (https://jenkins.tribler.org/job/Test_Tribler_idle_run_1H/788/artifact/output/00000.err/*view*/)