### PR TITLE
WIP: Fix unicode leveldb

### DIFF
--- a/Tribler/Core/Utilities/win32admincommand.py
+++ b/Tribler/Core/Utilities/win32admincommand.py
@@ -1,0 +1,28 @@
+"""
+This file contains a workaround for executing admin-only commands on Windows.
+Use only if absolutely necessary!
+"""
+
+from ctypes import windll
+from os.path import isdir
+
+
+def mklink(source, target):
+    """
+    Create a symlink folder ``source``, which links to the folder ``target``.
+
+    :return: whether or not the symlink creation was successful
+    :rtype: bool
+    """
+    succeeded = windll.shell32.ShellExecuteW(None,
+                                             u'runas',
+                                             u'cmd',
+                                             ur'/c mklink /d "%s" "%s"' % (source, target),
+                                             None,
+                                             0)
+
+    while succeeded and not isdir(source):
+        import time
+        time.sleep(.05)
+
+    return succeeded


### PR DESCRIPTION
Partially fixes #2946, #2862 .

Even though this fixes unicode paths for LevelDB, more errors exist for unicode paths, see #2955.

Hold up:

 - Doesn't seem to work when packed into a `.exe` (possibly built incorrectly?)