### PR TITLE
Fix always rechecking on restart

### DIFF
--- a/Tribler/Core/Libtorrent/LibtorrentDownloadImpl.py
+++ b/Tribler/Core/Libtorrent/LibtorrentDownloadImpl.py
@@ -1166,13 +1166,20 @@ class LibtorrentDownloadImpl(DownloadConfigInterface, TaskManager):
             return succeed(None)
 
         if not self.handle or not self.handle.is_valid():
-            resume_data = {
-                'file-format': "libtorrent resume file",
-                'file-version': 1,
-                'info-hash': self.tdef.get_infohash()
-            }
-            alert = type('anonymous_alert', (object, ), dict(resume_data=resume_data))
-            self.on_save_resume_data_alert(alert)
+            # Libtorrent hasn't received or initialized this download yet
+            # 1. Check if we have data for this infohash already (don't overwrite it if we do!)
+            basename = hexlify(self.tdef.get_infohash()) + '.state'
+            filename = os.path.join(self.session.get_downloads_pstate_dir(), basename)
+            if not os.path.isfile(filename):
+                # 2. If there is no saved data for this infohash, checkpoint it without data so we do not
+                #    lose it when we crash or restart before the download becomes known.
+                resume_data = {
+                    'file-format': "libtorrent resume file",
+                    'file-version': 1,
+                    'info-hash': self.tdef.get_infohash()
+                }
+                alert = type('anonymous_alert', (object, ), dict(resume_data=resume_data))
+                self.on_save_resume_data_alert(alert)
             return succeed(None)
 
         return self.save_resume_data()


### PR DESCRIPTION
Fixes #3102 

Before, we would always checkpoint with no data as early as possible. This ignored the fact that this save data might actually exist though. This PR checks whether save data already exists and only if it does NOT exist, it will write a dataless checkpoint as before.