### PR TITLE
Fix crash on remote host closing connection

### DIFF
--- a/Tribler/Core/Modules/restapi/rest_manager.py
+++ b/Tribler/Core/Modules/restapi/rest_manager.py
@@ -41,7 +41,8 @@ class RESTManager(TaskManager):
 
 class RESTRequest(server.Request):
     """
-    This class gracefully takes care of unhandled exceptions raised during the processing of any request.
+    This class overrides the write(data) method to do a safe write only when channel is not None and gracefully
+    takes care of unhandled exceptions raised during the processing of any request.
     """
     defaultContentType = b"text/json"
 
@@ -68,3 +69,10 @@ class RESTRequest(server.Request):
         self.write(body)
         self.finish()
         return failure
+
+    def write(self, data):
+        """
+        Writes data only if request has not finished and channel is not None
+        """
+        if not self.finished and self.channel:
+            server.Request.write(self, data)


### PR DESCRIPTION
Before any data is written by request.write() it now checks if the request has not already finished and the channel is not None. One case where the channel is None is when a remote host closes the connection before the response is served. In such a case just checking 'request.finished is not True' is not sufficient and channel should also be checked.

Fixes #3274 