### PR TITLE
Fix macOS installer issue with libsodium

### DIFF
--- a/tribler.spec
+++ b/tribler.spec
@@ -49,6 +49,7 @@ pyz = PYZ(a.pure, a.zipped_data,
 
 # Add libsodium.dylib on OS X
 if sys.platform == 'darwin':
+    a.binaries = a.binaries - TOC([('/usr/local/lib/libsodium.so', None, None),])
     a.binaries = a.binaries + TOC([('libsodium.dylib', '/usr/local/lib/libsodium.dylib', None),])
 
 exe = EXE(pyz,


### PR DESCRIPTION
Fixed issue with mac installer #3428
Removed `libsodium.so` from the included binaries for macOS