### PR TITLE
Force restart Tribler

### DIFF
--- a/check_os.py
+++ b/check_os.py
@@ -1,9 +1,14 @@
 import logging
 import os
+import subprocess
 import sys
 import tempfile
+
+from Tribler.Core.Modules.process_checker import ProcessChecker
 from Tribler.Core.SessionConfig import SessionStartupConfig
 
+FORCE_RESTART_MESSAGE = "A Tribler instance is already running. Do you want to force restart? " \
+                        "\n\nCaution: force restart could result in data corruption."
 
 def error_and_exit(title, main_text):
     """
@@ -117,3 +122,71 @@ def setup_logging(gui=False):
     logging.info_log_file = os.path.join(log_directory, info_filename)
     logging.error_log_file = os.path.join(log_directory, error_filename)
     logging.config.fileConfig(log_config, disable_existing_loggers=False)
+
+
+def get_existing_tribler_pids():
+    """ Get PID of all existing instances excluding the current one """
+    pids = []
+    if sys.platform == 'linux2':
+        for proc in subprocess.check_output(['ps', '-ef']).splitlines():
+            if 'python' in proc and 'run_tribler.py' in proc:
+                pids += [int(proc.split()[1])]
+    elif sys.platform == 'win32':
+        pids = [int(item.split()[1]) for item in os.popen('tasklist').read().splitlines()[4:] if
+                'tribler.exe' in item.split()]
+    elif sys.platform == 'darwin':
+        tribler_executable_partial_path = "Tribler.app/Contents/MacOS/tribler".lower()
+        for proc in subprocess.check_output(['ps', '-ef']).splitlines():
+            if tribler_executable_partial_path in proc.lower() or ('python' in proc and 'run_tribler.py' in proc):
+                pids += [int(proc.split()[1])]
+
+    # Remove the current instance PID from this list
+    current_pid = os.getpid()
+    # In Mac, there are two processes spawned somehow with consecutive pids, if so remove it from the list
+    current_pid_list = [current_pid, current_pid - 1, current_pid + 1]
+    for new_pid in current_pid_list:
+        if new_pid in pids:
+            pids.remove(new_pid)
+
+    # Get core process PID from the lock file (if any) and add it to the PID list
+    process_checker = ProcessChecker()
+    if process_checker.already_running:
+        core_pid = process_checker.get_pid_from_lock_file()
+        if core_pid not in pids:
+            pids.append(int(core_pid))
+    # ProcessChecker creates a lock file, remove it before continuing
+    process_checker.remove_lock_file()
+
+    return pids
+
+
+def should_kill_other_tribler_instances():
+    """ Asks user whether to force restart Tribler if there is more than one instance running.
+        This will help user to kill any zombie instances which might have been left behind from
+        previous force kill command or some other unexpected exceptions and relaunch Tribler again.
+        It ignores if Tribler is opened with some arguments, for eg. with a torrent.
+     """
+    # If there are cmd line args, let existing instance handle it
+    if len(sys.argv) > 1:
+        return
+
+    # Get PIDs of existing tribler instance
+    pids = get_existing_tribler_pids()
+
+    # If the PID list is not empty, then there is another Tribler instance running
+    # Ask user whether to force restart
+    if pids:
+        import Tkinter
+        import tkMessageBox
+        window = Tkinter.Tk()
+        window.withdraw()
+        result = tkMessageBox.askquestion("Warning", FORCE_RESTART_MESSAGE, icon='warning')
+        if result == 'yes':
+            for pid in pids:
+                os.kill(pid, 9)
+            window.update()
+            window.quit()
+        else:
+            window.update()
+            window.quit()
+            sys.exit(0)

--- a/run_tribler.py
+++ b/run_tribler.py
@@ -3,8 +3,8 @@ import sys
 import multiprocessing
 import logging.config
 
-from check_os import check_environment, check_free_space, setup_gui_logging
-from check_os import error_and_exit
+from check_os import check_environment, check_free_space, error_and_exit, setup_gui_logging, \
+    should_kill_other_tribler_instances
 
 
 if __name__ == "__main__":
@@ -12,6 +12,8 @@ if __name__ == "__main__":
     check_environment()
 
     multiprocessing.freeze_support()
+
+    should_kill_other_tribler_instances()
 
     check_free_space()
 


### PR DESCRIPTION
Asks user whether to force restart Tribler if there is more than one instance running. This will help user to kill any zombie instances which might have been left behind by previous force kill command or some other unexpected exceptions and relaunch Tribler again.

Fixes #3348 