### PR TITLE
Ignore invalid infohash

### DIFF
--- a/Tribler/Core/Session.py
+++ b/Tribler/Core/Session.py
@@ -251,6 +251,12 @@ class Session(SessionConfigInterface):
                 self._logger.error("Invalid DNS-ID")
                 return
 
+            # We already have a check for invalid infohash when adding a torrent, but if somehow we get this
+            # error then we simply log and ignore it.
+            if 'exceptions.RuntimeError: invalid info-hash' in text:
+                self._logger.error("Invalid info-hash found")
+                return
+
             if self.lm.api_manager and len(text) > 0:
                 self.lm.api_manager.root_endpoint.events_endpoint.on_tribler_exception(text)
                 self.lm.api_manager.root_endpoint.state_endpoint.on_tribler_exception(text)

--- a/Tribler/Test/Core/test_session.py
+++ b/Tribler/Test/Core/test_session.py
@@ -134,6 +134,8 @@ class TestSessionAsServer(TestAsServer):
         self.session.unhandled_error_observer({'isError': True,
                                                'log_failure': 'socket.error: [Errno %s]' % SOCKET_BLOCK_ERRORCODE})
         self.session.unhandled_error_observer({'isError': True, 'log_failure': 'exceptions.ValueError: Invalid DNS-ID'})
+        self.session.unhandled_error_observer({'isError': True,
+                                               'log_failure': 'exceptions.RuntimeError: invalid info-hash'})
 
 
     @deferred(timeout=10)


### PR DESCRIPTION
If the info hash is found invalid when trying to add a torrent, it is simply logged and ignored.