### PR TITLE
Fixed mainline DHT when used for hidden seeding

### DIFF
--- a/Tribler/Core/APIImplementation/LaunchManyCore.py
+++ b/Tribler/Core/APIImplementation/LaunchManyCore.py
@@ -364,6 +364,14 @@ class TriblerLaunchMany(TaskManager):
 
             self.session.readable_status = STATE_LOADING_COMMUNITIES
 
+        # We should load the mainline DHT before loading the IPv8 overlays since the DHT is used for the tunnel overlay.
+        if self.session.config.get_mainline_dht_enabled():
+            self.session.readable_status = STATE_START_MAINLINE_DHT
+            from Tribler.Core.DecentralizedTracking import mainlineDHT
+            self.mainline_dht = mainlineDHT.init(('127.0.0.1', self.session.config.get_mainline_dht_port()),
+                                                 self.session.config.get_state_dir())
+            self.upnp_ports.append((self.session.config.get_mainline_dht_port(), 'UDP'))
+
         if self.ipv8:
             self.load_ipv8_overlays()
 
@@ -378,13 +386,6 @@ class TriblerLaunchMany(TaskManager):
             from Tribler.Core.Modules.channel.channel_manager import ChannelManager
             self.channel_manager = ChannelManager(self.session)
             self.channel_manager.initialize()
-
-        if self.session.config.get_mainline_dht_enabled():
-            self.session.readable_status = STATE_START_MAINLINE_DHT
-            from Tribler.Core.DecentralizedTracking import mainlineDHT
-            self.mainline_dht = mainlineDHT.init(('127.0.0.1', self.session.config.get_mainline_dht_port()),
-                                                 self.session.config.get_state_dir())
-            self.upnp_ports.append((self.session.config.get_mainline_dht_port(), 'UDP'))
 
         if self.session.config.get_libtorrent_enabled():
             self.session.readable_status = STATE_START_LIBTORRENT

--- a/Tribler/community/market/community.py
+++ b/Tribler/community/market/community.py
@@ -102,6 +102,7 @@ class MarketCommunity(TrustChainCommunity):
         kwargs['db_name'] = self.DB_NAME
 
         super(MarketCommunity, self).__init__(*args, **kwargs)
+        self._use_main_thread = True  # Market community is unable to deal with thread pool message processing yet
         self.mid = self.my_peer.mid.encode('hex')
         self.mid_register = {}
         self.order_book = None


### PR DESCRIPTION
In this PR, I load the mainline DHT before loading IPv8 overlays. I also disabled thread pool processing of messages in the market and tunnel overlays.