### PR TITLE
Various memory fixes

### DIFF
--- a/Tribler/Core/APIImplementation/LaunchManyCore.py
+++ b/Tribler/Core/APIImplementation/LaunchManyCore.py
@@ -150,7 +150,6 @@ class TriblerLaunchMany(TaskManager):
 
                 from Tribler.Core.Modules.tracker_manager import TrackerManager
                 self.tracker_manager = TrackerManager(self.session)
-                self.tracker_manager.initialize()
 
             if self.session.get_videoserver_enabled():
                 self.video_server = VideoServer(self.session.get_videoserver_port(), self.session)
@@ -766,8 +765,6 @@ class TriblerLaunchMany(TaskManager):
             self.resource_monitor.stop()
         self.resource_monitor = None
 
-        if self.tracker_manager:
-            yield self.tracker_manager.shutdown()
         self.tracker_manager = None
 
         if self.dispersy:

--- a/Tribler/Core/Modules/tracker_manager.py
+++ b/Tribler/Core/Modules/tracker_manager.py
@@ -1,11 +1,11 @@
 import logging
 import time
 
-from Tribler.dispersy.util import blocking_call_on_reactor_thread, call_on_reactor_thread
+from Tribler.dispersy.util import blocking_call_on_reactor_thread
 from Tribler.Core.Utilities.tracker_utils import get_uniformed_tracker_url
 
 
-MAX_TRACKER_FAILURES = 5
+MAX_TRACKER_FAILURES = 5  # if a tracker fails this amount of times in a row, its 'is_alive' will be marked as 0 (dead).
 TRACKER_RETRY_INTERVAL = 60    # A "dead" tracker will be retired every 60 seconds
 
 
@@ -15,33 +15,23 @@ class TrackerManager(object):
         self._logger = logging.getLogger(self.__class__.__name__)
         self._session = session
 
-        self._tracker_id_to_url_dict = {}
-        self._tracker_dict = {}
+    @blocking_call_on_reactor_thread
+    def get_tracker_info(self, tracker_url):
+        """
+        Gets the tracker information with the given tracker URL.
+        :param tracker_url: The given tracker URL.
+        :return: The tracker info dict if exists, None otherwise.
+        """
+        sanitized_tracker_url = get_uniformed_tracker_url(tracker_url) if tracker_url != u"DHT" else tracker_url
+        try:
+            sql_stmt = u"SELECT tracker_id, tracker, last_check, failures, is_alive FROM TrackerInfo WHERE tracker = ?"
+            result = self._session.sqlite_db.execute(sql_stmt, (sanitized_tracker_url,)).next()
+        except StopIteration:
+            return None
 
-        # if a tracker fails this amount of times in a roll, its 'is_alive' will be marked as 0 (dead).
-        self._max_tracker_failures = MAX_TRACKER_FAILURES
-
-        # A "dead" tracker will be retired every this amount of time (in seconds)
-        self._tracker_retry_interval = TRACKER_RETRY_INTERVAL
+        return {u'id': result[0], u'last_check': result[2], u'failures': result[3], u'is_alive': bool(result[4])}
 
     @blocking_call_on_reactor_thread
-    def initialize(self):
-        # load all tracker information into the memory
-        sql_stmt = u"SELECT tracker_id, tracker, last_check, failures, is_alive FROM TrackerInfo"
-        result_list = self._session.sqlite_db.execute(sql_stmt)
-        for tracker_id, tracker_url, last_check, failures, is_alive in result_list:
-            self._tracker_dict[tracker_url] = {u'id': tracker_id,
-                                               u'last_check': last_check,
-                                               u'failures': failures,
-                                               u'is_alive': bool(is_alive)}
-            self._tracker_id_to_url_dict[tracker_id] = tracker_url
-
-    @blocking_call_on_reactor_thread
-    def shutdown(self):
-        self._tracker_dict = None
-        self._tracker_id_to_url_dict = None
-
-    @call_on_reactor_thread
     def add_tracker(self, tracker_url):
         """
         Adds a new tracker into the tracker info dict and the database.
@@ -52,7 +42,9 @@ class TrackerManager(object):
             self._logger.warn(u"skip invalid tracker: %s", repr(tracker_url))
             return
 
-        if sanitized_tracker_url in self._tracker_dict:
+        sql_stmt = u"SELECT COUNT() FROM TrackerInfo WHERE tracker = ?"
+        num = self._session.sqlite_db.execute(sql_stmt, (sanitized_tracker_url,)).next()[0]
+        if num > 0:
             self._logger.debug(u"skip existing tracker: %s", repr(tracker_url))
             return
 
@@ -67,22 +59,7 @@ class TrackerManager(object):
                     """
         value_tuple = (sanitized_tracker_url, tracker_info[u'last_check'], tracker_info[u'failures'],
                        tracker_info[u'is_alive'], sanitized_tracker_url)
-        tracker_id, = self._session.sqlite_db.execute(sql_stmt, value_tuple).next()
-
-        # update dict
-        tracker_info[u'id'] = tracker_id
-        self._tracker_dict[sanitized_tracker_url] = tracker_info
-        self._tracker_id_to_url_dict[tracker_id] = sanitized_tracker_url
-
-    @call_on_reactor_thread
-    def get_tracker_info(self, tracker_url):
-        """
-        Gets the tracker information with the given tracker URL.
-        :param tracker_url: The given tracker URL.
-        :return: The tracker info dict if exists, None otherwise.
-        """
-        sanitized_tracker_url = get_uniformed_tracker_url(tracker_url)
-        return self._tracker_dict.get(sanitized_tracker_url)
+        self._session.sqlite_db.execute(sql_stmt, value_tuple).next()
 
     def update_tracker_info(self, tracker_url, is_successful):
         """
@@ -90,15 +67,18 @@ class TrackerManager(object):
         :param tracker_url: The given tracker_url.
         :param is_successful: If the check was successful.
         """
-        if tracker_url not in self._tracker_dict:
+        sql_stmt = u"SELECT tracker_id, tracker, last_check, failures, is_alive FROM TrackerInfo WHERE tracker = ?"
+        try:
+            self._session.sqlite_db.execute(sql_stmt, (tracker_url,)).next()
+        except StopIteration:
             self._logger.error("Trying to update the tracker info of an unknown tracker URL")
             return
 
-        tracker_info = self._tracker_dict[tracker_url]
+        tracker_info = self.get_tracker_info(tracker_url)
 
         current_time = int(time.time())
         failures = 0 if is_successful else tracker_info[u'failures'] + 1
-        is_alive = tracker_info[u'failures'] < self._max_tracker_failures
+        is_alive = tracker_info[u'failures'] < MAX_TRACKER_FAILURES
 
         # update the dict
         tracker_info[u'last_check'] = current_time
@@ -111,45 +91,17 @@ class TrackerManager(object):
                        tracker_info[u'id'])
         self._session.sqlite_db.execute(sql_stmt, value_tuple)
 
-    @call_on_reactor_thread
-    def should_check_tracker(self, tracker_url):
-        """
-        Checks if the given tracker URL should be checked right now or not.
-        :param tracker_url: The given tracker URL.
-        :return: True or False.
-        """
-        current_time = int(time.time())
-
-        tracker_info = self._tracker_dict.get(tracker_url, {u'is_alive': True, u'last_check': 0, u'failures': 0})
-
-        # this_interval = retry_interval * 2^failures
-        next_check_time = tracker_info[u'last_check'] + self._tracker_retry_interval * (2**tracker_info[u'failures'])
-        return next_check_time <= current_time
-
-    @call_on_reactor_thread
+    @blocking_call_on_reactor_thread
     def get_next_tracker_for_auto_check(self):
         """
         Gets the next tracker for automatic tracker-checking.
         :return: The next tracker for automatic tracker-checking.
         """
-        if len(self._tracker_dict) == 0:
-            return
+        try:
+            sql_stmt = u"SELECT tracker FROM TrackerInfo WHERE tracker != 'no-DHT' AND tracker != 'DHT' AND " \
+                       u"last_check + ? <= strftime('%s','now') AND is_alive = 1 ORDER BY last_check LIMIT 1;"
+            result = self._session.sqlite_db.execute(sql_stmt, (TRACKER_RETRY_INTERVAL,)).next()
+        except StopIteration:
+            return None
 
-        next_tracker_url = None
-        next_tracker_info = None
-
-        sorted_tracker_list = sorted(self._tracker_dict.items(), key=lambda d: d[1][u'last_check'])
-
-        for tracker_url, tracker_info in sorted_tracker_list:
-            if tracker_url == u'DHT':
-                next_tracker_url = tracker_url
-                next_tracker_info = {u'is_alive': True, u'last_check': int(time.time())}
-                break
-            elif tracker_url != u'no-DHT' and self.should_check_tracker(tracker_url):
-                next_tracker_url = tracker_url
-                next_tracker_info = tracker_info
-                break
-
-        if next_tracker_url is None:
-            return
-        return next_tracker_url, next_tracker_info
+        return result[0]

--- a/Tribler/Core/TorrentChecker/torrent_checker.py
+++ b/Tribler/Core/TorrentChecker/torrent_checker.py
@@ -99,12 +99,11 @@ class TorrentChecker(TaskManager):
         self._reschedule_tracker_select()
 
         # start selecting torrents
-        result = self.tribler_session.lm.tracker_manager.get_next_tracker_for_auto_check()
-        if result is None:
+        tracker_url = self.tribler_session.lm.tracker_manager.get_next_tracker_for_auto_check()
+        if tracker_url is None:
             self._logger.warn(u"No tracker to select from, skip")
             return succeed(None)
 
-        tracker_url, _ = result
         self._logger.debug(u"Start selecting torrents on tracker %s.", tracker_url)
 
         # get the torrents that should be checked
@@ -115,9 +114,7 @@ class TorrentChecker(TaskManager):
             self._logger.info("No torrent to check for tracker %s", tracker_url)
             self.tribler_session.lm.tracker_manager.update_tracker_info(tracker_url, True)
             return succeed(None)
-        elif tracker_url != u'DHT' and tracker_url != u'no-DHT'\
-                and self.tribler_session.lm.tracker_manager.should_check_tracker(tracker_url):
-
+        elif tracker_url != u'DHT' and tracker_url != u'no-DHT':
             try:
                 session = self._create_session_for_request(tracker_url, timeout=30)
             except MalformedTrackerURLException as e:

--- a/Tribler/Core/TorrentChecker/torrent_checker.py
+++ b/Tribler/Core/TorrentChecker/torrent_checker.py
@@ -220,6 +220,8 @@ class TorrentChecker(TaskManager):
         failure.trap(ValueError, CancelledError, ConnectingCancelledError, RuntimeError)
         self._logger.warning(u"Got session error for URL %s: %s", session.tracker_url, failure)
 
+        self.clean_session(session)
+
         # Do not update if the connection got cancelled, we are probably shutting down
         # and the tracker_manager may have shutdown already.
         if failure.check(CancelledError, ConnectingCancelledError) is None:
@@ -244,6 +246,8 @@ class TorrentChecker(TaskManager):
 
         # Remove the session from our session list dictionary
         self._session_list[session.tracker_url].remove(session)
+        if len(self._session_list[session.tracker_url]) == 0 and session.tracker_url != u"DHT":
+            del self._session_list[session.tracker_url]
 
     def _on_result_from_session(self, session, result_list):
         if self._should_stop:

--- a/Tribler/Test/Community/Tunnel/test_tunnelcommunity.py
+++ b/Tribler/Test/Community/Tunnel/test_tunnelcommunity.py
@@ -1,4 +1,5 @@
 import time
+
 from twisted.internet.defer import inlineCallbacks, returnValue
 
 from Tribler.Test.Community.Tunnel.test_tunnel_base import AbstractTestTunnelCommunity
@@ -7,7 +8,7 @@ from Tribler.community.tunnel.conversion import TunnelConversion
 from Tribler.community.tunnel.crypto.tunnelcrypto import CryptoException, TunnelCrypto
 from Tribler.community.tunnel.routing import Circuit, Hop, RelayRoute
 from Tribler.community.tunnel.tunnel_community import (TunnelSettings, TunnelExitSocket, CircuitRequestCache,
-                                                       PingRequestCache)
+                                                       PingRequestCache, ExtendRequestCache)
 from Tribler.dispersy.candidate import Candidate
 from Tribler.dispersy.message import DropMessage
 from Tribler.dispersy.util import blocking_call_on_reactor_thread
@@ -26,6 +27,14 @@ class TestTunnelCommunity(AbstractTestTunnelCommunity):
         circuit._broken = True
         circuit_request_cache.on_timeout()
         self.assertNotIn(42, self.tunnel_community.circuits)
+
+    @blocking_call_on_reactor_thread
+    def test_extend_request_cache(self):
+        circuit = Circuit(42L)
+        circuit.goal_hops = 3
+        extend_request_cache = ExtendRequestCache(self.tunnel_community, 1234, 4321, None, None, None, None)
+        self.tunnel_community.circuits[1234] = circuit
+        extend_request_cache.on_timeout()
 
     @blocking_call_on_reactor_thread
     def test_ping_request_cache(self):

--- a/Tribler/Test/Core/Modules/test_tracker_manager.py
+++ b/Tribler/Test/Core/Modules/test_tracker_manager.py
@@ -1,3 +1,5 @@
+from twisted.internet.defer import inlineCallbacks
+
 from Tribler.Core.Modules.tracker_manager import TrackerManager
 from Tribler.Core.Session import Session
 from Tribler.Core.SessionConfig import SessionStartupConfig
@@ -11,8 +13,10 @@ class TestTrackerManager(TriblerCoreTest):
         self.config = SessionStartupConfig()
         self.config.set_state_dir(self.getStateDir())
 
+    @blocking_call_on_reactor_thread
+    @inlineCallbacks
     def setUp(self, annotate=True):
-        super(TestTrackerManager, self).setUp(annotate=annotate)
+        yield super(TestTrackerManager, self).setUp(annotate=annotate)
 
         self.setUpPreSession()
         self.session = Session(self.config, ignore_singleton=True)
@@ -20,31 +24,15 @@ class TestTrackerManager(TriblerCoreTest):
         self.tracker_manager = TrackerManager(self.session)
 
     @blocking_call_on_reactor_thread
-    def test_initialize(self):
-        """
-        Test the initialization of the tracker manager
-        """
-        self.tracker_manager.add_tracker("http://test1.com:80/announce")
-        self.tracker_manager.add_tracker("http://test2.com:80/announce")
-        self.tracker_manager.initialize()
-        self.assertEqual(len(self.tracker_manager._tracker_dict.keys()), 4)
-        self.assertTrue("http://test1.com/announce" in self.tracker_manager._tracker_dict)
-        self.assertTrue("http://test2.com/announce" in self.tracker_manager._tracker_dict)
-
-    @blocking_call_on_reactor_thread
     def test_add_tracker(self):
         """
         Test whether adding a tracker works correctly
         """
         self.tracker_manager.add_tracker("http://test1.com")
-        self.assertEqual(len(self.tracker_manager._tracker_dict), 0)
+        self.assertFalse(self.tracker_manager.get_tracker_info("http://test1.com"))
 
         self.tracker_manager.add_tracker("http://test1.com:80/announce")
-        self.assertEqual(len(self.tracker_manager._tracker_dict), 1)
-
-        # Add the same URL again, it shouldn't be inserted
-        self.tracker_manager.add_tracker("http://test1.com:80/announce")
-        self.assertEqual(len(self.tracker_manager._tracker_dict), 1)
+        self.assertTrue(self.tracker_manager.get_tracker_info("http://test1.com:80/announce"))
 
     @blocking_call_on_reactor_thread
     def test_get_tracker_info(self):
@@ -62,24 +50,18 @@ class TestTrackerManager(TriblerCoreTest):
         Test whether the tracker info is correctly updated
         """
         self.tracker_manager.update_tracker_info("http://nonexisting.com", True)
-        self.assertEqual(len(self.tracker_manager._tracker_dict), 0)
+        self.assertFalse(self.tracker_manager.get_tracker_info("http://nonexisting.com"))
 
         self.tracker_manager.add_tracker("http://test1.com:80/announce")
         self.tracker_manager.update_tracker_info("http://test1.com/announce", False)
-        self.assertEqual(self.tracker_manager._tracker_dict["http://test1.com/announce"]['failures'], 1)
+
+        tracker_info = self.tracker_manager.get_tracker_info("http://test1.com/announce")
+        self.assertTrue(tracker_info)
+        self.assertEqual(tracker_info['failures'], 1)
+
         self.tracker_manager.update_tracker_info("http://test1.com/announce", True)
-        self.assertTrue(self.tracker_manager._tracker_dict["http://test1.com/announce"]['is_alive'])
-
-    @blocking_call_on_reactor_thread
-    def test_should_check_tracker(self):
-        """
-        Test whether we should check a tracker or not
-        """
-        self.assertTrue(self.tracker_manager.should_check_tracker("http://nonexisting.com"))
-
-        self.tracker_manager.add_tracker("http://test1.com:80/announce")
-        self.tracker_manager.update_tracker_info("http://test1.com/announce", False)
-        self.assertFalse(self.tracker_manager.should_check_tracker("http://test1.com/announce"))
+        tracker_info = self.tracker_manager.get_tracker_info("http://test1.com/announce")
+        self.assertTrue(tracker_info['is_alive'])
 
     @blocking_call_on_reactor_thread
     def test_get_tracker_for_check(self):
@@ -87,10 +69,6 @@ class TestTrackerManager(TriblerCoreTest):
         Test whether the correct tracker is returned when fetching the next eligable tracker for the auto check
         """
         self.assertFalse(self.tracker_manager.get_next_tracker_for_auto_check())
-        self.tracker_manager.initialize()
-        self.assertEqual('DHT', self.tracker_manager.get_next_tracker_for_auto_check()[0])
 
         self.tracker_manager.add_tracker("http://test1.com:80/announce")
-        self.tracker_manager._tracker_dict["http://test1.com/announce"]['last_check'] = 0
-        self.tracker_manager._tracker_dict["DHT"]['last_check'] = 1000
-        self.assertEqual('http://test1.com/announce', self.tracker_manager.get_next_tracker_for_auto_check()[0])
+        self.assertEqual('http://test1.com/announce', self.tracker_manager.get_next_tracker_for_auto_check())

--- a/Tribler/Test/Core/TorrentChecker/test_torrentchecker.py
+++ b/Tribler/Test/Core/TorrentChecker/test_torrentchecker.py
@@ -114,9 +114,13 @@ class TestTorrentChecker(TriblerCoreTest):
         """
         Test whether we capture the error when a tracker check fails
         """
+        def verify_cleanup(_):
+            # Verify whether we successfully cleaned up the session after an error
+            self.assertEqual(len(self.torrent_checker._session_list), 1)
+
         self.torrent_checker._torrent_db.addExternalTorrentNoDef(
             'a' * 20, 'ubuntu.iso', [['a.test', 1234]], ['udp://non123exiszzting456tracker89fle.abc:80/announce'], 5)
-        return self.torrent_checker._task_select_tracker()
+        return self.torrent_checker._task_select_tracker().addCallback(verify_cleanup)
 
     @blocking_call_on_reactor_thread
     def test_tracker_test_invalid_tracker(self):

--- a/Tribler/Test/Core/test_sqlitecachedbhandler_torrents.py
+++ b/Tribler/Test/Core/test_sqlitecachedbhandler_torrents.py
@@ -137,7 +137,6 @@ class TestTorrentDBHandler(AbstractDB):
         from Tribler.Core.Modules.tracker_manager import TrackerManager
         self.session.lm = TriblerLaunchMany()
         self.session.lm.tracker_manager = TrackerManager(self.session)
-        self.session.lm.tracker_manager.initialize()
         self.tdb = TorrentDBHandler(self.session)
         self.tdb.torrent_dir = TESTS_DATA_DIR
         self.tdb.category = Category()

--- a/Tribler/community/tunnel/tunnel_community.py
+++ b/Tribler/community/tunnel/tunnel_community.py
@@ -636,8 +636,9 @@ class TunnelCommunity(Community):
                     if s == ltmgr.get_session(d.get_hops()):
                         d.get_handle().addCallback(update_torrents, d)
 
-            return True
-        return False
+        # Clean up the directions dictionary
+        if circuit_id in self.directions:
+            del self.directions[circuit_id]
 
     def remove_relay(self, circuit_id, additional_info='', destroy=False, got_destroy_from=None, both_sides=True):
 
@@ -666,6 +667,9 @@ class TunnelCommunity(Community):
                 # Remove old session key
                 if cid in self.relay_session_keys:
                     del self.relay_session_keys[cid]
+
+                if cid in self.directions:
+                    del self.directions[cid]
             else:
                 self.tunnel_logger.error("Could not remove relay %d %s", circuit_id, additional_info)
 

--- a/Tribler/community/tunnel/tunnel_community.py
+++ b/Tribler/community/tunnel/tunnel_community.py
@@ -60,9 +60,11 @@ class CircuitRequestCache(NumberCache):
                 self.circuit.state, self.circuit.first_hop)
             self.community.remove_circuit(self.number, reason)
 
+
 class ExtendRequestCache(NumberCache):
     def __init__(self, community, to_circuit_id, from_circuit_id, candidate_sock_addr, candidate_mid, to_candidate_sock_addr, to_candidate_mid):
         super(ExtendRequestCache, self).__init__(community.request_cache, u"anon-circuit", to_circuit_id)
+        self.community = community
         self.to_circuit_id = to_circuit_id
         self.from_circuit_id = from_circuit_id
         self.candidate_sock_addr = candidate_sock_addr
@@ -72,7 +74,10 @@ class ExtendRequestCache(NumberCache):
         self.should_forward = True
 
     def on_timeout(self):
-        pass
+        to_circuit = self.community.circuits.get(self.to_circuit_id)
+        if to_circuit and to_circuit.state != CIRCUIT_STATE_READY:
+            self.community.remove_relay(self.to_circuit_id)
+
 
 class CreatedRequestCache(NumberCache):
 
@@ -602,8 +607,6 @@ class TunnelCommunity(Community):
     def remove_circuit(self, circuit_id, additional_info='', destroy=False):
         assert isinstance(circuit_id, (long, int)), type(circuit_id)
 
-        self.tunnel_logger.info("MULTICHAIN: Removing circuit")
-
         if circuit_id in self.circuits:
             self.tunnel_logger.info("removing circuit %d " + additional_info, circuit_id)
 
@@ -641,9 +644,6 @@ class TunnelCommunity(Community):
             del self.directions[circuit_id]
 
     def remove_relay(self, circuit_id, additional_info='', destroy=False, got_destroy_from=None, both_sides=True):
-
-        self.tunnel_logger.info("MULTICHAIN: Removing relay")
-
         # Find other side of relay
         to_remove = [circuit_id]
         if both_sides:
@@ -674,9 +674,6 @@ class TunnelCommunity(Community):
                 self.tunnel_logger.error("Could not remove relay %d %s", circuit_id, additional_info)
 
     def remove_exit_socket(self, circuit_id, additional_info='', destroy=False):
-
-        self.tunnel_logger.info("MULTICHAIN: Removing exit socket")
-
         if circuit_id in self.exit_sockets:
             if destroy:
                 self.destroy_exit_socket(circuit_id)


### PR DESCRIPTION
This PR fixes various memory issues which caused the Tribler memory to grow over time. This issue most likely fixes #2966.

Additionally, I've refactored the torrent checker. Before, we kept all tracker status dictionaries in memory. Now, we will fetch them from the SQLite database.