### PR TITLE
Only attempt to load metadata when metadata store is enabled

### DIFF
--- a/Tribler/Core/TFTP/handler.py
+++ b/Tribler/Core/TFTP/handler.py
@@ -296,6 +296,8 @@ class TftpHandler(TaskManager):
         # read the file/directory into memory
         try:
             if file_name.startswith(METADATA_PREFIX):
+                if not self.session.get_enable_metadata():
+                    return
                 file_data, file_size = self._load_metadata(file_name[len(METADATA_PREFIX):])
             else:
                 file_data, file_size = self._load_torrent(file_name)


### PR DESCRIPTION
Instead of risking an AttributeError, return from handling a request.