### PR TITLE
Catch all exceptions of urlparse in tracker_utils

### DIFF
--- a/Tribler/Core/Utilities/tracker_utils.py
+++ b/Tribler/Core/Utilities/tracker_utils.py
@@ -36,37 +36,41 @@ def get_uniformed_tracker_url(tracker_url):
 
     url = urlparse(tracker_url)
 
-    # scheme must be either UDP or HTTP
-    if url.scheme == 'udp' or url.scheme == 'http':
-        uniformed_scheme = url.scheme
-    else:
-        return None
-
-    uniformed_hostname = url.hostname
-
-    if not url.port:
-        # UDP trackers must have a port
-        if url.scheme == 'udp':
+    # accessing urlparse attributes may throw UnicodeError's or ValueError's
+    try:
+        # scheme must be either UDP or HTTP
+        if url.scheme == 'udp' or url.scheme == 'http':
+            uniformed_scheme = url.scheme
+        else:
             return None
-        # HTTP trackers default to port HTTP_PORT
-        elif url.scheme == 'http':
-            uniformed_port = HTTP_PORT
-    else:
-        uniformed_port = url.port
 
-    # UDP trackers have no path
-    if url.scheme == 'udp':
-        uniformed_path = ''
-    else:
-        uniformed_path = url.path.rstrip('/')
-    # HTTP trackers must have a path
-    if url.scheme == 'http' and not url.path:
+        uniformed_hostname = url.hostname
+
+        if not url.port:
+            # UDP trackers must have a port
+            if url.scheme == 'udp':
+                return None
+            # HTTP trackers default to port HTTP_PORT
+            elif url.scheme == 'http':
+                uniformed_port = HTTP_PORT
+        else:
+            uniformed_port = url.port
+
+        # UDP trackers have no path
+        if url.scheme == 'udp':
+            uniformed_path = ''
+        else:
+            uniformed_path = url.path.rstrip('/')
+        # HTTP trackers must have a path
+        if url.scheme == 'http' and not url.path:
+            return None
+
+        if url.scheme == 'http' and uniformed_port == HTTP_PORT:
+            uniformed_url = u'%s://%s%s' % (uniformed_scheme, uniformed_hostname, uniformed_path)
+        else:
+            uniformed_url = u'%s://%s:%d%s' % (uniformed_scheme, uniformed_hostname, uniformed_port, uniformed_path)
+    except (UnicodeError, ValueError):
         return None
-
-    if url.scheme == 'http' and uniformed_port == HTTP_PORT:
-        uniformed_url = u'%s://%s%s' % (uniformed_scheme, uniformed_hostname, uniformed_path)
-    else:
-        uniformed_url = u'%s://%s:%d%s' % (uniformed_scheme, uniformed_hostname, uniformed_port, uniformed_path)
 
     return uniformed_url
 

--- a/Tribler/Test/Core/Utilities/test_tracker_utils.py
+++ b/Tribler/Test/Core/Utilities/test_tracker_utils.py
@@ -51,6 +51,10 @@ class TestGetUniformedTrackerUrl(TriblerCoreTest):
         result = get_uniformed_tracker_url("http://torrent.ubuntu.com:80/announce")
         self.assertEqual(result, u'http://torrent.ubuntu.com/announce')
 
+    def test_uniform_trailing_hex(self):
+        result = get_uniformed_tracker_url("udp://tracker.1337x.org:80\x00")
+        self.assertIsNone(result)
+
 
 class TestParseTrackerUrl(TriblerCoreTest):
     """


### PR DESCRIPTION
Fixes https://github.com/Tribler/tribler/issues/2860.

I catch all exceptions in that come from parsing the given tracker url with `urlparse`. I believe violating pylint rules is justified.