### PR TITLE
Fixed compatibility with newer versions of libtorrent while maintaining backwards compatibility (devel)

### DIFF
--- a/Tribler/Core/Libtorrent/LibtorrentDownloadImpl.py
+++ b/Tribler/Core/Libtorrent/LibtorrentDownloadImpl.py
@@ -360,9 +360,6 @@ class LibtorrentDownloadImpl(DownloadConfigInterface, TaskManager):
                 max_conn_download = self.session.config.get_libtorrent_max_conn_download()
                 if max_conn_download != -1:
                     self.handle.set_max_connections(max(2, max_conn_download))
-
-                self.handle.resolve_countries(True)
-
             else:
                 self._logger.error("Could not add torrent to LibtorrentManager %s", self.tdef.get_name_as_unicode())
 
@@ -952,7 +949,6 @@ class LibtorrentDownloadImpl(DownloadConfigInterface, TaskManager):
                      'dtotal': peer_info.total_download,
                      'completed': peer_info.progress,
                      'have': peer_info.pieces, 'speed': peer_info.remote_dl_rate,
-                     'country': peer_info.country,
                      'connection_type': peer_info.connection_type,
                      # add upload_only and/or seed
                      'seed': bool(peer_info.flags & peer_info.seed),

--- a/Tribler/Core/Libtorrent/LibtorrentMgr.py
+++ b/Tribler/Core/Libtorrent/LibtorrentMgr.py
@@ -12,6 +12,7 @@ import threading
 import time
 from binascii import hexlify
 from copy import deepcopy
+from distutils.version import LooseVersion
 from shutil import rmtree
 from urllib import url2pathname
 
@@ -136,19 +137,23 @@ class LibtorrentMgr(TaskManager):
         # Copy construct so we don't modify the default list
         extensions = list(DEFAULT_LT_EXTENSIONS)
 
+        # Elric: Strip out the -rcX, -beta, -whatever tail on the version string.
+        fingerprint = ['TL'] + map(int, version_id.split('-')[0].split('.')) + [0]
+        ltsession = lt.session(lt.fingerprint(*fingerprint), flags=0) if hops == 0 else lt.session(flags=0)
+
         if hops == 0:
             settings['user_agent'] = 'Tribler/' + version_id
-            # Elric: Strip out the -rcX, -beta, -whatever tail on the version string.
-            fingerprint = ['TL'] + map(int, version_id.split('-')[0].split('.')) + [0]
-            # Workaround for libtorrent 0.16.3 segfault (see https://code.google.com/p/libtorrent/issues/detail?id=369)
-            ltsession = lt.session(lt.fingerprint(*fingerprint), flags=0)
             enable_utp = self.tribler_session.config.get_libtorrent_utp()
             settings['enable_outgoing_utp'] = enable_utp
             settings['enable_incoming_utp'] = enable_utp
 
-            pe_settings = lt.pe_settings()
-            pe_settings.prefer_rc4 = True
-            ltsession.set_pe_settings(pe_settings)
+            if LooseVersion(self.get_libtorrent_version()) >= LooseVersion("1.1.0"):
+                settings['prefer_rc4'] = True
+                settings["listen_interfaces"] = "0.0.0.0:%d" % self.tribler_session.config.get_libtorrent_port()
+            else:
+                pe_settings = lt.pe_settings()
+                pe_settings.prefer_rc4 = True
+                ltsession.set_pe_settings(pe_settings)
         else:
             settings['enable_outgoing_utp'] = True
             settings['enable_incoming_utp'] = True
@@ -156,7 +161,10 @@ class LibtorrentMgr(TaskManager):
             settings['enable_incoming_tcp'] = False
             settings['anonymous_mode'] = True
             settings['force_proxy'] = True
-            ltsession = lt.session(flags=0)
+
+            if LooseVersion(self.get_libtorrent_version()) >= LooseVersion("1.1.0"):
+                settings["listen_interfaces"] = "0.0.0.0:%d" % self.tribler_session.config.get_anon_listen_port()
+
             # No PEX for anonymous sessions
             if lt.create_ut_pex_plugin in extensions:
                 extensions.remove(lt.create_ut_pex_plugin)
@@ -216,22 +224,34 @@ class LibtorrentMgr(TaskManager):
         return self.ltsessions[hops]
 
     def set_proxy_settings(self, ltsession, ptype, server=None, auth=None):
-        proxy_settings = lt.proxy_settings()
-        proxy_settings.type = lt.proxy_type(ptype)
-        if server and server[0] and server[1]:
-            proxy_settings.hostname = server[0]
-            proxy_settings.port = int(server[1])
-        if auth:
-            proxy_settings.username = auth[0]
-            proxy_settings.password = auth[1]
-        proxy_settings.proxy_hostnames = True
-        proxy_settings.proxy_peer_connections = True
-
-        if ltsession is not None:
-            ltsession.set_proxy(proxy_settings)
+        """
+        Apply the proxy settings to a libtorrent session. This mechanism changed significantly in libtorrent 1.1.0.
+        """
+        if LooseVersion(self.get_libtorrent_version()) >= LooseVersion("1.1.0"):
+            settings = ltsession.get_settings()
+            settings["proxy_type"] = ptype
+            settings["proxy_hostnames"] = True
+            settings["proxy_peer_connections"] = True
+            if server and server[0] and server[1]:
+                settings["proxy_hostname"] = server[0]
+                settings["proxy_port"] = int(server[1])
+            if auth:
+                settings["proxy_username"] = auth[0]
+                settings["proxy_password"] = auth[1]
+            ltsession.set_settings(settings)
         else:
-            # only apply the proxy settings to normal libtorrent session (with hops = 0)
-            self.ltsessions[0].set_proxy(proxy_settings)
+            proxy_settings = lt.proxy_settings()
+            proxy_settings.type = lt.proxy_type(ptype)
+            if server and server[0] and server[1]:
+                proxy_settings.hostname = server[0]
+                proxy_settings.port = int(server[1])
+            if auth:
+                proxy_settings.username = auth[0]
+                proxy_settings.password = auth[1]
+            proxy_settings.proxy_hostnames = True
+            proxy_settings.proxy_peer_connections = True
+
+            ltsession.set_proxy(proxy_settings)
 
     def set_utp(self, enable, hops=None):
         def do_set_utp(ltsession):

--- a/Tribler/Test/Core/CreditMining/mock_creditmining.py
+++ b/Tribler/Test/Core/CreditMining/mock_creditmining.py
@@ -82,7 +82,6 @@ class MockLtPeer(object):
         self.progress = 0
         self.pieces = 0
         self.remote_dl_rate = 0
-        self.country = "ID"
         self.connection_type = 0
         self.seed = 1
         self.upload_only = 1

--- a/Tribler/Test/Core/Libtorrent/test_libtorrent_download_impl.py
+++ b/Tribler/Test/Core/Libtorrent/test_libtorrent_download_impl.py
@@ -142,7 +142,6 @@ class TestLibtorrentDownloadImpl(TestAsServer):
         fake_handler.status = lambda: fake_status
         fake_handler.set_share_mode = lambda _: None
         fake_handler.resume = lambda: None
-        fake_handler.resolve_countries = lambda _: None
         fake_status = MockObject()
         fake_status.share_mode = False
         # Create a dummy download config

--- a/Tribler/Test/Core/Libtorrent/test_libtorrent_mgr.py
+++ b/Tribler/Test/Core/Libtorrent/test_libtorrent_mgr.py
@@ -338,8 +338,19 @@ class TestLibtorrentMgr(AbstractServer):
             self.assertEqual(settings.username, 'abc')
             self.assertEqual(settings.password, 'def')
 
+        def on_set_settings(settings):
+            self.assertTrue(settings)
+            self.assertEqual(settings['proxy_hostname'], 'a')
+            self.assertEqual(settings['proxy_port'], 1234)
+            self.assertEqual(settings['proxy_username'], 'abc')
+            self.assertEqual(settings['proxy_password'], 'def')
+            self.assertEqual(settings['proxy_peer_connections'], True)
+            self.assertEqual(settings['proxy_hostnames'], True)
+
         mock_lt_session = MockObject()
-        mock_lt_session.set_proxy = on_proxy_set
+        mock_lt_session.get_settings = lambda: {}
+        mock_lt_session.set_settings = on_set_settings
+        mock_lt_session.set_proxy = on_proxy_set  # Libtorrent < 1.1.0 uses set_proxy to set proxy settings
         self.ltmgr.metadata_tmpdir = tempfile.mkdtemp(suffix=u'tribler_metainfo_tmpdir')
         self.ltmgr.set_proxy_settings(mock_lt_session, 0, ('a', "1234"), ('abc', 'def'))
 


### PR DESCRIPTION
This PR fixes anonymous downloading and anonymous seeding in Tribler for libtorrent 1.1.0 and higher.

Based on #3084 and credits to @Captain-Coder for finding most of the new settings.

Fixes #3353