### PR TITLE
Various Tribler fixes for 7.0.2

### DIFF
--- a/Tribler/Core/Utilities/utilities.py
+++ b/Tribler/Core/Utilities/utilities.py
@@ -12,8 +12,8 @@ import binascii
 import logging
 from libtorrent import bencode, bdecode
 
-import treq
 from twisted.internet import reactor
+from twisted.internet.defer import fail
 from twisted.web import http
 from twisted.web.client import Agent, readBody
 from twisted.web.http_headers import Headers
@@ -22,6 +22,12 @@ from Tribler.Core.version import version_id
 from Tribler.Core.exceptions import HttpError
 
 logger = logging.getLogger(__name__)
+
+try:
+    import treq
+    use_treq = True
+except ImportError:
+    use_treq = False
 
 
 def validTorrentFile(metainfo):
@@ -208,9 +214,17 @@ def http_get(uri):
             return readBody(response)
         raise HttpError(response)
 
-    treq_deferred = treq.get(uri, persistent=False)
-    treq_deferred.addCallback(_on_response)
-    return treq_deferred
+    try:
+        if use_treq:
+            deferred = treq.get(uri, persistent=False)
+        else:
+            agent = Agent(reactor)
+            deferred = agent.request('GET', uri, Headers({'User-Agent': ['Tribler ' + version_id]}), None)
+
+        deferred.addCallback(_on_response)
+        return deferred
+    except:
+        return fail()
 
 
 def parse_magnetlink(url):

--- a/TriblerGUI/tribler_window.py
+++ b/TriblerGUI/tribler_window.py
@@ -485,6 +485,14 @@ class TriblerWindow(QMainWindow):
             self.dialog.show()
             self.start_download_dialog_active = True
         else:
+            # In the unlikely scenario that tribler settings are not available yet, try to fetch settings again and
+            # add the download uri back to self.pending_uri_requests to process again.
+            if not self.tribler_settings:
+                self.fetch_settings()
+                if self.download_uri not in self.pending_uri_requests:
+                    self.pending_uri_requests.append(self.download_uri)
+                return
+
             self.window().perform_start_download_request(self.download_uri,
                                                          get_gui_setting(self.gui_settings,
                                                                          "default_anonymity_enabled", True,

--- a/TriblerGUI/widgets/downloadspage.py
+++ b/TriblerGUI/widgets/downloadspage.py
@@ -237,7 +237,7 @@ class DownloadsPage(QWidget):
         self.window().left_menu_playlist.set_loading()
 
     def on_download_stopped(self, json_result):
-        if json_result["modified"]:
+        if json_result and "modified" in json_result:
             self.selected_item.download_info['status'] = "DLSTATUS_STOPPED"
             self.selected_item.update_item()
             self.on_download_item_clicked()
@@ -266,7 +266,7 @@ class DownloadsPage(QWidget):
         self.dialog = None
 
     def on_download_removed(self, json_result):
-        if json_result["removed"]:
+        if json_result and "removed" in json_result:
             infohash = self.selected_item.download_info["infohash"]
             index = self.window().downloads_list.indexOfTopLevelItem(self.selected_item)
             self.window().downloads_list.takeTopLevelItem(index)
@@ -281,7 +281,7 @@ class DownloadsPage(QWidget):
                                          method='PATCH', data='state=recheck')
 
     def on_forced_recheck(self, result):
-        if result['modified']:
+        if result and "modified" in result:
             self.selected_item.download_info['status'] = "DLSTATUS_HASHCHECKING"
             self.selected_item.update_item()
             self.on_download_item_clicked()

--- a/check_os.py
+++ b/check_os.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import psutil
 import subprocess
 import sys
 import tempfile
@@ -185,9 +186,25 @@ def should_kill_other_tribler_instances():
             window.update()
             window.quit()
 
-            # Restart Tribler again with the same arguments
-            os.execl(sys.executable, sys.executable, *sys.argv)
+            # Restart Tribler properly
+            restart_tribler_properly()
         else:
             window.update()
             window.quit()
             sys.exit(0)
+
+
+def restart_tribler_properly():
+    """
+    Restarting Tribler with proper cleanup of file objects and descriptors
+    """
+    try:
+        process = psutil.Process(os.getpid())
+        for handler in process.open_files() + process.connections():
+            os.close(handler.fd)
+    except Exception as e:
+        # If exception occurs on cleaning up the resources, simply log it and continue with the restart
+        logging.error(e)
+
+    python = sys.executable
+    os.execl(python, python, *sys.argv)

--- a/debian/control
+++ b/debian/control
@@ -38,6 +38,7 @@ Depends: ${misc:Depends},
          python-pyqt5,
          python-pyqt5.qtsvg,
          python-twisted,
+         python-treq,
          vlc (>= 1.1.0),
 Description: Python based Bittorrent/Internet TV application
  It allows you to watch videos and download content. Tribler aims to combine

--- a/debian/control
+++ b/debian/control
@@ -38,8 +38,8 @@ Depends: ${misc:Depends},
          python-pyqt5,
          python-pyqt5.qtsvg,
          python-twisted,
-         python-treq,
          vlc (>= 1.1.0),
+Recommends: python-treq,
 Description: Python based Bittorrent/Internet TV application
  It allows you to watch videos and download content. Tribler aims to combine
  the ease of Youtube.com with the performance of peer-to-peer.

--- a/run_tribler.py
+++ b/run_tribler.py
@@ -28,7 +28,7 @@ if __name__ == "__main__":
 
         if app.is_running():
             for arg in sys.argv[1:]:
-                if os.path.exists(arg):
+                if os.path.exists(arg) and arg.endswith(".torrent"):
                     app.send_message("file:%s" % arg)
                 elif arg.startswith('magnet'):
                     app.send_message(arg)


### PR DESCRIPTION
Various Tribler fixes:
- Check if Tribler settings are available before starting download ( Fixes #3460 )
- Checked for NoneType in various JSON responses in the downloads page
- Restart Tribler with proper resource cleanup
- Added treq as optional debian dependency