### PR TITLE
Removed VLC plugin check

### DIFF
--- a/TriblerGUI/widgets/videoplayerpage.py
+++ b/TriblerGUI/widgets/videoplayerpage.py
@@ -41,8 +41,6 @@ class VideoPlayerPage(QWidget):
 
         if vlc and vlc.plugin_path:
             os.environ['VLC_PLUGIN_PATH'] = vlc.plugin_path
-        else:
-            vlc_available = False
 
         if not vlc_available:
             # VLC is not available, we hide the video player button


### PR DESCRIPTION
This check was a bit too strict; on some systems it could be that there is no plugin path set but that VLC is still functioning.