### PR TITLE
Removed border around torrent details pane

### DIFF
--- a/TriblerGUI/qt_resources/torrent_channel_list_container.ui
+++ b/TriblerGUI/qt_resources/torrent_channel_list_container.ui
@@ -134,6 +134,9 @@ QTabBar::tab:selected {
         </property>
         <item>
          <widget class="QScrollArea" name="scrollArea">
+          <property name="styleSheet">
+           <string notr="true">border: none;</string>
+          </property>
           <property name="widgetResizable">
            <bool>true</bool>
           </property>
@@ -141,9 +144,9 @@ QTabBar::tab:selected {
            <property name="geometry">
             <rect>
              <x>0</x>
-             <y>-26</y>
-             <width>789</width>
-             <height>112</height>
+             <y>0</y>
+             <width>806</width>
+             <height>239</height>
             </rect>
            </property>
            <layout class="QFormLayout" name="formLayout">


### PR DESCRIPTION
To make it consistent with the details pane on the downloads page.