### PR TITLE
WIP: Fix trust chain transaction sql usability

### DIFF
--- a/Tribler/Test/Community/Market/Integration/test_market_base.py
+++ b/Tribler/Test/Community/Market/Integration/test_market_base.py
@@ -39,7 +39,7 @@ class MarketCommunityTests(MarketCommunity):
         super(MarketCommunityTests, self).received_block_pair(messages)
 
         for message in messages:
-            if message.payload.block1.transaction["type"] == 'tx_done' and message.name == BLOCK_PAIR_BROADCAST:
+            if message.payload.block1.transaction_dict["type"] == 'tx_done' and message.name == BLOCK_PAIR_BROADCAST:
                 self.test_deferred.callback(None)
 
 

--- a/Tribler/Test/Community/Market/Wallet/test_trustchain_wallet.py
+++ b/Tribler/Test/Community/Market/Wallet/test_trustchain_wallet.py
@@ -16,7 +16,11 @@ class TestTrustchainWallet(AbstractServer):
         yield super(TestTrustchainWallet, self).setUp(annotate=annotate)
 
         latest_block = MockObject()
-        latest_block.transaction = {"total_up": 10 * 1024 * 1024, "total_down": 5 * 1024 * 1024}
+        latest_block.up = 10 * 1024 * 1024
+        latest_block.down = 5 * 1024 * 1024
+        latest_block.total_up = latest_block.up
+        latest_block.total_down = latest_block.down
+        latest_block.transaction = [latest_block.up, latest_block.down, latest_block.total_up, latest_block.total_down]
         latest_block.previous_hash_requester = 'b' * 5
 
         self.tc_community = MockObject()

--- a/Tribler/Test/Community/Triblerchain/test_block.py
+++ b/Tribler/Test/Community/Triblerchain/test_block.py
@@ -29,7 +29,7 @@ class TestBlocks(TrustChainTestCase):
         db.add_block(block1)
         db.add_block(block3)
         # Act
-        block2.transaction["up"] += 10
+        block2.up += 10
         block2.sign(block2.key)
         block3.previous_hash = block2.hash
         result = block2.validate(db)
@@ -44,7 +44,7 @@ class TestBlocks(TrustChainTestCase):
         db.add_block(block1)
         db.add_block(block3)
         # Act
-        block2.transaction["down"] += 10
+        block2.down += 10
         block2.sign(block2.key)
         block3.previous_hash = block2.hash
         result = block2.validate(db)
@@ -61,7 +61,7 @@ class TestBlocks(TrustChainTestCase):
         db.add_block(block3)
         # Act
         block2 = TriblerChainBlock(block2.pack_db_insert())
-        block2.transaction["up"] += 10
+        block2.up += 10
         block2.sign(db.get(block2.public_key, block2.sequence_number).key)
         result = block2.validate(db)
         # Assert
@@ -77,7 +77,7 @@ class TestBlocks(TrustChainTestCase):
         db.add_block(block3)
         # Act
         block2 = TriblerChainBlock(block2.pack_db_insert())
-        block2.transaction["down"] += 10
+        block2.down += 10
         block2.sign(db.get(block2.public_key, block2.sequence_number).key)
         result = block2.validate(db)
         # Assert
@@ -93,7 +93,7 @@ class TestBlocks(TrustChainTestCase):
         db.add_block(block3)
         # Act
         block2 = TriblerChainBlock(block2.pack_db_insert())
-        block2.transaction["total_up"] += 10
+        block2.total_up += 10
         block2.sign(db.get(block2.public_key, block2.sequence_number).key)
         result = block2.validate(db)
         # Assert
@@ -109,7 +109,7 @@ class TestBlocks(TrustChainTestCase):
         db.add_block(block3)
         # Act
         block2 = TriblerChainBlock(block2.pack_db_insert())
-        block2.transaction["total_down"] += 10
+        block2.total_down += 10
         block2.sign(db.get(block2.public_key, block2.sequence_number).key)
         result = block2.validate(db)
         # Assert
@@ -121,8 +121,8 @@ class TestBlocks(TrustChainTestCase):
         db = MockDatabase()
         (block1, _, _, _) = TestBlocks.setup_validate()
         # Act
-        block1.transaction["up"] += 10
-        block1.transaction["down"] += 10
+        block1.up += 10
+        block1.down += 10
         block1.sign(block1.key)
         result = block1.validate(db)
         # Assert
@@ -137,7 +137,7 @@ class TestBlocks(TrustChainTestCase):
         db.add_block(block1)
         db.add_block(block3)
         # Act
-        block2.transaction["total_up"] += 10
+        block2.total_up += 10
         block2.sign(block2.key)
         block3.previous_hash = block2.hash
         result = block2.validate(db)
@@ -152,7 +152,7 @@ class TestBlocks(TrustChainTestCase):
         db.add_block(block1)
         db.add_block(block3)
         # Act
-        block2.transaction["total_down"] += 10
+        block2.total_down += 10
         block2.sign(block2.key)
         block3.previous_hash = block2.hash
         result = block2.validate(db)
@@ -166,7 +166,7 @@ class TestBlocks(TrustChainTestCase):
         db.add_block(block2)
         # Act
         db.add_block(TriblerChainBlock.create(block1.transaction, db, block1.link_public_key, block1))
-        block1.transaction["up"] += 5
+        block1.up += 5
         result = block1.validate(db)
         self.assertEqual(result[0], ValidationResult.invalid)
         self.assertIn("Up/down mismatch on linked block", result[1])
@@ -177,7 +177,7 @@ class TestBlocks(TrustChainTestCase):
         db.add_block(block2)
         # Act
         db.add_block(TriblerChainBlock.create(block1.transaction, db, block1.link_public_key, block1))
-        block1.transaction["down"] -= 5
+        block1.down -= 5
         result = block1.validate(db)
         self.assertEqual(result[0], ValidationResult.invalid)
         self.assertIn("Down/up mismatch on linked block", result[1])
@@ -186,7 +186,7 @@ class TestBlocks(TrustChainTestCase):
         db = MockDatabase()
         block1 = TriblerChainBlock()
         # Act
-        block1.transaction = {'up': -10, 'down': -10, 'total_up': -20, 'total_down': -10}
+        block1.transaction = [-10, -10, -10, -10]
         result = block1.validate(db)
         self.assertEqual(result[0], ValidationResult.invalid)
         self.assertIn("Up field is negative", result[1])
@@ -198,7 +198,7 @@ class TestBlocks(TrustChainTestCase):
         db = MockDatabase()
         block1 = TriblerChainBlock()
         # Act
-        block1.transaction = {'up': 0, 'down': 0, 'total_up': 30, 'total_down': 40}
+        block1.transaction = [0, 0, 0, 0]
         result = block1.validate(db)
         self.assertEqual(result[0], ValidationResult.invalid)
         self.assertIn("Up and down are zero", result[1])

--- a/Tribler/Test/Community/Triblerchain/test_community.py
+++ b/Tribler/Test/Community/Triblerchain/test_community.py
@@ -148,14 +148,14 @@ class TestTriblerChainCommunity(BaseTestTrustChainCommunity):
         node, other = self.create_nodes(2)
         target_other = self._create_target(node, other)
         TestTriblerChainCommunity.set_expectation(other, node, 10, 5)
-        transaction = {"up": 10, "down": 5}
+        transaction = [10, 5]
         node.call(node.community.sign_block, target_other, other.my_member.public_key, transaction)
         _, block_req = other.receive_message(names=[HALF_BLOCK]).next()
         # Act
         # construct faked block
         block = block_req.payload.block
-        block.transaction["up"] += 10
-        block.transaction["total_up"] = block.transaction["up"]
+        block.up += 10
+        block.total_up = block.up
         block_req = node.community.get_meta_message(HALF_BLOCK).impl(
             authentication=tuple(),
             distribution=(node.community.claim_global_time(),),
@@ -178,7 +178,7 @@ class TestTriblerChainCommunity(BaseTestTrustChainCommunity):
         # Arrange
         node, other = self.create_nodes(2)
         target_other = self._create_target(node, other)
-        transaction = {"up": 10, "down": 5}
+        transaction = [10, 5]
         TestTriblerChainCommunity.set_expectation(node, other, 50, 50)
         TestTriblerChainCommunity.set_expectation(other, node, 50, 50)
         TestTriblerChainCommunity.create_block(node, other, target_other, transaction)
@@ -208,7 +208,7 @@ class TestTriblerChainCommunity(BaseTestTrustChainCommunity):
         node, other = self.create_nodes(2)
         target_other = self._create_target(node, other)
         TestTriblerChainCommunity.set_expectation(other, node, 3, 3)
-        transaction = {"up": 10, "down": 5}
+        transaction = [10, 5]
         node.call(node.community.sign_block, target_other, other.my_member.public_key, transaction)
         # Act
         other.give_message(other.receive_message(names=[HALF_BLOCK]).next()[1], node)
@@ -228,7 +228,7 @@ class TestTriblerChainCommunity(BaseTestTrustChainCommunity):
         # Arrange
         node, other = self.create_nodes(2)
         target_other = self._create_target(node, other)
-        transaction = {"up": 10, "down": 5}
+        transaction = [10, 5]
         node.call(node.community.sign_block, target_other, other.my_member.public_key, transaction)
         # Act
         other.give_message(other.receive_message(names=[HALF_BLOCK]).next()[1], node)
@@ -250,7 +250,7 @@ class TestTriblerChainCommunity(BaseTestTrustChainCommunity):
         node, other = self.create_nodes(2)
         TestTriblerChainCommunity.set_expectation(node, other, 50, 50)
         TestTriblerChainCommunity.set_expectation(other, node, 50, 50)
-        transaction = {"up": 10, "down": 5}
+        transaction = [10, 5]
 
         # Act
         TestTriblerChainCommunity.create_block(node, other, self._create_target(node, other), transaction)
@@ -258,12 +258,12 @@ class TestTriblerChainCommunity(BaseTestTrustChainCommunity):
         # Assert
         block = node.call(TriblerChainBlock.create, transaction, node.community.persistence,
                           node.community.my_member.public_key)
-        self.assertEqual(20, block.transaction["total_up"])
-        self.assertEqual(10, block.transaction["total_down"])
+        self.assertEqual(20, block.total_up)
+        self.assertEqual(10, block.total_down)
         block = other.call(TriblerChainBlock.create, transaction, other.community.persistence,
                            other.community.my_member.public_key)
-        self.assertEqual(15, block.transaction["total_up"])
-        self.assertEqual(15, block.transaction["total_down"])
+        self.assertEqual(15, block.total_up)
+        self.assertEqual(15, block.total_down)
 
     def test_block_values_after_request(self):
         """
@@ -271,14 +271,14 @@ class TestTriblerChainCommunity(BaseTestTrustChainCommunity):
         """
         # Arrange
         node, other = self.create_nodes(2)
-        transaction = {"up": 10, "down": 5}
+        transaction = [10, 5]
         node.call(node.community.sign_block, self._create_target(node, other), other.my_member.public_key, transaction)
 
         # Assert
         block = node.call(TriblerChainBlock.create, transaction, node.community.persistence,
                           node.community.my_member.public_key)
-        self.assertEqual(20, block.transaction["total_up"])
-        self.assertEqual(10, block.transaction["total_down"])
+        self.assertEqual(20, block.total_up)
+        self.assertEqual(10, block.total_down)
 
     def test_crawler_on_introduction_received(self):
         """
@@ -336,7 +336,7 @@ class TestTriblerChainCommunity(BaseTestTrustChainCommunity):
         """
         # Arrange
         node, other = self.create_nodes(2)
-        transaction = {"up": 10, "down": 5}
+        transaction = [10, 5]
         TestTriblerChainCommunity.create_block(node, other, self._create_target(node, other), transaction)
 
         # Get statistics
@@ -350,7 +350,7 @@ class TestTriblerChainCommunity(BaseTestTrustChainCommunity):
         """
         # Arrange
         node, other = self.create_nodes(2)
-        transaction = {"up": 10, "down": 5}
+        transaction = [10, 5]
         TestTriblerChainCommunity.create_block(node, other, self._create_target(node, other), transaction)
 
         # Get statistics
@@ -364,7 +364,7 @@ class TestTriblerChainCommunity(BaseTestTrustChainCommunity):
         """
         # Arrange
         node, other = self.create_nodes(2)
-        transaction = {'up': 10, 'down': 5, 'total_up': 10, 'total_down': 5}
+        transaction = [10, 5]
         TestTriblerChainCommunity.create_block(node, other, self._create_target(node, other), transaction)
         TestTriblerChainCommunity.create_block(other, node, self._create_target(other, node), transaction)
 

--- a/Tribler/Test/Community/Triblerchain/test_database.py
+++ b/Tribler/Test/Community/Triblerchain/test_database.py
@@ -2,7 +2,8 @@ import os
 
 from twisted.internet.defer import inlineCallbacks
 
-from Tribler.Test.Community.Trustchain.test_trustchain_utilities import TrustChainTestCase, TestBlock
+from Tribler.Test.Community.Triblerchain.test_triblerchain_utilities import TriblerTestBlock
+from Tribler.Test.Community.Trustchain.test_trustchain_utilities import TrustChainTestCase
 from Tribler.community.triblerchain.database import TriblerChainDB
 from Tribler.community.trustchain.database import DATABASE_DIRECTORY
 from Tribler.dispersy.util import blocking_call_on_reactor_thread
@@ -21,15 +22,15 @@ class TestDatabase(TrustChainTestCase):
         if not os.path.exists(path):
             os.makedirs(path)
         self.db = TriblerChainDB(self.getStateDir(), u'triblerchain')
-        self.block1 = TestBlock(transaction={'up': 42, 'down': 42})
-        self.block2 = TestBlock(transaction={'up': 42, 'down': 42})
+        self.block1 = TriblerTestBlock()
+        self.block2 = TriblerTestBlock()
 
     @blocking_call_on_reactor_thread
     def test_get_num_interactors(self):
         """
         Test whether the right number of interactors is returned
         """
-        self.block2 = TestBlock(previous=self.block1, transaction={'up': 42, 'down': 42})
+        self.block2 = TriblerTestBlock(previous=self.block1)
         self.db.add_block(self.block1)
         self.db.add_block(self.block2)
         self.assertEqual((2, 2), self.db.get_num_unique_interactors(self.block1.public_key))

--- a/Tribler/Test/Community/Triblerchain/test_triblerchain_utilities.py
+++ b/Tribler/Test/Community/Triblerchain/test_triblerchain_utilities.py
@@ -2,7 +2,6 @@ import random
 
 from hashlib import sha256
 
-from Tribler.Core.Utilities.encoding import encode
 from Tribler.community.triblerchain.block import TriblerChainBlock
 from Tribler.dispersy.crypto import ECCrypto
 
@@ -14,23 +13,22 @@ class TriblerTestBlock(TriblerChainBlock):
     """
 
     def __init__(self, previous=None):
-        super(TriblerTestBlock, self).__init__()
+
         crypto = ECCrypto()
         other = crypto.generate_key(u"curve25519").pub().key_to_bin()
 
-        transaction = {'up': random.randint(201, 220), 'down': random.randint(221, 240), 'total_up': 0, 'total_down': 0}
+        self.transaction = [random.randint(201, 220), random.randint(221, 240), 0, 0]
 
         if previous:
+            self.total_up = previous.total_up + self.up
+            self.total_down = previous.total_down + self.down
             self.key = previous.key
-            transaction['total_up'] = previous.transaction['total_up'] + transaction['up']
-            transaction['total_down'] = previous.transaction['total_down'] + transaction['down']
-            TriblerChainBlock.__init__(self, (encode(transaction), previous.public_key, previous.sequence_number + 1,
-                                              other, 0, previous.hash, 0, 0))
+            super(TriblerTestBlock, self).__init__(data=(previous.public_key, previous.sequence_number + 1,
+                                                         other, 0, previous.hash, 0, 0))
         else:
-            transaction['total_up'] = random.randint(241, 260)
-            transaction['total_down'] = random.randint(261, 280)
+            self.total_up = random.randint(241, 260)
+            self.total_down = random.randint(261, 280)
             self.key = crypto.generate_key(u"curve25519")
-            TriblerChainBlock.__init__(self, (
-                encode(transaction), self.key.pub().key_to_bin(), random.randint(50, 100), other, 0,
-                sha256(str(random.randint(0, 100000))).digest(), 0, 0))
+            super(TriblerTestBlock, self).__init__(data=(self.key.pub().key_to_bin(), random.randint(50, 100), other, 0,
+                                                         sha256(str(random.randint(0, 100000))).digest(), 0, 0))
         self.sign(self.key)

--- a/Tribler/Test/Community/Trustchain/test_block.py
+++ b/Tribler/Test/Community/Trustchain/test_block.py
@@ -59,8 +59,7 @@ class TestBlocks(TrustChainTestCase):
 
     def test_hash(self):
         block = TrustChainBlock()
-        self.assertEqual(block.hash, '\x1f\x1bp\x90\xe3>\x83\xf6\xcd\xafd\xd9\xee\xfb"&|<ZLsyB:Z\r'
-                                     '<\xc5\xb0\x97\xa3\xaf')
+        self.assertEqual(block.hash, 'f\xfb\xd2ZQQ]:<5\xaf\xf0_\xcb<\x14\x80S\x8e\x9b\x93h\xb1\x0c!(2\xe8FJ\x98z')
 
     def test_sign(self):
         crypto = ECCrypto()
@@ -70,7 +69,7 @@ class TestBlocks(TrustChainTestCase):
     def test_create_genesis(self):
         key = ECCrypto().generate_key(u"curve25519")
         db = MockDatabase()
-        block = TrustChainBlock.create({'id': 42}, db, key.pub().key_to_bin(), link=None)
+        block = TrustChainBlock.create([42], db, key.pub().key_to_bin(), link=None)
         self.assertEqual(block.previous_hash, GENESIS_HASH)
         self.assertEqual(block.sequence_number, GENESIS_SEQ)
         self.assertEqual(block.public_key, key.pub().key_to_bin())
@@ -81,7 +80,7 @@ class TestBlocks(TrustChainTestCase):
         prev = TestBlock()
         prev.sequence_number = GENESIS_SEQ
         db.add_block(prev)
-        block = TrustChainBlock.create({'id': 42}, db, prev.public_key, link=None)
+        block = TrustChainBlock.create([42], db, prev.public_key, link=None)
         self.assertEqual(block.previous_hash, prev.hash)
         self.assertEqual(block.sequence_number, 2)
         self.assertEqual(block.public_key, prev.public_key)
@@ -91,7 +90,7 @@ class TestBlocks(TrustChainTestCase):
         db = MockDatabase()
         link = TestBlock()
         db.add_block(link)
-        block = TrustChainBlock.create({'id': 42}, db, key.pub().key_to_bin(), link=link)
+        block = TrustChainBlock.create([42], db, key.pub().key_to_bin(), link=link)
         self.assertEqual(block.previous_hash, GENESIS_HASH)
         self.assertEqual(block.sequence_number, GENESIS_SEQ)
         self.assertEqual(block.public_key, key.pub().key_to_bin())
@@ -105,7 +104,7 @@ class TestBlocks(TrustChainTestCase):
         db.add_block(prev)
         link = TestBlock()
         db.add_block(link)
-        block = TrustChainBlock.create({'id': 42}, db, prev.public_key, link=link)
+        block = TrustChainBlock.create([42], db, prev.public_key, link=link)
         self.assertEqual(block.previous_hash, prev.hash)
         self.assertEqual(block.sequence_number, 2)
         self.assertEqual(block.public_key, prev.public_key)

--- a/Tribler/Test/Community/Trustchain/test_conversion.py
+++ b/Tribler/Test/Community/Trustchain/test_conversion.py
@@ -149,6 +149,8 @@ class TestPlaceholder:
 class TestCommunity(Community):
     crypto = ECCrypto()
 
+    BLOCK_CLASS = TestBlock
+
     def __init__(self):
         self.key = self.crypto.generate_key(u"medium")
         self.pk = self.crypto.key_to_bin(self.key.pub())

--- a/Tribler/Test/Community/Trustchain/test_database.py
+++ b/Tribler/Test/Community/Trustchain/test_database.py
@@ -32,8 +32,12 @@ class TestDatabase(TrustChainTestCase):
         self.assertEqual_block(self.block1, result)
 
     @blocking_call_on_reactor_thread
-    def test_get_upgrade_script(self):
-        self.assertIsNone(self.db.get_upgrade_script(42))
+    def test_get_upgrade_script_future(self):
+        self.assertIsNone(self.db.get_upgrade_script(0, 42))
+
+    @blocking_call_on_reactor_thread
+    def test_get_upgrade_script_past(self):
+        self.assertIsNotNone(self.db.get_upgrade_script(0, 0))
 
     @blocking_call_on_reactor_thread
     def test_add_two_blocks(self):
@@ -176,5 +180,5 @@ class TestDatabase(TrustChainTestCase):
         Test whether a block is correctly represented when converted to a dictionary
         """
         block_dict = dict(self.block1)
-        self.assertDictEqual(block_dict["transaction"], {"id": 42})
+        self.assertListEqual(block_dict["transaction"], ['42'])
         self.assertEqual(block_dict["insert_time"], self.block1.insert_time)

--- a/Tribler/Test/Community/Trustchain/test_trustchain_utilities.py
+++ b/Tribler/Test/Community/Trustchain/test_trustchain_utilities.py
@@ -20,21 +20,20 @@ class TestBlock(TrustChainBlock):
         crypto = ECCrypto()
         other = crypto.generate_key(u"curve25519").pub().key_to_bin()
 
-        transaction = transaction or {'id': 42}
+        transaction = transaction or ['42']
 
         if previous:
             self.key = previous.key
-            TrustChainBlock.__init__(self, (encode(transaction), previous.public_key, previous.sequence_number + 1,
-                                            other, 0, previous.hash, 0, 0))
+            TrustChainBlock.__init__(self, tuple([previous.public_key, previous.sequence_number + 1,
+                                                  other, 0, previous.hash, 0, 0] + transaction))
         else:
             if key:
                 self.key = key
             else:
                 self.key = crypto.generate_key(u"curve25519")
 
-            TrustChainBlock.__init__(self, (
-                encode(transaction), self.key.pub().key_to_bin(), random.randint(50, 100), other, 0,
-                sha256(str(random.randint(0, 100000))).digest(), 0, 0))
+            TrustChainBlock.__init__(self, tuple([self.key.pub().key_to_bin(), random.randint(50, 100), other, 0,
+                                                  sha256(str(random.randint(0, 100000))).digest(), 0, 0] + transaction))
         self.sign(self.key)
 
 
@@ -48,7 +47,7 @@ class TrustChainTestCase(AbstractServer):
         self.assertTrue(actual_block is not None)
         self.assertTrue(crypto.is_valid_public_bin(expected_block.public_key))
         self.assertTrue(crypto.is_valid_public_bin(actual_block.public_key))
-        self.assertDictEqual(expected_block.transaction, actual_block.transaction)
+        self.assertListEqual(expected_block.transaction, actual_block.transaction)
         self.assertEqual(expected_block.public_key, actual_block.public_key)
         self.assertEqual(expected_block.sequence_number, actual_block.sequence_number)
         self.assertEqual(expected_block.link_public_key, actual_block.link_public_key)

--- a/Tribler/Test/Core/Modules/RestApi/test_trustchain_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_trustchain_endpoint.py
@@ -9,7 +9,7 @@ from Tribler.dispersy.dispersy import Dispersy
 from Tribler.dispersy.endpoint import ManualEnpoint
 from Tribler.dispersy.member import DummyMember
 from Tribler.dispersy.util import blocking_call_on_reactor_thread
-from Tribler.Test.Community.Trustchain.test_trustchain_utilities import TestBlock
+from Tribler.Test.Community.Triblerchain.test_triblerchain_utilities import TriblerTestBlock
 from Tribler.Test.Core.Modules.RestApi.base_api_test import AbstractApiTest
 from Tribler.Test.twisted_thread import deferred
 
@@ -50,7 +50,7 @@ class TestTrustchainStatsEndpoint(AbstractApiTest):
         block.public_key = self.member.public_key
         block.link_public_key = "deadbeef".decode("HEX")
         block.link_sequence_number = 21
-        block.transaction = {"up": 42, "down": 8, "total_up": 1024, "total_down": 2048}
+        block.transaction = [42L, 8L, 1024L, 2048L]
         block.sequence_number = 3
         block.previous_hash = "babecafe".decode("HEX")
         block.signature = "babebeef".decode("HEX")
@@ -115,7 +115,7 @@ class TestTrustchainStatsEndpoint(AbstractApiTest):
             response_json = json.loads(response)
             self.assertEqual(len(response_json["blocks"]), 1)
 
-        test_block = TestBlock()
+        test_block = TriblerTestBlock()
         self.tc_community.persistence.add_block(test_block)
         self.should_check_equality = False
         return self.do_request('trustchain/blocks/%s?limit=10' % test_block.public_key.encode("HEX"),
@@ -127,9 +127,8 @@ class TestTrustchainStatsEndpoint(AbstractApiTest):
         Testing whether the API takes large values for the limit
         """
         self.should_check_equality = False
-        return self.do_request('trustchain/blocks/%s?limit=10000000' % TestBlock().public_key.encode("HEX"),
+        return self.do_request('trustchain/blocks/%s?limit=10000000' % TriblerTestBlock().public_key.encode("HEX"),
                                expected_code=400)
-
 
     @deferred(timeout=10)
     def test_get_blocks_bad_limit_negative(self):
@@ -137,7 +136,7 @@ class TestTrustchainStatsEndpoint(AbstractApiTest):
         Testing whether the API takes negative values for the limit
         """
         self.should_check_equality = False
-        return self.do_request('trustchain/blocks/%s?limit=-10000000' % TestBlock().public_key.encode("HEX"),
+        return self.do_request('trustchain/blocks/%s?limit=-10000000' % TriblerTestBlock().public_key.encode("HEX"),
                                expected_code=400)
 
     @deferred(timeout=10)
@@ -146,7 +145,7 @@ class TestTrustchainStatsEndpoint(AbstractApiTest):
         Testing whether the API takes odd values for the limit
         """
         self.should_check_equality = False
-        return self.do_request('trustchain/blocks/%s?limit=bla' % TestBlock().public_key.encode("HEX"),
+        return self.do_request('trustchain/blocks/%s?limit=bla' % TriblerTestBlock().public_key.encode("HEX"),
                                expected_code=400)
 
     @deferred(timeout=10)
@@ -155,7 +154,7 @@ class TestTrustchainStatsEndpoint(AbstractApiTest):
         Testing whether the API takes no values for the limit
         """
         self.should_check_equality = False
-        return self.do_request('trustchain/blocks/%s?limit=' % TestBlock().public_key.encode("HEX"),
+        return self.do_request('trustchain/blocks/%s?limit=' % TriblerTestBlock().public_key.encode("HEX"),
                                expected_code=400)
 
     @deferred(timeout=10)
@@ -164,7 +163,7 @@ class TestTrustchainStatsEndpoint(AbstractApiTest):
         Testing whether the API takes no limit argument
         """
         self.should_check_equality = False
-        return self.do_request('trustchain/blocks/%s' % TestBlock().public_key.encode("HEX"),
+        return self.do_request('trustchain/blocks/%s' % TriblerTestBlock().public_key.encode("HEX"),
                                expected_code=200)
 
     @deferred(timeout=10)

--- a/Tribler/community/market/block.py
+++ b/Tribler/community/market/block.py
@@ -1,0 +1,25 @@
+from Tribler.community.trustchain.block import TrustChainBlock, ValidationResult, GENESIS_SEQ, GENESIS_HASH, EMPTY_SIG
+
+
+class MarketBlock(TrustChainBlock):
+    """
+    Container for TriblerChain block information
+    """
+
+    def __init__(self, data=None):
+        super(MarketBlock, self).__init__(data)
+        if len(self.transaction) != 1:
+            self.transaction = [dict()]
+
+    @property
+    def transaction_dict(self):
+        return self.transaction[0]
+
+    @transaction_dict.setter
+    def transaction_dict(self, value):
+        assert isinstance(value, dict), "Must assign dictionary!"
+        self.transaction[0] = value
+
+    @classmethod
+    def create(cls, transaction, database, public_key, link=None, link_pk=None):
+        return super(MarketBlock, cls).create([transaction], database, public_key, link, link_pk)

--- a/Tribler/community/market/core/tick.py
+++ b/Tribler/community/market/core/tick.py
@@ -212,7 +212,7 @@ class Ask(Tick):
         :return: Restored ask
         :rtype: Ask
         """
-        tx_dict = block.transaction["tick"]
+        tx_dict = block.transaction_dict["tick"]
         return cls(
             OrderId(TraderId(tx_dict["trader_id"]), OrderNumber(tx_dict["order_number"])),
             Price(tx_dict["price"], tx_dict["price_type"]),
@@ -249,7 +249,7 @@ class Bid(Tick):
         :return: Restored bid
         :rtype: Bid
         """
-        tx_dict = block.transaction["tick"]
+        tx_dict = block.transaction_dict["tick"]
         return cls(
             OrderId(TraderId(tx_dict["trader_id"]), OrderNumber(tx_dict["order_number"])),
             Price(tx_dict["price"], tx_dict["price_type"]),

--- a/Tribler/community/market/wallet/tc_wallet.py
+++ b/Tribler/community/market/wallet/tc_wallet.py
@@ -33,8 +33,8 @@ class TrustchainWallet(Wallet):
 
     def get_balance(self):
         latest_block = self.tc_community.persistence.get_latest(self.tc_community.my_member.public_key)
-        total_up = latest_block.transaction["total_up"] / MEGA_DIV if latest_block else 0
-        total_down = latest_block.transaction["total_down"] / MEGA_DIV if latest_block else 0
+        total_up = latest_block.total_up / MEGA_DIV if latest_block else 0
+        total_down = latest_block.total_down / MEGA_DIV if latest_block else 0
         return succeed({'available': total_up - total_down, 'pending': 0, 'currency': self.get_identifier()})
 
     def transfer(self, quantity, candidate):
@@ -56,11 +56,10 @@ class TrustchainWallet(Wallet):
         return self.get_balance().addCallback(on_balance)
 
     def send_signature(self, candidate, quantity):
-        transaction = {"up": 0, "down": int(quantity * MEGA_DIV)}
-        self.tc_community.sign_block(candidate, candidate.get_member().public_key, transaction)
-        latest_block = self.tc_community.persistence.get_latest(self.tc_community.my_member.public_key)
+        transaction = [0, int(quantity * MEGA_DIV)]
+        latest_block = self.tc_community.sign_block(candidate, candidate.get_member().public_key, transaction)
         txid = "%s.%s.%d.%d" % (latest_block.public_key.encode('hex'),
-                                latest_block.sequence_number, 0, int(quantity * MEGA_DIV))
+                                latest_block.sequence_number, latest_block.up, latest_block.down)
 
         self.transaction_history.append({
             'id': txid,

--- a/Tribler/community/triblerchain/block.py
+++ b/Tribler/community/triblerchain/block.py
@@ -11,8 +11,8 @@ class TriblerChainBlock(TrustChainBlock):
         if len(self.transaction) != 4:
             self.transaction = [0, 0, 0, 0]
         for i in range(0, 4):
-            if not isinstance(self.transaction[i], int):
-                self.transaction[i] = int(self.transaction[i])
+            if not isinstance(self.transaction[i], long):
+                self.transaction[i] = long(self.transaction[i])
 
     @classmethod
     def create(cls, transaction, database, public_key, link=None, link_pk=None):
@@ -57,7 +57,7 @@ class TriblerChainBlock(TrustChainBlock):
 
     @up.setter
     def up(self, value):
-        assert isinstance(value, int), "Must assign int!"
+        assert isinstance(value, (long, int)), "Must assign int!"
         self.transaction[0] = value
 
     @property
@@ -66,7 +66,7 @@ class TriblerChainBlock(TrustChainBlock):
 
     @down.setter
     def down(self, value):
-        assert isinstance(value, int), "Must assign int!"
+        assert isinstance(value, (long, int)), "Must assign int!"
         self.transaction[1] = value
 
     @property
@@ -75,7 +75,7 @@ class TriblerChainBlock(TrustChainBlock):
 
     @total_up.setter
     def total_up(self, value):
-        assert isinstance(value, int), "Must assign int!"
+        assert isinstance(value, (long, int)), "Must assign int!"
         self.transaction[2] = value
 
     @property
@@ -84,7 +84,7 @@ class TriblerChainBlock(TrustChainBlock):
 
     @total_down.setter
     def total_down(self, value):
-        assert isinstance(value, int), "Must assign int!"
+        assert isinstance(value, (long, int)), "Must assign int!"
         self.transaction[3] = value
 
     def validate_transaction(self, database):

--- a/Tribler/community/triblerchain/database.py
+++ b/Tribler/community/triblerchain/database.py
@@ -2,12 +2,13 @@ from Tribler.community.triblerchain.block import TriblerChainBlock
 
 from Tribler.community.trustchain.database import TrustChainDB
 
+LATEST_DB_VERSION = "4"
+
 
 class TriblerChainDB(TrustChainDB):
     """
     Persistence layer for the TriblerChain Community.
     """
-    LATEST_DB_VERSION = 4
     BLOCK_CLASS = TriblerChainBlock
 
     def __init__(self, working_directory, db_name):
@@ -35,8 +36,8 @@ class TriblerChainDB(TrustChainDB):
 
     def get_subjective_work_graph(self):
         graph = {}
-        db_result = self.execute(u"SELECT public_key, link_public_key, SUM(tx_up), SUM(tx_down) FROM trustchain "
-                                 u"GROUP BY public_key, link_public_key").fetchall()
+        db_result = self.execute(u"SELECT public_key, link_public_key, SUM(tx_up), SUM(tx_down) FROM %s_blocks "
+                                 u"GROUP BY public_key, link_public_key" % self.db_name).fetchall()
         if db_result:
             for row in db_result:
                 index = (str(row[0]), str(row[1]))
@@ -51,13 +52,23 @@ class TriblerChainDB(TrustChainDB):
                     graph[index] = (int(row[3]), int(row[2]))
         return graph
 
-    def get_upgrade_script(self, current_version):
+    def get_upgrade_script(self, level, to_version):
         """
         Return the upgrade script for a specific version.
         :param current_version: the version of the script to return.
         """
-        if current_version == 2 or current_version == 3:
-            return u"""
-            DROP TABLE IF EXISTS blocks;
-            DROP TABLE IF EXISTS option;
+        script = super(TriblerChainDB, self).get_upgrade_script(level, to_version)
+        if level == 0:
+            script += u"""
+            DROP TABLE IF EXISTS multi_chain;
             """
+        return script
+
+    def get_db_version(self, level=None):
+        """
+        Returns the current database version for a specific inheritance level. TrustChain = 0
+        :param level: the inheritance level who's db version to get, or Null (default) to pass the entire version string
+        :return: the current highest version of the database layout
+        """
+        # we can get away with this since the triblerchain does not have additional levels of sql schemas
+        return LATEST_DB_VERSION

--- a/Tribler/community/triblerchain/database.py
+++ b/Tribler/community/triblerchain/database.py
@@ -1,3 +1,5 @@
+from Tribler.community.triblerchain.block import TriblerChainBlock
+
 from Tribler.community.trustchain.database import TrustChainDB
 
 
@@ -6,6 +8,15 @@ class TriblerChainDB(TrustChainDB):
     Persistence layer for the TriblerChain Community.
     """
     LATEST_DB_VERSION = 4
+    BLOCK_CLASS = TriblerChainBlock
+
+    def __init__(self, working_directory, db_name):
+        super(TriblerChainDB, self).__init__(working_directory, db_name, transaction_fields=[
+            ("up", "INTEGER"),
+            ("down", "INTEGER"),
+            ("total_up", "INTEGER"),
+            ("total_down", "INTEGER")
+        ])
 
     def get_num_unique_interactors(self, public_key):
         """
@@ -16,11 +27,29 @@ class TriblerChainDB(TrustChainDB):
         peers_you_helped = set()
         peers_helped_you = set()
         for block in self.get_latest_blocks(public_key, limit=-1):
-            if int(block.transaction["up"]) > 0:
+            if block.up > 0:
                 peers_you_helped.add(block.link_public_key)
-            if int(block.transaction["down"]) > 0:
+            if block.down > 0:
                 peers_helped_you.add(block.link_public_key)
         return len(peers_you_helped), len(peers_helped_you)
+
+    def get_subjective_work_graph(self):
+        graph = {}
+        db_result = self.execute(u"SELECT public_key, link_public_key, SUM(tx_up), SUM(tx_down) FROM trustchain "
+                                 u"GROUP BY public_key, link_public_key").fetchall()
+        if db_result:
+            for row in db_result:
+                index = (str(row[0]), str(row[1]))
+                if index in graph:
+                    graph[index] = (max(graph[index][0], int(row[2])), max(graph[index][1], int(row[3])))
+                else:
+                    graph[index] = (int(row[2]), int(row[3]))
+                index = (str(row[1]), str(row[0]))
+                if index in graph:
+                    graph[index] = (max(graph[index][0], int(row[3])), max(graph[index][1], int(row[2])))
+                else:
+                    graph[index] = (int(row[3]), int(row[2]))
+        return graph
 
     def get_upgrade_script(self, current_version):
         """

--- a/Tribler/community/trustchain/community.py
+++ b/Tribler/community/trustchain/community.py
@@ -236,7 +236,7 @@ class TrustChainCommunity(Community):
             "Cannot counter sign block not addressed to self"
         assert linked is None or linked.link_sequence_number == UNKNOWN_SEQ, \
             "Cannot counter sign block that is not a request"
-        assert transaction is None or isinstance(transaction, dict), "Transaction should be a dictionary"
+        assert transaction is None or isinstance(transaction, list), "Transaction should be a list not %r" % transaction
 
         block = self.BLOCK_CLASS.create(transaction, self.persistence, self.my_member.public_key,
                                         link=linked, link_pk=public_key)
@@ -246,11 +246,11 @@ class TrustChainCommunity(Community):
                          block.link_public_key.encode("hex")[-8:], block, validation)
         if validation[0] != ValidationResult.partial_next and validation[0] != ValidationResult.valid:
             self.logger.error("Signed block did not validate?! Result %s", repr(validation))
+            return None
         else:
             self.persistence.add_block(block)
             self.send_block(block, candidate)
-
-        return block
+            return block
 
     def validate_persist_block(self, block):
         """

--- a/Tribler/community/trustchain/database.py
+++ b/Tribler/community/trustchain/database.py
@@ -8,6 +8,7 @@ from Tribler.community.trustchain.block import TrustChainBlock
 
 
 DATABASE_DIRECTORY = os.path.join(u"sqlite")
+LATEST_DB_VERSION = "1"
 
 
 class TrustChainDB(Database):
@@ -16,10 +17,9 @@ class TrustChainDB(Database):
     Connection layer to SQLiteDB.
     Ensures a proper DB schema on startup.
     """
-    LATEST_DB_VERSION = 1
     BLOCK_CLASS = TrustChainBlock
 
-    def __init__(self, working_directory, db_name, transaction_fields=[("blob", "TEXT")]):
+    def __init__(self, working_directory, db_name, transaction_fields=[("tx", "TEXT")]):
         """
         Sets up the persistence layer ready for use.
         :param working_directory: Path to the working directory
@@ -41,9 +41,9 @@ class TrustChainDB(Database):
         :param block: The data that will be saved.
         """
         self.execute(
-            (u"INSERT INTO %s (public_key, sequence_number, link_public_key," +
+            (u"INSERT INTO %s_blocks (public_key, sequence_number, link_public_key," +
              u"link_sequence_number, previous_hash, signature, block_hash, tx_" +
-             u", tx_".join([tx[0] for tx in self.transaction_fields]) + u") VALUES(?,?,?,?,?,?,?,?," +
+             u", tx_".join([tx[0] for tx in self.transaction_fields]) + u") VALUES(?,?,?,?,?,?,?" +
              (u",?" * len(self.transaction_fields)) + u")")
             % self.db_name, block.pack_db_insert())
         self.commit()
@@ -79,8 +79,8 @@ class TrustChainDB(Database):
         :param public_key: The public_key for which the latest block has to be found.
         :return: the latest block or None if it is not known
         """
-        return self._get(u"WHERE public_key = ? AND sequence_number = (SELECT MAX(sequence_number) FROM blocks "
-                         u"WHERE public_key = ?)", (buffer(public_key), buffer(public_key)))
+        return self._get(u"WHERE public_key = ? AND sequence_number = (SELECT MAX(sequence_number) FROM %s_blocks "
+                         u"WHERE public_key = ?)" % self.db_name, (buffer(public_key), buffer(public_key)))
 
     def get_latest_blocks(self, public_key, limit=25):
         return self._getall(u"WHERE public_key = ? ORDER BY sequence_number DESC LIMIT ?", (buffer(public_key), limit))
@@ -115,9 +115,9 @@ class TrustChainDB(Database):
 
     def crawl(self, public_key, sequence_number, limit=100):
         assert limit <= 100, "Don't fetch too much"
-        return self._getall(u"WHERE insert_time >= (SELECT MAX(insert_time) FROM blocks WHERE public_key = ? AND "
+        return self._getall(u"WHERE insert_time >= (SELECT MAX(insert_time) FROM %s_blocks WHERE public_key = ? AND "
                             u"sequence_number <= ?) AND (public_key = ? OR link_public_key = ?) "
-                            u"ORDER BY insert_time ASC LIMIT ?",
+                            u"ORDER BY insert_time ASC LIMIT ?" % self.db_name,
                             (buffer(public_key), sequence_number, buffer(public_key), buffer(public_key), limit))
 
     def get_sql_header(self):
@@ -127,14 +127,14 @@ class TrustChainDB(Database):
         _columns = u"public_key, sequence_number, link_public_key, link_sequence_number, " \
                    u"previous_hash, signature, insert_time, tx_" + \
                    u", tx_".join([tx[0] for tx in self.transaction_fields])
-        return u"SELECT " + _columns + u" FROM %s " % self.db_name
+        return u"SELECT " + _columns + u" FROM %s_blocks " % self.db_name
 
-    def get_schema(self):
+    def get_schema(self, level = None):
         """
         Return the schema for the database.
         """
         return u"""
-        CREATE TABLE IF NOT EXISTS %s(
+        CREATE TABLE IF NOT EXISTS %s_blocks(
          public_key           TEXT NOT NULL,
          sequence_number      INTEGER NOT NULL,
          link_public_key      TEXT NOT NULL,
@@ -145,7 +145,7 @@ class TrustChainDB(Database):
          insert_time          TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
          block_hash	          TEXT NOT NULL,
 
-         %s
+         %s,
 
          PRIMARY KEY (public_key, sequence_number)
          );
@@ -153,14 +153,20 @@ class TrustChainDB(Database):
         CREATE TABLE option(key TEXT PRIMARY KEY, value BLOB);
         INSERT INTO option(key, value) VALUES('database_version', '%s');
         """ % (self.db_name,
-               u",\n".join([tx[0] + u" " + tx[1] + u" NOT NULL" for tx in self.transaction_fields]),
-               str(self.LATEST_DB_VERSION))
+               u",\n".join(["tx_" + tx[0] + u" " + tx[1] + u" NOT NULL" for tx in self.transaction_fields]),
+               self.get_db_version())
 
-    def get_upgrade_script(self, current_version):
+    def get_upgrade_script(self, level, to_version):
         """
         Return the upgrade script for a specific version.
-        :param current_version: the version of the script to return.
+        :param to_version: the version of the script to return.
         """
+        if level == 0 and to_version <= int(LATEST_DB_VERSION):
+            return u"""
+            DROP TABLE IF EXISTS blocks;
+            DROP TABLE IF EXISTS %s_blocks;
+            """ % self.db_name
+
         return None
 
     def open(self, initial_statements=True, prepare_visioning=True):
@@ -169,24 +175,43 @@ class TrustChainDB(Database):
     def close(self, commit=True):
         return super(TrustChainDB, self).close(commit)
 
-    def check_database(self, database_version):
+    def get_db_version(self, level=None):
+        """
+        Returns the current database version for a specific inheritance level. TrustChain = 0
+        :param level: the inheritance level who's db version to get, or Null (default) to pass the entire version string
+        :return: the current highest version of the database layout
+        """
+        return LATEST_DB_VERSION
+
+    def check_database(self, database_version, levels = 1):
         """
         Ensure the proper schema is used by the database.
         :param database_version: Current version of the database.
         :return:
         """
         assert isinstance(database_version, unicode)
-        assert database_version.isdigit()
-        assert int(database_version) >= 0
-        database_version = int(database_version)
+        version_parts = database_version.split(u'.')
+        if database_version == u"0":
+            version_parts = [u"0"] * levels
+        assert len(version_parts) == levels, "invalid number of levels/versions"
+        assert len([part for part in version_parts if not part.isdigit()]) == 0, \
+            "non digit version part %s" % repr(database_version)
+        assert len([part for part in version_parts if not int(part) >= 0]) == 0, \
+            "negative version part %s" % repr(database_version)
 
-        if database_version < self.LATEST_DB_VERSION:
-            while database_version < self.LATEST_DB_VERSION:
-                upgrade_script = self.get_upgrade_script(current_version=database_version)
-                if upgrade_script:
-                    self.executescript(upgrade_script)
-                database_version += 1
-            self.executescript(self.get_schema())
-            self.commit()
+        for level in range(0, levels):
+            version = version_parts[level]
 
-        return self.LATEST_DB_VERSION
+            if version < self.get_db_version(level):
+                while version < LATEST_DB_VERSION:
+                    version = str(int(version) + 1)
+                    upgrade_script = self.get_upgrade_script(0, int(version))
+                    if upgrade_script:
+                        self.executescript(upgrade_script)
+                self.executescript(self.get_schema(level))
+                self.executescript(u"""
+                    UPDATE option SET value = '%s' WHERE key = 'database_version';                
+                """ % self.get_db_version())
+                self.commit()
+
+        return sum([int(part) for part in version_parts])


### PR DESCRIPTION
The current implementation of trust chain packs the transaction details in a blob in the sql database. For triblerchain this is a problem when constructing the subjective work graph (or asking anything aggregating over many transactions really). It is much more efficient to be able to do this in SQL. So this PR changes the way trust chain handles the transaction fields such that they can be used in SQL.