### PR TITLE
Do not remove the tray icon twice

### DIFF
--- a/TriblerGUI/tribler_window.py
+++ b/TriblerGUI/tribler_window.py
@@ -64,7 +64,13 @@ class TriblerWindow(QMainWindow):
         self.exception_handler_called = True
 
         if self.tray_icon:
-            self.tray_icon.deleteLater()
+            try:
+                self.tray_icon.deleteLater()
+            except RuntimeError:
+                # The tray icon might have already been removed when unloading Qt.
+                # This is due to the C code actually being asynchronous.
+                logging.debug("Tray icon already removed, no further deletion necessary.")
+            self.tray_icon = None
 
         # Stop the download loop
         self.downloads_page.stop_loading_downloads()


### PR DESCRIPTION
Solves:

```python
Error in sys.excepthook:
Traceback (most recent call last):
  File "/home/quinten/Documents/tribler/TriblerGUI/tribler_window.py", line 67, in on_exception
    self.tray_icon.deleteLater()
RuntimeError: wrapped C/C++ object of type QSystemTrayIcon has been deleted

Original exception was:
Traceback (most recent call last):
  File "/home/quinten/Documents/tribler/TriblerGUI/widgets/trustpage.py", line 112, in received_trustchain_statistics
```

on shutdown