### PR TITLE
Fixed find_torrents finding invalid torrents

### DIFF
--- a/Tribler/Core/Libtorrent/LibtorrentMgr.py
+++ b/Tribler/Core/Libtorrent/LibtorrentMgr.py
@@ -276,10 +276,10 @@ class LibtorrentMgr(TaskManager):
                     ltsession.remove_torrent(request_handle, 0)
 
             # Check if we added this torrent before
-            known = ltsession.find_torrent(lt.sha1_hash(infohash))
-            if known.is_valid():
+            known = [str(h.info_hash()) for h in ltsession.get_torrents()]
+            if infohash in known:
                 self.torrents[infohash] = (torrentdl, ltsession)
-                return known
+                return ltsession.find_torrent(lt.sha1_hash(infohash))
 
             # Otherwise, add it anew
             torrent_handle = ltsession.add_torrent(encode_atp(atp))

--- a/Tribler/Test/Core/Libtorrent/test_libtorrent_mgr.py
+++ b/Tribler/Test/Core/Libtorrent/test_libtorrent_mgr.py
@@ -185,6 +185,7 @@ class TestLibtorrentMgr(TriblerCoreTest):
         mock_ltsession = MockObject()
         mock_ltsession.add_torrent = lambda _: mock_handle
         mock_ltsession.find_torrent = lambda _: mock_handle
+        mock_ltsession.get_torrents = lambda: []
         mock_ltsession.stop_upnp = lambda: None
         mock_ltsession.save_state = lambda: None
 
@@ -207,6 +208,7 @@ class TestLibtorrentMgr(TriblerCoreTest):
         mock_ltsession = MockObject()
         mock_ltsession.add_torrent = lambda _: mock_handle
         mock_ltsession.find_torrent = lambda _: mock_handle
+        mock_ltsession.get_torrents = lambda: [mock_handle]
         mock_ltsession.stop_upnp = lambda: None
         mock_ltsession.save_state = lambda: None
 


### PR DESCRIPTION
Fixes #3070.

In particular what was happening:

- If `libtorrent.find_torrent()` does not find a download, it returns an invalid handle.
- If `libtorrent.find_torrent()` finds a download it can have an invalid handle if it is still in the `checking_resume_data` state while it needs to fetch metadata.

I previously assumed that an invalid handle always means the torrent does not exist.