### PR TITLE
Update documentation on dependencies for Arch Linux

### DIFF
--- a/doc/development/development_on_linux.rst
+++ b/doc/development/development_on_linux.rst
@@ -64,4 +64,4 @@ Execute the following command in your terminal:
 
 .. code-block:: none
 
-    sudo pacman -S libsodium libtorrent-rasterbar python2-apsw python2-cherrypy python2-cryptography python2-decorator python2-feedparser python2-gmpy2 python2-m2crypto python2-netifaces python2-pillow python2-plyvel python2-twisted wxpython2.8
+    pacman -S libsodium libtorrent-rasterbar python2-pyqt5 qt5-svg phonon-qt5-vlc python2-apsw python2-cherrypy python2-cryptography python2-decorator python2-feedparser python2-chardet python2-m2crypto python2-netifaces python2-plyvel python2-requests python2-twisted


### PR DESCRIPTION
Second attempt, this time for `devel`. I removed the python2-gmpy2, python2-pillow and wxpython2.8 packages and added python2-chardet, python2-pyqt5, qt5-svg and phonon-qt5-vlc.

This fixes https://github.com/Tribler/tribler/issues/2732.