### PR TITLE
Live edges

### DIFF
--- a/Tribler/Core/Config/config.spec
+++ b/Tribler/Core/Config/config.spec
@@ -25,6 +25,7 @@ exitnode_enabled = boolean(default=False)
 [trustchain]
 enabled = boolean(default=True)
 ec_keypair_filename = string(default='')
+live_edges_enabled = boolean(default=True)
 
 [metadata]
 enabled = boolean(default=True)

--- a/Tribler/Core/Config/tribler_config.py
+++ b/Tribler/Core/Config/tribler_config.py
@@ -196,6 +196,12 @@ class TriblerConfig(object):
             self.set_trustchain_permid_keypair_filename(file_name)
         return file_name
 
+    def set_trustchain_live_edges_enabled(self, value):
+        self.config['trustchain']['live_edges_enabled'] = value
+
+    def get_trustchain_live_edges_enabled(self):
+        return self.config['trustchain']['live_edges_enabled']
+
     def set_megacache_enabled(self, value):
         self.config['general']['megacache'] = value
 

--- a/Tribler/community/trustchain/conversion.py
+++ b/Tribler/community/trustchain/conversion.py
@@ -9,7 +9,7 @@ from Tribler.dispersy.message import DropPacket
 
 
 # The crawl message format permits future extensions by providing space for a public key and response limit
-crawl_request_format = "! {0}s I I ".format(PK_LENGTH)
+crawl_request_format = "! {0}s l I ".format(PK_LENGTH)
 crawl_request_size = calcsize(crawl_request_format)
 
 


### PR DESCRIPTION
This PR implements live edges for the MultiChain community as discussed in https://github.com/Tribler/tribler/issues/2894 and https://github.com/Tribler/tribler/issues/2458 .

Extra functionality:

 - Refactored `MultiChainCommunity.cleanup_pending()` to be a `TaskManager` task, so that it gets destroyed when the community is unloaded.
 - Added negative chain sequence numbers. This behaves like Python negative array indices: -1 gives the last element, -2 the last two elements and so on.