### PR TITLE
READY: Revert "Fix #3161 torrent name error"

### DIFF
--- a/Tribler/Core/Modules/restapi/torrentinfo_endpoint.py
+++ b/Tribler/Core/Modules/restapi/torrentinfo_endpoint.py
@@ -1,14 +1,15 @@
 import logging
-from urllib import url2pathname, unquote_plus
 from libtorrent import bdecode, bencode
+from urllib import url2pathname
 
 from twisted.internet.defer import Deferred
 from twisted.internet.error import DNSLookupError, ConnectError
 from twisted.web import http, resource
 from twisted.web.server import NOT_DONE_YET
 
-import Tribler.Core.Utilities.json_util as json
+from Tribler.Core.Modules.restapi.util import fix_unicode_dict
 from Tribler.Core.TorrentDef import TorrentDef
+import Tribler.Core.Utilities.json_util as json
 from Tribler.Core.Utilities.utilities import fix_torrent, http_get, parse_magnetlink
 
 
@@ -85,7 +86,7 @@ class TorrentInfoEndpoint(resource.Resource):
             request.setResponseCode(http.BAD_REQUEST)
             return json.dumps({"error": "uri parameter missing"})
 
-        uri = unicode(unquote_plus(request.args['uri'][0]), 'utf-8')
+        uri = unicode(request.args['uri'][0], 'utf-8')
         if uri.startswith('file:'):
             try:
                 filename = url2pathname(uri[5:])

--- a/TriblerGUI/dialogs/startdownloaddialog.py
+++ b/TriblerGUI/dialogs/startdownloaddialog.py
@@ -1,4 +1,4 @@
-from urllib import unquote_plus, quote_plus
+from urllib import unquote_plus
 
 from PyQt5 import uic
 from PyQt5.QtCore import pyqtSignal, Qt
@@ -106,8 +106,8 @@ class StartDownloadDialog(DialogContainer):
 
     def perform_files_request(self):
         self.request_mgr = TriblerRequestManager()
-        self.request_mgr.perform_request("torrentinfo?uri=%s" % quote_plus(self.download_uri),
-                                         self.on_received_metainfo, capture_errors=False)
+        self.request_mgr.perform_request("torrentinfo?uri=%s" % self.download_uri, self.on_received_metainfo,
+                                         capture_errors=False)
 
     def on_received_metainfo(self, metainfo):
         if not metainfo:


### PR DESCRIPTION
This reverts commit a0a49cc20e6d13ff0a26e6d19843dc2dc8375e70.

Fixes #3185 (see for more details), reopens #3161.