### PR TITLE
Throw MalformedTrackerURLException

### DIFF
--- a/Tribler/Core/TorrentChecker/torrent_checker.py
+++ b/Tribler/Core/TorrentChecker/torrent_checker.py
@@ -13,6 +13,7 @@ from Tribler.dispersy.util import blocking_call_on_reactor_thread, call_on_react
 
 from Tribler.Core.simpledefs import NTFY_TORRENTS
 from Tribler.Core.TorrentChecker.session import create_tracker_session, FakeDHTSession
+from Tribler.Core.Utilities.tracker_utils import MalformedTrackerURLException
 
 # some settings
 DEFAULT_TORRENT_SELECTION_INTERVAL = 20  # every 20 seconds, the thread will select torrents to check
@@ -116,7 +117,13 @@ class TorrentChecker(TaskManager):
             return succeed(None)
         elif tracker_url != u'DHT' and tracker_url != u'no-DHT'\
                 and self.tribler_session.lm.tracker_manager.should_check_tracker(tracker_url):
-            session = self._create_session_for_request(tracker_url, timeout=30)
+
+            try:
+                session = self._create_session_for_request(tracker_url, timeout=30)
+            except MalformedTrackerURLException as e:
+                self._logger.error(e)
+                return succeed(None)
+
             for infohash in infohashes:
                 session.add_infohash(infohash)
 

--- a/Tribler/Core/Utilities/tracker_utils.py
+++ b/Tribler/Core/Utilities/tracker_utils.py
@@ -1,4 +1,3 @@
-import socket
 import re
 
 url_regex = re.compile(
@@ -8,6 +7,10 @@ url_regex = re.compile(
     r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})'  # ...or ip
     r'(?::\d+)?'  # optional port
     r'(?:/?|[/?]\S+)$', re.IGNORECASE | re.UNICODE)
+
+
+class MalformedTrackerURLException(Exception):
+    pass
 
 
 # ------------------------------------------------------------
@@ -85,7 +88,7 @@ def parse_tracker_url(tracker_url):
     elif tracker_url.startswith(u'udp'):
         tracker_type = u'UDP'
     else:
-        raise RuntimeError(u'Unexpected tracker type.')
+        raise MalformedTrackerURLException(u'Unexpected tracker type (%s).' % tracker_url)
 
     # get URL information
     url_fields = tracker_url.split(u'://')[1]
@@ -95,7 +98,7 @@ def parse_tracker_url(tracker_url):
             hostname_part = url_fields
             announce_page = None
         else:
-            raise RuntimeError(u'Invalid tracker URL (%s).' % tracker_url)
+            raise MalformedTrackerURLException(u'Invalid tracker URL (%s).' % tracker_url)
     else:
         hostname_part, announce_page = url_fields.split(u'/', 1)
 
@@ -107,6 +110,6 @@ def parse_tracker_url(tracker_url):
         hostname = hostname_part
         port = 80
     else:
-        raise RuntimeError(u'No port number for UDP tracker URL.')
+        raise MalformedTrackerURLException(u'No port number for UDP tracker URL (%s).' % tracker_url)
 
     return tracker_type, (hostname, port), announce_page

--- a/Tribler/Test/Core/test_tracker_utils.py
+++ b/Tribler/Test/Core/test_tracker_utils.py
@@ -1,5 +1,6 @@
 from nose.tools import raises
-from Tribler.Core.Utilities.tracker_utils import get_uniformed_tracker_url, parse_tracker_url
+from Tribler.Core.Utilities.tracker_utils import get_uniformed_tracker_url, parse_tracker_url,\
+    MalformedTrackerURLException
 from Tribler.Test.Core.base_test import TriblerCoreTest
 
 
@@ -50,15 +51,15 @@ class TriblerCoreTestTrackerUtils(TriblerCoreTest):
         self.assertEqual(result[0], "HTTP")
         self.assertEqual(result[2], "announce")
 
-    @raises(RuntimeError)
+    @raises(MalformedTrackerURLException)
     def test_parse_tracker_url_wrong_type_1(self):
         parse_tracker_url("abc://tracker.openbittorrent.com:80/announce")
 
-    @raises(RuntimeError)
+    @raises(MalformedTrackerURLException)
     def test_parse_tracker_url_wrong_type_2(self):
         parse_tracker_url("udp://tracker.openbittorrent.com/announce")
 
-    @raises(RuntimeError)
+    @raises(MalformedTrackerURLException)
     def test_parse_tracker_url_wrong_type_3(self):
         parse_tracker_url("http://tracker.openbittorrent.com:80")
 


### PR DESCRIPTION
RuntimeError crashes the GUI, so we throw MalformedTrackerURLException, catch it and log the error.

Fixes #2723

I didn't attempt to delete the invalid tracker, I may attempt it at a later stage. I did see a `update_tracker_info` method in `TrackerManager`, it has a `is_successful` flag that increments the failure count. If it's reasonable to increment the failure count in this scenario then I can modify my code to do it.