### PR TITLE
Fix for AttributeError: 'NoneType' object has no attribute 'dialog_widget'

### DIFF
--- a/TriblerGUI/tribler_window.py
+++ b/TriblerGUI/tribler_window.py
@@ -467,12 +467,16 @@ class TriblerWindow(QMainWindow):
 
     def on_start_download_action(self, action):
         if action == 1:
-            self.window().perform_start_download_request(self.download_uri,
-                                                         self.dialog.dialog_widget.anon_download_checkbox.isChecked(),
-                                                         self.dialog.dialog_widget.safe_seed_checkbox.isChecked(),
-                                                         self.dialog.dialog_widget.destination_input.currentText(),
-                                                         self.dialog.get_selected_files(),
-                                                         self.dialog.dialog_widget.files_list_view.topLevelItemCount())
+            if self.dialog and self.dialog.dialog_widget:
+                self.window().perform_start_download_request(
+                    self.download_uri, self.dialog.dialog_widget.anon_download_checkbox.isChecked(),
+                    self.dialog.dialog_widget.safe_seed_checkbox.isChecked(),
+                    self.dialog.dialog_widget.destination_input.currentText(),
+                    self.dialog.get_selected_files(),
+                    self.dialog.dialog_widget.files_list_view.topLevelItemCount())
+            else:
+                ConfirmationDialog.show_error(self, "Tribler UI Error", "Something went wrong. Please try again.")
+                logging.exception("Error while trying to download. Either dialog or dialog.dialog_widget is None")
 
         self.dialog.request_mgr.cancel_request()  # To abort the torrent info request
         self.dialog.setParent(None)


### PR DESCRIPTION
Checked if the dialog or dialog_widget is None before performing start download request. An error dialog is shown in case any of them is None.

Fix #3301 