### PR TITLE
Fix #3163 non-responsive debug logs

### DIFF
--- a/logger.conf
+++ b/logger.conf
@@ -87,18 +87,14 @@ class=logging.Formatter
 [handler_infoHandler]
 class=handlers.RotatingFileHandler
 level=INFO
-backupCount=5
-maxBytes=10485760 # 10MB
-args=(info_log_file,)
 formatter=debugging
+args=(info_log_file, 'a', 10485760, 5)
 
 [handler_errorHandler]
 class=handlers.RotatingFileHandler
 level=ERROR
-backupCount=5
-maxBytes=10485760 # 10MB
-args=(error_log_file,)
 formatter=debugging
+args=(error_log_file, 'a', 10485760, 5)
 
 [handler_infoMemoryHandler]
 class=handlers.MemoryHandler

--- a/run_tribler.py
+++ b/run_tribler.py
@@ -69,3 +69,10 @@ if __name__ == "__main__":
     except ImportError as ie:
         logging.exception(ie)
         error_and_exit("Import Error", "Import error: {0}".format(ie))
+
+    except SystemExit as se:
+        logging.info("Shutting down Tribler")
+        # Flush all the logs to make sure it is written to file before it exits
+        for handler in logging.getLogger().handlers:
+            handler.flush()
+        raise


### PR DESCRIPTION
Fixed log rotation and enforced flushing all logs before system exit