### PR TITLE
Fix download reappear

### DIFF
--- a/Tribler/Core/APIImplementation/LaunchManyCore.py
+++ b/Tribler/Core/APIImplementation/LaunchManyCore.py
@@ -534,8 +534,6 @@ class TriblerLaunchMany(TaskManager):
 
         return deferToThread(callback, dslist).addCallback(on_cb_done)
 
-    @blocking_call_on_reactor_thread
-    @inlineCallbacks
     def sesscb_states_callback(self, states_list):
         """
         This method is periodically (every second) called with a list of the download states of the active downloads.
@@ -567,18 +565,6 @@ class TriblerLaunchMany(TaskManager):
                     self.session.notifier.notify(NTFY_TORRENT, NTFY_FINISHED, tdef.get_infohash(), safename)
                     do_checkpoint = True
 
-                elif download.get_hops() == 0 and download.get_safe_seeding():
-                    hops = tribler_defaults.get('Tribler', {}).get('default_number_hops', 1)
-                    self._logger.info("Moving completed torrent to tunneled session %d for hidden seeding %r",
-                                      hops, download)
-                    yield self.session.remove_download(download)
-
-                    # copy the old download_config and change the hop count
-                    dscfg = download.copy()
-                    dscfg.set_hops(hops)
-
-                    self.session.start_download_from_tdef(tdef, dscfg)
-
         self.previous_active_downloads = new_active_downloads
         if do_checkpoint:
             self.session.checkpoint_downloads()
@@ -586,7 +572,7 @@ class TriblerLaunchMany(TaskManager):
         if self.state_cb_count % 4 == 0 and self.tunnel_community:
             self.tunnel_community.monitor_downloads(states_list)
 
-        returnValue([])
+        return []
 
     #
     # Persistence methods

--- a/Tribler/Core/Libtorrent/LibtorrentMgr.py
+++ b/Tribler/Core/Libtorrent/LibtorrentMgr.py
@@ -341,8 +341,9 @@ class LibtorrentMgr(TaskManager):
                 if alert_type == 'torrent_removed_alert':
                     info_hash = str(alert.info_hash)
                     if info_hash in self.torrents:
-                        self.torrents[info_hash][0].deferred_removed.callback(None)
+                        deferred = self.torrents[info_hash][0].deferred_removed
                         del self.torrents[info_hash]
+                        deferred.callback(None)
                 self._logger.debug("Alert for invalid torrent")
 
     def get_metainfo(self, infohash_or_magnet, callback, timeout=30, timeout_callback=None, notify=True):

--- a/Tribler/Test/Core/test_launch_many_cores.py
+++ b/Tribler/Test/Core/test_launch_many_cores.py
@@ -109,42 +109,6 @@ class TestLaunchManyCore(TriblerCoreTest):
 
         return error_stop_deferred
 
-    @deferred(timeout=10)
-    def test_dlstates_cb_seeding(self):
-        """
-        Testing whether a download is readded when safe seeding in the download states callback in LaunchManyCore
-        """
-        readd_deferred = Deferred()
-
-        def mocked_start_download(tdef, dscfg):
-            self.assertEqual(tdef, seed_tdef)
-            self.assertEqual(dscfg, seed_download)
-            readd_deferred.callback(None)
-
-        def mocked_remove_download(download):
-            self.assertEqual(download, seed_download)
-
-        self.lm.session.start_download_from_tdef = mocked_start_download
-        self.lm.session.remove_download = mocked_remove_download
-
-        seed_tdef = TorrentDef()
-        seed_tdef.get_infohash = lambda: 'aaaa'
-        seed_download = MockObject()
-        seed_download.get_def = lambda: seed_tdef
-        seed_download.get_def().get_name_as_unicode = lambda: "test.iso"
-        seed_download.get_hops = lambda: 0
-        seed_download.get_safe_seeding = lambda: True
-        seed_download.copy = lambda: seed_download
-        seed_download.set_hops = lambda _: None
-        fake_seed_download_state = MockObject()
-        fake_seed_download_state.get_infohash = lambda: 'aaaa'
-        fake_seed_download_state.get_status = lambda: DLSTATUS_SEEDING
-        fake_seed_download_state.get_download = lambda: seed_download
-
-        self.lm.sesscb_states_callback([fake_seed_download_state])
-
-        return readd_deferred
-
     def test_load_checkpoint(self):
         """
         Test whether we are resuming downloads after loading checkpoint


### PR DESCRIPTION
Fixes #3169, fixes #3186.

This PR removes the hidden seeding feature which readds the torrent with a different amount of hops for hidden seeding.

This PR also fixes a LibtorrentDownloadImpl still being in LibtorrentMgr.torrents when its removed deferred is fired.