### PR TITLE
Refactored Process Checker

### DIFF
--- a/Tribler/Core/Modules/process_checker.py
+++ b/Tribler/Core/Modules/process_checker.py
@@ -1,4 +1,5 @@
 import os
+import psutil
 
 from Tribler.Core.SessionConfig import SessionStartupConfig
 
@@ -12,35 +13,29 @@ class ProcessChecker(object):
     """
 
     def __init__(self):
-        """
-        Check whether a lock file exists in the Tribler directory. If not, create the file. If it exists,
-        check the PID that is written inside the lock file.
-        """
-        self.already_running = False
 
         self.statedir = SessionStartupConfig().get_state_dir()
         self.lock_file_path = os.path.join(self.statedir, LOCK_FILE_NAME)
 
         if os.path.exists(self.lock_file_path):
-            try:
-                file_pid = int(self.get_pid_from_lock_file())
-            except ValueError:
-                # Apparently, the data written inside the lock file is not an int, just remove the file and recreate it.
+            # Check for stale lock file (created before the os was last restarted).
+            # The stale file might contain the pid of another running process and
+            # not the Tribler itself. To find out we can simply check if the lock file
+            # was last modified before os reboot.
+            # lock_file_modification_time < system boot time
+            file_pid = self.get_pid_from_lock_file()
+            if file_pid < 1 or os.path.getmtime(self.lock_file_path) < psutil.boot_time():
                 self.remove_lock_file()
-                self.create_lock_file()
-                return
 
-            if file_pid == os.getpid():
-                # Ignore when we find our own PID inside the lock file
-                self.already_running = False
-            elif file_pid != os.getpid() and not ProcessChecker.is_pid_running(file_pid):
-                # The process ID written inside the lock file is old, just remove the lock file and create a new one.
-                self.remove_lock_file()
-                self.create_lock_file()
-            else:
-                self.already_running = True
-        else:
-            self.create_lock_file()
+        self.already_running = self.is_process_running()
+
+    def is_process_running(self):
+        if os.path.exists(self.lock_file_path):
+            file_pid = self.get_pid_from_lock_file()
+
+            if file_pid == os.getpid() or ProcessChecker.is_pid_running(file_pid):
+                return True
+        return False
 
     @staticmethod
     def is_pid_running(pid):
@@ -64,18 +59,27 @@ class ProcessChecker(object):
         if not os.path.exists(self.statedir):
             os.makedirs(self.statedir)
 
+        # Remove the previous lock file
+        self.remove_lock_file()
+
         with open(self.lock_file_path, 'wb') as lock_file:
             lock_file.write(str(os.getpid()))
 
     def remove_lock_file(self):
         """
-        Remove the lock file.
+        Remove the lock file if it exists.
         """
-        os.unlink(self.lock_file_path)
+        if os.path.exists(self.lock_file_path):
+            os.unlink(self.lock_file_path)
 
     def get_pid_from_lock_file(self):
         """
         Returns the PID from the lock file.
         """
+        if not os.path.exists(self.lock_file_path):
+            return -1
         with open(self.lock_file_path, 'rb') as lock_file:
-            return lock_file.read()
+            try:
+                return int(lock_file.read())
+            except ValueError:
+                return -1

--- a/Tribler/Test/Core/Modules/test_process_checker.py
+++ b/Tribler/Test/Core/Modules/test_process_checker.py
@@ -26,31 +26,49 @@ class TestProcessChecker(AbstractServer):
         with open(os.path.join(self.state_dir, LOCK_FILE_NAME), 'wb') as lock_file:
             lock_file.write(str(pid))
 
+    def test_create_lock_file(self):
+        """
+        Testing if lock file is created
+        """
+        process_checker = ProcessChecker()
+        process_checker.create_lock_file()
+        self.assertTrue(os.path.exists(os.path.join(self.state_dir, LOCK_FILE_NAME)))
+
+    def test_remove_lock_file(self):
+        """
+        Testing if lock file is removed on calling remove_lock_file()
+        """
+        process_checker = ProcessChecker()
+        process_checker.create_lock_file()
+        process_checker.remove_lock_file()
+        self.assertFalse(os.path.exists(os.path.join(self.state_dir, LOCK_FILE_NAME)))
+
     def test_no_lock_file(self):
         """
         Testing whether the process checker returns false when there is no lock file
         """
         process_checker = ProcessChecker()
-        self.assertTrue(os.path.exists(os.path.join(self.state_dir, LOCK_FILE_NAME)))
+        # Process checker does not create a lock file itself now, Core manager will call to create it.
+        self.assertFalse(os.path.exists(os.path.join(self.state_dir, LOCK_FILE_NAME)))
         self.assertFalse(process_checker.already_running)
 
     def test_invalid_pid_in_lock_file(self):
         """
-        Test whether a new lock file is created when an invalid pid is written inside the current lock file
+        Testing pid should be -1 if the lock file is invalid
         """
         with open(os.path.join(self.state_dir, LOCK_FILE_NAME), 'wb') as lock_file:
             lock_file.write("Hello world")
 
         process_checker = ProcessChecker()
-        self.assertGreater(int(process_checker.get_pid_from_lock_file()), 0)
+        self.assertEqual(process_checker.get_pid_from_lock_file(), -1)
 
     def test_own_pid_in_lock_file(self):
         """
-        Testing whether the process checker returns false when it finds its own pid in the lock file
+        Testing whether the process checker returns True when it finds its own pid in the lock file
         """
         self.create_lock_file_with_pid(os.getpid())
         process_checker = ProcessChecker()
-        self.assertFalse(process_checker.already_running)
+        self.assertTrue(process_checker.already_running)
 
     def test_other_instance_running(self):
         """

--- a/TriblerGUI/core_manager.py
+++ b/TriblerGUI/core_manager.py
@@ -55,6 +55,8 @@ def start_tribler_core(base_path):
         process_checker = ProcessChecker()
         if process_checker.already_running:
             return
+        else:
+            process_checker.create_lock_file()
 
         session = Session(config)
 

--- a/check_os.py
+++ b/check_os.py
@@ -154,8 +154,6 @@ def get_existing_tribler_pids():
         core_pid = process_checker.get_pid_from_lock_file()
         if core_pid not in pids:
             pids.append(int(core_pid))
-    # ProcessChecker creates a lock file, remove it before continuing
-    process_checker.remove_lock_file()
 
     return pids
 
@@ -186,6 +184,9 @@ def should_kill_other_tribler_instances():
                 os.kill(pid, 9)
             window.update()
             window.quit()
+
+            # Restart Tribler again with the same arguments
+            os.execl(sys.executable, sys.executable, *sys.argv)
         else:
             window.update()
             window.quit()


### PR DESCRIPTION
Refactored Process Checker so that it does not create a lock file immediately. This fixes the problem with running Tribler with twistd possibly caused by the fix for zombie process.

Also, added a restart timer which restarts the Core if it does not restart within 30 seconds. This fixes one of the problems causing Tribler to get stuck at gear window.
> Inconsistency detected by ld.so: dl-tls.c: 493: _dl_allocate_tls_init: Assertion `listp->slotinfo[cnt].gen <= GL(dl_tls_generation)' failed!