### PR TITLE
If check_os is not found tribler will not run

### DIFF
--- a/debian/tribler.install
+++ b/debian/tribler.install
@@ -7,4 +7,5 @@ Tribler/Main/Build/Ubuntu/tribler_big.xpm usr/share/pixmaps
 debian/bin/* usr/bin
 logger.conf usr/share/tribler
 run_tribler.py /usr/share/tribler
+check_os.py /usr/share/tribler
 twisted usr/share/tribler


### PR DESCRIPTION
This is a backport of #3110. Fixes #3123.