### PR TITLE
Implemented matchmakers in the market

### DIFF
--- a/Tribler/Core/Config/config.spec
+++ b/Tribler/Core/Config/config.spec
@@ -24,6 +24,7 @@ exitnode_enabled = boolean(default=False)
 
 [market_community]
 enabled = boolean(default=True)
+matchmaker = boolean(default=True)
 
 [trustchain]
 enabled = boolean(default=True)

--- a/Tribler/Core/Config/tribler_config.py
+++ b/Tribler/Core/Config/tribler_config.py
@@ -478,6 +478,12 @@ class TriblerConfig(object):
     def get_market_community_enabled(self):
         return self.config['market_community']['enabled']
 
+    def set_is_matchmaker(self, value):
+        self.config['market_community']['matchmaker'] = value
+
+    def get_is_matchmaker(self):
+        return self.config['market_community']['matchmaker']
+
     # Wallets
 
     def set_btc_testnet(self, value):

--- a/Tribler/Test/Community/Market/Integration/test_market_community.py
+++ b/Tribler/Test/Community/Market/Integration/test_market_community.py
@@ -154,7 +154,7 @@ class TestMarketCommunity(BaseTestMarketCommunity):
         proposed_trade = Trade.propose(self.node_b.community.message_repository.next_identity(),
                                        order_a.order_id, order_b.order_id, Price(10, 'DUM1'),
                                        order_a.total_quantity, Timestamp.now())
-        self.node_a.community.send_proposed_trade(proposed_trade)
+        self.node_a.community.send_proposed_trade(proposed_trade, 'a')
 
         yield self.parse_assert_packets(self.node_b)
         yield self.parse_assert_packets(self.node_a)
@@ -183,13 +183,18 @@ class TestMarketCommunity(BaseTestMarketCommunity):
         self.node_b.community.send_proposed_trade(proposed_trade, 'a')
         deferred = Deferred()
 
-        def mocked_remove(_):
+        def mocked_send_decline(*_):
             deferred.callback(None)
 
-        self.node_b.community.order_book.remove_tick = mocked_remove
+        self.node_b.community.send_decline_match_message = mocked_send_decline
 
-        yield self.parse_assert_packets(self.node_a)
-        yield self.parse_assert_packets(self.node_b)
+        mocked_match_message = MockObject()
+        mocked_match_message.payload = MockObject()
+        mocked_match_message.payload.matchmaker_trader_id = 3
+        self.node_b.community.incoming_match_messages['a'] = mocked_match_message
+
+        yield self.parse_assert_packets(self.node_a)  # Parse proposed-trade message
+        yield self.parse_assert_packets(self.node_b)  # Parse declined-trade message
         yield deferred
 
     @blocking_call_on_reactor_thread
@@ -237,13 +242,6 @@ class TestMarketCommunityMatching(BaseTestMarketCommunity):
         """
         Test whether a central node matches two other nodes
         """
-        deferred = Deferred()
-
-        def mocked_start_transaction(*_):
-            deferred.callback(None)
-
-        self.node_a.community.start_transaction = mocked_start_transaction
-
         yield self.introduce_nodes(self.node_a, self.node_c)
         yield self.introduce_nodes(self.node_b, self.node_c)
 
@@ -251,6 +249,23 @@ class TestMarketCommunityMatching(BaseTestMarketCommunity):
         yield self.create_send_bid(self.node_b, self.node_c)
         yield self.parse_assert_packets(self.node_b)  # Parse the match message
         yield self.parse_assert_packets(self.node_a)  # Parse the proposed-trade message
+        yield self.parse_assert_packets(self.node_b)  # Parse the start-transaction message
         yield self.parse_assert_packets(self.node_c)  # Parse the accept-match message
 
-        yield deferred
+    @blocking_call_on_reactor_thread
+    @inlineCallbacks
+    def test_matching_declined(self):
+        """
+        Test whether a central node matches two other nodes and the match is declined
+        """
+        yield self.introduce_nodes(self.node_a, self.node_c)
+        yield self.introduce_nodes(self.node_b, self.node_c)
+
+        yield self.create_send_ask(self.node_a, self.node_c)
+        yield self.create_send_bid(self.node_b, self.node_c)
+        order_b = self.node_b.community.order_manager.order_repository.find_all()[0]
+        order_b._traded_quantity = Quantity(10, 'DUM2')
+        self.node_b.community.order_manager.order_repository.update(order_b)
+
+        yield self.parse_assert_packets(self.node_b)  # Parse the match message
+        yield self.parse_assert_packets(self.node_c)  # Parse the decline-match message

--- a/Tribler/Test/Community/Market/Integration/test_market_community.py
+++ b/Tribler/Test/Community/Market/Integration/test_market_community.py
@@ -20,38 +20,27 @@ from Tribler.dispersy.tests.debugcommunity.node import DebugNode
 from Tribler.community.market.wallet.dummy_wallet import DummyWallet1, DummyWallet2
 
 
-class TestMarketCommunity(DispersyTestFunc):
+class BaseTestMarketCommunity(DispersyTestFunc):
     """
-    This class contains various Dispersy live tests for the market community.
-    These tests are able to control each message and parse them at will.
+    This is the base class for the market community tests on integration level.
     """
-
     @blocking_call_on_reactor_thread
     @inlineCallbacks
     def setUp(self):
         yield DispersyTestFunc.setUp(self)
-
         self.temp_dir = mkdtemp(suffix="_iom_tests")
 
-        self.node_a, self.node_b = yield self.create_nodes(2)
-
-        dummy1_a = DummyWallet1()
-        dummy1_b = DummyWallet1()
-        dummy2_a = DummyWallet2()
-        dummy2_b = DummyWallet2()
-
-        self.node_a.community.wallets = {dummy1_a.get_identifier(): dummy1_a, dummy2_a.get_identifier(): dummy2_a}
-        self.node_b.community.wallets = {dummy1_b.get_identifier(): dummy1_b, dummy2_b.get_identifier(): dummy2_b}
-
+    @blocking_call_on_reactor_thread
+    @inlineCallbacks
     def tearDown(self):
-        DispersyTestFunc.tearDown(self)
+        yield DispersyTestFunc.tearDown(self)
         rmtree(unicode(self.temp_dir), ignore_errors=True)
 
     @blocking_call_on_reactor_thread
     @inlineCallbacks
     def create_nodes(self, *args, **kwargs):
-        nodes = yield super(TestMarketCommunity, self).create_nodes(*args, community_class=MarketCommunity,
-                                                                    memory_database=False, **kwargs)
+        nodes = yield super(BaseTestMarketCommunity, self).create_nodes(*args, community_class=MarketCommunity,
+                                                                        memory_database=False, **kwargs)
         for outer in nodes:
             for inner in nodes:
                 if outer != inner:
@@ -72,7 +61,14 @@ class TestMarketCommunity(DispersyTestFunc):
     def create_send_ask(self, ask_node, bid_node):
         order = ask_node.community.create_ask(10, 'DUM1', 10, 'DUM2', 3600)
         yield self.parse_assert_packets(bid_node)
-        self.assertEqual(len(bid_node.community.order_book.asks), 1)
+        self.assertGreaterEqual(len(bid_node.community.order_book.asks), 1)
+        returnValue(order)
+
+    @inlineCallbacks
+    def create_send_bid(self, bid_node, ask_node):
+        order = bid_node.community.create_bid(10, 'DUM1', 10, 'DUM2', 3600)
+        yield self.parse_assert_packets(ask_node)
+        self.assertGreaterEqual(len(ask_node.community.order_book.bids), 1)
         returnValue(order)
 
     def _create_node(self, dispersy, community_class, c_master_member):
@@ -85,6 +81,28 @@ class TestMarketCommunity(DispersyTestFunc):
         packets = node.process_packets()
         self.assertIsNotNone(packets)
         yield deferLater(reactor, 0.05, lambda: None)
+
+
+class TestMarketCommunity(BaseTestMarketCommunity):
+    """
+    This class contains various Dispersy live tests for the market community.
+    These tests are able to control each message and parse them at will.
+    """
+
+    @blocking_call_on_reactor_thread
+    @inlineCallbacks
+    def setUp(self):
+        yield BaseTestMarketCommunity.setUp(self)
+
+        self.node_a, self.node_b = yield self.create_nodes(2)
+
+        dummy1_a = DummyWallet1()
+        dummy1_b = DummyWallet1()
+        dummy2_a = DummyWallet2()
+        dummy2_b = DummyWallet2()
+
+        self.node_a.community.wallets = {dummy1_a.get_identifier(): dummy1_a, dummy2_a.get_identifier(): dummy2_a}
+        self.node_b.community.wallets = {dummy1_b.get_identifier(): dummy1_b, dummy2_b.get_identifier(): dummy2_b}
 
     @blocking_call_on_reactor_thread
     @inlineCallbacks
@@ -100,11 +118,10 @@ class TestMarketCommunity(DispersyTestFunc):
         self.node_b.community.start_transaction = mocked_start_transaction
         yield self.introduce_nodes(self.node_a, self.node_b)
         yield self.create_send_ask(self.node_a, self.node_b)
+        yield self.create_send_bid(self.node_b, self.node_a)
 
-        # Send a proposed trade message
-        self.node_b.community.create_bid(10, 'DUM1', 10, 'DUM2', 3600)
-        yield self.parse_assert_packets(self.node_a)  # Parse the bid message
-        yield self.parse_assert_packets(self.node_b)
+        yield self.parse_assert_packets(self.node_a)  # Parse the match message
+        yield self.parse_assert_packets(self.node_b)  # Parse the proposed-trade message
         yield deferred
 
     @blocking_call_on_reactor_thread
@@ -124,11 +141,9 @@ class TestMarketCommunity(DispersyTestFunc):
         self.node_a.community.start_transaction = mocked_start_transaction
         yield self.introduce_nodes(self.node_a, self.node_b)
         yield self.create_send_ask(self.node_a, self.node_b)
+        yield self.create_send_bid(self.node_b, self.node_a)
 
-        # Send a proposed trade message
-        self.node_b.community.create_bid(10, 'DUM1', 10, 'DUM2', 3600)
-        yield self.parse_assert_packets(self.node_a)  # Parse the bid message
-        yield self.parse_assert_packets(self.node_b)
+        yield self.parse_assert_packets(self.node_b)  # Parse the proposed-trade message
 
         order_a = self.node_a.community.order_manager.order_repository.find_all()[0]
         order_b = self.node_b.community.order_manager.order_repository.find_all()[0]
@@ -136,7 +151,7 @@ class TestMarketCommunity(DispersyTestFunc):
         self.node_b.community.order_manager.order_repository.update(order_b)
         order_a.reserve_quantity_for_tick(order_b.order_id, order_a.total_quantity)
         self.node_a.community.order_manager.order_repository.update(order_a)
-        proposed_trade = Trade.propose(self.node_b.community.order_book.message_repository.next_identity(),
+        proposed_trade = Trade.propose(self.node_b.community.message_repository.next_identity(),
                                        order_a.order_id, order_b.order_id, Price(10, 'DUM1'),
                                        order_a.total_quantity, Timestamp.now())
         self.node_a.community.send_proposed_trade(proposed_trade)
@@ -162,10 +177,10 @@ class TestMarketCommunity(DispersyTestFunc):
         order_b = self.node_b.community.order_manager.order_repository.find_all()[0]
         order_b.reserve_quantity_for_tick(order_a.order_id, order_b.total_quantity)
         self.node_b.community.order_manager.order_repository.update(order_b)
-        proposed_trade = Trade.propose(self.node_b.community.order_book.message_repository.next_identity(),
+        proposed_trade = Trade.propose(self.node_b.community.message_repository.next_identity(),
                                        order_b.order_id, order_a.order_id, Price(9, 'DUM1'),
                                        order_b.total_quantity, Timestamp.now())
-        self.node_b.community.send_proposed_trade(proposed_trade)
+        self.node_b.community.send_proposed_trade(proposed_trade, 'a')
         deferred = Deferred()
 
         def mocked_remove(_):
@@ -189,3 +204,53 @@ class TestMarketCommunity(DispersyTestFunc):
         self.node_a.community.cancel_order(order.order_id)
         yield self.parse_assert_packets(self.node_b)
         self.assertEqual(len(self.node_b.community.order_book.asks), 0)
+
+
+class TestMarketCommunityMatching(BaseTestMarketCommunity):
+    """
+    This class contains various Dispersy live tests for the market community, in particular, for matching.
+    """
+
+    @blocking_call_on_reactor_thread
+    @inlineCallbacks
+    def setUp(self):
+        yield BaseTestMarketCommunity.setUp(self)
+
+        self.node_a, self.node_b, self.node_c = yield self.create_nodes(3)
+        self.node_a.community.is_matchmaker = False
+        self.node_b.community.is_matchmaker = False
+
+        dummy1_a = DummyWallet1()
+        dummy1_b = DummyWallet1()
+        dummy1_c = DummyWallet1()
+        dummy2_a = DummyWallet2()
+        dummy2_b = DummyWallet2()
+        dummy2_c = DummyWallet2()
+
+        self.node_a.community.wallets = {dummy1_a.get_identifier(): dummy1_a, dummy2_a.get_identifier(): dummy2_a}
+        self.node_b.community.wallets = {dummy1_b.get_identifier(): dummy1_b, dummy2_b.get_identifier(): dummy2_b}
+        self.node_c.community.wallets = {dummy1_c.get_identifier(): dummy1_c, dummy2_c.get_identifier(): dummy2_c}
+
+    @blocking_call_on_reactor_thread
+    @inlineCallbacks
+    def test_matching(self):
+        """
+        Test whether a central node matches two other nodes
+        """
+        deferred = Deferred()
+
+        def mocked_start_transaction(*_):
+            deferred.callback(None)
+
+        self.node_a.community.start_transaction = mocked_start_transaction
+
+        yield self.introduce_nodes(self.node_a, self.node_c)
+        yield self.introduce_nodes(self.node_b, self.node_c)
+
+        yield self.create_send_ask(self.node_a, self.node_c)
+        yield self.create_send_bid(self.node_b, self.node_c)
+        yield self.parse_assert_packets(self.node_b)  # Parse the match message
+        yield self.parse_assert_packets(self.node_a)  # Parse the proposed-trade message
+        yield self.parse_assert_packets(self.node_c)  # Parse the accept-match message
+
+        yield deferred

--- a/Tribler/Test/Community/Market/Integration/test_market_session.py
+++ b/Tribler/Test/Community/Market/Integration/test_market_session.py
@@ -57,7 +57,7 @@ class TestMarketSession(TestMarketBase):
             Candidate(bid_session.get_dispersy_instance().lan_address, tunnel=False))
         bid_community.add_discovered_candidate(
             Candidate(self.session.get_dispersy_instance().lan_address, tunnel=False))
-        yield self.async_sleep(3)
+        yield self.async_sleep(7)
         bid_community.create_bid(10, 'DUM1', 10, 'MC', 3600)
         ask_community.create_ask(10, 'DUM1', 10, 'MC', 3600)
 

--- a/Tribler/Test/Community/Market/test_community.py
+++ b/Tribler/Test/Community/Market/test_community.py
@@ -199,7 +199,7 @@ class CommunityTestSuite(AbstractTestCommunity):
         Test sending a proposed trade
         """
         self.market_community.update_ip(TraderId(self.market_community.mid), ('127.0.0.1', 1234))
-        self.assertEqual(self.market_community.send_proposed_trade_messages([self.proposed_trade]), [True])
+        self.assertEqual(self.market_community.send_proposed_trade(self.proposed_trade), [True])
 
     @blocking_call_on_reactor_thread
     def test_send_counter_trade(self):

--- a/Tribler/Test/Community/Market/test_community.py
+++ b/Tribler/Test/Community/Market/test_community.py
@@ -1,5 +1,6 @@
 import hashlib
 
+from Tribler.community.market.core.transaction import TransactionNumber, StartTransaction
 from twisted.internet.defer import inlineCallbacks
 
 from Tribler.Test.Community.AbstractTestCommunity import AbstractTestCommunity
@@ -71,6 +72,27 @@ class CommunityTestSuite(AbstractTestCommunity):
         self.assertTrue(MarketCommunity.get_master_members(self.dispersy))
 
     @blocking_call_on_reactor_thread
+    def test_disable_matchmaker(self):
+        """
+        Test the disabling of the matchmaker functionality
+        """
+        self.market_community.disable_matchmaker()
+        self.assertIsNone(self.market_community.order_book)
+        self.assertFalse(self.market_community.is_matchmaker)
+
+    @blocking_call_on_reactor_thread
+    def test_get_introduce_candidate(self):
+        """
+        Test the retrieval of an introduce candidate
+        """
+        def mocked_get_candidate(mm):
+            return mm
+
+        self.market_community.get_candidate = mocked_get_candidate
+        self.market_community.matchmakers = [('abcd', 1234)]
+        self.assertEqual(self.market_community.dispersy_get_introduce_candidate(), ('abcd', 1234))
+
+    @blocking_call_on_reactor_thread
     def test_proposed_trade_cache_timeout(self):
         """
         Test the timeout method of a proposed trade request in the cache
@@ -85,14 +107,25 @@ class CommunityTestSuite(AbstractTestCommunity):
         self.market_community.order_manager.order_repository.add(order)
         order.reserve_quantity_for_tick(self.proposed_trade.recipient_order_id, Quantity(30, 'DUM2'))
         self.market_community.order_manager.order_repository.update(order)
-        cache = ProposedTradeRequestCache(self.market_community, self.proposed_trade)
+
+        mocked_match_message = MockObject()
+        mocked_match_message.payload = MockObject()
+        mocked_match_message.payload.matchmaker_trader_id = 'a'
+        self.market_community.incoming_match_messages['a'] = mocked_match_message
+
+        def mocked_send_decline(*_):
+            mocked_send_decline.called = True
+
+        mocked_send_decline.called = False
+        self.market_community.send_decline_match_message = mocked_send_decline
+
+        cache = ProposedTradeRequestCache(self.market_community, self.proposed_trade, 'a')
         cache.on_timeout()
-        self.assertEqual(len(self.market_community.order_book.asks), 0)
+        self.assertTrue(mocked_send_decline.called)
 
     def get_tick_message(self, tick):
         meta = self.market_community.get_meta_message(u"ask" if isinstance(tick, Ask) else u"bid")
         return meta.impl(
-            authentication=(self.market_community.my_member,),
             distribution=(self.market_community.claim_global_time(),),
             payload=tick.to_network() + (Ttl.default(), "127.0.0.1", 1234)
         )
@@ -106,6 +139,34 @@ class CommunityTestSuite(AbstractTestCommunity):
             destination=(candidate,),
             payload=tick.to_network() + (Ttl(1),) + ("127.0.0.1", 1234) + (isinstance(tick, Ask),)
         )
+
+    def get_transaction_completed_msg(self):
+        meta = self.market_community.get_meta_message(u"transaction-completed-bc")
+        candidate = Candidate(self.market_community.lookup_ip(TraderId(self.market_community.mid)), False)
+        return meta.impl(
+            distribution=(self.market_community.claim_global_time(),),
+            destination=(candidate,),
+            payload=(TraderId('abc'), MessageNumber('3'), TraderId('def'), TransactionNumber(5), TraderId('abc'),
+                     OrderNumber(3), TraderId('def'), OrderNumber(4), 'match_id', Quantity(2, 'BTC'), Timestamp.now(),
+                     Ttl(3))
+        )
+
+    def get_start_transaction_msg(self):
+        transaction = self.market_community.transaction_manager.create_from_proposed_trade(self.proposed_trade, 'abcd')
+        start_transaction = StartTransaction(self.market_community.message_repository.next_identity(),
+                                             transaction.transaction_id, transaction.order_id,
+                                             self.proposed_trade.order_id, self.proposed_trade.proposal_id,
+                                             self.proposed_trade.price, self.proposed_trade.quantity, Timestamp.now())
+
+        meta = self.market_community.get_meta_message(u"start-transaction")
+        candidate = Candidate(self.market_community.lookup_ip(TraderId(self.market_community.mid)), False)
+        return meta.impl(
+            authentication=(self.market_community.my_member,),
+            distribution=(self.market_community.claim_global_time(),),
+            destination=(candidate,),
+            payload=start_transaction.to_network()
+        )
+
 
     @blocking_call_on_reactor_thread
     def test_verify_offer_creation(self):
@@ -147,10 +208,6 @@ class CommunityTestSuite(AbstractTestCommunity):
         [self.assertIsInstance(msg, DropMessage) for msg in
          self.market_community.check_tick_message([self.get_tick_message(self.ask)])]
 
-        self.market_community.timeline.check = lambda _: (False, None)
-        [self.assertIsInstance(msg, DelayMessageByProof) for msg in
-         self.market_community.check_tick_message([self.get_tick_message(self.ask)])]
-
         self.market_community.timeline.check = lambda _: (True, None)
         self.ask.order_id._trader_id = TraderId(self.market_community.mid)
         [self.assertIsInstance(msg, DropMessage) for msg in
@@ -183,6 +240,20 @@ class CommunityTestSuite(AbstractTestCommunity):
          self.market_community.check_trade_message([self.get_proposed_trade_msg()])]
 
     @blocking_call_on_reactor_thread
+    def test_check_transaction_message(self):
+        """
+        Test the general check of the validity of a trade message in the market community
+        """
+        self.market_community.update_ip(TraderId(self.market_community.mid), ('2.2.2.2', 2))
+        self.market_community.timeline.check = lambda _: (False, None)
+        [self.assertIsInstance(msg, DelayMessageByProof) for msg in
+         self.market_community.check_transaction_message([self.get_start_transaction_msg()])]
+
+        self.market_community.timeline.check = lambda _: (True, None)
+        [self.assertIsInstance(msg, DropMessage) for msg in
+         self.market_community.check_trade_message([self.get_start_transaction_msg()])]
+
+    @blocking_call_on_reactor_thread
     def test_send_offer_sync(self):
         """
         Test sending an offer sync
@@ -199,7 +270,7 @@ class CommunityTestSuite(AbstractTestCommunity):
         Test sending a proposed trade
         """
         self.market_community.update_ip(TraderId(self.market_community.mid), ('127.0.0.1', 1234))
-        self.assertEqual(self.market_community.send_proposed_trade(self.proposed_trade), [True])
+        self.assertEqual(self.market_community.send_proposed_trade(self.proposed_trade, 'a'), True)
 
     @blocking_call_on_reactor_thread
     def test_send_counter_trade(self):
@@ -219,7 +290,7 @@ class CommunityTestSuite(AbstractTestCommunity):
         """
         self.market_community.order_manager.order_repository.add(self.order)
         self.market_community.update_ip(TraderId('0'), ("127.0.0.1", 1234))
-        self.market_community.start_transaction(self.proposed_trade)
+        self.market_community.start_transaction(self.proposed_trade, 'a')
         self.assertEqual(len(self.market_community.transaction_manager.find_all()), 1)
 
     @blocking_call_on_reactor_thread
@@ -293,14 +364,6 @@ class CommunityTestSuite(AbstractTestCommunity):
         self.market_community.on_tick([self.get_tick_message(self.ask), self.get_tick_message(self.bid)])
         self.assertEquals(1, len(self.market_community.order_book.asks))
         self.assertEquals(1, len(self.market_community.order_book.bids))
-
-        # Update the timestamp of the ticks
-        ask_timestamp = float(self.ask.timestamp)
-        self.ask.update_timestamp()
-        self.market_community.on_tick([self.get_tick_message(self.ask)])
-        self.assertEquals(1, len(self.market_community.order_book.asks))
-        new_timestamp = self.market_community.order_book.get_tick(self.ask.order_id).tick.timestamp
-        self.assertGreater(new_timestamp, ask_timestamp)
 
     @blocking_call_on_reactor_thread
     def test_create_bid(self):
@@ -394,6 +457,15 @@ class CommunityTestSuite(AbstractTestCommunity):
         self.assertEqual(len(self.market_community.order_book.bids), 1)
 
     @blocking_call_on_reactor_thread
+    def test_on_transaction_completed_bc(self):
+        """
+        Test whether the right operatiosn happen when we receive a transaction completed broadcast
+        """
+        self.market_community.update_ip(TraderId(self.market_community.mid), ('2.2.2.2', 2))
+        self.market_community.on_transaction_completed_bc_message([self.get_transaction_completed_msg()])
+        self.assertEqual(len(self.market_community.relayed_completed_transaction), 1)
+
+    @blocking_call_on_reactor_thread
     def test_compute_reputation(self):
         """
         Test the compute_reputation method
@@ -412,7 +484,7 @@ class CommunityTestSuite(AbstractTestCommunity):
         self.order.reserve_quantity_for_tick(OrderId(TraderId('0'), OrderNumber(23)), Quantity(30, 'DUM2'))
         self.market_community.order_manager.order_repository.add(self.order)
         self.market_community.update_ip(TraderId('0'), ("127.0.0.1", 1234))
-        self.market_community.start_transaction(self.proposed_trade)
+        self.market_community.start_transaction(self.proposed_trade, 'a')
         transaction = self.market_community.transaction_manager.find_all()[0]
         self.assertTrue(transaction)
         self.assertEqual(self.order.reserved_quantity, Quantity(30, 'DUM2'))

--- a/Tribler/Test/Community/Market/test_database.py
+++ b/Tribler/Test/Community/Market/test_database.py
@@ -36,6 +36,7 @@ class TestDatabase(AbstractServer):
         self.order_id2 = OrderId(TraderId('4'), OrderNumber(5))
         self.order1 = Order(self.order_id1, Price(5, 'EUR'), Quantity(6, 'BTC'), Timeout(3600), Timestamp.now(), True)
         self.order2 = Order(self.order_id2, Price(5, 'EUR'), Quantity(6, 'BTC'), Timeout(3600), Timestamp.now(), False)
+        self.order2.reserve_quantity_for_tick(OrderId(TraderId('3'), OrderNumber(4)), Quantity(3, 'BTC'))
 
         self.transaction_id1 = TransactionId(TraderId("0"), TransactionNumber(4))
         self.transaction1 = Transaction(self.transaction_id1, Price(100, 'BTC'), Quantity(30, 'MC'),
@@ -54,8 +55,9 @@ class TestDatabase(AbstractServer):
         Test the insertion and retrieval of an order in the database
         """
         self.database.add_order(self.order1)
+        self.database.add_order(self.order2)
         orders = self.database.get_all_orders()
-        self.assertEqual(len(orders), 1)
+        self.assertEqual(len(orders), 2)
 
     @blocking_call_on_reactor_thread
     def test_get_specific_order(self):

--- a/Tribler/Test/Community/Market/test_matching_engine.py
+++ b/Tribler/Test/Community/Market/test_matching_engine.py
@@ -62,6 +62,26 @@ class PriceTimeStrategyTestSuite(AbstractServer):
         self.order_book.cancel_all_pending_tasks()
         yield super(PriceTimeStrategyTestSuite, self).tearDown(annotate=annotate)
 
+    def test_generate_match_id(self):
+        """
+        Test generation of a match id
+        """
+        def mocked_get_random_match_id():
+            if not mocked_get_random_match_id.called:
+                mocked_get_random_match_id.called = True
+                return 'a' * 20
+            else:
+                return 'b' * 20
+        mocked_get_random_match_id.called = False
+
+        rand_id = self.price_time_strategy.get_unique_match_id()
+        self.assertEqual(len(rand_id), 20)
+        self.assertEqual(len(self.price_time_strategy.used_match_ids), 1)
+
+        self.price_time_strategy.get_random_match_id = mocked_get_random_match_id
+        self.price_time_strategy.used_match_ids.add('a' * 20)
+        self.assertEqual(self.price_time_strategy.get_unique_match_id(), 'b' * 20)
+
     def test_empty_match_order(self):
         """
         Test for match order with an empty order book
@@ -96,7 +116,7 @@ class PriceTimeStrategyTestSuite(AbstractServer):
         Test for match ask order
         """
         self.order_book.insert_bid(self.bid)
-        matching_ticks = self.price_time_strategy.match(self.ask_order.order_id,self.ask_order.price,
+        matching_ticks = self.price_time_strategy.match(self.ask_order.order_id, self.ask_order.price,
                                                         self.ask_order.available_quantity, True)
         self.assertEquals(1, len(matching_ticks))
         self.assertEquals(self.order_book.get_tick(self.bid.order_id), matching_ticks[0][1])
@@ -272,24 +292,29 @@ class MatchingEngineTestSuite(AbstractServer):
 
     def test_empty_match_order_empty(self):
         # Test for match order with an empty order book
-        self.assertEquals([], self.matching_engine.match(self.bid_order.price,
-                                                         self.bid_order.available_quantity, False))
-        self.assertEquals([], self.matching_engine.match(self.ask_order.price,
-                                                         self.ask_order.available_quantity, True))
+        self.order_book.insert_ask(self.ask)
+        self.assertEquals([], self.matching_engine.match(self.order_book.get_ask(self.ask.order_id)))
+        self.order_book.remove_ask(self.ask.order_id)
+
+        self.order_book.insert_bid(self.bid)
+        self.assertEquals([], self.matching_engine.match(self.order_book.get_bid(self.bid.order_id)))
+        self.order_book.remove_bid(self.bid.order_id)
 
     def test_match_order_bid(self):
         # Test for match bid order
         self.order_book.insert_ask(self.ask)
-        matching_ticks = self.matching_engine.match(self.bid_order.price, self.bid_order.available_quantity, False)
+        self.order_book.insert_bid(self.bid)
+        matching_ticks = self.matching_engine.match(self.order_book.get_bid(self.bid.order_id))
         self.assertEquals(1, len(matching_ticks))
-        self.assertEquals(Quantity(30, 'MC'), matching_ticks[0][1])
+        self.assertEquals(Quantity(30, 'MC'), matching_ticks[0][2])
 
     def test_match_order_ask(self):
         # Test for match ask order
         self.order_book.insert_bid(self.bid)
-        matching_ticks = self.matching_engine.match(self.ask_order.price, self.ask_order.available_quantity, True)
+        self.order_book.insert_ask(self.ask)
+        matching_ticks = self.matching_engine.match(self.order_book.get_ask(self.ask.order_id))
         self.assertEquals(1, len(matching_ticks))
-        self.assertEquals(Quantity(30, 'MC'), matching_ticks[0][1])
+        self.assertEquals(Quantity(30, 'MC'), matching_ticks[0][2])
 
     def test_no_match_reserved(self):
         """
@@ -297,5 +322,6 @@ class MatchingEngineTestSuite(AbstractServer):
         """
         self.order_book.insert_bid(self.bid)
         self.order_book.get_tick(self.bid.order_id).reserve_for_matching(Quantity(30, 'MC'))
-        matching_ticks = self.matching_engine.match(self.ask_order.price, self.ask_order.available_quantity, True)
+        self.order_book.insert_ask(self.ask)
+        matching_ticks = self.matching_engine.match(self.order_book.get_ask(self.ask.order_id))
         self.assertEquals([], matching_ticks)

--- a/Tribler/Test/Community/Market/test_order.py
+++ b/Tribler/Test/Community/Market/test_order.py
@@ -33,8 +33,10 @@ class OrderTestSuite(unittest.TestCase):
         self.tick2 = Tick(MessageId(TraderId('0'), MessageNumber('message_number')),
                           OrderId(TraderId('0'), OrderNumber(2)), Price(100, 'BTC'), Quantity(100, 'MC'),
                           Timeout(0.0), Timestamp(float("inf")), True)
+
+        self.order_timestamp = Timestamp.now()
         self.order = Order(OrderId(TraderId("0"), OrderNumber(3)), Price(100, 'BTC'), Quantity(30, 'MC'),
-                           Timeout(5000), Timestamp(time.time()), False)
+                           Timeout(5000), self.order_timestamp, False)
         self.order2 = Order(OrderId(TraderId("0"), OrderNumber(4)), Price(100, 'BTC'), Quantity(30, 'MC'),
                             Timeout(5), Timestamp(time.time() - 1000), True)
 
@@ -46,6 +48,11 @@ class OrderTestSuite(unittest.TestCase):
         self.assertEquals(self.order.traded_quantity, Quantity(0, 'MC'))
         self.order.add_trade(OrderId(TraderId('5'), OrderNumber(1)), Quantity(10, 'MC'))
         self.assertEquals(self.order.traded_quantity, Quantity(10, 'MC'))
+
+        self.order.reserve_quantity_for_tick(OrderId(TraderId('6'), OrderNumber(1)), Quantity(20, 'MC'))
+        self.order.add_trade(OrderId(TraderId('6'), OrderNumber(1)), Quantity(20, 'MC'))
+        self.assertTrue(self.order.is_complete())
+        self.assertFalse(self.order.cancelled)
 
     def test_is_ask(self):
         # Test for is ask
@@ -95,6 +102,27 @@ class OrderTestSuite(unittest.TestCase):
         self.assertEqual(self.order.status, "completed")
         self.order._cancelled = True
         self.assertEqual(self.order.status, "cancelled")
+
+    def test_to_dict(self):
+        """
+        Test the conversion of an order to a dictionary
+        """
+        self.assertEqual(self.order.to_dictionary(), {
+            "trader_id": "0",
+            "cancelled": False,
+            "completed_timestamp": None,
+            "is_ask": False,
+            "order_number": 3,
+            "price": 100.0,
+            "price_type": "BTC",
+            "quantity": 30.0,
+            "quantity_type": "MC",
+            "reserved_quantity": 0.0,
+            "traded_quantity": 0.0,
+            "status": "open",
+            "timeout": 5000.0,
+            "timestamp": float(self.order_timestamp)
+        })
 
 
 class OrderIDTestSuite(unittest.TestCase):

--- a/Tribler/Test/Community/Market/test_orderbook.py
+++ b/Tribler/Test/Community/Market/test_orderbook.py
@@ -182,19 +182,23 @@ class TestOrderBook(AbstractTestOrderBook):
         self.order_book.insert_ask(self.ask2)
         self.order_book.insert_bid(self.bid2)
 
+        # Reserve quantities for matching
+        self.order_book.get_tick(self.ask.order_id).reserve_for_matching(Quantity(20, 'MC'))
+        self.order_book.get_tick(self.bid.order_id).reserve_for_matching(Quantity(20, 'MC'))
+        self.order_book.get_tick(self.ask2.order_id).reserve_for_matching(Quantity(30, 'MC'))
+        self.order_book.get_tick(self.bid2.order_id).reserve_for_matching(Quantity(30, 'MC'))
+
         # Trade self.ask <-> self.bid
-        self.order_book.trade_tick(self.ask.order_id, self.bid.order_id, Quantity(20, 'MC'), Timestamp.now())
+        self.order_book.trade_tick(self.ask.order_id, self.bid.order_id, Quantity(20, 'MC'), unreserve=True)
         self.assertTrue(self.order_book.tick_exists(self.ask.order_id))
         self.assertTrue(self.order_book.tick_exists(self.bid.order_id))
         self.assertEqual(self.order_book.get_tick(self.ask.order_id).tick.quantity, Quantity(10, 'MC'))
         self.assertEqual(self.order_book.get_tick(self.bid.order_id).tick.quantity, Quantity(10, 'MC'))
 
         # Trade self.bid2 <-> self.ask2
-        self.order_book.trade_tick(self.bid2.order_id, self.ask2.order_id, Quantity(30, 'MC'), Timestamp.now())
-        self.assertTrue(self.order_book.tick_exists(self.ask2.order_id))
-        self.assertTrue(self.order_book.tick_exists(self.bid2.order_id))
-        self.assertEqual(self.order_book.get_tick(self.ask2.order_id).tick.quantity, Quantity(0, 'MC'))
-        self.assertEqual(self.order_book.get_tick(self.bid2.order_id).tick.quantity, Quantity(0, 'MC'))
+        self.order_book.trade_tick(self.bid2.order_id, self.ask2.order_id, Quantity(30, 'MC'), unreserve=True)
+        self.assertFalse(self.order_book.tick_exists(self.ask2.order_id))
+        self.assertFalse(self.order_book.tick_exists(self.bid2.order_id))
 
     def test_get_order_ids(self):
         """

--- a/Tribler/Test/Community/Market/test_orderbook.py
+++ b/Tribler/Test/Community/Market/test_orderbook.py
@@ -50,7 +50,7 @@ class AbstractTestOrderBook(AbstractServer):
                                    OrderId(TraderId('0'), OrderNumber(1)),
                                    OrderId(TraderId('0'), OrderNumber(1)), Price(100, 'BTC'),
                                    Quantity(30, 'MC'), Timestamp(1462224447.117))
-        self.order_book = OrderBook(MemoryMessageRepository('0'))
+        self.order_book = OrderBook()
 
     def tearDown(self, annotate=True):
         self.order_book.cancel_all_pending_tasks()
@@ -231,7 +231,7 @@ class TestDatabaseOrderBook(AbstractTestOrderBook):
             os.makedirs(path)
 
         self.database = MarketDB(self.getStateDir())
-        self.order_book = DatabaseOrderBook(MemoryMessageRepository('0'), self.database)
+        self.order_book = DatabaseOrderBook(self.database)
 
     @blocking_call_on_reactor_thread
     def test_save_to_db(self):

--- a/Tribler/Test/Community/Market/test_payload.py
+++ b/Tribler/Test/Community/Market/test_payload.py
@@ -1,5 +1,6 @@
 import unittest
 
+from Tribler.community.market.core import DeclinedTradeReason, DeclineMatchReason
 from Tribler.community.market.core.message import TraderId, MessageNumber
 from Tribler.community.market.core.order import OrderNumber
 from Tribler.community.market.core.payment_id import PaymentId
@@ -11,7 +12,8 @@ from Tribler.community.market.core.transaction import TransactionNumber
 from Tribler.community.market.core.ttl import Ttl
 from Tribler.community.market.core.wallet_address import WalletAddress
 from Tribler.community.market.payload import DeclinedTradePayload, TradePayload, \
-    OfferPayload, StartTransactionPayload, PaymentPayload, WalletInfoPayload, MarketIntroPayload, CancelOrderPayload
+    OfferPayload, StartTransactionPayload, PaymentPayload, WalletInfoPayload, MarketIntroPayload, CancelOrderPayload, \
+    MatchPayload, AcceptMatchPayload, DeclineMatchPayload, TransactionCompletedPayload
 from Tribler.dispersy.meta import MetaObject
 
 
@@ -21,12 +23,13 @@ class MarketIntroPayloadTestSuite(unittest.TestCase):
     def setUp(self):
         # Object creation
         self.market_intro_payload = MarketIntroPayload.Implementation(MetaObject(), ("a", 1324), ("b", 1234),
-                                                                      ("c", 1234), True, u"public", None, 3, "f")
+                                                                      ("c", 1234), True, u"public", None, 3, True, "f")
 
     def test_properties(self):
         """
         Test the market intro payload
         """
+        self.assertTrue(self.market_intro_payload.is_matchmaker)
         self.assertEqual(self.market_intro_payload.orders_bloom_filter, "f")
         self.market_intro_payload.set_orders_bloom_filter("g")
         self.assertEqual(self.market_intro_payload.orders_bloom_filter, "g")
@@ -56,7 +59,8 @@ class DeclinedTradePayloadTestSuite(unittest.TestCase):
                                                                           MessageNumber('message_number'),
                                                                           OrderNumber(1), TraderId('1'),
                                                                           OrderNumber(2), 1234,
-                                                                          Timestamp(1462224447.117))
+                                                                          Timestamp(1462224447.117),
+                                                                          DeclinedTradeReason.ORDER_COMPLETED)
 
     def test_properties(self):
         # Test for properties
@@ -67,6 +71,7 @@ class DeclinedTradePayloadTestSuite(unittest.TestCase):
         self.assertEquals(Timestamp(1462224447.117), self.declined_trade_payload.timestamp)
         self.assertEquals(1234, self.declined_trade_payload.proposal_id)
         self.assertEquals(TraderId('0'), self.declined_trade_payload.trader_id)
+        self.assertEquals(DeclinedTradeReason.ORDER_COMPLETED, self.declined_trade_payload.decline_reason)
 
 
 class ProposedTradePayloadTestSuite(unittest.TestCase):
@@ -190,3 +195,85 @@ class WalletInfoPayloadTestSuite(unittest.TestCase):
         """
         self.assertEquals(WalletAddress('a'), self.wallet_info_payload.incoming_address)
         self.assertEquals(WalletAddress('b'), self.wallet_info_payload.outgoing_address)
+
+
+class MatchPayloadTestSuite(unittest.TestCase):
+    """Match payload test cases."""
+
+    def setUp(self):
+        # Object creation
+        self.match_payload = MatchPayload.Implementation(MetaObject(), TraderId('0'), MessageNumber('message_number'),
+                                                         OrderNumber(1), Price(63400, 'BTC'),
+                                                         Quantity(30, 'MC'), Timeout(1470004447.117),
+                                                         Timestamp(1462224447.117), 'a', 'b', Ttl(2), "1.1.1.1", 1,
+                                                         OrderNumber(2), Quantity(20, 'MC'), TraderId('1'),
+                                                         TraderId('2'), 'a')
+
+    def test_properties(self):
+        """
+        Test the wallet info payload
+        """
+        self.assertEquals(OrderNumber(2), self.match_payload.recipient_order_number)
+        self.assertEquals(Quantity(20, 'MC'), self.match_payload.match_quantity)
+        self.assertEquals(TraderId('1'), self.match_payload.match_trader_id)
+        self.assertEquals(TraderId('2'), self.match_payload.matchmaker_trader_id)
+        self.assertEquals('a', self.match_payload.match_id)
+
+
+class AcceptMatchPayloadTestSuite(unittest.TestCase):
+    """Accept match payload test cases."""
+
+    def setUp(self):
+        # Object creation
+        self.accept_match_payload = AcceptMatchPayload.Implementation(MetaObject(), TraderId('0'),
+                                                                      MessageNumber('message_number'), Timestamp.now(),
+                                                                      'a', Quantity(20, 'MC'))
+
+    def test_properties(self):
+        # Test for properties
+        self.assertEquals('a', self.accept_match_payload.match_id)
+        self.assertEquals(Quantity(20, 'MC'), self.accept_match_payload.quantity)
+
+
+class DeclineMatchPayloadTestSuite(unittest.TestCase):
+    """Decline match payload test cases."""
+
+    def setUp(self):
+        # Object creation
+        self.decline_match_payload = DeclineMatchPayload.Implementation(MetaObject(), TraderId('0'),
+                                                                        MessageNumber('message_number'),
+                                                                        Timestamp.now(), 'a',
+                                                                        DeclineMatchReason.ORDER_COMPLETED)
+
+    def test_properties(self):
+        # Test for properties
+        self.assertEquals('a', self.decline_match_payload.match_id)
+        self.assertEquals(DeclineMatchReason.ORDER_COMPLETED, self.decline_match_payload.decline_reason)
+
+
+class TransactionCompletedPayloadTestSuite(unittest.TestCase):
+    """Tranasaction completed payload test cases."""
+
+    def setUp(self):
+        # Object creation
+        self.transaction_completed_payload = TransactionCompletedPayload.Implementation(MetaObject(), TraderId('0'),
+                                                                                        MessageNumber('1'),
+                                                                                        TraderId('2'),
+                                                                                        TransactionNumber(2),
+                                                                                        TraderId('2'),
+                                                                                        OrderNumber(3),
+                                                                                        TraderId('0'),
+                                                                                        OrderNumber(4),
+                                                                                        'a', Quantity(20, 'MC'),
+                                                                                        Timestamp(0.0))
+
+    def test_properties(self):
+        """
+        Test the transaction completed payload
+        """
+        self.assertEquals(TraderId('2'), self.transaction_completed_payload.order_trader_id)
+        self.assertEquals(OrderNumber(3), self.transaction_completed_payload.order_number)
+        self.assertEquals(TraderId('0'), self.transaction_completed_payload.recipient_trader_id)
+        self.assertEquals(OrderNumber(4), self.transaction_completed_payload.recipient_order_number)
+        self.assertEquals('a', self.transaction_completed_payload.match_id)
+        self.assertEquals(Quantity(20, 'MC'), self.transaction_completed_payload.quantity)

--- a/Tribler/Test/Community/Market/test_trade.py
+++ b/Tribler/Test/Community/Market/test_trade.py
@@ -1,5 +1,6 @@
 import unittest
 
+from Tribler.community.market.core import DeclinedTradeReason
 from Tribler.community.market.core.message import TraderId, MessageNumber, MessageId
 from Tribler.community.market.core.order import OrderId, OrderNumber
 from Tribler.community.market.core.price import Price
@@ -73,7 +74,8 @@ class DeclinedTradeTestSuite(unittest.TestCase):
                                             OrderId(TraderId('1'), OrderNumber(2)),
                                             Price(63400, 'BTC'), Quantity(30, 'MC'), Timestamp(1462224447.117))
         self.declined_trade = Trade.decline(MessageId(TraderId('0'), MessageNumber('message_number')),
-                                            Timestamp(1462224447.117), self.proposed_trade)
+                                            Timestamp(1462224447.117), self.proposed_trade,
+                                            DeclinedTradeReason.ORDER_COMPLETED)
 
     def test_to_network(self):
         # Test for to network
@@ -96,13 +98,20 @@ class DeclinedTradeTestSuite(unittest.TestCase):
                                                                    "recipient_trader_id": TraderId('1'),
                                                                    "recipient_order_number": OrderNumber(2),
                                                                    "proposal_id": 1235,
-                                                                   "timestamp": Timestamp(1462224447.117),}))
+                                                                   "timestamp": Timestamp(1462224447.117),
+                                                                   "decline_reason": 0}))
 
         self.assertEquals(MessageId(TraderId('0'), MessageNumber('message_number')), data.message_id)
         self.assertEquals(OrderId(TraderId('1'), OrderNumber(2)),
                           data.recipient_order_id)
         self.assertEquals(1235, data.proposal_id)
         self.assertEquals(Timestamp(1462224447.117), data.timestamp)
+
+    def test_decline_reason(self):
+        """
+        Test the declined reason
+        """
+        self.assertEqual(self.declined_trade.decline_reason, DeclinedTradeReason.ORDER_COMPLETED)
 
 
 class CounterTradeTestSuite(unittest.TestCase):

--- a/Tribler/Test/Community/Market/test_transaction_manager.py
+++ b/Tribler/Test/Community/Market/test_transaction_manager.py
@@ -1,5 +1,7 @@
 import unittest
 
+from Tribler.community.market.core.payment import Payment
+from Tribler.community.market.core.payment_id import PaymentId
 from Tribler.community.market.core.quantity import Quantity
 from Tribler.community.market.core.price import Price
 from Tribler.community.market.core.timeout import Timestamp
@@ -9,6 +11,7 @@ from Tribler.community.market.core.transaction_manager import TransactionManager
 from Tribler.community.market.core.order import OrderId, OrderNumber
 from Tribler.community.market.core.message import TraderId, MessageNumber, MessageId
 from Tribler.community.market.core.trade import Trade
+from Tribler.community.market.core.wallet_address import WalletAddress
 
 
 class TransactionManagerTestSuite(unittest.TestCase):
@@ -35,7 +38,7 @@ class TransactionManagerTestSuite(unittest.TestCase):
 
     def test_create_from_proposed_trade(self):
         # Test for create from a proposed trade
-        transaction = self.transaction_manager.create_from_proposed_trade(self.proposed_trade)
+        transaction = self.transaction_manager.create_from_proposed_trade(self.proposed_trade, 'a')
         self.assertEquals(transaction, self.transaction_manager.find_by_id(transaction.transaction_id))
 
     def test_find_by_id(self):
@@ -52,5 +55,19 @@ class TransactionManagerTestSuite(unittest.TestCase):
 
     def test_create_from_start_transaction(self):
         # Test for create from start transaction
-        transaction = self.transaction_manager.create_from_start_transaction(self.start_transaction)
+        transaction = self.transaction_manager.create_from_start_transaction(self.start_transaction, 'a')
         self.assertEquals(transaction, self.transaction_manager.find_by_id(transaction.transaction_id))
+
+    def test_create_payment_message(self):
+        """
+        Test the creation of a payment message
+        """
+        self.transaction.incoming_address = WalletAddress('abc')
+        self.transaction.outgoing_address = WalletAddress('def')
+        self.transaction.partner_incoming_address = WalletAddress('ghi')
+        self.transaction.partner_outgoing_address = WalletAddress('jkl')
+        payment_msg = self.transaction_manager.create_payment_message(MessageId(TraderId("0"), MessageNumber('3')),
+                                                                      PaymentId('abc'), self.transaction,
+                                                                      (Quantity(3, 'MC'), Price(4, 'BTC')),
+                                                                      True)
+        self.assertIsInstance(payment_msg, Payment)

--- a/Tribler/Test/Core/Config/test_tribler_config.py
+++ b/Tribler/Test/Core/Config/test_tribler_config.py
@@ -258,6 +258,13 @@ class TestTriblerConfig(TriblerCoreTest):
         self.tribler_config.set_dummy_wallets_enabled(True)
         self.assertTrue(self.tribler_config.get_dummy_wallets_enabled())
 
+    def test_get_set_is_matchmaker(self):
+        """
+        Check whether matchmaker get and set methods are working as expected.
+        """
+        self.tribler_config.set_is_matchmaker(False)
+        self.assertFalse(self.tribler_config.get_is_matchmaker())
+
     def test_get_set_methods_metadata(self):
         """
         Check whether metadata get and set methods are working as expected.

--- a/Tribler/Test/Core/Modules/RestApi/test_market_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_market_endpoint.py
@@ -48,7 +48,8 @@ class TestMarketEndpoint(AbstractApiTest):
                                        OrderId(TraderId('0'), OrderNumber(1)),
                                        OrderId(TraderId('1'), OrderNumber(2)),
                                        Price(63400, 'BTC'), Quantity(30, 'MC'), Timestamp(1462224447.117))
-        transaction = self.session.lm.market_community.transaction_manager.create_from_proposed_trade(proposed_trade)
+        transaction = self.session.lm.market_community.transaction_manager.create_from_proposed_trade(
+            proposed_trade, 'abcd')
 
         payment = Payment(MessageId(TraderId("0"), MessageNumber("1")), transaction.transaction_id,
                           Quantity(0, 'MC'), Price(20, 'BTC'), WalletAddress('a'), WalletAddress('b'),

--- a/Tribler/community/market/community.py
+++ b/Tribler/community/market/community.py
@@ -1,15 +1,16 @@
+import random
 import time
 from base64 import b64decode
 
-from twisted.internet import reactor
 from twisted.internet.defer import inlineCallbacks
-from twisted.internet.task import LoopingCall, deferLater
+from twisted.internet.task import LoopingCall
 
 from Tribler.Core.simpledefs import NTFY_MARKET_ON_ASK, NTFY_MARKET_ON_BID, NTFY_MARKET_ON_TRANSACTION_COMPLETE, \
     NTFY_MARKET_ON_ASK_TIMEOUT, NTFY_MARKET_ON_BID_TIMEOUT, NTFY_MARKET_ON_PAYMENT_RECEIVED, NTFY_MARKET_ON_PAYMENT_SENT
 from Tribler.Core.simpledefs import NTFY_UPDATE
 from Tribler.community.market.conversion import MarketConversion
 from Tribler.community.market.core.matching_engine import MatchingEngine, PriceTimeStrategy
+from Tribler.community.market.core import DeclineMatchReason, DeclinedTradeReason
 from Tribler.community.market.core.message import TraderId
 from Tribler.community.market.core.message_repository import MemoryMessageRepository
 from Tribler.community.market.core.order import OrderId, Order
@@ -33,10 +34,11 @@ from Tribler.community.market.core.wallet_address import WalletAddress
 from Tribler.community.market.database import MarketDB
 from Tribler.community.market.payload import OfferPayload, TradePayload, DeclinedTradePayload,\
     StartTransactionPayload, TransactionPayload, WalletInfoPayload, MarketIntroPayload, OfferSyncPayload,\
-    PaymentPayload, CancelOrderPayload
+    PaymentPayload, CancelOrderPayload, MatchPayload, AcceptMatchPayload, DeclineMatchPayload, \
+    TransactionCompletedPayload, TransactionCompletedBCPayload
 from Tribler.community.market.reputation.pagerank_manager import PagerankReputationManager
 from Tribler.community.market.wallet.tc_wallet import TrustchainWallet
-from Tribler.dispersy.authentication import MemberAuthentication
+from Tribler.dispersy.authentication import MemberAuthentication, NoAuthentication
 from Tribler.dispersy.bloomfilter import BloomFilter
 from Tribler.dispersy.candidate import Candidate, WalkCandidate
 from Tribler.dispersy.community import Community
@@ -52,11 +54,12 @@ class ProposedTradeRequestCache(NumberCache):
     """
     This cache keeps track of outstanding proposed trade messages.
     """
-    def __init__(self, community, proposed_trade):
+    def __init__(self, community, proposed_trade, match_id):
         super(ProposedTradeRequestCache, self).__init__(community.request_cache, u"proposed-trade",
                                                         proposed_trade.proposal_id)
         self.community = community
         self.proposed_trade = proposed_trade
+        self.match_id = match_id
 
     def on_timeout(self):
         # Just remove the reserved quantity from the order
@@ -64,9 +67,11 @@ class ProposedTradeRequestCache(NumberCache):
         order.release_quantity_for_tick(self.proposed_trade.recipient_order_id, self.proposed_trade.quantity)
         self.community.order_manager.order_repository.update(order)
 
-        self._logger.debug("Proposed trade timed out, trying to find a new match for this order")
-        self.community.order_book.remove_tick(self.proposed_trade.recipient_order_id)
-        self.community.match(order)
+        if self.match_id:
+            # Inform the matchmaker about the failed trade
+            match_message = self.community.incoming_match_messages[self.match_id]
+            self.community.send_decline_match_message(self.match_id, match_message.payload.matchmaker_trader_id,
+                                                      DeclineMatchReason.OTHER)
 
 
 class MarketCommunity(Community):
@@ -103,10 +108,12 @@ class MarketCommunity(Community):
         self.mid_register = {}
         self.relayed_ticks = {}  # Dictionary of OrderId -> Timestamp
         self.relayed_cancels = []
+        self.relayed_completed_transaction = {}
         self.order_manager = None
         self.order_book = None
         self.market_database = None
         self.matching_engine = None
+        self.incoming_match_messages = {}  # Map of TraderId -> Message (we save all incoming matches)
         self.tribler_session = None
         self.tradechain_community = None
         self.wallets = None
@@ -114,18 +121,23 @@ class MarketCommunity(Community):
         self.reputation_dict = {}
         self.use_local_address = False
         self.matching_enabled = True
+        self.is_matchmaker = True
+        self.message_repository = None
         self.use_incremental_payments = True
         self.validate_tick_signatures = True
-        self.pending_proposed_trades = []  # List of tuple (order_id, ProposedTrade)
+        self.matchmakers = set()
 
-    def initialize(self, tribler_session=None, tradechain_community=None, wallets=None, use_database=True):
+    def initialize(self, tribler_session=None, tradechain_community=None, wallets=None,
+                   use_database=True, is_matchmaker=True):
         super(MarketCommunity, self).initialize()
 
         self.mid = self.my_member.mid.encode('hex')
-        message_repository = MemoryMessageRepository(self.mid)
+        self.is_matchmaker = is_matchmaker
+        self.message_repository = MemoryMessageRepository(self.mid)
         self.market_database = MarketDB(self.dispersy.working_directory)
-        self.order_book = DatabaseOrderBook(message_repository, self.market_database)
-        self.order_book.restore_from_database()
+
+        if self.is_matchmaker:
+            self.enable_matchmaker()
 
         for trader in self.market_database.get_traders():
             self.update_ip(TraderId(str(trader[0])), (str(trader[1]), trader[2]))
@@ -138,7 +150,6 @@ class MarketCommunity(Community):
             transaction_repository = MemoryTransactionRepository(self.mid)
 
         self.order_manager = OrderManager(order_repository)
-        self.matching_engine = MatchingEngine(PriceTimeStrategy(self.order_book))
         self.tribler_session = tribler_session
         self.tradechain_community = tradechain_community
         self.wallets = wallets or {}
@@ -152,7 +163,7 @@ class MarketCommunity(Community):
     def initiate_meta_messages(self):
         return super(MarketCommunity, self).initiate_meta_messages() + [
             Message(self, u"ask",
-                    MemberAuthentication(),
+                    NoAuthentication(),
                     PublicResolution(),
                     DirectDistribution(),
                     CommunityDestination(node_count=10),
@@ -160,7 +171,7 @@ class MarketCommunity(Community):
                     self.check_tick_message,
                     self.on_tick),
             Message(self, u"bid",
-                    MemberAuthentication(),
+                    NoAuthentication(),
                     PublicResolution(),
                     DirectDistribution(),
                     CommunityDestination(node_count=10),
@@ -175,6 +186,30 @@ class MarketCommunity(Community):
                     CancelOrderPayload(),
                     self.check_message,
                     self.on_cancel_order),
+            Message(self, u"match",
+                    MemberAuthentication(),
+                    PublicResolution(),
+                    DirectDistribution(),
+                    CandidateDestination(),
+                    MatchPayload(),
+                    self.check_message,
+                    self.on_match_message),
+            Message(self, u"accept-match",
+                    MemberAuthentication(),
+                    PublicResolution(),
+                    DirectDistribution(),
+                    CandidateDestination(),
+                    AcceptMatchPayload(),
+                    self.check_message,
+                    self.on_accept_match_message),
+            Message(self, u"decline-match",
+                    MemberAuthentication(),
+                    PublicResolution(),
+                    DirectDistribution(),
+                    CandidateDestination(),
+                    DeclineMatchPayload(),
+                    self.check_message,
+                    self.on_decline_match_message),
             Message(self, u"offer-sync",
                     MemberAuthentication(),
                     PublicResolution(),
@@ -238,7 +273,23 @@ class MarketCommunity(Community):
                     CandidateDestination(),
                     TransactionPayload(),
                     self.check_transaction_message,
-                    self.on_end_transaction)
+                    self.on_end_transaction),
+            Message(self, u"transaction-completed",
+                    MemberAuthentication(),
+                    PublicResolution(),
+                    DirectDistribution(),
+                    CandidateDestination(),
+                    TransactionCompletedPayload(),
+                    self.check_transaction_message,
+                    self.on_transaction_completed_message),
+            Message(self, u"transaction-completed-bc",
+                    NoAuthentication(),
+                    PublicResolution(),
+                    DirectDistribution(),
+                    CommunityDestination(node_count=10),
+                    TransactionCompletedBCPayload(),
+                    self.check_transaction_message,
+                    self.on_transaction_completed_bc_message)
         ]
 
     def _initialize_meta_messages(self):
@@ -252,25 +303,58 @@ class MarketCommunity(Community):
     def initiate_conversions(self):
         return [DefaultConversion(self), MarketConversion(self)]
 
+    def start_walking(self):
+        self.register_task("take step", LoopingCall(self.take_step)).start(5.0, now=False)
+
+    def enable_matchmaker(self):
+        """
+        Enable this node to be a matchmaker
+        """
+        self.order_book = DatabaseOrderBook(self.market_database)
+        self.order_book.restore_from_database()
+        self.matching_engine = MatchingEngine(PriceTimeStrategy(self.order_book))
+        self.is_matchmaker = True
+
+    def disable_matchmaker(self):
+        """
+        Disable the matchmaker status of this node
+        """
+        self.order_book = None
+        self.matching_engine = None
+        self.is_matchmaker = False
+
     def get_wallet_ids(self):
         """
         Return the IDs of all wallets in the market community.
         """
         return self.wallets.keys()
 
+    def dispersy_get_introduce_candidate(self, exclude_candidate=None):
+        """
+        Return a matchmaker with higher priority as introduce candidate.
+        """
+        if len(self.matchmakers) == 0:
+            return super(MarketCommunity, self).dispersy_get_introduce_candidate(exclude_candidate)
+
+        matchmaker = random.sample(self.matchmakers, 1)[0]
+        self._logger.debug("Introducing other node to matchmaker %s:%d", *matchmaker)
+        return self.get_candidate(matchmaker)
+
     def create_introduction_request(self, destination, allow_sync):
         assert isinstance(destination, WalkCandidate), [type(destination), destination]
 
-        order_ids = [str(order_id) for order_id in self.order_book.get_order_ids()]
-        if len(order_ids) == 0:
-            orders_bloom_filter = None
-        else:
-            orders_bloom_filter = BloomFilter(0.005, len(order_ids), prefix=' ')
-            orders_bloom_filter.add_keys(order_ids)
+        orders_bloom_filter = None
+        if self.is_matchmaker:
+            order_ids = [str(order_id) for order_id in self.order_book.get_order_ids()]
+            if len(order_ids) == 0:
+                orders_bloom_filter = None
+            else:
+                orders_bloom_filter = BloomFilter(0.005, len(order_ids), prefix=' ')
+                orders_bloom_filter.add_keys(order_ids)
 
         cache = self._request_cache.add(IntroductionRequestCache(self, destination))
         payload = (destination.sock_addr, self._dispersy.lan_address, self._dispersy.wan_address, True,
-                   self._dispersy.connection_type, None, cache.number, orders_bloom_filter)
+                   self._dispersy.connection_type, None, cache.number, self.is_matchmaker, orders_bloom_filter)
 
         destination.walk(time.time())
         self.add_candidate(destination)
@@ -290,9 +374,16 @@ class MarketCommunity(Community):
         super(MarketCommunity, self).on_introduction_request(messages)
 
         for message in messages:
+            if not self.is_matchmaker:
+                continue
+
+            if message.payload.is_matchmaker:
+                self.matchmakers.add(message.candidate.sock_addr)
+
             orders_bloom_filter = message.payload.orders_bloom_filter
             for order_id in self.order_book.get_order_ids():
-                if not orders_bloom_filter or str(order_id) not in orders_bloom_filter:
+                if (not orders_bloom_filter or str(order_id) not in orders_bloom_filter) and \
+                        message.payload.is_matchmaker:
                     is_ask = self.order_book.ask_exists(order_id)
                     entry = self.order_book.get_ask(order_id) if is_ask else self.order_book.get_bid(order_id)
                     self.send_offer_sync(message.candidate, entry.tick)
@@ -315,10 +406,6 @@ class MarketCommunity(Community):
             else:
                 tick = Ask.from_network(message.payload)\
                     if message.name == u"ask" else Bid.from_network(message.payload)
-            allowed, _ = self._timeline.check(message)
-            if not allowed:
-                yield DelayMessageByProof(message)
-                continue
 
             if tick.order_id.trader_id == TraderId(self.mid):
                 yield DropMessage(message, "We don't accept ticks originating from ourselves")
@@ -337,9 +424,9 @@ class MarketCommunity(Community):
             self.market_database.add_trader_identity(trader_id, sock_addr[0], sock_addr[1])
 
         # Save the ticks to the database
-        self.order_book.save_to_database()
-
-        self.order_book.cancel_all_pending_tasks()
+        if self.is_matchmaker:
+            self.order_book.save_to_database()
+            self.order_book.cancel_all_pending_tasks()
         yield super(MarketCommunity, self).unload_community()
 
     def get_dispersy_address(self):
@@ -370,32 +457,24 @@ class MarketCommunity(Community):
             return WalletAddress(self.wallets[order.total_quantity.wallet_id].get_address()), \
                    WalletAddress(self.wallets[order.price.wallet_id].get_address())
 
-    def match(self, order):
+    def match(self, tick):
         """
-        Try to find a match for a specific order and send proposed trade messages if there is a match
-        :param order: The order to match
+        Try to find a match for a specific tick and send proposed trade messages if there is a match
+        :param tick: The tick to find matches for
         """
         if not self.matching_enabled:
             return
 
-        matched_ticks = self.matching_engine.match(order.price, order.available_quantity, order.is_ask())
+        order_tick_entry = self.order_book.get_tick(tick.order_id)
+        if tick.quantity - order_tick_entry.reserved_for_matching == Quantity(0, tick.quantity.wallet_id):
+            self._logger.debug("Tick %s does not have any quantity to match!", tick.order_id)
+            return
 
-        # Create proposed trade messages and reserve quantity
-        proposed_trades = []
-        for matched_tick, quantity in matched_ticks:
-            order.reserve_quantity_for_tick(matched_tick.order_id, quantity)
-            proposed_trades.append(Trade.propose(
-                self.order_book.message_repository.next_identity(),
-                order.order_id,
-                matched_tick.order_id,
-                matched_tick.price,
-                quantity,
-                Timestamp.now()
-            ))
-
-        if proposed_trades:
-            self.order_manager.order_repository.update(order)
-        self.send_proposed_trade_messages(proposed_trades)
+        matched_ticks = self.matching_engine.match(order_tick_entry)
+        for _, tick_entry, trading_quantity in matched_ticks:
+            tick_entry.reserve_for_matching(trading_quantity)
+            order_tick_entry.reserve_for_matching(trading_quantity)
+        self.send_match_messages(matched_ticks, tick.order_id)
 
     def lookup_ip(self, trader_id):
         """
@@ -488,14 +567,16 @@ class MarketCommunity(Community):
         # Create the order
         order = self.order_manager.create_ask_order(price, quantity, timeout)
 
-        # Search for matches
-        self.match(order)
-
         # Create the tick
-        tick = Tick.from_order(order, self.order_book.message_repository.next_identity())
+        tick = Tick.from_order(order, self.message_repository.next_identity())
         tick.sign(self.my_member)
         assert isinstance(tick, Ask), type(tick)
-        self.order_book.insert_ask(tick).addCallback(self.on_ask_timeout)
+
+        if self.is_matchmaker:
+            # Search for matches
+            self.order_book.insert_ask(tick).addCallback(self.on_ask_timeout)
+            self.match(tick)
+
         self.send_tick(tick)
 
         self._logger.debug("Ask created with price %s and quantity %s", price, quantity)
@@ -521,12 +602,11 @@ class MarketCommunity(Community):
 
         meta = self.get_meta_message(u"ask" if isinstance(tick, Ask) else u"bid")
         message = meta.impl(
-            authentication=(self.my_member,),
             distribution=(self.claim_global_time(),),
             payload=payload
         )
 
-        self.dispersy.store_update_forward([message], True, True, True)
+        self.dispersy.store_update_forward([message], True, False, True)
 
     def on_tick(self, messages):
         for message in messages:
@@ -535,33 +615,35 @@ class MarketCommunity(Community):
             self._logger.debug("%s received from trader %s (price: %s, quantity: %s)", type(tick),
                                str(tick.order_id.trader_id), tick.price, tick.quantity)
 
-            # Update the pubkey register with the current address
-            self.update_ip(tick.message_id.trader_id, (message.payload.address.ip, message.payload.address.port))
+            # Update the mid register with the current address
+            self.update_ip(tick.order_id.trader_id, (message.payload.address.ip, message.payload.address.port))
 
-            insert_method = self.order_book.insert_ask if isinstance(tick, Ask) else self.order_book.insert_bid
-            timeout_method = self.on_ask_timeout if isinstance(tick, Ask) else self.on_bid_timeout
+            if self.is_matchmaker:
+                insert_method = self.order_book.insert_ask if isinstance(tick, Ask) else self.order_book.insert_bid
+                timeout_method = self.on_ask_timeout if isinstance(tick, Ask) else self.on_bid_timeout
 
-            if not self.order_book.tick_exists(tick.order_id) and tick.quantity > Quantity(0, tick.quantity.wallet_id):
-                self._logger.debug("Inserting %s from %s (price: %s, quantity: %s)",
-                                   tick, tick.order_id, tick.price, tick.quantity)
-                insert_method(tick).addCallback(timeout_method)
-                if self.tribler_session:
-                    subject = NTFY_MARKET_ON_ASK if isinstance(tick, Ask) else NTFY_MARKET_ON_BID
-                    self.tribler_session.notifier.notify(subject, NTFY_UPDATE, None, tick.to_dictionary())
-
-                # Check for new matches against the orders of this node
-                for order in self.order_manager.order_repository.find_all():
-                    if order.is_ask() and order.is_valid():
-                        self.match(order)
-            elif self.order_book.tick_exists(tick.order_id) and \
-                    self.order_book.get_tick(tick.order_id).tick.timestamp < tick.timestamp:
-                # Update the tick with a newer one
-                self.order_book.remove_tick(tick.order_id)
-                if tick.quantity > Quantity(0, tick.quantity.wallet_id):
-                    self._logger.debug("Updating %s from %s (price: %s, quantity: %s)",
+                if not self.order_book.tick_exists(tick.order_id) and \
+                                tick.quantity > Quantity(0, tick.quantity.wallet_id):
+                    self._logger.debug("Inserting %s from %s (price: %s, quantity: %s)",
                                        tick, tick.order_id, tick.price, tick.quantity)
                     insert_method(tick).addCallback(timeout_method)
+                    if self.tribler_session:
+                        subject = NTFY_MARKET_ON_ASK if isinstance(tick, Ask) else NTFY_MARKET_ON_BID
+                        self.tribler_session.notifier.notify(subject, NTFY_UPDATE, None, tick.to_dictionary())
 
+                    if self.order_book.tick_exists(tick.order_id):
+                        # Check for new matches against the orders of this node
+                        for order in self.order_manager.order_repository.find_all():
+                            order_tick_entry = self.order_book.get_tick(order.order_id)
+                            if not order.is_valid() or not order_tick_entry:
+                                continue
+
+                            self.match(order_tick_entry.tick)
+
+                        # Only after we have matched our own orders, do the matching with other ticks if necessary
+                        self.match(tick)
+
+            # Relay the tick regardless whether we are a matchmaker or not
             if tick.order_id not in self.relayed_ticks or self.relayed_ticks[tick.order_id] < tick.timestamp:
                 self.relayed_ticks[tick.order_id] = tick.timestamp
                 self.relay_message(message)
@@ -571,9 +653,10 @@ class MarketCommunity(Community):
         ttl = message.payload.ttl
 
         ttl.make_hop()  # Complete the hop from the previous node
+        message.regenerate_packet()
 
         if ttl.is_alive():  # The ttl is still alive and can be forwarded
-            self.dispersy.store_update_forward([message], True, True, True)
+            self.dispersy.store_update_forward([message], True, False, True)
 
     # Bid
     def create_bid(self, price, price_wallet_id, quantity, quantity_wallet_id, timeout):
@@ -603,14 +686,16 @@ class MarketCommunity(Community):
         # Create the order
         order = self.order_manager.create_bid_order(price, quantity, timeout)
 
-        # Search for matches
-        self.match(order)
-
         # Create the tick
-        tick = Tick.from_order(order, self.order_book.message_repository.next_identity())
+        tick = Tick.from_order(order, self.message_repository.next_identity())
         tick.sign(self.my_member)
         assert isinstance(tick, Bid), type(tick)
-        self.order_book.insert_bid(tick).addCallback(self.on_bid_timeout)
+
+        if self.is_matchmaker:
+            # Search for matches
+            self.order_book.insert_bid(tick).addCallback(self.on_bid_timeout)
+            self.match(tick)
+
         self.send_tick(tick)
 
         self._logger.debug("Bid created with price %s and quantity %s", price, quantity)
@@ -623,7 +708,7 @@ class MarketCommunity(Community):
         """
         assert isinstance(order, Order), type(order)
 
-        message_id = self.order_book.message_repository.next_identity()
+        message_id = self.message_repository.next_identity()
 
         meta = self.get_meta_message(u"cancel-order")
         message = meta.impl(
@@ -638,7 +723,7 @@ class MarketCommunity(Community):
     def on_cancel_order(self, messages):
         for message in messages:
             order_id = OrderId(message.payload.trader_id, message.payload.order_number)
-            if self.order_book.tick_exists(order_id):
+            if self.is_matchmaker and self.order_book.tick_exists(order_id):
                 self.order_book.remove_tick(order_id)
 
             if str(order_id) not in self.relayed_cancels:
@@ -648,9 +733,10 @@ class MarketCommunity(Community):
                 ttl = message.payload.ttl
 
                 ttl.make_hop()  # Complete the hop from the previous node
+                message.regenerate_packet()
 
                 if ttl.is_alive():  # The ttl is still alive and can be forwarded
-                    self.dispersy.store_update_forward([message], True, True, True)
+                    self.dispersy.store_update_forward([message], True, False, True)
 
     def send_offer_sync(self, target_candidate, tick):
         """
@@ -670,8 +756,12 @@ class MarketCommunity(Community):
         payload = tick.to_network()
 
         # Add ttl and the trader wan address
-        trader_ip = self.lookup_ip(tick.order_id.trader_id)
-        payload += (Ttl(1),) + trader_ip + (isinstance(tick, Ask),)
+        if str(tick.message_id.trader_id) == self.mid:
+            tick_address = self.get_dispersy_address()
+        else:
+            tick_address = self.lookup_ip(tick.message_id.trader_id)
+
+        payload += (Ttl(1),) + tick_address + (isinstance(tick, Ask),)
 
         meta = self.get_meta_message(u"offer-sync")
         message = meta.impl(
@@ -683,8 +773,210 @@ class MarketCommunity(Community):
 
         return self.dispersy.store_update_forward([message], True, False, True)
 
+    def send_match_messages(self, matching_ticks, order_id):
+        return [self.send_match_message(match_id, tick_entry.tick, order_id, matching_quantity)
+                for match_id, tick_entry, matching_quantity in matching_ticks]
+
+    def send_match_message(self, match_id, tick, recipient_order_id, matched_quantity):
+        """
+        Send a match message to a specific node
+        :param match_id: The ID of the match
+        :param tick: The matched tick
+        :param recipient_order_id: The order id of the recipient, matching the tick
+        :param matched_quantity: The quantity that has been matched
+        """
+        assert isinstance(match_id, str), type(match_id)
+        assert isinstance(tick, Tick), type(tick)
+        assert isinstance(recipient_order_id, OrderId), type(recipient_order_id)
+        assert isinstance(matched_quantity, Quantity), type(matched_quantity)
+
+        payload = tick.to_network()
+
+        # Add ttl and the local wan address of the trader that created the tick
+        if str(tick.message_id.trader_id) == self.mid:
+            tick_address = self.get_dispersy_address()
+        else:
+            tick_address = self.lookup_ip(tick.message_id.trader_id)
+
+        payload += (Ttl.default(),) + tick_address
+
+        # Add recipient order number, matched quantity, trader ID of the matched person, our own trader ID and match ID
+        my_id = TraderId(self.mid)
+        payload += (recipient_order_id.order_number, matched_quantity, tick.message_id.trader_id, my_id, match_id)
+
+        # Lookup the remote address of the peer with the pubkey
+        if str(recipient_order_id.trader_id) == self.mid:
+            address = self.get_dispersy_address()
+        else:
+            address = self.lookup_ip(recipient_order_id.trader_id)
+        candidate = Candidate(address, False)
+
+        self._logger.debug("Sending match message with order id %s and tick order id %s to trader "
+                           "%s (ip: %s, port: %s)", str(recipient_order_id),
+                           str(tick.order_id), recipient_order_id.trader_id, *address)
+
+        meta = self.get_meta_message(u"match")
+        message = meta.impl(
+            authentication=(self.my_member,),
+            distribution=(self.claim_global_time(),),
+            destination=(candidate,),
+            payload=payload
+        )
+
+        return self.dispersy.store_update_forward([message], True, False, True)
+
+    def on_match_message(self, messages):
+        for message in messages:
+            # We got a match, check whether we can respond to this match
+            self.update_ip(message.payload.matchmaker_trader_id, message.candidate.sock_addr)
+            self.update_ip(message.payload.trader_id, (message.payload.address.ip, message.payload.address.port))
+            self.matchmakers.add(message.candidate.sock_addr)
+
+            # Immediately send an introduction request to this matchmaker so it's verified
+            walk_candidate = self.create_or_update_walkcandidate(message.candidate.sock_addr, ('0.0.0.0', 0),
+                                                                 message.candidate.sock_addr, False, u'unknown')
+            self.create_introduction_request(walk_candidate, self.dispersy_enable_bloom_filter_sync)
+
+            order_id = OrderId(TraderId(self.mid), message.payload.recipient_order_number)
+            other_order_id = OrderId(message.payload.trader_id, message.payload.order_number)
+            order = self.order_manager.order_repository.find_by_id(order_id)
+
+            # Store the message for later
+            self.incoming_match_messages[message.payload.match_id] = message
+
+            if order.status != "open" or order.available_quantity == Quantity(0, order.available_quantity.wallet_id):
+                # Send a declined trade back
+                self.send_decline_match_message(message.payload.match_id,
+                                                message.payload.matchmaker_trader_id,
+                                                DeclineMatchReason.ORDER_COMPLETED)
+                continue
+
+            propose_quantity = Quantity(min(float(order.available_quantity), float(message.payload.match_quantity)),
+                                        order.available_quantity.wallet_id)
+
+            # Reserve the quantity
+            order.reserve_quantity_for_tick(other_order_id, propose_quantity)
+            self.order_manager.order_repository.update(order)
+
+            propose_trade = Trade.propose(
+                self.message_repository.next_identity(),
+                order.order_id,
+                other_order_id,
+                message.payload.price,
+                propose_quantity,
+                Timestamp.now()
+            )
+            self.send_proposed_trade(propose_trade, message.payload.match_id)
+
+    def check_match_message(self, messages):
+        for message in messages:
+            allowed, _ = self._timeline.check(message)
+            if not allowed:
+                yield DelayMessageByProof(message)
+                continue
+
+            if not self.is_matchmaker:
+                yield DropMessage(message, "Node is not a matchmaker")
+                continue
+
+            if message.payload.match_id not in self.matching_engine.matches:
+                yield DropMessage(message, "Matching id %s not found" % message.payload.match_id)
+
+            yield message
+
+    def send_accept_match_message(self, match_id, matchmaker_trader_id, quantity):
+        address = self.lookup_ip(matchmaker_trader_id)
+        candidate = Candidate(address, False)
+
+        self._logger.debug("Sending accept match message with match id %s to trader "
+                           "%s (ip: %s, port: %s)", str(match_id), str(matchmaker_trader_id), *address)
+
+        msg_id = self.message_repository.next_identity()
+        payload = (msg_id.trader_id, msg_id.message_number, Timestamp.now(), match_id, quantity)
+
+        meta = self.get_meta_message(u"accept-match")
+        message = meta.impl(
+            authentication=(self.my_member,),
+            distribution=(self.claim_global_time(),),
+            destination=(candidate,),
+            payload=payload
+        )
+
+        return self.dispersy.store_update_forward([message], True, False, True)
+
+    def on_accept_match_message(self, messages):
+        for message in messages:
+            order_id, matched_order_id, reserved_quantity = self.matching_engine.matches[message.payload.match_id]
+            self._logger.debug("Received accept-match message (%s vs %s), modifying quantities if necessary",
+                               order_id, matched_order_id)
+            tick_entry = self.order_book.get_tick(order_id)
+            matched_tick_entry = self.order_book.get_tick(matched_order_id)
+
+            # The ticks could already have been removed
+            if tick_entry:
+                tick_entry.release_for_matching(reserved_quantity)
+                tick_entry.reserve_for_matching(message.payload.quantity)
+
+            if matched_tick_entry:
+                matched_tick_entry.release_for_matching(reserved_quantity)
+                matched_tick_entry.reserve_for_matching(message.payload.quantity)
+
+            del self.matching_engine.matches[message.payload.match_id]
+            self.matching_engine.matching_strategy.used_match_ids.remove(message.payload.match_id)
+
+    def send_decline_match_message(self, match_id, matchmaker_trader_id, decline_reason):
+        del self.incoming_match_messages[match_id]
+        address = self.lookup_ip(matchmaker_trader_id)
+        candidate = Candidate(address, False)
+
+        self._logger.debug("Sending decline match message with match id %s to trader "
+                           "%s (ip: %s, port: %s)", str(match_id), str(matchmaker_trader_id), *address)
+
+        msg_id = self.message_repository.next_identity()
+        payload = (msg_id.trader_id, msg_id.message_number, Timestamp.now(), match_id, decline_reason)
+
+        meta = self.get_meta_message(u"decline-match")
+        message = meta.impl(
+            authentication=(self.my_member,),
+            distribution=(self.claim_global_time(),),
+            destination=(candidate,),
+            payload=payload
+        )
+
+        return self.dispersy.store_update_forward([message], True, False, True)
+
+    def on_decline_match_message(self, messages):
+        for message in messages:
+            order_id, matched_order_id, quantity = self.matching_engine.matches[message.payload.match_id]
+            self._logger.debug("Received decline-match message for tick %s matched with %s", order_id, matched_order_id)
+            tick_entry = self.order_book.get_tick(order_id)
+            matched_tick_entry = self.order_book.get_tick(matched_order_id)
+            tick_entry.release_for_matching(quantity)
+
+            if matched_tick_entry:
+                matched_tick_entry.release_for_matching(quantity)
+                tick_entry.block_for_matching(matched_tick_entry.order_id)
+                matched_tick_entry.block_for_matching(tick_entry.order_id)
+
+            del self.matching_engine.matches[message.payload.match_id]
+            self.matching_engine.matching_strategy.used_match_ids.remove(message.payload.match_id)
+
+            if matched_tick_entry and message.payload.decline_reason == DeclineMatchReason.OTHER_ORDER_COMPLETED:
+                self.order_book.remove_tick(matched_tick_entry.order_id)
+                self.order_book.completed_orders.append(matched_tick_entry.order_id)
+
+            if message.payload.decline_reason == DeclineMatchReason.ORDER_COMPLETED:
+                self.order_book.remove_tick(tick_entry.order_id)
+                self.order_book.completed_orders.append(tick_entry.order_id)
+            else:
+                # Search for a new match
+                self.match(tick_entry.tick)
+
     def on_offer_sync(self, messages):
         for message in messages:
+            if not self.is_matchmaker:
+                continue
+
             if message.payload.is_ask:
                 tick = Ask.from_network(message.payload)
                 insert_method = self.order_book.insert_ask
@@ -696,27 +988,32 @@ class MarketCommunity(Community):
 
             self.update_ip(tick.message_id.trader_id, (message.payload.address.ip, message.payload.address.port))
 
-            if not self.order_book.tick_exists(tick.order_id) or \
-                    float(self.order_book.get_tick(tick.order_id).tick.timestamp) < float(tick.timestamp):
+            if not self.order_book.tick_exists(tick.order_id):
                 insert_method(tick).addCallback(timeout_method)
 
                 if self.tribler_session:
                     notify_subject = NTFY_MARKET_ON_ASK if message.payload.is_ask else NTFY_MARKET_ON_BID
                     self.tribler_session.notifier.notify(notify_subject, NTFY_UPDATE, None, tick.to_dictionary())
 
+            if self.order_book.tick_exists(tick.order_id):
+                self.match(tick)
+
     def cancel_order(self, order_id):
         order = self.order_manager.order_repository.find_by_id(order_id)
         if order and order.status == "open":
             self.order_manager.cancel_order(order_id)
-            self.order_book.remove_tick(order_id)
             self.send_cancel_order(order)
 
+            if self.is_matchmaker:
+                self.order_book.remove_tick(order_id)
+
     # Proposed trade
-    def send_proposed_trade(self, proposed_trade):
+    def send_proposed_trade(self, proposed_trade, match_id):
         assert isinstance(proposed_trade, ProposedTrade), type(proposed_trade)
+        assert isinstance(match_id, str), type(match_id)
         destination, payload = proposed_trade.to_network()
 
-        self.request_cache.add(ProposedTradeRequestCache(self, proposed_trade))
+        self.request_cache.add(ProposedTradeRequestCache(self, proposed_trade, match_id))
 
         # Add the local address to the payload
         payload += self.get_dispersy_address()
@@ -725,8 +1022,9 @@ class MarketCommunity(Community):
         candidate = Candidate(self.lookup_ip(destination), False)
 
         self._logger.debug("Sending proposed trade with own order id %s and other order id %s to trader "
-                           "%s (ip: %s, port: %s)", str(proposed_trade.order_id),
-                           str(proposed_trade.recipient_order_id), destination, *self.lookup_ip(destination))
+                           "%s, quantity: %s (ip: %s, port: %s)", str(proposed_trade.order_id),
+                           str(proposed_trade.recipient_order_id), destination, proposed_trade.quantity,
+                           *self.lookup_ip(destination))
 
         meta = self.get_meta_message(u"proposed-trade")
         message = meta.impl(
@@ -737,9 +1035,6 @@ class MarketCommunity(Community):
         )
 
         return self.dispersy.store_update_forward([message], True, False, True)
-
-    def send_proposed_trade_messages(self, messages):
-        return [self.send_proposed_trade(message) for message in messages]
 
     def check_trade_message(self, messages):
         for message in messages:
@@ -795,46 +1090,48 @@ class MarketCommunity(Community):
                     request = self.request_cache.pop(u"proposed-trade", int(proposal_id.split(':')[1]))
                     order.release_quantity_for_tick(proposed_trade.order_id, request.proposed_trade.quantity)
 
-            if order.is_valid() and order.available_quantity > Quantity(0, order.available_quantity.wallet_id) \
-                    and proposed_trade.has_acceptable_price(order.is_ask(), order.price):
-                self._logger.debug("Proposed trade received with id: %s for order with id: %s",
-                                   str(proposed_trade.message_id), str(order.order_id))
+            should_decline = True
+            decline_reason = 0
+            if not order.is_valid:
+                decline_reason = DeclinedTradeReason.ORDER_INVALID
+            elif order.status == "completed":
+                decline_reason = DeclinedTradeReason.ORDER_COMPLETED
+            elif order.status == "expired":
+                decline_reason = DeclinedTradeReason.ORDER_EXPIRED
+            elif order.available_quantity == Quantity(0, order.available_quantity.wallet_id):
+                decline_reason = DeclinedTradeReason.ORDER_RESERVED
+            elif not proposed_trade.has_acceptable_price(order.is_ask(), order.price):
+                decline_reason = DeclinedTradeReason.UNACCEPTABLE_PRICE
+            else:
+                should_decline = False
 
-                if order.available_quantity >= proposed_trade.quantity:  # Enough quantity left
-                    order.reserve_quantity_for_tick(proposed_trade.order_id, proposed_trade.quantity)
-                    self.order_manager.order_repository.update(order)
-                    self.start_transaction(proposed_trade)
-                else:  # Not all quantity can be traded
-                    counter_quantity = order.available_quantity
-                    order.reserve_quantity_for_tick(proposed_trade.order_id, counter_quantity)
-                    self.order_manager.order_repository.update(order)
-
-                    counter_trade = Trade.counter(self.order_book.message_repository.next_identity(),
-                                                  counter_quantity, Timestamp.now(), proposed_trade)
-                    self._logger.debug("Counter trade made with quantity: %s for proposed trade with id: %s",
-                                       str(counter_trade.quantity), str(proposed_trade.message_id))
-                    self.send_counter_trade(counter_trade)
-            else:  # Order invalid send cancel
-                declined_trade = Trade.decline(self.order_book.message_repository.next_identity(),
-                                               Timestamp.now(), proposed_trade)
+            if should_decline:
+                declined_trade = Trade.decline(self.message_repository.next_identity(),
+                                               Timestamp.now(), proposed_trade, decline_reason)
                 self._logger.debug("Declined trade made with id: %s for proposed trade with id: %s "
                                    "(valid? %s, available quantity of order: %s, reserved: %s, traded: %s)",
                                    str(declined_trade.message_id), str(proposed_trade.message_id),
                                    order.is_valid(), order.available_quantity, order.reserved_quantity,
                                    order.traded_quantity)
                 self.send_declined_trade(declined_trade)
+            else:
+                self._logger.debug("Proposed trade received with id: %s for order with id: %s",
+                                   str(proposed_trade.message_id), str(order.order_id))
 
-                # We declined the proposed trade, however, we might want to save it since the proposed trade might still
-                # be relevant if one of our outstanding proposal trades is declined.
-                for cache in self.request_cache._identifiers.itervalues():
-                    if isinstance(cache, ProposedTradeRequestCache) and order.order_id == cache.proposed_trade.order_id:
-                        # We have an outstanding propose trade for this order, save the incoming proposed trade
-                        tup = (order.order_id, proposed_trade)
-                        removal_task = deferLater(reactor, 10, self.pending_proposed_trades.remove, tup)\
-                            .addErrback(lambda _: None)
-                        self.register_task("pending_propose_%s_%s_timeout" %
-                                           (proposed_trade.order_id, proposed_trade.recipient_order_id), removal_task)
-                        self.pending_proposed_trades.append(tup)
+                if order.available_quantity >= proposed_trade.quantity:  # Enough quantity left
+                    order.reserve_quantity_for_tick(proposed_trade.order_id, proposed_trade.quantity)
+                    self.order_manager.order_repository.update(order)
+                    self.start_transaction(proposed_trade, '')
+                else:  # Not all quantity can be traded
+                    counter_quantity = order.available_quantity
+                    order.reserve_quantity_for_tick(proposed_trade.order_id, counter_quantity)
+                    self.order_manager.order_repository.update(order)
+
+                    counter_trade = Trade.counter(self.message_repository.next_identity(),
+                                                  counter_quantity, Timestamp.now(), proposed_trade)
+                    self._logger.debug("Counter trade made with quantity: %s for proposed trade with id: %s",
+                                       str(counter_trade.quantity), str(proposed_trade.message_id))
+                    self.send_counter_trade(counter_trade)
 
     # Declined trade
     def send_declined_trade(self, declined_trade):
@@ -867,29 +1164,22 @@ class MarketCommunity(Community):
             # Just remove the tick with the order id of the other party and try to find a new match
             self._logger.debug("Received declined trade (proposal id: %d), trying to find a new match for this order",
                                declined_trade.proposal_id)
-            self.order_book.remove_tick(declined_trade.order_id)
 
-            # Do we have any pending propose trades for this order?
-            pending_proposals = [proposed_trade for order_id, proposed_trade in self.pending_proposed_trades
-                                 if order_id == order.order_id]
-            if pending_proposals:
-                self.pending_proposed_trades.remove((order.order_id, pending_proposals[0]))
-                order.reserve_quantity_for_tick(pending_proposals[0].order_id, pending_proposals[0].quantity)
-                proposed_trade = Trade.propose(self.order_book.message_repository.next_identity(),
-                                               pending_proposals[0].recipient_order_id,
-                                               pending_proposals[0].order_id,
-                                               pending_proposals[0].price, pending_proposals[0].quantity,
-                                               Timestamp.now())
-                self.send_proposed_trade(proposed_trade)
-            else:
-                self.match(order)
+            # Let the matchmaker know that we don't have a match
+            match_message = self.incoming_match_messages[request.match_id]
+            match_decline_reason = DeclineMatchReason.OTHER
+            if declined_trade.decline_reason == DeclinedTradeReason.ORDER_COMPLETED:
+                match_decline_reason = DeclineMatchReason.OTHER_ORDER_COMPLETED
+
+            self.send_decline_match_message(request.match_id, match_message.payload.matchmaker_trader_id,
+                                            match_decline_reason)
 
     # Counter trade
     def send_counter_trade(self, counter_trade):
         assert isinstance(counter_trade, CounterTrade), type(counter_trade)
         destination, payload = counter_trade.to_network()
 
-        self.request_cache.add(ProposedTradeRequestCache(self, counter_trade))
+        self.request_cache.add(ProposedTradeRequestCache(self, counter_trade, ''))
 
         # Add the local address to the payload
         payload += self.get_dispersy_address()
@@ -914,29 +1204,41 @@ class MarketCommunity(Community):
             request = self.request_cache.pop(u"proposed-trade", counter_trade.proposal_id)
 
             order = self.order_manager.order_repository.find_by_id(counter_trade.recipient_order_id)
-            if order.is_valid() and counter_trade.has_acceptable_price(order.is_ask(), order.price):  # Accept trade
-                order.release_quantity_for_tick(counter_trade.order_id, request.proposed_trade.quantity)
-                order.reserve_quantity_for_tick(counter_trade.order_id, counter_trade.quantity)
-                self.order_manager.order_repository.update(order)
-                self.start_transaction(counter_trade)
+            should_decline = True
+            decline_reason = 0
+            if not order.is_valid:
+                decline_reason = DeclinedTradeReason.ORDER_INVALID
+            elif not counter_trade.has_acceptable_price(order.is_ask(), order.price):
+                decline_reason = DeclinedTradeReason.UNACCEPTABLE_PRICE
             else:
-                declined_trade = Trade.decline(self.order_book.message_repository.next_identity(),
-                                               Timestamp.now(), counter_trade)
+                should_decline = False
+
+            if should_decline:
+                declined_trade = Trade.decline(self.message_repository.next_identity(),
+                                               Timestamp.now(), counter_trade, decline_reason)
                 self._logger.debug("Declined trade made with id: %s for counter trade with id: %s",
                                    str(declined_trade.message_id), str(counter_trade.message_id))
                 self.send_declined_trade(declined_trade)
+            else:
+                order.release_quantity_for_tick(counter_trade.order_id, request.proposed_trade.quantity)
+                order.reserve_quantity_for_tick(counter_trade.order_id, counter_trade.quantity)
+                self.order_manager.order_repository.update(order)
+                self.start_transaction(counter_trade, request.match_id)
+
+                # Let the matchmaker know that we have a match
+                match_message = self.incoming_match_messages[request.match_id]
+                self.send_accept_match_message(request.match_id, match_message.payload.matchmaker_trader_id,
+                                               counter_trade.quantity)
 
     # Transactions
-    def start_transaction(self, proposed_trade):
+    def start_transaction(self, proposed_trade, match_id):
         order = self.order_manager.order_repository.find_by_id(proposed_trade.recipient_order_id)
-
-        if order:
-            transaction = self.transaction_manager.create_from_proposed_trade(proposed_trade)
-            start_transaction = StartTransaction(self.order_book.message_repository.next_identity(),
-                                                 transaction.transaction_id, order.order_id,
-                                                 proposed_trade.order_id, proposed_trade.proposal_id,
-                                                 proposed_trade.price, proposed_trade.quantity, Timestamp.now())
-            self.send_start_transaction(transaction, start_transaction)
+        transaction = self.transaction_manager.create_from_proposed_trade(proposed_trade, match_id)
+        start_transaction = StartTransaction(self.message_repository.next_identity(),
+                                             transaction.transaction_id, order.order_id,
+                                             proposed_trade.order_id, proposed_trade.proposal_id,
+                                             proposed_trade.price, proposed_trade.quantity, Timestamp.now())
+        self.send_start_transaction(transaction, start_transaction)
 
     # Start transaction
     def send_start_transaction(self, transaction, start_transaction):
@@ -960,8 +1262,7 @@ class MarketCommunity(Community):
         for message in messages:
             transaction_id = TransactionId(message.payload.transaction_trader_id, message.payload.transaction_number)
 
-            allowed, _ = self._timeline.check(message)
-            if not allowed:
+            if message.name != 'transaction-completed-bc' and not self._timeline.check(message)[0]:
                 yield DelayMessageByProof(message)
                 continue
 
@@ -971,12 +1272,15 @@ class MarketCommunity(Community):
                                   (message.name, message.payload.proposal_id))
                 continue
 
-            if message.name != 'start-transaction' and not self.transaction_manager.find_by_id(transaction_id):
+            if message.name != 'start-transaction' and message.name != 'transaction-completed' \
+                    and message.name != 'transaction-completed-bc' \
+                    and not self.transaction_manager.find_by_id(transaction_id):
                 yield DropMessage(message, "Unknown transaction in %s message" % message.name)
                 continue
 
             transaction = self.transaction_manager.find_by_id(transaction_id)
-            if message.name not in ['start-transaction', 'end-transaction'] and transaction.is_payment_complete():
+            if message.name not in ['start-transaction', 'end-transaction', 'transaction-completed',
+                                    'transaction-completed-bc'] and transaction.is_payment_complete():
                 yield DropMessage(message, "Transaction in %s message is already complete" % message.name)
                 continue
 
@@ -986,13 +1290,19 @@ class MarketCommunity(Community):
         for message in messages:
             start_transaction = StartTransaction.from_network(message.payload)
 
-            self.request_cache.pop(u"proposed-trade", start_transaction.proposal_id)
+            request = self.request_cache.pop(u"proposed-trade", start_transaction.proposal_id)
 
             # The recipient_order_id in the start_transaction message is our own order
             order = self.order_manager.order_repository.find_by_id(start_transaction.recipient_order_id)
 
             if order:
-                transaction = self.transaction_manager.create_from_start_transaction(start_transaction)
+                # Let the matchmaker know that we have a match
+                match_message = self.incoming_match_messages[request.match_id]
+                self.send_accept_match_message(request.match_id, match_message.payload.matchmaker_trader_id,
+                                               start_transaction.quantity)
+
+                transaction = self.transaction_manager.create_from_start_transaction(start_transaction,
+                                                                                     request.match_id)
                 incoming_address, outgoing_address = self.get_order_addresses(order)
                 self.send_wallet_info(transaction, incoming_address, outgoing_address)
 
@@ -1009,7 +1319,7 @@ class MarketCommunity(Community):
         self._logger.debug("Sending wallet info to trader %s (incoming address: %s, outgoing address: %s",
                            transaction.partner_order_id.trader_id, incoming_address, outgoing_address)
 
-        message_id = self.order_book.message_repository.next_identity()
+        message_id = self.message_repository.next_identity()
 
         meta = self.get_meta_message(u"wallet-info")
         message = meta.impl(
@@ -1098,7 +1408,7 @@ class MarketCommunity(Community):
             order.add_trade(transaction.partner_order_id, payment[0])
             self.order_manager.order_repository.update(order)
 
-        message_id = self.order_book.message_repository.next_identity()
+        message_id = self.message_repository.next_identity()
         payment_message = self.transaction_manager.create_payment_message(
             message_id, payment_id, transaction, payment, success)
         self._logger.debug("Sending payment message with price %s and quantity %s (success? %s)",
@@ -1170,7 +1480,7 @@ class MarketCommunity(Community):
         else:
             end_transaction_timestamp = Timestamp.now()
             self.send_end_transaction(transaction, end_transaction_timestamp)
-            self.update_ticks(transaction, end_transaction_timestamp)
+            self.send_transaction_completed(transaction)
 
     # End transaction
     def send_end_transaction(self, transaction, timestamp):
@@ -1178,7 +1488,7 @@ class MarketCommunity(Community):
         self._logger.debug("Sending end transaction (quantity: %s)", transaction.total_quantity)
         candidate = Candidate(self.lookup_ip(transaction.partner_order_id.trader_id), False)
 
-        message_id = self.order_book.message_repository.next_identity()
+        message_id = self.message_repository.next_identity()
 
         meta = self.get_meta_message(u"end-transaction")
         message = meta.impl(
@@ -1209,29 +1519,6 @@ class MarketCommunity(Community):
                            "asset2_type": quantity.wallet_id, "asset2_amount": float(quantity)}
             self.tradechain_community.sign_block(candidate, candidate.get_member().public_key, transaction)
 
-    def update_ticks(self, transaction, end_transaction_timestamp):
-        """
-        Update your tick in the order book according to a specific transaction.
-        Afterwards, send the updated tick.
-        """
-        self._logger.debug("Updating own tick and sending it to other traders")
-        self.order_book.trade_tick(transaction.order_id, transaction.partner_order_id,
-                                   transaction.transferred_quantity, end_transaction_timestamp)
-        if self.order_book.tick_exists(transaction.order_id):
-            tick = self.order_book.get_tick(transaction.order_id).tick
-            tick.update_timestamp()
-            tick.sign(self.my_member)  # Tick content have changed, update the signature
-            self.send_tick(tick)
-
-            if tick.quantity == Quantity(0, tick.quantity.wallet_id):
-                self.order_book.remove_tick(transaction.order_id)
-
-        # Remove the tick of the counterparty if it's fulfilled
-        if self.order_book.tick_exists(transaction.partner_order_id):
-            tick = self.order_book.get_tick(transaction.partner_order_id)
-            if tick.quantity == Quantity(0, tick.quantity.wallet_id):
-                self.order_book.remove_tick(transaction.order_id)
-
     def abort_transaction(self, transaction):
         """
         Abort a specific transaction by releasing all reserved quantity for this order.
@@ -1241,20 +1528,120 @@ class MarketCommunity(Community):
         order.release_quantity_for_tick(transaction.partner_order_id,
                                         transaction.total_quantity - transaction.transferred_quantity)
         self.order_manager.order_repository.update(order)
-        self.update_ticks(transaction, Timestamp.now())
+        self.send_transaction_completed(transaction)
 
     def on_end_transaction(self, messages):
         for message in messages:
             self._logger.debug("Finishing transaction %s", message.payload.transaction_number)
             transaction_id = TransactionId(message.payload.transaction_trader_id, message.payload.transaction_number)
             transaction = self.transaction_manager.find_by_id(transaction_id)
-            self.update_ticks(transaction, message.payload.timestamp)
             self.notify_transaction_complete(self.transaction_manager.find_by_id(transaction_id))
+            self.send_transaction_completed(transaction)
 
     def notify_transaction_complete(self, transaction):
         if self.tribler_session:
             self.tribler_session.notifier.notify(NTFY_MARKET_ON_TRANSACTION_COMPLETE, NTFY_UPDATE, None,
                                                  transaction.to_dictionary())
+
+    def send_transaction_completed(self, transaction):
+        if not transaction.match_id or transaction.match_id not in self.incoming_match_messages:
+            # We did not receive this match from a matchmaker. Still, if we are a matchmaker, we can update our
+            # local orderbook with the new knowledge of this transaction.
+            if self.is_matchmaker:
+                self.order_book.trade_tick(transaction.order_id, transaction.partner_order_id,
+                                           transaction.transferred_quantity, unreserve=False)
+
+            return
+
+        self._logger.debug("Sending transaction completed (match id: %s)", transaction.match_id)
+
+        # Lookup the remote address of the peer with the pubkey
+        match_message = self.incoming_match_messages[transaction.match_id]
+        del self.incoming_match_messages[transaction.match_id]
+        candidate = Candidate(self.lookup_ip(match_message.payload.matchmaker_trader_id), False)
+
+        message_id = self.message_repository.next_identity()
+
+        meta = self.get_meta_message(u"transaction-completed")
+        message = meta.impl(
+            authentication=(self.my_member,),
+            distribution=(self.claim_global_time(),),
+            destination=(candidate,),
+            payload=(
+                message_id.trader_id,
+                message_id.message_number,
+                transaction.transaction_id.trader_id,
+                transaction.transaction_id.transaction_number,
+                transaction.order_id.trader_id,
+                transaction.order_id.order_number,
+                transaction.partner_order_id.trader_id,
+                transaction.partner_order_id.order_number,
+                transaction.match_id,
+                transaction.transferred_quantity,
+                Timestamp.now(),
+            )
+        )
+
+        self.dispersy.store_update_forward([message], True, False, True)
+
+    def on_transaction_completed_message(self, messages):
+        for message in messages:
+            self._logger.debug("Received transaction-completed message")
+            if not self.is_matchmaker:
+                continue
+
+            # Update ticks in order book, release the reserved quantity and find a new match
+            order_id = OrderId(message.payload.trader_id, message.payload.order_number)
+            recipient_order_id = OrderId(message.payload.recipient_trader_id, message.payload.recipient_order_number)
+            self.order_book.trade_tick(order_id, recipient_order_id, message.payload.quantity)
+
+            self.send_transaction_completed_bc(message)
+
+            tick_entry_sender = self.order_book.get_tick(order_id)
+            if tick_entry_sender:
+                self.match(tick_entry_sender.tick)
+
+    def send_transaction_completed_bc(self, completed_message):
+        self._logger.debug("Sending transaction completed bc (match id: %s)", completed_message.payload.match_id)
+
+        message_id = self.message_repository.next_identity()
+
+        meta = self.get_meta_message(u"transaction-completed-bc")
+        message = meta.impl(
+            distribution=(self.claim_global_time(),),
+            payload=(
+                message_id.trader_id,
+                message_id.message_number,
+                completed_message.payload.transaction_trader_id,
+                completed_message.payload.transaction_number,
+                completed_message.payload.order_trader_id,
+                completed_message.payload.order_number,
+                completed_message.payload.recipient_trader_id,
+                completed_message.payload.recipient_order_number,
+                completed_message.payload.match_id,
+                completed_message.payload.quantity,
+                Timestamp.now(),
+                Ttl.default()
+            )
+        )
+
+        self.dispersy.store_update_forward([message], True, False, True)
+
+    def on_transaction_completed_bc_message(self, messages):
+        for message in messages:
+            self._logger.debug("Received transaction-completed-bc message")
+            if not self.is_matchmaker:
+                continue
+
+            # Update ticks in order book, release the reserved quantity
+            order_id = OrderId(message.payload.trader_id, message.payload.order_number)
+            recipient_order_id = OrderId(message.payload.recipient_trader_id, message.payload.recipient_order_number)
+            self.order_book.trade_tick(order_id, recipient_order_id, message.payload.quantity, unreserve=False)
+
+            transaction_id = TransactionId(message.payload.transaction_trader_id, message.payload.transaction_number)
+            if transaction_id not in self.relayed_completed_transaction:
+                self.relayed_completed_transaction[transaction_id] = True
+                self.relay_message(message)
 
     def compute_reputation(self):
         """

--- a/Tribler/community/market/core/__init__.py
+++ b/Tribler/community/market/core/__init__.py
@@ -1,0 +1,12 @@
+class DeclinedTradeReason(object):
+    ORDER_COMPLETED = 0
+    ORDER_EXPIRED = 1
+    ORDER_RESERVED = 2
+    ORDER_INVALID = 3
+    UNACCEPTABLE_PRICE = 4
+
+
+class DeclineMatchReason(object):
+    ORDER_COMPLETED = 0
+    OTHER_ORDER_COMPLETED = 1
+    OTHER = 2

--- a/Tribler/community/market/core/matching_engine.py
+++ b/Tribler/community/market/core/matching_engine.py
@@ -1,7 +1,9 @@
 import logging
+import random
 from abc import ABCMeta, abstractmethod
 from time import time
 
+from Tribler.community.market.core.order import OrderId
 from Tribler.community.market.core.orderbook import OrderBook
 from Tribler.community.market.core.price import Price
 from Tribler.community.market.core.pricelevel import PriceLevel
@@ -24,18 +26,41 @@ class MatchingStrategy(object):
         assert isinstance(order_book, OrderBook), type(order_book)
 
         self.order_book = order_book
+        self.used_match_ids = set()
+
+    def get_random_match_id(self):
+        """
+        Generate a random matching ID (20 hex characters).
+        :return: A random matching ID
+        :rtype: str
+        """
+        return ''.join(random.choice('0123456789abcdef') for _ in xrange(20))
+
+    def get_unique_match_id(self):
+        """
+        Generate a random, unique matching ID that has not been used yet.
+        :return: A random matching ID
+        :rtype: str
+        """
+        random_match_id = self.get_random_match_id()
+        while random_match_id in self.used_match_ids:
+            random_match_id = self.get_random_match_id()
+        self.used_match_ids.add(random_match_id)
+        return random_match_id
 
     @abstractmethod
-    def match(self, price, quantity, is_ask):
+    def match(self, order_id, price, quantity, is_ask):
         """
+        :param order_id: The order id of the tick to match
         :param price: The price to match against
         :param quantity: The quantity that should be matched
         :param is_ask: Whether the object we want to match is an ask
+        :type order_id: OrderId
         :type price: Price
         :type quantity: Quantity
         :type is_ask: Bool
         :return: A list of tuples containing the ticks and the matched quantity
-        :rtype: [(Tick, Quantity)]
+        :rtype: [(str, TickEntry, Quantity)]
         """
         return
 
@@ -43,65 +68,72 @@ class MatchingStrategy(object):
 class PriceTimeStrategy(MatchingStrategy):
     """Strategy that uses the price time method for picking ticks"""
 
-    def match(self, price, quantity, is_ask):
+    def match(self, order_id, price, quantity, is_ask):
         """
+        :param order_id: The order id of the tick to match
         :param price: The price to match against
         :param quantity: The quantity that should be matched
         :param is_ask: Whether the object we want to match is an ask
+        :type order_id: OrderId
         :type price: Price
         :type quantity: Quantity
         :type is_ask: Bool
         :return: A list of tuples containing the ticks and the matched quantity
-        :rtype: [(Tick, Quantity)]
+        :rtype: [(str, TickEntry, Quantity)]
         """
-        matched_ticks = self._match_ask(price, quantity, is_ask) if is_ask else self._match_bid(price, quantity, is_ask)
+        matched_ticks = self._match_ask(order_id, price, quantity, is_ask) if is_ask \
+            else self._match_bid(order_id, price, quantity, is_ask)
 
         return matched_ticks
 
-    def _match_ask(self, price, quantity, is_ask):
+    def _match_ask(self, order_id, price, quantity, is_ask):
         matched_ticks = []
 
         if price <= self.order_book.get_bid_price(price.wallet_id, quantity.wallet_id) \
                 and quantity > Quantity(0, quantity.wallet_id):
             # Scan the price levels in the order book
             matched_ticks = self._search_for_quantity_in_order_book(
+                order_id,
                 self.order_book.get_bid_price(price.wallet_id, quantity.wallet_id),
                 self.order_book.get_bid_price_level(price.wallet_id, quantity.wallet_id),
                 quantity, price, is_ask)
         return matched_ticks
 
-    def _match_bid(self, price, quantity, is_ask):
+    def _match_bid(self, order_id, price, quantity, is_ask):
         matched_ticks = []
 
         if price >= self.order_book.get_ask_price(price.wallet_id, quantity.wallet_id) \
                 and quantity > Quantity(0, quantity.wallet_id):
             # Scan the price levels in the order book
             matched_ticks = self._search_for_quantity_in_order_book(
+                order_id,
                 self.order_book.get_ask_price(price.wallet_id, quantity.wallet_id),
                 self.order_book.get_ask_price_level(price.wallet_id, quantity.wallet_id),
                 quantity, price, is_ask)
         return matched_ticks
 
-    def _search_for_quantity_in_order_book(self, price, price_level, quantity_to_trade, tick_price, is_ask):
+    def _search_for_quantity_in_order_book(self, order_id, price, price_level, quantity_to_trade, tick_price, is_ask):
         """
         Search through the price levels in the order book
-
+        :param order_id: The order id of the tick to match
         :param price: The price of the price level
         :param price_level: The price level to search in
         :param quantity_to_trade: The quantity still to be matched
         :param tick_price: The price of the tick being matched
         :param is_ask: Whether our tick being matched is an ask
+        :type order_id: OrderId
         :type price: Price
         :type price_level: PriceLevel
         :type quantity_to_trade: Quantity
         :type tick_price: Price
         :type is_ask: bool
         :return: A list of tuples containing the ticks and the matched quantity
-        :rtype: [(Tick, Quantity)]
+        :rtype: [(str, TickEntry, Quantity)]
         """
         if price_level is None:  # Last price level
             return []
 
+        assert isinstance(order_id, OrderId), type(order_id)
         assert isinstance(price, Price), type(price)
         assert isinstance(price_level, PriceLevel), type(price_level)
         assert isinstance(quantity_to_trade, Quantity), type(quantity_to_trade)
@@ -110,25 +142,29 @@ class PriceTimeStrategy(MatchingStrategy):
 
         self._logger.debug("Searching in price level: %f", float(price))
 
-        if quantity_to_trade <= price_level.depth:  # All the quantity can be matched in this price level
-            return self._search_for_quantity_in_price_level(price_level.first_tick,
+        if quantity_to_trade <= price_level.depth - price_level.reserved:
+            # All the quantity can be matched in this price level
+            return self._search_for_quantity_in_price_level(order_id, price_level.first_tick,
                                                             quantity_to_trade,
                                                             tick_price, is_ask)
-        else:  # Not all the quantity can be matched in this price level
-            return self._search_for_quantity_in_order_book_partial(price, price_level, quantity_to_trade,
+        else:
+            # Not all the quantity can be matched in this price level
+            return self._search_for_quantity_in_order_book_partial(order_id, price, price_level, quantity_to_trade,
                                                                    tick_price, is_ask)
 
-    def _search_for_quantity_in_order_book_partial(self, price, price_level, quantity_to_trade, tick_price, is_ask):
+    def _search_for_quantity_in_order_book_partial(self, order_id, price, price_level, quantity_to_trade,
+                                                   tick_price, is_ask):
         # Not all the quantity can be matched in this price level
-        matching_ticks = self._search_for_quantity_in_price_level(price_level.first_tick, quantity_to_trade, tick_price, is_ask)
+        matching_ticks = self._search_for_quantity_in_price_level(order_id, price_level.first_tick, quantity_to_trade,
+                                                                  tick_price, is_ask)
         if is_ask:
-            return self._search_for_quantity_in_order_book_partial_ask(price, quantity_to_trade,
+            return self._search_for_quantity_in_order_book_partial_ask(order_id, price, quantity_to_trade,
                                                                        matching_ticks, tick_price, is_ask)
         else:
-            return self._search_for_quantity_in_order_book_partial_bid(price, quantity_to_trade,
+            return self._search_for_quantity_in_order_book_partial_bid(order_id, price, quantity_to_trade,
                                                                        matching_ticks, tick_price, is_ask)
 
-    def _search_for_quantity_in_order_book_partial_ask(self, price, quantity_to_trade, matching_ticks,
+    def _search_for_quantity_in_order_book_partial_ask(self, order_id, price, quantity_to_trade, matching_ticks,
                                                        tick_price, is_ask):
         # Select the next price level
         try:
@@ -141,12 +177,12 @@ class PriceTimeStrategy(MatchingStrategy):
         if tick_price > next_price:  # Price is too low
             return matching_ticks
 
-        matching_ticks += self._search_for_quantity_in_order_book(next_price, next_price_level, quantity_to_trade,
-                                                                  tick_price, is_ask)
+        matching_ticks += self._search_for_quantity_in_order_book(order_id, next_price, next_price_level,
+                                                                  quantity_to_trade, tick_price, is_ask)
 
         return matching_ticks
 
-    def _search_for_quantity_in_order_book_partial_bid(self, price, quantity_to_trade, matching_ticks,
+    def _search_for_quantity_in_order_book_partial_bid(self, order_id, price, quantity_to_trade, matching_ticks,
                                                        tick_price, is_ask):
         # Select the next price level
         try:
@@ -159,15 +195,16 @@ class PriceTimeStrategy(MatchingStrategy):
         if tick_price < next_price:  # Price is too high
             return matching_ticks
 
-        matching_ticks += self._search_for_quantity_in_order_book(next_price, next_price_level, quantity_to_trade,
-                                                                  tick_price, is_ask)
+        matching_ticks += self._search_for_quantity_in_order_book(order_id, next_price, next_price_level,
+                                                                  quantity_to_trade, tick_price, is_ask)
 
         return matching_ticks
 
-    def _search_for_quantity_in_price_level(self, tick_entry, quantity_to_trade, tick_price, is_ask):
+    def _search_for_quantity_in_price_level(self, order_id, tick_entry, quantity_to_trade, tick_price, is_ask):
         """
         Search through the tick entries in the price levels
 
+        :param order_id: The order id to match
         :param tick_entry: The tick entry to match against
         :param quantity_to_trade: The quantity still to be matched
         :param tick_price: The price of the tick being matched
@@ -177,44 +214,49 @@ class PriceTimeStrategy(MatchingStrategy):
         :type tick_price: Price
         :type is_ask: bool
         :return: A list of tuples containing the ticks and the matched quantity
-        :rtype: [(Tick, Quantity)]
+        :rtype: [(str, TickEntry, Quantity)]
         """
         if tick_entry is None:  # Last tick
             return []
 
-        # TODO check whether you are not matching with yourself!
-        # Check if order and tick entry have the same trader id / origin
-        #if order.order_id.trader_id == tick_entry.order_id.trader_id:
-        #    return quantity_to_trade, []
-
+        assert isinstance(order_id, OrderId), type(order_id)
         assert isinstance(tick_entry, TickEntry), type(tick_entry)
         assert isinstance(quantity_to_trade, Quantity), type(quantity_to_trade)
         assert isinstance(tick_price, Price), type(tick_price)
         assert isinstance(is_ask, bool), type(is_ask)
 
-        if quantity_to_trade <= tick_entry.quantity:  # All the quantity can be matched in this tick
-            return self._search_for_quantity_in_price_level_total(tick_entry, quantity_to_trade, tick_price, is_ask)
-        else:  # Not all the quantity can be matched in this tick
-            return self._search_for_quantity_in_price_level_partial(tick_entry, quantity_to_trade, tick_price, is_ask)
+        if quantity_to_trade <= tick_entry.quantity - tick_entry.reserved_for_matching \
+                and not tick_entry.is_blocked_for_matching(order_id):
+            # All the quantity can be matched in this tick
+            return self._search_for_quantity_in_price_level_total(tick_entry, quantity_to_trade)
+        else:
+            # Not all the quantity can be matched in this tick
+            return self._search_for_quantity_in_price_level_partial(order_id, tick_entry, quantity_to_trade,
+                                                                    tick_price, is_ask)
 
-    def _search_for_quantity_in_price_level_total(self, tick_entry, quantity_to_trade, tick_price, is_ask):
+    def _search_for_quantity_in_price_level_total(self, tick_entry, quantity_to_trade):
         trading_quantity = quantity_to_trade
 
         self._logger.debug("Match with the id (%s) was found: price %i, quantity %i",
                            str(tick_entry.order_id), float(tick_entry.price), int(trading_quantity))
 
-        return [(tick_entry.tick, trading_quantity)]
+        return [(self.get_unique_match_id(), tick_entry, trading_quantity)]
 
-    def _search_for_quantity_in_price_level_partial(self, tick_entry, quantity_to_trade, tick_price, is_ask):
-        quantity_to_trade -= tick_entry.quantity
+    def _search_for_quantity_in_price_level_partial(self, order_id, tick_entry, quantity_to_trade, tick_price, is_ask):
+        matched_quantity = tick_entry.quantity - tick_entry.reserved_for_matching
+        matching_ticks = []
 
-        self._logger.debug("Match with the id (%s) was found: price %i, quantity %i",
-                           str(tick_entry.order_id), float(tick_entry.price), int(tick_entry.quantity))
+        if matched_quantity > Quantity(0, matched_quantity.wallet_id) and not \
+                tick_entry.is_blocked_for_matching(order_id):
+            quantity_to_trade -= matched_quantity
 
-        matching_ticks = [(tick_entry.tick, tick_entry.quantity)]
+            self._logger.debug("Match with the id (%s) was found: price %i, quantity %i",
+                               str(tick_entry.order_id), float(tick_entry.price), int(matched_quantity))
+
+            matching_ticks = [(self.get_unique_match_id(), tick_entry, matched_quantity)]
 
         # Search the next tick
-        matching_ticks += self._search_for_quantity_in_price_level(tick_entry.next_tick, quantity_to_trade,
+        matching_ticks += self._search_for_quantity_in_price_level(order_id, tick_entry.next_tick, quantity_to_trade,
                                                                    tick_price, is_ask)
         return matching_ticks
 
@@ -232,23 +274,26 @@ class MatchingEngine(object):
 
         assert isinstance(matching_strategy, MatchingStrategy), type(matching_strategy)
         self.matching_strategy = matching_strategy
+        self.matches = {}  # Keep track of all matches
 
-    def match(self, price, quantity, is_ask):
+    def match(self, tick_entry):
         """
-        :param price: The price to match against
-        :param quantity: The quantity that should be matched
-        :param is_ask: Whether the object we want to match is an ask
-        :type price: Price
-        :type quantity: Quantity
-        :type is_ask: Bool
-        :return: A list of tuples containing the ticks and the matched quantity
-        :rtype: [(Tick, Quantity)]
+        :param tick_entry: The TickEntry that should be matched
+        :type tick_entry: TickEntry
+        :return: A list of tuples containing a random match id, ticks and the matched quantity
+        :rtype: [(str, TickEntry, Quantity)]
         """
-        assert isinstance(price, Price), type(price)
-        assert isinstance(quantity, Quantity), type(quantity)
-        assert isinstance(is_ask, bool), type(is_ask)
+        assert isinstance(tick_entry, TickEntry), type(tick_entry)
         now = time()
-        matched_ticks = self.matching_strategy.match(price, quantity, is_ask)
+
+        matched_ticks = self.matching_strategy.match(tick_entry.order_id,
+                                                     tick_entry.price,
+                                                     tick_entry.quantity - tick_entry.reserved_for_matching,
+                                                     tick_entry.tick.is_ask())
+
+        for match_id, matched_tick_entry, quantity in matched_ticks:  # Store the matches
+            self.matches[match_id] = (tick_entry.order_id, matched_tick_entry.order_id, quantity)
+
         diff = time() - now
         self._logger.debug("Matching engine completed in %.2f seconds", diff)
         return matched_ticks

--- a/Tribler/community/market/core/order.py
+++ b/Tribler/community/market/core/order.py
@@ -311,7 +311,7 @@ class Order(object):
             else:
                 self._reserved_ticks[order_id] += quantity
         else:
-            raise ValueError("Tick does not have enough available quantity for reservation")
+            raise ValueError("Order %s does not have enough available quantity for reservation", self.order_id)
 
         self._logger.debug("reserved quantity for order id %s (own order id: %s),"
                            "total quantity: %s, traded quantity: %s, reserved quantity: %s",

--- a/Tribler/community/market/core/pricelevel.py
+++ b/Tribler/community/market/core/pricelevel.py
@@ -10,6 +10,7 @@ class PriceLevel(object):
         self._tail_tick = None  # Last tick of the double linked list
         self._length = 0  # The number of ticks in the price level
         self._depth = Quantity(0, quantity_wallet_id)  # Total amount of quantity contained in this price level
+        self._reserved = Quantity(0, quantity_wallet_id)  # Total amount of reserved quantity in this price level
         self._last = None  # The current tick of the iterator
         self._quantity_wallet_id = quantity_wallet_id  # The quantity wallet ID of the price level
 
@@ -45,6 +46,23 @@ class PriceLevel(object):
         assert isinstance(new_depth, Quantity), type(new_depth)
 
         self._depth = new_depth
+
+    @property
+    def reserved(self):
+        """
+        The amount of reserved quantity (for matching) in this price level
+        """
+        return self._reserved
+
+    @reserved.setter
+    def reserved(self, new_reserved):
+        """
+        :param new_reserved: The new amount of quantity to reserve
+        :type new_reserved: Quantity
+        """
+        assert isinstance(new_reserved, Quantity), type(new_reserved)
+
+        self._reserved = new_reserved
 
     def __len__(self):
         """
@@ -97,6 +115,7 @@ class PriceLevel(object):
 
         # Update the counters
         self._depth -= tick.quantity
+        self._reserved -= tick.reserved_for_matching
         self._length -= 1
 
         if self._length == 0:  # Was the only tick in this price level

--- a/Tribler/community/market/core/side.py
+++ b/Tribler/community/market/core/side.py
@@ -117,6 +117,7 @@ class Side(object):
         assert isinstance(order_id, OrderId), type(order_id)
 
         tick = self.get_tick(order_id)
+        tick.cancel_all_pending_tasks()
         tick.price_level().remove_tick(tick)
         if len(tick.price_level()) == 0:  # Last tick for that price
             self._remove_price_level(tick.price, tick.quantity.wallet_id)

--- a/Tribler/community/market/core/tickentry.py
+++ b/Tribler/community/market/core/tickentry.py
@@ -1,8 +1,13 @@
+import logging
+
+from twisted.internet import reactor
+
 from Tribler.community.market.core.quantity import Quantity
 from Tribler.community.market.core.tick import Tick
+from Tribler.dispersy.taskmanager import TaskManager
 
 
-class TickEntry(object):
+class TickEntry(TaskManager):
     """Class for representing a tick in the order book"""
 
     def __init__(self, tick, price_level):
@@ -12,12 +17,17 @@ class TickEntry(object):
         :type tick: Tick
         :type price_level: PriceLevel
         """
+        super(TickEntry, self).__init__()
         assert isinstance(tick, Tick), type(tick)
+
+        self._logger = logging.getLogger(self.__class__.__name__)
 
         self._tick = tick
         self._price_level = price_level
         self._prev_tick = None
         self._next_tick = None
+        self._reserved_for_matching = Quantity(0, tick.quantity.wallet_id)
+        self._blocked_for_matching = []
 
     @property
     def tick(self):
@@ -58,6 +68,48 @@ class TickEntry(object):
         self._price_level.depth -= (self._tick.quantity - new_quantity)
         self._tick.quantity = new_quantity
 
+    def block_for_matching(self, order_id):
+        """
+        Temporarily block an order id for matching
+        """
+        if order_id in self._blocked_for_matching:
+            self._logger.debug("Not blocking %s for matching; already blocked", order_id)
+            return
+
+        def unblock_order_id(unblock_id):
+            self._logger.debug("Unblocking order id %s", unblock_id)
+            self._blocked_for_matching.remove(unblock_id)
+
+        self._logger.debug("Blocking %s for tick %s", order_id, self.order_id)
+        self._blocked_for_matching.append(order_id)
+        self.register_task("unblock_%s" % order_id, reactor.callLater(10, unblock_order_id, order_id))
+
+    def is_blocked_for_matching(self, order_id):
+        """
+        Return whether the order_id is blocked for matching
+        """
+        return order_id in self._blocked_for_matching
+
+    def reserve_for_matching(self, reserve_quantity):
+        """
+        Reserve some quantity of this tick entry for matching.
+        :param reserve_quantity: The quantity to reserve
+        """
+        self._logger.debug("Reserved %s quantity for matching (in tick %s)", reserve_quantity, self.tick)
+
+        self._reserved_for_matching += reserve_quantity
+        self._price_level.reserved += reserve_quantity
+
+    def release_for_matching(self, release_quantity):
+        """
+        Release some quantity of this tick entry for matching.
+        :param release_quantity: The quantity to release
+        """
+        self._logger.debug("Released %s quantity for matching (in tick %s)", release_quantity, self.tick)
+
+        self._reserved_for_matching -= release_quantity
+        self._price_level.reserved -= release_quantity
+
     def is_valid(self):
         """
         Return if the tick is still valid
@@ -95,6 +147,13 @@ class TickEntry(object):
         :rtype: TickEntry
         """
         return self._next_tick
+
+    @property
+    def reserved_for_matching(self):
+        """
+        :rtype: Quantity
+        """
+        return self._reserved_for_matching
 
     @next_tick.setter
     def next_tick(self, new_next_tick):

--- a/Tribler/community/market/core/transaction.py
+++ b/Tribler/community/market/core/transaction.py
@@ -145,6 +145,7 @@ class Transaction(object):
         self.outgoing_address = None
         self.partner_incoming_address = None
         self.partner_outgoing_address = None
+        self.match_id = ''
 
         self._payments = []
         self._current_payment = 0
@@ -157,7 +158,7 @@ class Transaction(object):
         trader_id, transaction_number, order_trader_id, order_number, partner_trader_id, partner_order_number, price,\
         price_type, transferred_price, quantity, quantity_type, transferred_quantity, transaction_timestamp,\
         sent_wallet_info, received_wallet_info, incoming_address, outgoing_address, partner_incoming_address,\
-        partner_outgoing_address = data
+        partner_outgoing_address, match_id = data
 
         transaction_id = TransactionId(TraderId(str(trader_id)), TransactionNumber(transaction_number))
         transaction = cls(transaction_id, Price(price, str(price_type)),
@@ -174,6 +175,7 @@ class Transaction(object):
         transaction.outgoing_address = WalletAddress(str(outgoing_address))
         transaction.partner_incoming_address = WalletAddress(str(partner_incoming_address))
         transaction.partner_outgoing_address = WalletAddress(str(partner_outgoing_address))
+        transaction.match_id = str(match_id)
         transaction._payments = payments
 
         return transaction
@@ -190,7 +192,7 @@ class Transaction(object):
                 unicode(self.total_quantity.wallet_id), float(self.transferred_quantity), float(self.timestamp),
                 self.sent_wallet_info, self.received_wallet_info, unicode(self.incoming_address),
                 unicode(self.outgoing_address), unicode(self.partner_incoming_address),
-                unicode(self.partner_outgoing_address))
+                unicode(self.partner_outgoing_address), unicode(self.match_id))
 
     @classmethod
     def from_proposed_trade(cls, proposed_trade, transaction_id):

--- a/Tribler/community/market/core/transaction_manager.py
+++ b/Tribler/community/market/core/transaction_manager.py
@@ -23,29 +23,33 @@ class TransactionManager(object):
 
         self.transaction_repository = transaction_repository
 
-    def create_from_proposed_trade(self, proposed_trade):
+    def create_from_proposed_trade(self, proposed_trade, match_id):
         """
         :type proposed_trade: ProposedTrade
+        :type match_id: str
         :rtype: Transaction
         """
         assert isinstance(proposed_trade, ProposedTrade), type(proposed_trade)
 
         transaction = Transaction.from_proposed_trade(proposed_trade, self.transaction_repository.next_identity())
+        transaction.match_id = match_id
         self.transaction_repository.add(transaction)
 
         self._logger.info("Transaction created with id: %s, quantity: %s, price: %s",
                           str(transaction.transaction_id), str(transaction.total_quantity), str(transaction.price))
         return transaction
 
-    def create_from_start_transaction(self, start_transaction):
+    def create_from_start_transaction(self, start_transaction, match_id):
         """
         :type start_transaction: StartTransaction
+        :type match_id: str
         :rtype: Transaction
         """
         assert isinstance(start_transaction, StartTransaction), type(start_transaction)
 
         transaction = Transaction(start_transaction.transaction_id, start_transaction.price, start_transaction.quantity,
                                   start_transaction.recipient_order_id, start_transaction.order_id, Timestamp.now())
+        transaction.match_id = match_id
         self.transaction_repository.add(transaction)
 
         self._logger.info("Transaction created with id: %s, quantity: %s, price: %s",

--- a/Tribler/community/market/database.py
+++ b/Tribler/community/market/database.py
@@ -57,6 +57,7 @@ CREATE TABLE IF NOT EXISTS orders(
   outgoing_address         TEXT NOT NULL,
   partner_incoming_address TEXT NOT NULL,
   partner_outgoing_address TEXT NOT NULL,
+  match_id                 TEXT NOT NULL,
 
   PRIMARY KEY (trader_id, transaction_number)
  );
@@ -240,8 +241,8 @@ class MarketDB(Database):
             u"INSERT INTO transactions (trader_id, transaction_number, order_trader_id, order_number,"
             u"partner_trader_id, partner_order_number, price, price_type, transferred_price, quantity, quantity_type,"
             u"transferred_quantity, transaction_timestamp, sent_wallet_info, received_wallet_info,"
-            u"incoming_address, outgoing_address, partner_incoming_address, partner_outgoing_address) "
-            u"VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)", transaction.to_database())
+            u"incoming_address, outgoing_address, partner_incoming_address, partner_outgoing_address, match_id) "
+            u"VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)", transaction.to_database())
         self.commit()
 
         self.delete_payments(transaction.transaction_id)


### PR DESCRIPTION
This PR implements various functionalities in the market community:
- **generic matching**: instead of matching orders, it is now possible to match any tick with any other tick (first commit).
- **matchmakers**: matchmakers are responsible for finding matches between asks and bids in the market. By default, every new user in a matchmaker, however, being matchmaker can be disabled with a configuration option (second commit).
- **test suite improvement**: I've added some additional tests and fixed existing ones (third commit). 

Matchmaking protocol:

![matching](https://user-images.githubusercontent.com/1707075/29660500-ce9db8e8-88c1-11e7-8517-49c92290702a.png)
