### PR TITLE
Ignore Invalid DNS-ID exception

### DIFF
--- a/Tribler/Core/Session.py
+++ b/Tribler/Core/Session.py
@@ -247,6 +247,10 @@ class Session(SessionConfigInterface):
                 self._logger.error("Could not send data: network is unreachable.")
                 return
 
+            if 'exceptions.ValueError: Invalid DNS-ID' in text:
+                self._logger.error("Invalid DNS-ID")
+                return
+
             if self.lm.api_manager and len(text) > 0:
                 self.lm.api_manager.root_endpoint.events_endpoint.on_tribler_exception(text)
                 self.lm.api_manager.root_endpoint.state_endpoint.on_tribler_exception(text)

--- a/Tribler/Test/Core/test_session.py
+++ b/Tribler/Test/Core/test_session.py
@@ -133,6 +133,7 @@ class TestSessionAsServer(TestAsServer):
         self.session.unhandled_error_observer({'isError': True, 'log_failure': 'socket.error: [Errno 51]'})
         self.session.unhandled_error_observer({'isError': True,
                                                'log_failure': 'socket.error: [Errno %s]' % SOCKET_BLOCK_ERRORCODE})
+        self.session.unhandled_error_observer({'isError': True, 'log_failure': 'exceptions.ValueError: Invalid DNS-ID'})
 
 
     @deferred(timeout=10)


### PR DESCRIPTION
Fix #3315 Invalid DNS-ID
This error occurs if twisted cannot verify the SSL certificate of the DNS-ID. Since this is handled by twisted internally, we can just ignore the error in the upper layer.