### PR TITLE
Added libnacl library dependencies

### DIFF
--- a/doc/development/development_on_linux.rst
+++ b/doc/development/development_on_linux.rst
@@ -7,7 +7,7 @@ First, install the required dependencies by executing the following command in y
 
 .. code-block:: none
 
-    sudo apt-get install libav-tools libsodium18 libx11-6 python-apsw python-cherrypy3 python-cryptography python-decorator python-dnspython python-ecdsa python-feedparser python-jsonrpclib python-keyring python-keyrings.alt python-leveldb python-libtorrent python-matplotlib python-meliae python-m2crypto python-netifaces python-pbkdf2 python-pil python-protobuf python-pyasn1 python-pysocks python-requests python-scipy python-twisted python2.7 vlc python-chardet python-configobj python-pyqt5 python-pyqt5.qtsvg
+    sudo apt-get install libav-tools libsodium18 libx11-6 python-apsw python-cherrypy3 python-cryptography python-decorator python-dnspython python-ecdsa python-feedparser python-jsonrpclib python-keyring python-keyrings.alt python-leveldb python-libtorrent python-matplotlib python-meliae python-m2crypto python-netifaces python-pbkdf2 python-pil python-protobuf python-pyasn1 python-pysocks python-requests python-scipy python-twisted python2.7 vlc python-chardet python-configobj python-pyqt5 python-pyqt5.qtsvg python-libnacl
 
 Next, download the latest .deb file from `here <https://jenkins.tribler.org/job/Build-Tribler_Ubuntu-64_devel/lastStableBuild/>`_.
 
@@ -71,4 +71,4 @@ Execute the following command in your terminal:
 
 .. code-block:: none
 
-    pacman -S libsodium libtorrent-rasterbar python2-pyqt5 qt5-svg phonon-qt5-vlc python2-apsw python2-cherrypy python2-cryptography python2-decorator python2-dnspython python2-ecdsa python2-feedparser python2-chardet python2-jsonrpclib python2-keyring python2-keyrings-alt python2-m2crypto python2-netifaces python2-pbkdf2 python2-plyvel python2-protobuf python2-pysocks python2-requests python2-pyaes python2-twisted python2-configobj python2-matplotlib python2-networkx python2-scipy
+    pacman -S libsodium libtorrent-rasterbar python2-pyqt5 qt5-svg phonon-qt5-vlc python2-apsw python2-cherrypy python2-cryptography python2-decorator python2-dnspython python2-ecdsa python2-feedparser python2-chardet python2-jsonrpclib python2-keyring python2-keyrings-alt python2-m2crypto python2-netifaces python2-pbkdf2 python2-plyvel python2-protobuf python2-pysocks python2-requests python2-pyaes python2-twisted python2-configobj python2-matplotlib python2-networkx python2-scipy python2-libnacl

--- a/doc/development/development_on_osx.rst
+++ b/doc/development/development_on_osx.rst
@@ -13,7 +13,7 @@ To install the Tribler dependencies using MacPorts, please run the following com
 
 .. code-block:: bash
 
-    sudo port -N install git ffmpeg qt5-qtcreator libtorrent-rasterbar gmp mpfr libmpc libsodium py27-m2crypto py27-apsw py27-Pillow py27-twisted py27-cherrypy3 py27-cffi py27-chardet py27-configobj py27-gmpy2 py27-pycparser py27-numpy py27-idna py27-leveldb py27-cryptography py27-decorator py27-feedparser py27-netifaces py27-service_identity py27-asn1-modules py27-pyinstaller py27-pyqt5 py27-sqlite py27-matplotlib
+    sudo port -N install git ffmpeg qt5-qtcreator libtorrent-rasterbar gmp mpfr libmpc libsodium py27-m2crypto py27-apsw py27-Pillow py27-twisted py27-cherrypy3 py27-cffi py27-chardet py27-configobj py27-gmpy2 py27-pycparser py27-numpy py27-idna py27-leveldb py27-cryptography py27-decorator py27-feedparser py27-netifaces py27-service_identity py27-asn1-modules py27-pyinstaller py27-pyqt5 py27-sqlite py27-matplotlib py27-libnacl
     
 HomeBrew
 --------
@@ -139,7 +139,7 @@ There are a bunch of other packages that can easily be installed using pip and b
     brew install homebrew/python/pillow gmp mpfr libmpc libsodium
     sudo easy_install pip
     pip install --user cython  # Needs to be installed first for meliae
-    pip install --user cherrypy cffi chardet configobj cryptography decorator dnspython ecdsa feedparser gmpy2 jsonrpclib idna keyring leveldb meliae netifaces numpy pbkdf2 pillow protobuf pyasn1 pysocks pycparser requests scipy twisted service_identity
+    pip install --user cherrypy cffi chardet configobj cryptography decorator dnspython ecdsa feedparser gmpy2 jsonrpclib idna keyring leveldb meliae netifaces numpy pbkdf2 pillow protobuf pyasn1 pysocks pycparser requests scipy twisted service_identity libnacl
 
 If you encounter any error during the installation of Pillow, make sure that libjpeg and zlib are installed. They can be installed using:
 

--- a/doc/development/development_on_windows.rst
+++ b/doc/development/development_on_windows.rst
@@ -172,7 +172,7 @@ There are some additional packages which should be installed. They can easily be
 .. code-block:: none
 
     pip install cython  # Needs to be installed first for meliae
-    pip install cherrypy chardet configobj cryptography decorator dnspython ecdsa feedparser jsonrpclib keyring meliae netifaces networkx pbkdf2 pillow protobuf pyaes pysocks requests twisted win_inet_pton keyring pbkdf2
+    pip install cherrypy chardet configobj cryptography decorator dnspython ecdsa feedparser jsonrpclib keyring meliae netifaces networkx pbkdf2 pillow protobuf pyaes pysocks requests twisted win_inet_pton keyring pbkdf2 libnacl
 
 Running Tribler
 ---------------


### PR DESCRIPTION
This adds the `libnacl` dependency installation instructions to the Windows/Unix/Mac development documents.