### PR TITLE
Increased multichain db version

### DIFF
--- a/Tribler/Test/Community/Multichain/test_multichain_database.py
+++ b/Tribler/Test/Community/Multichain/test_multichain_database.py
@@ -172,13 +172,13 @@ class TestDatabase(MultiChainTestCase):
     def test_database_upgrade(self):
         self.set_db_version(1)
         version, = next(self.db.execute(u"SELECT value FROM option WHERE key = 'database_version' LIMIT 1"))
-        self.assertEqual(version, u"2")
+        self.assertEqual(version, u"3")
 
     @blocking_call_on_reactor_thread
     def test_database_create(self):
         self.set_db_version(0)
         version, = next(self.db.execute(u"SELECT value FROM option WHERE key = 'database_version' LIMIT 1"))
-        self.assertEqual(version, u"2")
+        self.assertEqual(version, u"3")
 
     @blocking_call_on_reactor_thread
     def test_database_no_downgrade(self):

--- a/Tribler/community/multichain/database.py
+++ b/Tribler/community/multichain/database.py
@@ -11,7 +11,7 @@ DATABASE_DIRECTORY = path.join(u"sqlite")
 # Path to the database location + dispersy._workingdirectory
 DATABASE_PATH = path.join(DATABASE_DIRECTORY, u"multichain.db")
 # Version to keep track if the db schema needs to be updated.
-LATEST_DB_VERSION = 2
+LATEST_DB_VERSION = 3
 # Schema for the MultiChain DB.
 schema = u"""
 CREATE TABLE IF NOT EXISTS multi_chain(


### PR DESCRIPTION
Fixes #2916 

Apparently the multichain database version was already 2 at some point in time. This causes the database not to update to the new version introduced by the true halves PR.