### PR TITLE
Fixed crash in torrent export functionality

### DIFF
--- a/TriblerGUI/tribler_request_manager.py
+++ b/TriblerGUI/tribler_request_manager.py
@@ -27,7 +27,6 @@ class TriblerRequestManager(QNetworkAccessManager):
         self.request_id = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(10))
         self.base_url = "http://localhost:%d/" % API_PORT
         self.reply = None
-        self.error_dialog = None
 
     def perform_request(self, endpoint, read_callback, data="", method='GET', capture_errors=True):
         """
@@ -112,14 +111,14 @@ class TriblerRequestManager(QNetworkAccessManager):
 
     def show_error(self, error_text):
         main_text = "An error occurred during the request:\n\n%s" % error_text
-        self.error_dialog = ConfirmationDialog(TriblerRequestManager.window, "Request error",
-                                               main_text, [('CLOSE', BUTTON_TYPE_NORMAL)])
-        self.error_dialog.button_clicked.connect(self.on_error_dialog_cancel_clicked)
-        self.error_dialog.show()
+        error_dialog = ConfirmationDialog(TriblerRequestManager.window, "Request error",
+                                          main_text, [('CLOSE', BUTTON_TYPE_NORMAL)])
 
-    def on_error_dialog_cancel_clicked(self, _):
-        self.error_dialog.setParent(None)
-        self.error_dialog = None
+        def on_close():
+            error_dialog.setParent(None)
+
+        error_dialog.button_clicked.connect(on_close)
+        error_dialog.show()
 
     def cancel_request(self):
         if self.reply:

--- a/TriblerGUI/widgets/downloadspage.py
+++ b/TriblerGUI/widgets/downloadspage.py
@@ -267,16 +267,23 @@ class DownloadsPage(QWidget):
         self.export_dir = QFileDialog.getExistingDirectory(self, "Please select the destination directory", "",
                                                            QFileDialog.ShowDirsOnly)
 
-        self.request_mgr = TriblerRequestManager()
-        self.request_mgr.download_file("downloads/%s/torrent" % self.selected_item.download_info['infohash'],
-                                       self.on_export_download_request_done)
+        if len(self.export_dir) > 0:
+            self.request_mgr = TriblerRequestManager()
+            self.request_mgr.download_file("downloads/%s/torrent" % self.selected_item.download_info['infohash'],
+                                           self.on_export_download_request_done)
 
     def on_export_download_request_done(self, filename, data):
         dest_path = os.path.join(self.export_dir, filename)
-        with open(dest_path, "wb") as torrent_file:
+        try:
+            torrent_file = open(dest_path, "wb")
             torrent_file.write(data)
-
-        self.window().tray_icon.showMessage("Torrent file exported", "Torrent file exported to %s" % dest_path)
+            torrent_file.close()
+        except IOError as exc:
+            ConfirmationDialog.show_error(self.window(),
+                                          "Error when exporting file",
+                                          "An error occurred when exporting the torrent file: %s" % str(exc))
+        else:
+            self.window().tray_icon.showMessage("Torrent file exported", "Torrent file exported to %s" % dest_path)
 
     def on_right_click_item(self, pos):
         item_clicked = self.window().downloads_list.itemAt(pos)


### PR DESCRIPTION
Also increased the Dispersy pointer and fixed a crash when the error dialog was displayed during a request to Tribler and the cancel button was clicked.