### PR TITLE
Fixed issue with sending crash reports

### DIFF
--- a/Tribler/Test/GUI/test_gui.py
+++ b/Tribler/Test/GUI/test_gui.py
@@ -459,6 +459,21 @@ class TriblerGUITest(AbstractTriblerGUITest):
         QTimer.singleShot(1000, screenshot_dialog)
         dialog.exec_()
 
+    def test_feedback_dialog_report_sent(self):
+        def screenshot_dialog():
+            self.screenshot(dialog, name="feedback_dialog")
+            dialog.close()
+
+        def on_report_sent(response):
+            self.assertTrue(response[u'sent'])
+
+        dialog = FeedbackDialog(window, "Tribler GUI Test to test sending crash report works", "1.2.3", 23)
+        dialog.closeEvent = lambda _: None  # Otherwise, the application will stop
+        dialog.on_report_sent = on_report_sent
+        QTest.mouseClick(dialog.send_report_button, Qt.LeftButton)
+        QTimer.singleShot(1000, screenshot_dialog)
+        dialog.exec_()
+
     def test_discovered_page(self):
         QTest.mouseClick(window.left_menu_button_discovered, Qt.LeftButton)
         self.wait_for_list_populated(window.discovered_channels_list)

--- a/TriblerGUI/dialogs/feedbackdialog.py
+++ b/TriblerGUI/dialogs/feedbackdialog.py
@@ -110,7 +110,7 @@ class FeedbackDialog(QDialog):
 
     def on_send_clicked(self):
         self.request_mgr = TriblerRequestManager()
-        self.request_mgr.base_url = 'http://reporter.tribler.org/'
+        endpoint = 'http://reporter.tribler.org/report'
 
         sys_info = ""
         for ind in xrange(self.env_variables_list.topLevelItemCount()):
@@ -128,7 +128,7 @@ class FeedbackDialog(QDialog):
                     (self.tribler_version, platform.machine(), platform.platform(),
                      int(time.time()), sys_info, comments, stack)
 
-        self.request_mgr.perform_request("report", self.on_report_sent, data=str(post_data), method='POST')
+        self.request_mgr.perform_request(endpoint, self.on_report_sent, data=str(post_data), method='POST')
 
     def closeEvent(self, close_event):
         QApplication.quit()

--- a/TriblerGUI/tribler_request_manager.py
+++ b/TriblerGUI/tribler_request_manager.py
@@ -340,12 +340,15 @@ class TriblerRequestWorker(QNetworkAccessManager):
     def perform_request(self, endpoint, reply_callback, data, method):
         """
         Perform a HTTP request.
-        :param endpoint: the endpoint to call (i.e. "statistics")
+        :param endpoint: the endpoint to call (i.e. "statistics"), could also be a full URL
         :param reply_callback: the callback to be called with result info when we have the data
         :param data: optional POST data to be sent with the request
         :param method: the HTTP verb (GET/POST/PUT/PATCH)
         """
-        url = self.base_url + endpoint
+        if endpoint.startswith("http:") or endpoint.startswith("https:"):
+            url = endpoint
+        else:
+            url = self.base_url + endpoint
         self.status_code = -1
         network_reply = self.dispatch_map.get(method, lambda x, y, z: None)(endpoint, data, url)
         network_reply.finished.connect(lambda: reply_callback(network_reply))


### PR DESCRIPTION
Fixed issue with base URL on sending crash reports using TriblerRequestManager.
Added a GUI test to ensure crash reports are sent properly.