### PR TITLE
Wrapped JSON library to provide more info on failure

### DIFF
--- a/Tribler/Core/CacheDB/SqliteCacheDBHandler.py
+++ b/Tribler/Core/CacheDB/SqliteCacheDBHandler.py
@@ -3,7 +3,6 @@ SqlitecacheDBHanler.
 
 Author(s): Jie Yang
 """
-import json
 import logging
 import math
 import os
@@ -21,6 +20,7 @@ from twisted.internet.task import LoopingCall
 
 from Tribler.Core.CacheDB.sqlitecachedb import bin2str, str2bin
 from Tribler.Core.TorrentDef import TorrentDef
+import Tribler.Core.Utilities.json_util as json
 from Tribler.Core.Utilities.search_utils import split_into_keywords, filter_keywords
 from Tribler.Core.Utilities.tracker_utils import get_uniformed_tracker_url
 from Tribler.Core.Utilities.unicode import dunno2unicode

--- a/Tribler/Core/Modules/channel/cache.py
+++ b/Tribler/Core/Modules/channel/cache.py
@@ -1,7 +1,8 @@
 import codecs
-import json
 import logging
 import os
+
+import Tribler.Core.Utilities.json_util as json
 
 
 class SimpleCache(object):

--- a/Tribler/Core/Modules/channel/channel.py
+++ b/Tribler/Core/Modules/channel/channel.py
@@ -1,7 +1,6 @@
 from binascii import hexlify
 import codecs
 import collections
-import json
 import logging
 import os
 
@@ -12,6 +11,7 @@ from Tribler.dispersy.util import call_on_reactor_thread
 
 from Tribler.Core.simpledefs import SIGNAL_CHANNEL, SIGNAL_ON_CREATED, SIGNAL_RSS_FEED, SIGNAL_ON_UPDATED
 from Tribler.Core.Modules.channel.channel_rss import ChannelRssParser
+import Tribler.Core.Utilities.json_util as json
 
 
 class ChannelObject(TaskManager):
@@ -57,7 +57,7 @@ class ChannelObject(TaskManager):
             self._logger.debug(u"loading existing channel rss list from %s...", self._rss_file_path)
 
             with codecs.open(self._rss_file_path, 'rb', encoding='utf8') as f:
-                rss_list = json.load(f, encoding='utf8')
+                rss_list = json.load(f)
                 for rss_url in rss_list:
                     self._rss_feed_dict[rss_url] = None
 

--- a/Tribler/Core/Modules/channel/channel_rss.py
+++ b/Tribler/Core/Modules/channel/channel_rss.py
@@ -1,7 +1,6 @@
 from binascii import hexlify
 import logging
 import hashlib
-import json
 import time
 import os
 import re
@@ -18,6 +17,7 @@ from Tribler.Core.simpledefs import (SIGNAL_CHANNEL_COMMUNITY, SIGNAL_ON_TORRENT
                                      SIGNAL_ON_UPDATED)
 from Tribler.Core.TorrentDef import TorrentDef
 from Tribler.Core.Modules.channel.cache import SimpleCache
+import Tribler.Core.Utilities.json_util as json
 
 DEFAULT_CHECK_INTERVAL = 1800  # half an hour
 
@@ -152,8 +152,7 @@ class ChannelRssParser(TaskManager):
         # create modification message for channel
         modifications = {u'metadata-json': json.dumps({u'title': rss_item['title'][:64],
                                                        u'description': rss_item['description'][:768],
-                                                       u'thumb_hash': thumb_hash.encode('hex')},
-                                                      separators=(',', ':'))}
+                                                       u'thumb_hash': thumb_hash.encode('hex')})}
         self.channel_community.modifyTorrent(rss_item[u'channel_torrent_id'], modifications)
 
 

--- a/Tribler/Core/Modules/restapi/channels/base_channels_endpoint.py
+++ b/Tribler/Core/Modules/restapi/channels/base_channels_endpoint.py
@@ -1,8 +1,8 @@
-import json
 import logging
 import time
 from twisted.web import http, resource
 from Tribler.Core.simpledefs import NTFY_CHANNELCAST
+import Tribler.Core.Utilities.json_util as json
 from Tribler.community.allchannel.community import AllChannelCommunity
 from Tribler.dispersy.exception import CommunityNotFoundException
 

--- a/Tribler/Core/Modules/restapi/channels/channels_discovered_endpoint.py
+++ b/Tribler/Core/Modules/restapi/channels/channels_discovered_endpoint.py
@@ -1,4 +1,3 @@
-import json
 from twisted.web import http
 from Tribler.Core.Modules.restapi.channels.base_channels_endpoint import BaseChannelsEndpoint
 from Tribler.Core.Modules.restapi.channels.channels_playlists_endpoint import ChannelsPlaylistsEndpoint
@@ -7,6 +6,7 @@ from Tribler.Core.Modules.restapi.channels.channels_rss_endpoint import Channels
 from Tribler.Core.Modules.restapi.channels.channels_torrents_endpoint import ChannelsTorrentsEndpoint
 from Tribler.Core.Modules.restapi.util import convert_db_channel_to_json
 from Tribler.Core.exceptions import DuplicateChannelNameError
+import Tribler.Core.Utilities.json_util as json
 
 
 class ChannelsDiscoveredEndpoint(BaseChannelsEndpoint):

--- a/Tribler/Core/Modules/restapi/channels/channels_playlists_endpoint.py
+++ b/Tribler/Core/Modules/restapi/channels/channels_playlists_endpoint.py
@@ -1,10 +1,9 @@
-import json
-
 from twisted.web import http
 
 from Tribler.Core.CacheDB.sqlitecachedb import str2bin
 from Tribler.Core.Modules.restapi.channels.base_channels_endpoint import BaseChannelsEndpoint
 from Tribler.Core.Modules.restapi.util import convert_db_torrent_to_json
+import Tribler.Core.Utilities.json_util as json
 
 
 class ChannelsPlaylistsEndpoint(BaseChannelsEndpoint):

--- a/Tribler/Core/Modules/restapi/channels/channels_popular_endpoint.py
+++ b/Tribler/Core/Modules/restapi/channels/channels_popular_endpoint.py
@@ -1,7 +1,7 @@
-import json
 from twisted.web import http
 from Tribler.Core.Modules.restapi.channels.base_channels_endpoint import BaseChannelsEndpoint
 from Tribler.Core.Modules.restapi.util import convert_db_channel_to_json
+import Tribler.Core.Utilities.json_util as json
 
 
 class ChannelsPopularEndpoint(BaseChannelsEndpoint):

--- a/Tribler/Core/Modules/restapi/channels/channels_rss_endpoint.py
+++ b/Tribler/Core/Modules/restapi/channels/channels_rss_endpoint.py
@@ -1,6 +1,6 @@
-import json
 from twisted.web import http
 from Tribler.Core.Modules.restapi.channels.base_channels_endpoint import BaseChannelsEndpoint
+import Tribler.Core.Utilities.json_util as json
 
 
 class BaseChannelsRssFeedsEndpoint(BaseChannelsEndpoint):

--- a/Tribler/Core/Modules/restapi/channels/channels_subscription_endpoint.py
+++ b/Tribler/Core/Modules/restapi/channels/channels_subscription_endpoint.py
@@ -1,9 +1,9 @@
-import json
 from twisted.web import http
 from twisted.web.server import NOT_DONE_YET
 from Tribler.Core.Modules.restapi import VOTE_SUBSCRIBE, VOTE_UNSUBSCRIBE
 from Tribler.Core.Modules.restapi.channels.base_channels_endpoint import BaseChannelsEndpoint
 from Tribler.Core.Modules.restapi.util import convert_db_channel_to_json
+import Tribler.Core.Utilities.json_util as json
 
 
 ALREADY_SUBSCRIBED_RESPONSE_MSG = "you are already subscribed to this channel"

--- a/Tribler/Core/Modules/restapi/channels/channels_torrents_endpoint.py
+++ b/Tribler/Core/Modules/restapi/channels/channels_torrents_endpoint.py
@@ -1,5 +1,4 @@
 import base64
-import json
 
 from twisted.internet.defer import Deferred
 from twisted.web import http
@@ -9,6 +8,7 @@ from Tribler.Core.Modules.restapi.channels.base_channels_endpoint import BaseCha
 from Tribler.Core.Modules.restapi.util import convert_db_torrent_to_json
 from Tribler.Core.TorrentDef import TorrentDef
 from Tribler.Core.exceptions import DuplicateTorrentFileError, HttpError
+import Tribler.Core.Utilities.json_util as json
 from Tribler.Core.Utilities.utilities import http_get
 from Tribler.dispersy.util import blocking_call_on_reactor_thread
 

--- a/Tribler/Core/Modules/restapi/channels/my_channel_endpoint.py
+++ b/Tribler/Core/Modules/restapi/channels/my_channel_endpoint.py
@@ -1,7 +1,7 @@
-import json
 from twisted.web import http
 from Tribler.Core.Modules.restapi.channels.base_channels_endpoint import BaseChannelsEndpoint
 from Tribler.Core.Modules.restapi.util import get_parameter
+import Tribler.Core.Utilities.json_util as json
 
 
 NO_CHANNEL_CREATED_RESPONSE_MSG = "your channel has not been created"

--- a/Tribler/Core/Modules/restapi/create_torrent_endpoint.py
+++ b/Tribler/Core/Modules/restapi/create_torrent_endpoint.py
@@ -1,4 +1,3 @@
-import json
 import base64
 import logging
 
@@ -8,6 +7,7 @@ from twisted.web.server import NOT_DONE_YET
 from Tribler.Core.DownloadConfig import DownloadStartupConfig
 from Tribler.Core.Modules.restapi.util import return_handled_exception
 from Tribler.Core.exceptions import DuplicateDownloadException
+import Tribler.Core.Utilities.json_util as json
 
 
 class CreateTorrentEndpoint(resource.Resource):

--- a/Tribler/Core/Modules/restapi/debug_endpoint.py
+++ b/Tribler/Core/Modules/restapi/debug_endpoint.py
@@ -1,10 +1,9 @@
-import json
-
 import psutil
-from Tribler.Core.Utilities.instrumentation import WatchDog
 from twisted.web import http, resource
 
 from Tribler.community.tunnel.tunnel_community import TunnelCommunity
+from Tribler.Core.Utilities.instrumentation import WatchDog
+import Tribler.Core.Utilities.json_util as json
 
 
 class DebugEndpoint(resource.Resource):

--- a/Tribler/Core/Modules/restapi/downloads_endpoint.py
+++ b/Tribler/Core/Modules/restapi/downloads_endpoint.py
@@ -1,4 +1,3 @@
-import json
 import os
 
 import logging
@@ -8,6 +7,7 @@ from Tribler.Core.DownloadConfig import DownloadStartupConfig
 from Tribler.Core.Libtorrent.LibtorrentDownloadImpl import LibtorrentStatisticsResponse
 from Tribler.Core.Modules.restapi.util import return_handled_exception
 from Tribler.Core.TorrentDef import TorrentDef, TorrentDefNoMetainfo
+import Tribler.Core.Utilities.json_util as json
 
 from Tribler.Core.simpledefs import DOWNLOAD, UPLOAD, dlstatus_strings, NTFY_TORRENTS, DLMODE_VOD
 

--- a/Tribler/Core/Modules/restapi/events_endpoint.py
+++ b/Tribler/Core/Modules/restapi/events_endpoint.py
@@ -1,4 +1,3 @@
-import json
 from twisted.web import server, resource
 from Tribler.Core.Modules.restapi.util import convert_db_channel_to_json, convert_search_torrent_to_json, \
     fix_unicode_dict
@@ -6,6 +5,7 @@ from Tribler.Core.simpledefs import (NTFY_CHANNELCAST, SIGNAL_CHANNEL, SIGNAL_ON
                                      NTFY_UPGRADER, NTFY_STARTED, NTFY_WATCH_FOLDER_CORRUPT_TORRENT, NTFY_INSERT,
                                      NTFY_NEW_VERSION, NTFY_FINISHED, NTFY_TRIBLER, NTFY_UPGRADER_TICK, NTFY_CHANNEL,
                                      NTFY_DISCOVERED, NTFY_TORRENT, NTFY_ERROR, NTFY_DELETE)
+import Tribler.Core.Utilities.json_util as json
 from Tribler.Core.version import version_id
 
 

--- a/Tribler/Core/Modules/restapi/multichain_endpoint.py
+++ b/Tribler/Core/Modules/restapi/multichain_endpoint.py
@@ -1,9 +1,9 @@
 import base64
-import json
 
 from twisted.web import http, resource
 
 from Tribler.community.multichain.community import MultiChainCommunity
+import Tribler.Core.Utilities.json_util as json
 
 
 class MultichainEndpoint(resource.Resource):

--- a/Tribler/Core/Modules/restapi/rest_manager.py
+++ b/Tribler/Core/Modules/restapi/rest_manager.py
@@ -1,4 +1,3 @@
-import json
 import logging
 from traceback import format_tb
 
@@ -8,6 +7,7 @@ from twisted.python.compat import intToBytes
 from twisted.web import server, http
 
 from Tribler.Core.Modules.restapi.root_endpoint import RootEndpoint
+import Tribler.Core.Utilities.json_util as json
 from Tribler.dispersy.taskmanager import TaskManager
 
 

--- a/Tribler/Core/Modules/restapi/search_endpoint.py
+++ b/Tribler/Core/Modules/restapi/search_endpoint.py
@@ -1,4 +1,3 @@
-import json
 import logging
 
 from twisted.web import http, resource
@@ -6,6 +5,7 @@ from Tribler.Core.Utilities.search_utils import split_into_keywords
 from Tribler.Core.exceptions import OperationNotEnabledByConfigurationException
 from Tribler.Core.simpledefs import NTFY_CHANNELCAST, NTFY_TORRENTS, SIGNAL_TORRENT, SIGNAL_ON_SEARCH_RESULTS, \
     SIGNAL_CHANNEL
+import Tribler.Core.Utilities.json_util as json
 
 
 class SearchEndpoint(resource.Resource):

--- a/Tribler/Core/Modules/restapi/settings_endpoint.py
+++ b/Tribler/Core/Modules/restapi/settings_endpoint.py
@@ -1,5 +1,4 @@
 from ConfigParser import RawConfigParser
-import json
 import os
 
 from twisted.web import resource
@@ -7,6 +6,7 @@ from twisted.web import resource
 from Tribler.Core.Utilities.configparser import CallbackConfigParser
 from Tribler.Core.defaults import tribler_defaults
 from Tribler.Core.simpledefs import STATEDIR_GUICONFIG
+import Tribler.Core.Utilities.json_util as json
 
 
 class SettingsEndpoint(resource.Resource):

--- a/Tribler/Core/Modules/restapi/shutdown_endpoint.py
+++ b/Tribler/Core/Modules/restapi/shutdown_endpoint.py
@@ -1,11 +1,11 @@
 import os
-import json
 import logging
 
 from twisted.web import resource
 from twisted.internet import reactor, task
 
 from Tribler.Core.Modules.process_checker import ProcessChecker
+import Tribler.Core.Utilities.json_util as json
 
 
 class ShutdownEndpoint(resource.Resource):

--- a/Tribler/Core/Modules/restapi/state_endpoint.py
+++ b/Tribler/Core/Modules/restapi/state_endpoint.py
@@ -1,9 +1,8 @@
-import json
-
 from twisted.web import resource
 
 from Tribler.Core.simpledefs import STATE_STARTING, STATE_UPGRADING, STATE_STARTED, NTFY_UPGRADER, NTFY_STARTED, \
     NTFY_TRIBLER, NTFY_FINISHED, STATE_EXCEPTION
+import Tribler.Core.Utilities.json_util as json
 
 
 class StateEndpoint(resource.Resource):

--- a/Tribler/Core/Modules/restapi/statistics_endpoint.py
+++ b/Tribler/Core/Modules/restapi/statistics_endpoint.py
@@ -1,6 +1,6 @@
-import json
-
 from twisted.web import resource
+
+import Tribler.Core.Utilities.json_util as json
 
 
 class StatisticsEndpoint(resource.Resource):

--- a/Tribler/Core/Modules/restapi/torrentinfo_endpoint.py
+++ b/Tribler/Core/Modules/restapi/torrentinfo_endpoint.py
@@ -1,4 +1,3 @@
-import json
 import logging
 from libtorrent import bdecode, bencode
 from urllib import url2pathname
@@ -10,6 +9,7 @@ from twisted.web.server import NOT_DONE_YET
 
 from Tribler.Core.Modules.restapi.util import fix_unicode_dict
 from Tribler.Core.TorrentDef import TorrentDef
+import Tribler.Core.Utilities.json_util as json
 from Tribler.Core.Utilities.utilities import fix_torrent, http_get, parse_magnetlink
 
 

--- a/Tribler/Core/Modules/restapi/torrents_endpoint.py
+++ b/Tribler/Core/Modules/restapi/torrents_endpoint.py
@@ -1,11 +1,10 @@
-import json
-
 import logging
 from twisted.web import http, resource
 from twisted.web.server import NOT_DONE_YET
 
 from Tribler.Core.Modules.restapi.util import convert_db_torrent_to_json
 from Tribler.Core.simpledefs import NTFY_TORRENTS, NTFY_CHANNELCAST
+import Tribler.Core.Utilities.json_util as json
 
 
 class TorrentsEndpoint(resource.Resource):

--- a/Tribler/Core/Modules/restapi/util.py
+++ b/Tribler/Core/Modules/restapi/util.py
@@ -1,7 +1,6 @@
 """
 This file contains some utility methods that are used by the API.
 """
-import json
 from struct import unpack_from
 import math
 
@@ -9,6 +8,7 @@ from twisted.web import http
 
 from Tribler.Core.Modules.restapi import VOTE_SUBSCRIBE
 from Tribler.Core.simpledefs import NTFY_TORRENTS
+import Tribler.Core.Utilities.json_util as json
 from Tribler.community.channel.community import ChannelCommunity
 from Tribler.dispersy.exception import CommunityNotFoundException
 from Tribler.dispersy.util import blocking_call_on_reactor_thread

--- a/Tribler/Core/Modules/restapi/variables_endpoint.py
+++ b/Tribler/Core/Modules/restapi/variables_endpoint.py
@@ -1,6 +1,6 @@
-import json
-
 from twisted.web import resource
+
+import Tribler.Core.Utilities.json_util as json
 
 
 class VariablesEndpoint(resource.Resource):

--- a/Tribler/Core/Modules/versioncheck_manager.py
+++ b/Tribler/Core/Modules/versioncheck_manager.py
@@ -1,5 +1,4 @@
 from distutils.version import LooseVersion
-import json
 import logging
 
 from twisted.internet.error import ConnectError, DNSLookupError
@@ -9,6 +8,7 @@ from twisted.web.error import SchemeNotSupported
 from Tribler.Core.simpledefs import NTFY_INSERT, NTFY_NEW_VERSION
 from Tribler.Core.version import version_id
 from Tribler.dispersy.taskmanager import TaskManager
+import Tribler.Core.Utilities.json_util as json
 from Tribler.Core.Utilities.utilities import http_get
 from Tribler.Core.exceptions import HttpError
 

--- a/Tribler/Core/Upgrade/pickle_converter.py
+++ b/Tribler/Core/Upgrade/pickle_converter.py
@@ -1,7 +1,6 @@
 import io
 import os
 import glob
-import json
 import pickle
 import cPickle
 import StringIO
@@ -11,6 +10,7 @@ from ConfigParser import RawConfigParser
 from Tribler.Core.SessionConfig import SessionStartupConfig, SessionConfigInterface
 from Tribler.Core.DownloadConfig import DefaultDownloadStartupConfig, get_default_dscfg_filename
 from Tribler.Core.simpledefs import PERSISTENTSTATE_CURRENTVERSION, STATEDIR_GUICONFIG
+import Tribler.Core.Utilities.json_util as json
 
 
 class PickleConverter(object):

--- a/Tribler/Core/Utilities/encoding.py
+++ b/Tribler/Core/Utilities/encoding.py
@@ -1,7 +1,8 @@
 import logging
-from json import dumps
 from urllib import unquote, urlencode
 from urlparse import urlparse, parse_qsl, ParseResult
+
+from Tribler.Core.Utilities.json_util import dumps
 
 logger = logging.getLogger(__name__)
 

--- a/Tribler/Core/Utilities/json_util.py
+++ b/Tribler/Core/Utilities/json_util.py
@@ -1,0 +1,116 @@
+from collections import Iterable
+import json
+
+__all__ = ['dumps', 'loads']
+
+
+def _is_undumpable(obj):
+    """
+    Check if JSON can dump an object.
+
+    :param obj: the object to check for dumpability
+    :return: the string safe version of the object if undumpable, '' otherwise
+    """
+    try:
+        json.dumps(obj)
+        return ''
+    except UnicodeDecodeError:
+        return repr(obj)
+
+
+def _scan_iterable(obj, context=None):
+    """
+    Scan an object for dumpable members if iterable or the dumpability of itself, given some context.
+
+    This recurses over the obj if it is iterable.
+    Otherwise, it performs an _is_undumpable() check.
+
+    If the object appears to be undumpable, it will extend the return value with its name added to the current context.
+
+    :param obj: the (possibly iterable) object to check for dumpability
+    :param context: the context to report the dumpability of this object for
+    :return: a list of undumpable objects in context, represented as lists
+    """
+    if context is None:
+        context = []
+    out = []
+    # First check if we need to recurse into the children of obj.
+    # Note that there is one type of object we don't want to step into, which is a string object.
+    if not isinstance(obj, basestring) and isinstance(obj, Iterable):
+        for sub in obj:
+            # If we are iterating over a dict, we are iterating over its keys.
+            # 1. We can then give a named trace instead of an anonymous trace
+            # 2. We need to check if the key itself is dumpable
+            if isinstance(obj, dict):
+                undumpable = _is_undumpable(sub)
+                if undumpable:
+                    # We cant dump the key, output "OBJ_CLASS::KEY_NAME"
+                    out += [context + [obj.__class__.__name__ + '::' + repr(sub)]]
+                else:
+                    # Step into this key's value, our context is expanded with "OBJ_CLASS[KEY_NAME]"
+                    out += _scan_iterable(obj[sub], context=context[:]
+                                          + [obj.__class__.__name__ + '[' + str(sub) + ']'])
+            else:
+                # Step into this value, our context is expanded with "OBJ_CLASS"
+                # In JSON the index of the tuple or list entry shouldn't matter much, so we also keep these anonymous
+                out += _scan_iterable(sub, context=context[:] + [obj.__class__.__name__])
+    else:
+        # We can't step into this object, so check if it is dumpable
+        # If it is not, output "OBJ_CLASS::VALUE"
+        undumpable = _is_undumpable(obj)
+        if undumpable:
+            out += [context + [obj.__class__.__name__ + '::' + undumpable]]
+    return out
+
+
+def dump(obj, fp, ensure_ascii=True):
+    """
+    Attempt to json.dump() an object to a 'file'. This function provides additional info if the object can't
+    be serialized.
+
+    :param obj: the object to serialize.
+    :param fp: the file-like object to write to.
+    :param ensure_ascii: allow binary strings to be sent
+    """
+    try:
+        json.dump(obj, fp, ensure_ascii=ensure_ascii)
+    except UnicodeDecodeError as e:
+        undumpables = _scan_iterable(obj)
+        traces = '\n\t'.join(['->'.join(u) for u in undumpables])
+        raise UnicodeDecodeError(e.encoding, str(obj), e.start, e.end, "could not dump:\n\t%s" % traces)
+
+
+def dumps(obj, ensure_ascii=True):
+    """
+    Attempt to json.dumps() an object. This function provides additional info if the object can't be serialized.
+
+    :param obj: the object to serialize.
+    :param ensure_ascii: allow binary strings to be sent
+    :return: the JSON str representation of the object.
+    """
+    try:
+        return json.dumps(obj, ensure_ascii=ensure_ascii)
+    except UnicodeDecodeError as e:
+        undumpables = _scan_iterable(obj)
+        traces = '\n\t'.join(['->'.join(u) for u in undumpables])
+        raise UnicodeDecodeError(e.encoding, str(obj), e.start, e.end, "could not dump:\n\t%s" % traces)
+
+
+def loads(s, *args, **kwargs):
+    """
+    Attempt to json.loads() a string. This function wraps json.loads, to provide dumps and loads from the same file.
+
+    :param s: the JSON formatted string to load objects from.
+    :return: the Python object(s) extracted from the JSON input.
+    """
+    return json.loads(s, *args, **kwargs)
+
+
+def load(fp, *args, **kwargs):
+    """
+    Attempt to json.load() from a 'file'. This function wraps json.load, to provide dump and load from the same file.
+
+    :param s: the JSON formatted file-like object to load objects from.
+    :return: the Python object(s) extracted from the JSON input.
+    """
+    return json.load(fp, *args, **kwargs)

--- a/Tribler/Test/Core/Modules/RestApi/Channels/test_channels_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/Channels/test_channels_endpoint.py
@@ -1,5 +1,4 @@
-import json
-
+import Tribler.Core.Utilities.json_util as json
 from Tribler.Core.Modules.channel.channel import ChannelObject
 from Tribler.Core.Modules.channel.channel_manager import ChannelManager
 from Tribler.Core.exceptions import DuplicateChannelNameError

--- a/Tribler/Test/Core/Modules/RestApi/Channels/test_channels_playlist_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/Channels/test_channels_playlist_endpoint.py
@@ -1,7 +1,7 @@
-import json
 from twisted.internet.defer import inlineCallbacks
 
 from Tribler.Core.Modules.restapi.channels.base_channels_endpoint import UNKNOWN_CHANNEL_RESPONSE_MSG
+import Tribler.Core.Utilities.json_util as json
 from Tribler.Test.Core.Modules.RestApi.Channels.test_channels_endpoint import AbstractTestChannelsEndpoint
 from Tribler.Test.Core.base_test import MockObject
 from Tribler.Test.twisted_thread import deferred

--- a/Tribler/Test/Core/Modules/RestApi/Channels/test_channels_popular_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/Channels/test_channels_popular_endpoint.py
@@ -1,6 +1,6 @@
-import json
 from twisted.internet.defer import inlineCallbacks
 
+import Tribler.Core.Utilities.json_util as json
 from Tribler.Test.Core.Modules.RestApi.Channels.test_channels_endpoint import AbstractTestChannelsEndpoint
 from Tribler.Test.twisted_thread import deferred
 

--- a/Tribler/Test/Core/Modules/RestApi/Channels/test_channels_torrents_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/Channels/test_channels_torrents_endpoint.py
@@ -1,11 +1,11 @@
 import base64
-import json
 import os
 import shutil
 import urllib
 from twisted.internet.defer import inlineCallbacks
 
 from Tribler.Core.TorrentDef import TorrentDef
+import Tribler.Core.Utilities.json_util as json
 from Tribler.Core.Utilities.network_utils import get_random_port
 from Tribler.Test.Core.Modules.RestApi.Channels.test_channels_endpoint import AbstractTestChannelsEndpoint
 from Tribler.Test.Core.base_test import MockObject

--- a/Tribler/Test/Core/Modules/RestApi/Channels/test_create_channel_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/Channels/test_create_channel_endpoint.py
@@ -1,5 +1,4 @@
-import json
-
+import Tribler.Core.Utilities.json_util as json
 from Tribler.Test.Core.Modules.RestApi.Channels.test_channels_endpoint import AbstractTestChannelsEndpoint
 from Tribler.Test.twisted_thread import deferred
 

--- a/Tribler/Test/Core/Modules/RestApi/base_api_test.py
+++ b/Tribler/Test/Core/Modules/RestApi/base_api_test.py
@@ -1,4 +1,3 @@
-import json
 import os
 import urllib
 from twisted.internet.defer import succeed, inlineCallbacks
@@ -8,6 +7,7 @@ from twisted.web.http_headers import Headers
 from twisted.web.iweb import IBodyProducer
 from zope.interface import implements
 
+import Tribler.Core.Utilities.json_util as json
 from Tribler.Core.Utilities.network_utils import get_random_port
 from Tribler.Core.version import version_id
 from Tribler.Test.test_as_server import TestAsServer

--- a/Tribler/Test/Core/Modules/RestApi/test_create_torrent_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_create_torrent_endpoint.py
@@ -1,10 +1,10 @@
 import base64
-import json
 import os
 import shutil
 from twisted.internet.defer import inlineCallbacks
 
 from Tribler.Core.TorrentDef import TorrentDef
+import Tribler.Core.Utilities.json_util as json
 from Tribler.Test.Core.Modules.RestApi.base_api_test import AbstractApiTest
 from Tribler.Test.common import TESTS_DATA_DIR
 from Tribler.Test.twisted_thread import deferred

--- a/Tribler/Test/Core/Modules/RestApi/test_debug_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_debug_endpoint.py
@@ -1,10 +1,10 @@
-import json
 from twisted.internet.defer import inlineCallbacks
 
 from Tribler.Test.Core.Modules.RestApi.base_api_test import AbstractApiTest
 from Tribler.Test.Core.base_test import MockObject
 from Tribler.Test.twisted_thread import deferred
 from Tribler.community.tunnel.hidden_community import HiddenTunnelCommunity
+import Tribler.Core.Utilities.json_util as json
 from Tribler.dispersy.dispersy import Dispersy
 from Tribler.dispersy.endpoint import ManualEnpoint
 from Tribler.dispersy.member import DummyMember

--- a/Tribler/Test/Core/Modules/RestApi/test_downloads_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_downloads_endpoint.py
@@ -1,4 +1,3 @@
-import json
 import os
 from binascii import hexlify
 from urllib import pathname2url
@@ -6,6 +5,7 @@ from urllib import pathname2url
 from twisted.internet.defer import fail
 
 from Tribler.Core.DownloadConfig import DownloadStartupConfig
+import Tribler.Core.Utilities.json_util as json
 from Tribler.Core.Utilities.network_utils import get_random_port
 from Tribler.Test.Core.Modules.RestApi.base_api_test import AbstractApiTest
 from Tribler.Test.common import UBUNTU_1504_INFOHASH, TESTS_DATA_DIR

--- a/Tribler/Test/Core/Modules/RestApi/test_events_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_events_endpoint.py
@@ -1,4 +1,3 @@
-import json
 import logging
 from twisted.internet import reactor
 from twisted.internet.defer import Deferred, inlineCallbacks
@@ -10,6 +9,7 @@ from twisted.web.http_headers import Headers
 from Tribler.Core.simpledefs import SIGNAL_CHANNEL, SIGNAL_ON_SEARCH_RESULTS, SIGNAL_TORRENT, NTFY_UPGRADER, \
     NTFY_STARTED, NTFY_FINISHED, NTFY_UPGRADER_TICK, NTFY_WATCH_FOLDER_CORRUPT_TORRENT, NTFY_INSERT, NTFY_NEW_VERSION, \
     NTFY_CHANNEL, NTFY_DISCOVERED, NTFY_TORRENT, NTFY_ERROR, NTFY_DELETE
+import Tribler.Core.Utilities.json_util as json
 from Tribler.Core.version import version_id
 from Tribler.Test.Core.Modules.RestApi.base_api_test import AbstractApiTest
 from Tribler.Test.twisted_thread import deferred

--- a/Tribler/Test/Core/Modules/RestApi/test_multichain_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_multichain_endpoint.py
@@ -1,10 +1,10 @@
 import base64
-import json
 from urllib import quote_plus
 
 from twisted.internet.defer import inlineCallbacks
 
 from Tribler.community.multichain.community import MultiChainCommunity
+import Tribler.Core.Utilities.json_util as json
 from Tribler.dispersy.dispersy import Dispersy
 from Tribler.dispersy.endpoint import ManualEnpoint
 from Tribler.dispersy.member import DummyMember

--- a/Tribler/Test/Core/Modules/RestApi/test_rest_manager.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_rest_manager.py
@@ -1,6 +1,5 @@
-import json
-
 from Tribler.Core.exceptions import TriblerException
+import Tribler.Core.Utilities.json_util as json
 from Tribler.Test.twisted_thread import deferred
 from base_api_test import AbstractApiTest
 

--- a/Tribler/Test/Core/Modules/RestApi/test_settings_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_settings_endpoint.py
@@ -1,8 +1,8 @@
-import json
 import os
 from twisted.internet.defer import inlineCallbacks
 
 from Tribler.Core.Utilities.configparser import CallbackConfigParser
+import Tribler.Core.Utilities.json_util as json
 from Tribler.Test.Core.Modules.RestApi.base_api_test import AbstractApiTest
 from Tribler.Test.twisted_thread import deferred
 

--- a/Tribler/Test/Core/Modules/RestApi/test_statistics_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_statistics_endpoint.py
@@ -1,5 +1,4 @@
-import json
-
+import Tribler.Core.Utilities.json_util as json
 from Tribler.Test.Core.Modules.RestApi.base_api_test import AbstractApiTest
 from Tribler.Test.twisted_thread import deferred
 

--- a/Tribler/Test/Core/Modules/RestApi/test_torrentinfo_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_torrentinfo_endpoint.py
@@ -1,5 +1,4 @@
 from binascii import hexlify
-import json
 import os
 from urllib import pathname2url, quote_plus
 import shutil
@@ -7,6 +6,7 @@ import shutil
 from twisted.internet.defer import inlineCallbacks
 
 from Tribler.Core.TorrentDef import TorrentDef
+import Tribler.Core.Utilities.json_util as json
 from Tribler.Core.Utilities.network_utils import get_random_port
 from Tribler.Test.Core.Modules.RestApi.base_api_test import AbstractApiTest
 from Tribler.Test.Core.base_test import MockObject

--- a/Tribler/Test/Core/Modules/RestApi/test_torrents_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_torrents_endpoint.py
@@ -1,8 +1,8 @@
-import json
 import time
 from twisted.internet.defer import inlineCallbacks
 
 from Tribler.Core.TorrentChecker.torrent_checker import TorrentChecker
+import Tribler.Core.Utilities.json_util as json
 from Tribler.Core.Utilities.network_utils import get_random_port
 from Tribler.Core.simpledefs import NTFY_CHANNELCAST, NTFY_TORRENTS
 from Tribler.Test.Core.Modules.RestApi.base_api_test import AbstractApiTest

--- a/Tribler/Test/Core/Modules/test_versioncheck.py
+++ b/Tribler/Test/Core/Modules/test_versioncheck.py
@@ -1,8 +1,8 @@
-import json
 from twisted.internet.defer import maybeDeferred, inlineCallbacks
 from twisted.web import server, resource
 
 from Tribler.Core.Modules import versioncheck_manager
+import Tribler.Core.Utilities.json_util as json
 from Tribler.Core.Utilities.network_utils import get_random_port
 from Tribler.Test.test_as_server import TestAsServer
 from Tribler.Test.twisted_thread import reactor, deferred

--- a/Tribler/community/channel/community.py
+++ b/Tribler/community/channel/community.py
@@ -1,4 +1,3 @@
-import json
 import logging
 from binascii import hexlify
 from struct import pack
@@ -10,6 +9,7 @@ from twisted.python.threadable import isInIOThread
 from Tribler.Core.CacheDB.sqlitecachedb import str2bin
 from Tribler.Core.simpledefs import NTFY_CHANNEL, NTFY_TORRENT
 from Tribler.Core.simpledefs import NTFY_DISCOVERED
+import Tribler.Core.Utilities.json_util as json
 from Tribler.community.channel.payload import ModerationPayload
 from Tribler.dispersy.authentication import MemberAuthentication, NoAuthentication
 from Tribler.dispersy.candidate import CANDIDATE_WALK_LIFETIME

--- a/TriblerGUI/debug_window.py
+++ b/TriblerGUI/debug_window.py
@@ -1,4 +1,3 @@
-import json
 import socket
 from time import localtime, strftime
 
@@ -19,6 +18,7 @@ from matplotlib.backends.backend_qt5agg import FigureCanvas
 from matplotlib.dates import DateFormatter
 from matplotlib.figure import Figure
 
+import Tribler.Core.Utilities.json_util as json
 from TriblerGUI.utilities import get_ui_file_path, format_size
 from TriblerGUI.tribler_request_manager import performed_requests as tribler_performed_requests, TriblerRequestManager
 from TriblerGUI.event_request_manager import received_events as tribler_received_events

--- a/TriblerGUI/event_request_manager.py
+++ b/TriblerGUI/event_request_manager.py
@@ -1,9 +1,9 @@
-import json
 import logging
 from PyQt5.QtCore import QUrl, pyqtSignal, QTimer
 from PyQt5.QtNetwork import QNetworkAccessManager, QNetworkRequest, QNetworkReply
 import time
 
+import Tribler.Core.Utilities.json_util as json
 from TriblerGUI.defs import API_PORT
 
 received_events = []

--- a/TriblerGUI/tribler_request_manager.py
+++ b/TriblerGUI/tribler_request_manager.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import random
 import string
@@ -6,6 +5,8 @@ from time import time
 
 from PyQt5.QtCore import QUrl, pyqtSignal, QIODevice, QBuffer
 from PyQt5.QtNetwork import QNetworkAccessManager, QNetworkRequest
+
+import Tribler.Core.Utilities.json_util as json
 from TriblerGUI.defs import BUTTON_TYPE_NORMAL, API_PORT
 from TriblerGUI.dialogs.confirmationdialog import ConfirmationDialog
 

--- a/TriblerGUI/widgets/settingspage.py
+++ b/TriblerGUI/widgets/settingspage.py
@@ -1,6 +1,6 @@
-import json
 from PyQt5.QtWidgets import QWidget
 
+import Tribler.Core.Utilities.json_util as json
 from TriblerGUI.defs import PAGE_SETTINGS_GENERAL, PAGE_SETTINGS_CONNECTION, PAGE_SETTINGS_BANDWIDTH, \
     PAGE_SETTINGS_SEEDING, PAGE_SETTINGS_ANONYMITY, BUTTON_TYPE_NORMAL
 from TriblerGUI.dialogs.confirmationdialog import ConfirmationDialog

--- a/twisted/plugins/tunnel_helper_plugin.py
+++ b/twisted/plugins/tunnel_helper_plugin.py
@@ -1,7 +1,6 @@
 """
 This twistd plugin enables to start a tunnel helper headless using the twistd command.
 """
-import json
 import logging
 import logging.config
 import os
@@ -36,6 +35,7 @@ from zope.interface import implements
 from Tribler.Core.Session import Session
 from Tribler.Core.SessionConfig import SessionStartupConfig
 from Tribler.Core.TorrentDef import TorrentDef
+import Tribler.Core.Utilities.json_util as json
 from Tribler.Core.permid import read_keypair
 from Tribler.Core.simpledefs import dlstatus_strings
 from Tribler.Core.DownloadConfig import DefaultDownloadStartupConfig


### PR DESCRIPTION
This PR wraps the `json` library such that `UnicodeDecodeError`s have more information about unserializable fields in their error messages.