### PR TITLE
Remove unused dependency from Ubuntu documentation

### DIFF
--- a/doc/development/development_on_linux.rst
+++ b/doc/development/development_on_linux.rst
@@ -7,7 +7,7 @@ First, install the required dependencies by executing the following command in y
 
 .. code-block:: none
 
-    sudo apt-get install libav-tools libsodium18 libx11-6 python-apsw python-cherrypy3 python-crypto python-cryptography python-decorator python-feedparser python-leveldb python-libtorrent python-matplotlib python-m2crypto python-netifaces python-pil python-pyasn1 python-twisted python2.7 vlc python-chardet python-configobj python-pyqt5 python-pyqt5.qtsvg
+    sudo apt-get install libav-tools libsodium18 libx11-6 python-apsw python-cherrypy3 python-cryptography python-decorator python-feedparser python-leveldb python-libtorrent python-matplotlib python-m2crypto python-netifaces python-pil python-pyasn1 python-twisted python2.7 vlc python-chardet python-configobj python-pyqt5 python-pyqt5.qtsvg
 
 Next, download the latest .deb file from `here <https://jenkins.tribler.org/job/Build-Tribler_Ubuntu-64_devel/lastStableBuild/>`_.
 


### PR DESCRIPTION
The `python-crypto` is not necessary for Ubuntu. I tested this on 17.04. Moreover, for the Arch dependencies, the package is not listed either.