### PR TITLE
Implemented tunnel payouts

### DIFF
--- a/Tribler/Core/APIImplementation/LaunchManyCore.py
+++ b/Tribler/Core/APIImplementation/LaunchManyCore.py
@@ -257,7 +257,8 @@ class TriblerLaunchMany(TaskManager):
                                                            tribler_session=self.session,
                                                            dht_provider=MainlineDHTProvider(
                                                                self.mainline_dht,
-                                                               self.session.config.get_dispersy_port()))
+                                                               self.session.config.get_dispersy_port()),
+                                                           triblerchain_community=self.triblerchain_community)
             self.ipv8.overlays.append(self.tunnel_community)
             self.ipv8.strategies.append((RandomWalk(self.tunnel_community), 20))
 

--- a/Tribler/Test/Community/Market/test_community.py
+++ b/Tribler/Test/Community/Market/test_community.py
@@ -116,12 +116,12 @@ class TestMarketCommunity(TestMarketCommunityBase):
         order = self.nodes[0].overlay.create_ask(2, 'DUM1', 2, 'DUM2', 3600)
         order._traded_quantity._quantity = 1  # Partially fulfill this order
 
-        yield self.deliver_messages(timeout=.2)
+        yield self.deliver_messages(timeout=.4)
 
         self.assertEqual(len(self.nodes[2].overlay.order_book.asks), 1)
         self.nodes[1].overlay.create_bid(2, 'DUM1', 2, 'DUM2', 3600)
 
-        yield self.deliver_messages(timeout=.2)
+        yield self.deliver_messages(timeout=.4)
 
         self.assertTrue(self.nodes[0].overlay.transaction_manager.find_all())
         self.assertTrue(self.nodes[1].overlay.transaction_manager.find_all())
@@ -136,7 +136,7 @@ class TestMarketCommunity(TestMarketCommunityBase):
         self.nodes[0].overlay.create_ask(1, 'DUM1', 1, 'DUM2', 3600)
         self.nodes[1].overlay.create_bid(1, 'DUM1', 1, 'DUM2', 3600)
 
-        yield self.deliver_messages(timeout=.2)
+        yield self.deliver_messages(timeout=.5)
 
         # Compute reputation
         self.nodes[0].overlay.compute_reputation()
@@ -164,7 +164,7 @@ class TestMarketCommunity(TestMarketCommunityBase):
 
         ask_order = self.nodes[0].overlay.create_ask(1, 'DUM1', 1, 'DUM2', 3600)
 
-        yield self.deliver_messages(timeout=.2)
+        yield self.deliver_messages(timeout=.4)
 
         self.nodes[0].overlay.cancel_order(ask_order.order_id)
 
@@ -186,7 +186,7 @@ class TestMarketCommunity(TestMarketCommunityBase):
         self.nodes[0].overlay.create_ask(1, 'DUM1', 1, 'DUM2', 3600)
         self.nodes[1].overlay.create_bid(1, 'DUM1', 1, 'DUM2', 3600)
 
-        yield self.deliver_messages(timeout=.2)
+        yield self.deliver_messages(timeout=.4)
 
         self.assertEqual(self.nodes[0].overlay.transaction_manager.find_all()[0].status, "error")
         self.assertEqual(self.nodes[1].overlay.transaction_manager.find_all()[0].status, "error")
@@ -205,7 +205,7 @@ class TestMarketCommunityTwoNodes(TestMarketCommunityBase):
         self.nodes[0].overlay.create_ask(1, 'DUM1', 1, 'DUM2', 3600)
         self.nodes[1].overlay.create_bid(1, 'DUM1', 1, 'DUM2', 3600)
 
-        yield self.deliver_messages(timeout=.2)
+        yield self.deliver_messages(timeout=.5)
 
         # Verify that the trade has been made
         self.assertTrue(self.nodes[0].overlay.transaction_manager.find_all())

--- a/Tribler/Test/Community/Triblerchain/test_community.py
+++ b/Tribler/Test/Community/Triblerchain/test_community.py
@@ -1,43 +1,8 @@
-from Tribler.Test.Core.base_test import MockObject
 from Tribler.Test.ipv8_base import TestBase
 from Tribler.Test.mocking.ipv8 import MockIPv8
 from Tribler.Test.util.ipv8_util import twisted_wrapper
 from Tribler.community.triblerchain.block import TriblerChainBlock
-from Tribler.community.triblerchain.community import TriblerChainCommunity, TriblerChainCrawlerCommunity
-from Tribler.pyipv8.ipv8.messaging.anonymization.tunnel import Circuit
-
-
-class TestTriblerChainCommunity(TestBase):
-
-    def setUp(self):
-        super(TestTriblerChainCommunity, self).setUp()
-        self.initialize(TriblerChainCommunity, 2)
-        self.nodes[0].overlay.SIGN_DELAY = 0
-        self.nodes[1].overlay.SIGN_DELAY = 0
-
-    def create_node(self):
-        return MockIPv8(u"curve25519", TriblerChainCommunity, working_directory=u":memory:")
-
-    @twisted_wrapper
-    def test_on_tunnel_remove(self):
-        """
-        Test whether a message is created when a tunnel has been removed
-        """
-        tribler_session = MockObject()
-        tribler_session.lm = MockObject()
-        tribler_session.lm.tunnel_community = MockObject()
-        tribler_session.lm.tunnel_community.network = self.nodes[0].overlay.network
-        self.nodes[0].overlay.tribler_session = tribler_session
-
-        circuit = Circuit(3)
-        circuit.bytes_up = 50 * 1024 * 1024
-        self.nodes[0].overlay.on_tunnel_remove(None, None, circuit,
-                                               self.nodes[0].overlay.network.verified_peers[0].address)
-
-        yield self.sleep(time=0.1)
-
-        my_pk = self.nodes[0].overlay.my_peer.public_key.key_to_bin()
-        self.assertTrue(self.nodes[0].overlay.persistence.get(my_pk, 1))
+from Tribler.community.triblerchain.community import TriblerChainCrawlerCommunity
 
 
 class TestTriblerChainCrawlerCommunity(TestBase):
@@ -45,8 +10,6 @@ class TestTriblerChainCrawlerCommunity(TestBase):
     def setUp(self):
         super(TestTriblerChainCrawlerCommunity, self).setUp()
         self.initialize(TriblerChainCrawlerCommunity, 2)
-        self.nodes[0].overlay.SIGN_DELAY = 0
-        self.nodes[1].overlay.SIGN_DELAY = 0
 
     def create_node(self):
         return MockIPv8(u"curve25519", TriblerChainCrawlerCommunity, working_directory=u":memory:")

--- a/Tribler/Test/Core/Modules/RestApi/test_debug_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_debug_endpoint.py
@@ -4,6 +4,7 @@ import Tribler.Core.Utilities.json_util as json
 from Tribler.Test.Core.Modules.RestApi.base_api_test import AbstractApiTest
 from Tribler.Test.Core.base_test import MockObject
 from Tribler.Test.twisted_thread import deferred
+from Tribler.pyipv8.ipv8.messaging.anonymization.tunnel import CIRCUIT_TYPE_DATA
 
 
 class TestCircuitDebugEndpoint(AbstractApiTest):
@@ -40,6 +41,7 @@ class TestCircuitDebugEndpoint(AbstractApiTest):
         mock_circuit.hops = [mock_hop]
         mock_circuit.sock_addr = ("1.1.1.1", 1234)
         mock_circuit.circuit_id = 1234
+        mock_circuit.ctype = CIRCUIT_TYPE_DATA
         mock_circuit.destroy = lambda: None
 
         self.session.lm.tunnel_community.circuits = {1234: mock_circuit}

--- a/Tribler/Test/mocking/exit_socket.py
+++ b/Tribler/Test/mocking/exit_socket.py
@@ -1,0 +1,40 @@
+from __future__ import absolute_import
+
+from Tribler.Test.mocking.endpoint import AutoMockEndpoint
+from Tribler.pyipv8.ipv8.messaging.anonymization.tunnel import TunnelExitSocket, DataChecker
+from Tribler.pyipv8.ipv8.messaging.interfaces.endpoint import EndpointListener
+from twisted.internet.defer import succeed
+
+
+
+class MockTunnelExitSocket(TunnelExitSocket, EndpointListener):
+
+    def __init__(self, parent):
+        self.endpoint = AutoMockEndpoint()
+        self.endpoint.open()
+
+        TunnelExitSocket.__init__(self, parent.circuit_id, parent.overlay, parent.sock_addr, parent.mid)
+        parent.close()
+        EndpointListener.__init__(self, self.endpoint)
+
+        self.endpoint.add_listener(self)
+
+    def enable(self):
+        pass
+
+    @property
+    def enabled(self):
+        return True
+
+    def sendto(self, data, destination):
+        if DataChecker.is_allowed(data):
+            self.endpoint.send(destination, data)
+        else:
+            raise AssertionError("Attempted to exit data which is not allowed" % repr(data))
+
+    def on_packet(self, packet):
+        source_address, data = packet
+        self.datagramReceived(data, source_address)
+
+    def close(self):
+        return succeed(True)

--- a/Tribler/community/triblertunnel/community.py
+++ b/Tribler/community/triblertunnel/community.py
@@ -1,5 +1,7 @@
 import time
 
+from Tribler.community.triblertunnel.payload import PayoutPayload
+from Tribler.pyipv8.ipv8.deprecated.payload_headers import GlobalTimeDistributionPayload
 from twisted.internet.defer import inlineCallbacks
 
 from Tribler.community.triblertunnel.dispatcher import TunnelDispatcher
@@ -10,7 +12,8 @@ from Tribler.dispersy.util import call_on_reactor_thread
 from Tribler.pyipv8.ipv8.messaging.anonymization.community import CreatePayload
 from Tribler.pyipv8.ipv8.messaging.anonymization.hidden_services import HiddenTunnelCommunity
 from Tribler.pyipv8.ipv8.messaging.anonymization.payload import LinkedE2EPayload
-from Tribler.pyipv8.ipv8.messaging.anonymization.tunnel import CIRCUIT_STATE_READY, CIRCUIT_TYPE_RP
+from Tribler.pyipv8.ipv8.messaging.anonymization.tunnel import CIRCUIT_STATE_READY, CIRCUIT_TYPE_RP, \
+    CIRCUIT_TYPE_DATA, CIRCUIT_TYPE_RENDEZVOUS
 from Tribler.pyipv8.ipv8.peer import Peer
 
 
@@ -22,14 +25,18 @@ class TriblerTunnelCommunity(HiddenTunnelCommunity):
 
     def __init__(self, *args, **kwargs):
         self.tribler_session = kwargs.pop('tribler_session', None)
+        self.triblerchain_community = kwargs.pop('triblerchain_community', None)
+        socks_listen_ports = kwargs.pop('socks_listen_ports', None)
         super(TriblerTunnelCommunity, self).__init__(*args, **kwargs)
         self._use_main_thread = True
 
         if self.tribler_session:
             self.settings.become_exitnode = self.tribler_session.config.get_tunnel_community_exitnode_enabled()
-            socks_listen_ports = self.tribler_session.config.get_tunnel_community_socks5_listen_ports()
             self.tribler_session.lm.tunnel_community = self
-        else:
+
+            if not socks_listen_ports:
+                socks_listen_ports = self.tribler_session.config.get_tunnel_community_socks5_listen_ports()
+        elif socks_listen_ports is None:
             socks_listen_ports = range(1080, 1085)
 
         self.bittorrent_peers = {}
@@ -44,6 +51,31 @@ class TriblerTunnelCommunity(HiddenTunnelCommunity):
             self.socks_servers.append(socks_server)
 
         self.dispatcher.set_socks_servers(self.socks_servers)
+
+        self.decode_map.update({
+            chr(23): self.on_payout_block
+        })
+
+    def on_payout_block(self, source_address, data):
+        if not self.triblerchain_community:
+            self.logger.warning("Got payout while not having a TriblerChain community running!")
+            return
+
+        _, payload = self._ez_unpack_noauth(PayoutPayload, data)
+        peer = Peer(payload.public_key, source_address)
+        block = self.triblerchain_community.BLOCK_CLASS.from_payload(payload, self.serializer)
+        self.triblerchain_community.process_half_block(block, peer)
+
+        # Send the next payout
+        if payload.circuit_id in self.relay_from_to and block.transaction['down'] > payload.base_amount:
+            relay = self.relay_from_to[payload.circuit_id]
+            circuit_peer = self.get_peer_from_address(relay.sock_addr)
+            if not circuit_peer:
+                self.logger.warning("%s Unable to find next peer %s for payout!", self.my_peer, relay.mid.encode('hex'))
+                return
+
+            self.do_payout(circuit_peer, relay.circuit_id, block.transaction['down'] - payload.base_amount * 2,
+                           payload.base_amount)
 
     def on_download_removed(self, download):
         """
@@ -75,7 +107,40 @@ class TriblerTunnelCommunity(HiddenTunnelCommunity):
             if self.active_data_circuits():
                 self.readd_bittorrent_peers()
 
-    def remove_circuit(self, circuit_id, additional_info='', destroy=False):
+    def get_peer_from_address(self, address):
+        circuit_peer = None
+        for peer in self.network.verified_peers:
+            if peer.address == address:
+                circuit_peer = peer
+                break
+
+        return circuit_peer
+
+    def do_payout(self, peer, circuit_id, amount, base_amount):
+        """
+        Perform a payout to a specific peer.
+        :param peer: The peer to perform the payout to, usually the next node in the circuit.
+        :param circuit_id: The circuit id of the payout, used by the subsequent node.
+        :param amount: The amount to put in the transaction, multiplier of base_amount.
+        :param base_amount: The base amount for the payouts.
+        """
+        self.logger.info("Sending payout of %d (base: %d) to %s (cid: %s)", amount, base_amount, peer, circuit_id)
+
+        block = self.triblerchain_community.BLOCK_CLASS.create(
+            {'up': 0, 'down': amount},
+            self.triblerchain_community.persistence,
+            self.my_peer.public_key.key_to_bin(),
+            link_pk=peer.public_key.key_to_bin())
+        block.sign(self.my_peer.key)
+        self.triblerchain_community.persistence.add_block(block)
+
+        global_time = self.claim_global_time()
+        dist = GlobalTimeDistributionPayload(global_time).to_pack_list()
+        payload = PayoutPayload.from_half_block(block, circuit_id, base_amount).to_pack_list()
+        packet = self._ez_pack(self._prefix, 23, [dist, payload], False)
+        self.send_packet([peer], u"payout", packet)
+
+    def remove_circuit(self, circuit_id, additional_info='', remove_now=False, destroy=False):
         if circuit_id not in self.circuits:
             self.logger.warning("Circuit %d not found when trying to remove it", circuit_id)
             return
@@ -94,12 +159,30 @@ class TriblerTunnelCommunity(HiddenTunnelCommunity):
                 if s == ltmgr.get_session(d.get_hops()):
                     d.get_handle().addCallback(lambda handle: self.update_torrent(affected_peers, handle, d))
 
-        # Now we actually remove the circuit
-        super(TriblerTunnelCommunity, self).remove_circuit(circuit_id, additional_info=additional_info, destroy=destroy)
+        circuit_peer = self.get_peer_from_address(circuit.sock_addr)
+        if circuit.bytes_down >= 1024 * 1024 and self.triblerchain_community and circuit_peer:
+            # We should perform a payout of the removed circuit.
+            if circuit.ctype == CIRCUIT_TYPE_RENDEZVOUS:
+                # We remove an e2e circuit as downloader. We pay the subsequent nodes in the downloader part of the e2e
+                # circuit. In addition, we pay for one hop seeder anonymity since we don't know the circuit length at
+                # the seeder side.
+                self.do_payout(circuit_peer, circuit_id, circuit.bytes_down * (circuit.goal_hops * 2) + 1,
+                               circuit.bytes_down)
 
-    def remove_relay(self, circuit_id, additional_info='', destroy=False, got_destroy_from=None, both_sides=True):
+            if circuit.ctype == CIRCUIT_TYPE_DATA:
+                # We remove a regular data circuit as downloader. Pay the relay nodes and the exit nodes.
+                self.do_payout(circuit_peer, circuit_id, circuit.bytes_down * (circuit.goal_hops * 2 - 1),
+                               circuit.bytes_down)
+
+        # Now we actually remove the circuit
+        super(TriblerTunnelCommunity, self).remove_circuit(circuit_id, additional_info=additional_info,
+                                                           remove_now=remove_now, destroy=destroy)
+
+    def remove_relay(self, circuit_id, additional_info='', remove_now=False, destroy=False, got_destroy_from=None,
+                     both_sides=True):
         removed_relays = super(TriblerTunnelCommunity, self).remove_relay(circuit_id,
                                                                           additional_info=additional_info,
+                                                                          remove_now=remove_now,
                                                                           destroy=destroy,
                                                                           got_destroy_from=got_destroy_from,
                                                                           both_sides=both_sides)
@@ -108,13 +191,13 @@ class TriblerTunnelCommunity(HiddenTunnelCommunity):
             for removed_relay in removed_relays:
                 self.tribler_session.notifier.notify(NTFY_TUNNEL, NTFY_REMOVE, removed_relay, removed_relay.sock_addr)
 
-    def remove_exit_socket(self, circuit_id, additional_info='', destroy=False):
+    def remove_exit_socket(self, circuit_id, additional_info='', remove_now=False, destroy=False):
         if circuit_id in self.exit_sockets and self.tribler_session:
             exit_socket = self.exit_sockets[circuit_id]
             self.tribler_session.notifier.notify(NTFY_TUNNEL, NTFY_REMOVE, exit_socket, exit_socket.sock_addr)
 
         super(TriblerTunnelCommunity, self).remove_exit_socket(circuit_id, additional_info=additional_info,
-                                                               destroy=destroy)
+                                                               remove_now=remove_now, destroy=destroy)
 
     def _ours_on_created_extended(self, circuit, payload):
         super(TriblerTunnelCommunity, self)._ours_on_created_extended(circuit, payload)
@@ -211,6 +294,9 @@ class TriblerTunnelCommunity(HiddenTunnelCommunity):
         self.download_states = new_states
 
     def get_download(self, lookup_info_hash):
+        if not self.tribler_session:
+            return None
+
         for download in self.tribler_session.get_downloads():
             if lookup_info_hash == self.get_lookup_info_hash(download.get_def().get_infohash()):
                 return download

--- a/Tribler/community/triblertunnel/payload.py
+++ b/Tribler/community/triblertunnel/payload.py
@@ -1,0 +1,37 @@
+from Tribler.pyipv8.ipv8.attestation.trustchain.payload import HalfBlockPayload
+
+
+class PayoutPayload(HalfBlockPayload):
+
+    format_list = HalfBlockPayload.format_list + ["I", "I"]
+
+    def __init__(self, public_key, sequence_number, link_public_key, link_sequence_number, previous_hash,
+                 signature, transaction, circuit_id, base_amount):
+        super(PayoutPayload, self).__init__(public_key, sequence_number, link_public_key, link_sequence_number,
+                                            previous_hash, signature, transaction)
+        self.circuit_id = circuit_id
+        self.base_amount = base_amount
+
+    @classmethod
+    def from_half_block(cls, block, circuit_id, base_amount):
+        return PayoutPayload(
+            block.public_key,
+            block.sequence_number,
+            block.link_public_key,
+            block.link_sequence_number,
+            block.previous_hash,
+            block.signature,
+            block.transaction,
+            circuit_id,
+            base_amount
+        )
+
+    def to_pack_list(self):
+        data = super(PayoutPayload, self).to_pack_list()
+        data.append(('I', self.circuit_id))
+        data.append(('I', self.base_amount))
+        return data
+
+    @classmethod
+    def from_unpack_list(cls, *args):
+        return PayoutPayload(*args)


### PR DESCRIPTION
In this PR, I implemented the payouts for the tunnel community. When destroying a 'regular' data circuit or an e2e circuit, the downloader pays the subsequent node in the form of bandwidth tokens. Note that this implementation is the most basic implementation possible and does not contain any sophisticated security/anonymity features.

Depends on https://github.com/Tribler/py-ipv8/pull/67

Fixes #3493 