### PR TITLE
Twistd failed to reflect the tunnel helper plugin

### DIFF
--- a/twisted/plugins/tunnel_helper_plugin.py
+++ b/twisted/plugins/tunnel_helper_plugin.py
@@ -105,7 +105,10 @@ class Options(usage.Options):
     ]
 
 
-logging.config.fileConfig("logger.conf")
+if not os.path.exists("logger.conf"):
+    print "Unable to find logger.conf"
+else:
+    logging.config.fileConfig("logger.conf")
 logger = logging.getLogger('TunnelMain')
 
 BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__))))


### PR DESCRIPTION
If there is no logger.conf in the working directory, then invoking twistd will produce an uncaught exception on the stderr. This is because the tunnel_helper unconditionally uses the logger.conf file. This made gumby spew several errors that have nothing to do with my experiments.