### PR TITLE
READY: Allow UDP associate without circuits

### DIFF
--- a/Tribler/Core/Libtorrent/LibtorrentMgr.py
+++ b/Tribler/Core/Libtorrent/LibtorrentMgr.py
@@ -129,6 +129,7 @@ class LibtorrentMgr(TaskManager):
             settings['enable_outgoing_tcp'] = False
             settings['enable_incoming_tcp'] = False
             settings['anonymous_mode'] = True
+            settings['force_proxy'] = True
             # No PEX for anonymous sessions
             ltsession = lt.session(flags=0)
             ltsession.add_extension(lt.create_ut_metadata_plugin)

--- a/Tribler/Test/Community/Tunnel/Socks5/test_connection.py
+++ b/Tribler/Test/Community/Tunnel/Socks5/test_connection.py
@@ -1,0 +1,68 @@
+import unittest
+
+from twisted.internet.defer import inlineCallbacks
+
+from Tribler.community.tunnel.Socks5.conversion import decode_udp_packet, REP_SUCCEEDED
+from Tribler.community.tunnel.Socks5.server import Socks5Connection
+from Tribler.dispersy.util import blocking_call_on_reactor_thread
+
+
+class MockSocks5Server(object):
+    def connectionLost(self, _):
+        pass
+
+
+class MockSelectionStrategy(object):
+    def select(self, *_):
+        pass
+
+
+class MockHost(object):
+    def __init__(self):
+        self.host = "0.0.0.0"
+
+
+class MockTransport(object):
+    """
+    Store sent UDP packets as UdpRequests in self.out
+    """
+
+    def __init__(self):
+        self.out = []
+
+    def write(self, data):
+        self.out.append(decode_udp_packet(data))
+
+    def getHost(self):
+        return MockHost()
+
+    def loseConnection(self):
+        pass
+
+
+class MockRequest(object):
+    def __init__(self):
+        self.destination = ("0.0.0.0", 0)
+
+
+class TestSocks5Connection(unittest.TestCase):
+    def setUp(self):
+        self.connection = Socks5Connection(MockSocks5Server(),
+                                           MockSelectionStrategy(),
+                                           1)
+        self.connection.transport = MockTransport()
+
+    @blocking_call_on_reactor_thread
+    @inlineCallbacks
+    def tearDown(self):
+        yield self.connection._udp_socket.listen_port.stopListening()
+
+    def test_associate(self):
+        """
+        Test whether UDP ASSOCIATE requests are answered with a REP_SUCCEEDED
+        """
+        self.connection.on_udp_associate_request(self.connection,
+                                                 MockRequest())
+
+        self.assertGreater(len(self.connection.transport.out), 0)
+        self.assertEquals(self.connection.transport.out[0].frag, REP_SUCCEEDED)

--- a/Tribler/community/tunnel/Socks5/server.py
+++ b/Tribler/community/tunnel/Socks5/server.py
@@ -220,24 +220,18 @@ class Socks5Connection(Protocol):
         self._logger.error("DENYING SOCKS5 request, reason: %s" % reason)
 
     def on_udp_associate_request(self, connection, request):
-        if self.selection_strategy.has_options(self.hops):
-            # The DST.ADDR and DST.PORT fields contain the address and port that the client expects
-            # to use to send UDP datagrams on for the association.  The server MAY use this information
-            # to limit access to the association.
-            self._udp_socket = SocksUDPConnection(self, request.destination)
-            ip = self.transport.getHost().host
-            port = self._udp_socket.get_listen_port()
+        # The DST.ADDR and DST.PORT fields contain the address and port that the client expects
+        # to use to send UDP datagrams on for the association.  The server MAY use this information
+        # to limit access to the association.
+        self._udp_socket = SocksUDPConnection(self, request.destination)
+        ip = self.transport.getHost().host
+        port = self._udp_socket.get_listen_port()
 
-            self._logger.info("Accepting UDP ASSOCIATE request to %s:%d", ip, port)
+        self._logger.info("Accepting UDP ASSOCIATE request to %s:%d", ip, port)
 
-            response = conversion.encode_reply(
-                0x05, conversion.REP_SUCCEEDED, 0x00, conversion.ADDRESS_TYPE_IPV4, ip, port)
-            self.transport.write(response)
-
-        else:
-            reason = "not enough circuits"
-            self.deny_request(request, reason)
-            self.close(reason)
+        response = conversion.encode_reply(
+            0x05, conversion.REP_SUCCEEDED, 0x00, conversion.ADDRESS_TYPE_IPV4, ip, port)
+        self.transport.write(response)
 
     def select(self, destination):
         if destination not in self.destinations:


### PR DESCRIPTION
Fixes #2787, this switches the SOCKS5 behavior from old:

1. Deny connection if no circuits available
2. Fallback to naked downloading

To new:
1. Always allow connection
2. [Drop packets while no circuits are available](https://github.com/Tribler/tribler/blob/devel/Tribler/community/tunnel/Socks5/server.py#L64)

This also includes a base for future unittests for the Socks5Connection.

Pylint violation in unit test:
I had to use a protected member since [SocksUDPConnection does not yield on the listen_port.stopListening() deferred](https://github.com/Tribler/tribler/blob/devel/Tribler/community/tunnel/Socks5/server.py#L79) causing a dirty reactor.