### PR TITLE
Add timer to refresh trust page stats

### DIFF
--- a/TriblerGUI/widgets/trustpage.py
+++ b/TriblerGUI/widgets/trustpage.py
@@ -5,9 +5,9 @@ from TriblerGUI.defs import PAGE_MARKET
 matplotlib.use('Qt5Agg')
 
 import datetime
+from PyQt5.QtCore import QTimer
 from PyQt5.QtWidgets import QSizePolicy
 from PyQt5.QtWidgets import QWidget
-from PyQt5.QtCore import QTimer
 from matplotlib.backends.backend_qt5agg import FigureCanvas
 from matplotlib.dates import DateFormatter
 from matplotlib.figure import Figure

--- a/TriblerGUI/widgets/trustpage.py
+++ b/TriblerGUI/widgets/trustpage.py
@@ -92,7 +92,7 @@ class TrustPage(QWidget):
         vlayout = self.window().plot_widget.layout()
         self.trust_plot = TrustPlotMplCanvas(self.window().plot_widget, dpi=100)
         vlayout.addWidget(self.trust_plot)
-        
+
         self.refresh_timer = QTimer()
         self.refresh_timer.timeout.connect(self.load_trust_statistics)
         self.refresh_timer.start(60000)

--- a/TriblerGUI/widgets/trustpage.py
+++ b/TriblerGUI/widgets/trustpage.py
@@ -7,6 +7,7 @@ matplotlib.use('Qt5Agg')
 import datetime
 from PyQt5.QtWidgets import QSizePolicy
 from PyQt5.QtWidgets import QWidget
+from PyQt5.QtCore import QTimer
 from matplotlib.backends.backend_qt5agg import FigureCanvas
 from matplotlib.dates import DateFormatter
 from matplotlib.figure import Figure
@@ -85,16 +86,16 @@ class TrustPage(QWidget):
         self.statistics = None
         self.blocks = None
         self.byte_scale = 1024 * 1024
-        self.timer = None
+        self.refresh_timer = None
 
     def initialize_trust_page(self):
         vlayout = self.window().plot_widget.layout()
         self.trust_plot = TrustPlotMplCanvas(self.window().plot_widget, dpi=100)
         vlayout.addWidget(self.trust_plot)
         
-        self.timer = QtCore.QTimer()
-        self.timer.timeout.connect(self.load_trust_statistics)
-        self.timer.start(60000)
+        self.refresh_timer = QTimer()
+        self.refresh_timer.timeout.connect(self.load_trust_statistics)
+        self.refresh_timer.start(60000)
 
         self.window().trade_button.clicked.connect(self.on_trade_button_clicked)
 

--- a/TriblerGUI/widgets/trustpage.py
+++ b/TriblerGUI/widgets/trustpage.py
@@ -85,11 +85,16 @@ class TrustPage(QWidget):
         self.statistics = None
         self.blocks = None
         self.byte_scale = 1024 * 1024
+        self.timer = None
 
     def initialize_trust_page(self):
         vlayout = self.window().plot_widget.layout()
         self.trust_plot = TrustPlotMplCanvas(self.window().plot_widget, dpi=100)
         vlayout.addWidget(self.trust_plot)
+        
+        self.timer = QtCore.QTimer()
+        self.timer.timeout.connect(self.load_trust_statistics)
+        self.timer.start(60000)
 
         self.window().trade_button.clicked.connect(self.on_trade_button_clicked)
 


### PR DESCRIPTION
An untested basic idea.
Run the load_trust_statistics() every minute.