### PR TITLE
Fix #3131: export torrent now uses name instead of infohash

### DIFF
--- a/TriblerGUI/widgets/downloadspage.py
+++ b/TriblerGUI/widgets/downloadspage.py
@@ -290,13 +290,13 @@ class DownloadsPage(QWidget):
 
         if len(self.export_dir) > 0:
             # Show confirmation dialog where we specify the name of the file
-            infohash = self.selected_item.download_info['infohash']
+            torrent_name = self.selected_item.download_info['name']
             self.dialog = ConfirmationDialog(self, "Export torrent file",
                                              "Please enter the name of the torrent file:",
                                              [('SAVE', BUTTON_TYPE_NORMAL), ('CANCEL', BUTTON_TYPE_CONFIRM)],
                                              show_input=True)
             self.dialog.dialog_widget.dialog_input.setPlaceholderText('Torrent file name')
-            self.dialog.dialog_widget.dialog_input.setText("%s.torrent" % infohash)
+            self.dialog.dialog_widget.dialog_input.setText("%s.torrent" % torrent_name)
             self.dialog.dialog_widget.dialog_input.setFocus()
             self.dialog.button_clicked.connect(self.on_export_download_dialog_done)
             self.dialog.show()


### PR DESCRIPTION
Export torrent now uses name instead of infohash
[Issue #3131](https://github.com/Tribler/tribler/issues/3131)

Fixes #3131