### PR TITLE
Fixed compatibility with libtorrent 0.16.18

### DIFF
--- a/Tribler/Core/Libtorrent/LibtorrentMgr.py
+++ b/Tribler/Core/Libtorrent/LibtorrentMgr.py
@@ -277,7 +277,7 @@ class LibtorrentMgr(TaskManager):
             if infohash in known:
                 self.torrents[infohash] = (torrentdl, ltsession)
                 infohash_bin = binascii.unhexlify(infohash)
-                return ltsession.find_torrent(lt.sha1_hash(infohash_bin))
+                return ltsession.find_torrent(lt.big_number(infohash_bin))
 
             # Otherwise, add it anew
             torrent_handle = ltsession.add_torrent(encode_atp(atp))


### PR DESCRIPTION
The `sha1_hash` doesn't exist in older versions of libtorrent and we should use the `big_number` function instead. According to the Python bindings, `big_number` provides exactly the same functionality as `sha1_hash`.

Credits to @EinNarr for finding this bug.