### PR TITLE
READY: Fix torrent already exists in session exception

### DIFF
--- a/Tribler/Core/Libtorrent/LibtorrentMgr.py
+++ b/Tribler/Core/Libtorrent/LibtorrentMgr.py
@@ -377,8 +377,7 @@ class LibtorrentMgr(TaskManager):
             elif infohash not in self.metainfo_requests:
                 # Flags = 4 (upload mode), should prevent libtorrent from creating files
                 atp = {'save_path': self.metadata_tmpdir,
-                       'flags': (lt.add_torrent_params_flags_t.flag_duplicate_is_error |
-                                 lt.add_torrent_params_flags_t.flag_upload_mode)}
+                       'flags': (lt.add_torrent_params_flags_t.flag_upload_mode)}
                 if magnet:
                     atp['url'] = magnet
                 else:
@@ -400,6 +399,12 @@ class LibtorrentMgr(TaskManager):
                                                     'callbacks': [callback],
                                                     'timeout_callbacks': [timeout_callback] if timeout_callback else [],
                                                     'notify': notify}
+
+                # if the handle is valid and already has metadata which is the case when torrent already exists in
+                # session then metadata_received_alert is not fired so we call self.got_metainfo() directly here
+                if handle.is_valid() and handle.has_metadata():
+                    self.got_metainfo(infohash, timeout=False)
+                    return
 
                 def schedule_call():
                     random_id = ''.join(random.choice('0123456789abcdef') for _ in xrange(30))

--- a/Tribler/Test/Core/Libtorrent/test_libtorrent_mgr.py
+++ b/Tribler/Test/Core/Libtorrent/test_libtorrent_mgr.py
@@ -174,6 +174,41 @@ class TestLibtorrentMgr(TriblerCoreTest):
 
         return test_deferred
 
+    @deferred(timeout=20)
+    def test_get_metainfo_with_already_added_torrent(self):
+        """
+        Testing metainfo fetching for a torrent which is already in session.
+        got_metainfo() should be called with timeout=False.
+        """
+        magnet_link = "magnet:?xt=urn:btih:f72636475a375653083e49d501601675ce3e6619&dn=ubuntu-16.04.3-server-i386.iso"
+
+        test_deferred = Deferred()
+
+        def fake_got_metainfo(_, timeout):
+            self.assertFalse(timeout, "Timeout should not be True")
+            test_deferred.callback(None)
+
+        mock_handle = MockObject()
+        mock_handle.info_hash = lambda: 'a' * 20
+        mock_handle.is_valid = lambda: True
+        mock_handle.has_metadata = lambda: True
+
+        mock_ltsession = MockObject()
+        mock_ltsession.add_torrent = lambda _: mock_handle
+        mock_ltsession.find_torrent = lambda _: mock_handle
+        mock_ltsession.get_torrents = lambda: []
+        mock_ltsession.start_upnp = lambda: None
+        mock_ltsession.stop_upnp = lambda: None
+        mock_ltsession.save_state = lambda: None
+
+        self.ltmgr.get_session = lambda *_: mock_ltsession
+        self.ltmgr.metadata_tmpdir = tempfile.mkdtemp(suffix=u'tribler_metainfo_tmpdir')
+        self.ltmgr.is_dht_ready = lambda: True
+        self.ltmgr.got_metainfo = fake_got_metainfo
+
+        self.ltmgr.get_metainfo(magnet_link, lambda _: None)
+        return test_deferred
+
     def test_add_torrent(self):
         """
         Testing the addition of a torrent to the libtorrent manager


### PR DESCRIPTION
If torrent already exists in the session, it is now removed from the session and added again. This triggers the metadata_received_alert handled by 'process_alert'. This removal and addition of torrent to the session is done for the new torrents only so it does not affect the existing torrents in the downloads.

Issue #3263 