### PR TITLE
GUI HTTP request queue

### DIFF
--- a/TriblerGUI/debug_window.py
+++ b/TriblerGUI/debug_window.py
@@ -211,11 +211,11 @@ class DebugWindow(QMainWindow):
 
     def load_requests_tab(self):
         self.window().requests_tree_widget.clear()
-        for endpoint, method, data, timestamp, status_code in sorted(tribler_performed_requests.values(),
+        for endpoint, method, data, timestamp, status_code in sorted(tribler_performed_requests,
                                                                      key=lambda x: x[3]):
             item = QTreeWidgetItem(self.window().requests_tree_widget)
             item.setText(0, "%s %s %s" % (method, endpoint, data))
-            item.setText(1, ("%d" % status_code) if status_code else "unknown")
+            item.setText(1, ("%d" % status_code()) if status_code() else "unknown")
             item.setText(2, "%s" % strftime("%H:%M:%S", localtime(timestamp)))
             self.window().requests_tree_widget.addTopLevelItem(item)
 

--- a/TriblerGUI/dialogs/feedbackdialog.py
+++ b/TriblerGUI/dialogs/feedbackdialog.py
@@ -63,10 +63,10 @@ class FeedbackDialog(QDialog):
 
         # Add recent requests to feedback dialog
         request_ind = 1
-        for endpoint, method, data, timestamp, status_code in sorted(tribler_performed_requests.values(),
+        for endpoint, method, data, timestamp, status_code in sorted(tribler_performed_requests,
                                                                      key=lambda x: x[3])[-30:]:
             add_item_to_info_widget('request_%d' % request_ind, '%s %s %s (time: %s, code: %s)' %
-                                    (endpoint, method, data, timestamp, status_code))
+                                    (endpoint, method, data, timestamp, status_code()))
             request_ind += 1
 
         # Add recent events to feedback dialog

--- a/TriblerGUI/tribler_request_manager.py
+++ b/TriblerGUI/tribler_request_manager.py
@@ -1,6 +1,6 @@
+from collections import deque, namedtuple
 import logging
-import random
-import string
+from threading import RLock
 from time import time
 
 from PyQt5.QtCore import QUrl, pyqtSignal, QIODevice, QBuffer
@@ -10,8 +10,135 @@ import Tribler.Core.Utilities.json_util as json
 from TriblerGUI.defs import BUTTON_TYPE_NORMAL, API_PORT
 from TriblerGUI.dialogs.confirmationdialog import ConfirmationDialog
 
-performed_requests = {}
-performed_requests_ids = []
+
+class QueuePriorityEnum(object):
+    """
+    Enum for HTTP request priority.
+    """
+
+    CRITICAL = "CRITICAL"
+    HIGH = "HIGH"
+    MEDIUM = "MEDIUM"
+    LOW = "LOW"
+
+
+QueueItem = namedtuple('QueueItem', 'request_manager, callback, priority, insertion_time, performed')
+
+
+class RequestQueue(object):
+    """
+    Queue and rate limit HTTP requests as to not overload the socket count.
+    """
+
+    def __init__(self, max_outstanding=200, timeout=15):
+        """
+        Create a RequestQueue object for rate-limiting HTTP requests.
+
+        :param max_outstanding: the maximum number of requests which can be unanswered at any given time.
+        :param timeout: the time after which a request is assumed to never receive a response.
+        """
+        self.queue = [] # [(TriblerRequestManager, callable, QueuePriorityEnum, time, [performed])]
+        self.max_outstanding = max_outstanding
+        self.timeout = timeout
+        self.old_medium_index = 0.0 # The previous queue quotient where QueuePriorityEnum.MEDIUM items started
+        self.old_low_index = 0.0 # The previous queue quotient where QueuePriorityEnum.LOW items started
+        self.lock = RLock() # Don't allow asynchronous access to the queue
+
+    def parse_queue(self):
+        """
+        Update the current queue and check if requests are completed and/or need to be sent.
+        """
+        self.lock.acquire()
+        # 1. Filter out completed and timed-out requests
+        current_time = time()
+        self.queue = [(request_manager, callback, priority, insertion_time, performed)
+                      for request_manager, callback, priority, insertion_time, performed in self.queue
+                      if request_manager.status_code == -1 and
+                      (current_time - insertion_time < self.timeout or request_manager.cancel_request())] # or is lazy
+        # 2. Perform new requests, which aren't already pending
+        outstanding = 0
+        for _, callback, priority, _, performed in self.queue:
+            called = performed[0]
+            if not called:
+                callback()
+                performed[0] = True
+            outstanding += 1
+            if outstanding >= self.max_outstanding:
+                break
+        self.lock.release()
+
+    def enqueue(self, request_manager, callback, priority=QueuePriorityEnum.CRITICAL):
+        """
+        Add a new request to the queue.
+
+        If priority equals:
+         - CRITICAL: Send request immediately
+         - HIGH: Send request as soon as possible, respecting the 'max_outstanding' setting
+         - MEDIUM: Send request as soon as no more HIGH priority items exist, drop in case of very high load
+         - LOW: Send request if not MEDIUM or HIGH priority items exist, drop in case of average load
+
+        :param request_manager: the TriblerRequestManager wishing to perform a request.
+        :param callback: the callback to call if when this request is allowed to be sent.
+        :param priority: the priority for this request.
+        """
+        # Send CRITICAL requests immediately
+        if priority == QueuePriorityEnum.CRITICAL:
+            callback()
+            return
+        self.lock.acquire()
+        queue_length = len(self.queue)
+        insert_point = -1
+        insert_guess = 0
+        insert_step = 1
+        insert_find = QueuePriorityEnum.CRITICAL
+        # Create an educated guess to find where in the queue to insert a request
+        # If the queue is too full, drop/cancel the request
+        if priority == QueuePriorityEnum.HIGH and queue_length > 0:
+            insert_guess = max(min(int(queue_length * self.old_medium_index), queue_length), 0)
+            insert_step = 1 if self.queue[insert_guess] == QueuePriorityEnum.HIGH else -1
+            insert_find = QueuePriorityEnum.MEDIUM if insert_step == 1 else QueuePriorityEnum.HIGH
+        elif priority == QueuePriorityEnum.MEDIUM and queue_length > 0:
+            if queue_length > 200:
+                logging.error("Too many requests to handle new request with priority %s.", priority)
+                request_manager.cancel_request()
+                return
+            insert_guess = max(min(int(queue_length * self.old_low_index), queue_length), 0)
+            insert_step = 1 if self.queue[insert_guess] == QueuePriorityEnum.MEDIUM else -1
+            insert_find = QueuePriorityEnum.LOW if insert_step == 1 else QueuePriorityEnum.MEDIUM
+        else:
+            if queue_length > 80:
+                logging.error("Too many requests to handle new request with priority %s.", priority)
+                request_manager.cancel_request()
+                return
+            insert_point = queue_length
+        # Find the point to insert the request in the queue
+        if insert_point == -1:
+            for i in xrange(insert_guess, queue_length if insert_step == 1 else 0, insert_step):
+                if self.queue[i] == insert_find:
+                    insert_point = i + (0 if insert_step == 1 else 1)
+                    break
+        # Update pointers
+        if priority == QueuePriorityEnum.HIGH:
+            self.old_medium_index = (insert_point + 0.0)/(queue_length + 1.0)
+        elif priority == QueuePriorityEnum.MEDIUM:
+            self.old_low_index = (insert_point + 0.0) / (queue_length + 1.0)
+        self.queue.insert(insert_point, QueueItem(request_manager, callback, priority, time(), [False, ]))
+        self.parse_queue()
+        self.lock.release()
+
+    def clear(self):
+        """
+        Clear the queue.
+        """
+        self.lock.acquire()
+        for request_manager, _, _, _, _ in self.queue:
+            request_manager.cancel_request()
+        self.queue = []
+        self.lock.release()
+
+
+request_queue = RequestQueue()
+performed_requests = deque(maxlen=200)
 
 
 class TriblerRequestManager(QNetworkAccessManager):
@@ -25,15 +152,25 @@ class TriblerRequestManager(QNetworkAccessManager):
 
     def __init__(self):
         QNetworkAccessManager.__init__(self)
-        self.request_id = None
         self.base_url = "http://localhost:%d/" % API_PORT
         self.reply = None
-        self.generate_request_id()
+        self.status_code = -1
+        self.dispatch_map = {
+            'GET': self.perform_get,
+            'PATCH': self.perform_patch,
+            'PUT': self.perform_put,
+            'DELETE': self.perform_delete,
+            'POST': self.perform_post
+        }
 
-    def generate_request_id(self):
-        self.request_id = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(10))
+    def get_status_code(self):
+        """
+        Get the status code of this request.
+        """
+        return self.status_code
 
-    def perform_request(self, endpoint, read_callback, data="", method='GET', capture_errors=True):
+    def perform_request(self, endpoint, read_callback, data="", method='GET', capture_errors=True,
+                        priority=QueuePriorityEnum.CRITICAL):
         """
         Perform a HTTP request.
         :param endpoint: the endpoint to call (i.e. "statistics")
@@ -42,46 +179,91 @@ class TriblerRequestManager(QNetworkAccessManager):
         :param method: the HTTP verb (GET/POST/PUT/PATCH)
         :param capture_errors: whether errors should be handled by this class (defaults to True)
         """
-        performed_requests[self.request_id] = [endpoint, method, data, time(), -1]
-        performed_requests_ids.append(self.request_id)
-        if len(performed_requests_ids) > 200:
-            del performed_requests[performed_requests_ids.pop(0)]
         url = self.base_url + endpoint
 
-        if method == 'GET':
-            buf = QBuffer()
-            buf.setData(data)
-            buf.open(QIODevice.ReadOnly)
-            get_request = QNetworkRequest(QUrl(url))
-            self.reply = self.sendCustomRequest(get_request, "GET", buf)
-            buf.setParent(self.reply)
-        elif method == 'PATCH':
-            buf = QBuffer()
-            buf.setData(data)
-            buf.open(QIODevice.ReadOnly)
-            patch_request = QNetworkRequest(QUrl(url))
-            self.reply = self.sendCustomRequest(patch_request, "PATCH", buf)
-            buf.setParent(self.reply)
-        elif method == 'PUT':
-            request = QNetworkRequest(QUrl(url))
-            request.setHeader(QNetworkRequest.ContentTypeHeader, "application/x-www-form-urlencoded")
-            self.reply = self.put(request, data)
-        elif method == 'DELETE':
-            buf = QBuffer()
-            buf.setData(data)
-            buf.open(QIODevice.ReadOnly)
-            delete_request = QNetworkRequest(QUrl(url))
-            self.reply = self.sendCustomRequest(delete_request, "DELETE", buf)
-            buf.setParent(self.reply)
-        elif method == 'POST':
-            request = QNetworkRequest(QUrl(url))
-            request.setHeader(QNetworkRequest.ContentTypeHeader, "application/x-www-form-urlencoded")
-            self.reply = self.post(request, data)
+        self.status_code = -1
+        request_queue.enqueue(self,
+                              lambda: self.dispatch_map.get(method, lambda x, y, z: None)(endpoint, data, url),
+                              priority)
 
         if read_callback:
             self.received_json.connect(read_callback)
 
         self.finished.connect(lambda reply: self.on_finished(reply, capture_errors))
+
+    def perform_get(self, endpoint, data, url):
+        """
+        Perform an HTTP GET request.
+
+        :param endpoint: the name of the Tribler endpoint.
+        :param data: the data/body to send with the request.
+        :param url: the url to send the request to.
+        """
+        performed_requests.append([endpoint, "GET", data, time(), self.get_status_code])
+        buf = QBuffer()
+        buf.setData(data)
+        buf.open(QIODevice.ReadOnly)
+        get_request = QNetworkRequest(QUrl(url))
+        self.reply = self.sendCustomRequest(get_request, "GET", buf)
+        buf.setParent(self.reply)
+
+    def perform_patch(self, endpoint, data, url):
+        """
+        Perform an HTTP PATCH request.
+
+        :param endpoint: the name of the Tribler endpoint.
+        :param data: the data/body to send with the request.
+        :param url: the url to send the request to.
+        """
+        performed_requests.append([endpoint, "PATCH", data, time(), self.get_status_code])
+        buf = QBuffer()
+        buf.setData(data)
+        buf.open(QIODevice.ReadOnly)
+        patch_request = QNetworkRequest(QUrl(url))
+        self.reply = self.sendCustomRequest(patch_request, "PATCH", buf)
+        buf.setParent(self.reply)
+
+    def perform_put(self, endpoint, data, url):
+        """
+        Perform an HTTP PUT request.
+
+        :param endpoint: the name of the Tribler endpoint.
+        :param data: the data/body to send with the request.
+        :param url: the url to send the request to.
+        """
+        performed_requests.append([endpoint, "PUT", data, time(), self.get_status_code])
+        request = QNetworkRequest(QUrl(url))
+        request.setHeader(QNetworkRequest.ContentTypeHeader, "application/x-www-form-urlencoded")
+        self.reply = self.put(request, data)
+
+    def perform_delete(self, endpoint, data, url):
+        """
+        Perform an HTTP DELETE request.
+
+        :param endpoint: the name of the Tribler endpoint.
+        :param data: the data/body to send with the request.
+        :param url: the url to send the request to.
+        """
+        performed_requests.append([endpoint, "DELETE", data, time(), self.get_status_code])
+        buf = QBuffer()
+        buf.setData(data)
+        buf.open(QIODevice.ReadOnly)
+        delete_request = QNetworkRequest(QUrl(url))
+        self.reply = self.sendCustomRequest(delete_request, "DELETE", buf)
+        buf.setParent(self.reply)
+
+    def perform_post(self, endpoint, data, url):
+        """
+        Perform an HTTP POST request.
+
+        :param endpoint: the name of the Tribler endpoint.
+        :param data: the data/body to send with the request.
+        :param url: the url to send the request to.
+        """
+        performed_requests.append([endpoint, "POST", data, time(), self.get_status_code])
+        request = QNetworkRequest(QUrl(url))
+        request.setHeader(QNetworkRequest.ContentTypeHeader, "application/x-www-form-urlencoded")
+        self.reply = self.post(request, data)
 
     @staticmethod
     def get_message_from_error(error):
@@ -96,13 +278,12 @@ class TriblerRequestManager(QNetworkAccessManager):
         return return_error
 
     def on_finished(self, reply, capture_errors):
-        status_code = reply.attribute(QNetworkRequest.HttpStatusCodeAttribute)
-        if not reply.isOpen() or not status_code:
+        self.status_code = reply.attribute(QNetworkRequest.HttpStatusCodeAttribute)
+        request_queue.parse_queue()
+
+        if not reply.isOpen() or not self.status_code:
             self.received_json.emit(None, reply.error())
             return
-
-        if self.request_id in performed_requests:
-            performed_requests[self.request_id][4] = status_code
 
         data = reply.readAll()
         try:

--- a/TriblerGUI/tribler_request_manager.py
+++ b/TriblerGUI/tribler_request_manager.py
@@ -165,6 +165,7 @@ class TriblerRequestManager(QNetworkAccessManager):
             'DELETE': self.perform_delete,
             'POST': self.perform_post
         }
+        self.on_cancel = lambda: None
 
     def get_status_code(self):
         """
@@ -173,7 +174,7 @@ class TriblerRequestManager(QNetworkAccessManager):
         return self.status_code
 
     def perform_request(self, endpoint, read_callback, data="", method='GET', capture_errors=True,
-                        priority=QueuePriorityEnum.CRITICAL):
+                        priority=QueuePriorityEnum.CRITICAL, on_cancel=lambda: None):
         """
         Perform a HTTP request.
         :param endpoint: the endpoint to call (i.e. "statistics")
@@ -185,6 +186,7 @@ class TriblerRequestManager(QNetworkAccessManager):
         url = self.base_url + endpoint
 
         self.status_code = -1
+        self.on_cancel = on_cancel
         request_queue.enqueue(self,
                               lambda: self.dispatch_map.get(method, lambda x, y, z: None)(endpoint, data, url),
                               priority)
@@ -332,3 +334,4 @@ class TriblerRequestManager(QNetworkAccessManager):
     def cancel_request(self):
         if self.reply:
             self.reply.abort()
+        self.on_cancel()

--- a/TriblerGUI/tribler_window.py
+++ b/TriblerGUI/tribler_window.py
@@ -28,7 +28,7 @@ from TriblerGUI.defs import PAGE_SEARCH_RESULTS, \
 from TriblerGUI.dialogs.confirmationdialog import ConfirmationDialog
 from TriblerGUI.dialogs.feedbackdialog import FeedbackDialog
 from TriblerGUI.dialogs.startdownloaddialog import StartDownloadDialog
-from TriblerGUI.tribler_request_manager import TriblerRequestManager
+from TriblerGUI.tribler_request_manager import request_queue, TriblerRequestManager
 from TriblerGUI.utilities import get_ui_file_path, get_image_path, get_gui_setting, is_dir_writable
 
 # Pre-load form UI classes
@@ -305,7 +305,6 @@ class TriblerWindow(QMainWindow):
         post_data = post_data.encode('utf-8')  # We need to send bytes in the request, not unicode
 
         request_mgr = TriblerRequestManager()
-        self.pending_requests[request_mgr.request_id] = request_mgr
         request_mgr.perform_request("downloads", callback if callback else self.on_download_added,
                                     method='PUT', data=post_data)
 
@@ -686,6 +685,7 @@ class TriblerWindow(QMainWindow):
             self.core_manager.stop()
             self.core_manager.shutting_down = True
             self.downloads_page.stop_loading_downloads()
+            request_queue.clear()
 
     def closeEvent(self, close_event):
         self.close_tribler()

--- a/TriblerGUI/widgets/channel_torrent_list_item.py
+++ b/TriblerGUI/widgets/channel_torrent_list_item.py
@@ -116,7 +116,7 @@ class ChannelTorrentListItem(QWidget, fc_channel_torrent_list_item):
         self.is_health_checking = True
         self.health_request_mgr = TriblerRequestManager()
         self.health_request_mgr.perform_request("torrents/%s/health?timeout=15" % self.torrent_info["infohash"],
-                                                self.on_health_response, capture_errors=False)
+                                                self.on_health_response, capture_errors=False, priority="LOW")
 
     def on_health_response(self, response):
         """

--- a/TriblerGUI/widgets/channel_torrent_list_item.py
+++ b/TriblerGUI/widgets/channel_torrent_list_item.py
@@ -103,6 +103,16 @@ class ChannelTorrentListItem(QWidget, fc_channel_torrent_list_item):
     def leaveEvent(self, _):
         self.hide_buttons()
 
+    def on_cancel_health_check(self):
+        """
+        The request for torrent health could not be queued.
+        Go back to the intial state.
+        """
+        self.health_text.setText("unknown health")
+        self.set_health_indicator(STATUS_UNKNOWN)
+        self.is_health_checking = False
+        self.has_health = False
+
     def check_health(self):
         """
         Perform a request to check the health of the torrent that is represented by this widget.
@@ -116,7 +126,8 @@ class ChannelTorrentListItem(QWidget, fc_channel_torrent_list_item):
         self.is_health_checking = True
         self.health_request_mgr = TriblerRequestManager()
         self.health_request_mgr.perform_request("torrents/%s/health?timeout=15" % self.torrent_info["infohash"],
-                                                self.on_health_response, capture_errors=False, priority="LOW")
+                                                self.on_health_response, capture_errors=False, priority="LOW",
+                                                on_cancel=self.on_cancel_health_check)
 
     def on_health_response(self, response):
         """

--- a/TriblerGUI/widgets/downloadspage.py
+++ b/TriblerGUI/widgets/downloadspage.py
@@ -90,7 +90,6 @@ class DownloadsPage(QWidget):
         if self.window().download_details_widget.currentIndex() == 3:
             url = "downloads?get_peers=1&get_pieces=1"
 
-        self.downloads_request_mgr.generate_request_id()
         self.downloads_request_mgr.perform_request(url, self.on_received_downloads)
 
     def on_received_downloads(self, downloads):


### PR DESCRIPTION
This PR adds a priority-based request queue for the GUI's HTTP requests to the core.
This PR also immediately lowers the maximum amount of (non-critical) outstanding requests to 200 and assigns health requests a low priority.

The code is done, but this PR still requires some stress testing on different machines before merging.

Fixes #3303.
Fixes #3319.
  