### PR TITLE
Bundle VLC with Tribler

### DIFF
--- a/Tribler/Main/Build/Win/tribler.nsi
+++ b/Tribler/Main/Build/Win/tribler.nsi
@@ -4,7 +4,6 @@
 !define VERSION "__GIT__"
 ; Laurens, 2016-03-14: The _x86 will be replaced by _x64 if needed in update_version_from_git.py
 !define BITVERSION "x86"
-!define VLCBITVERSION "32"
 
 !include "MUI2.nsh"
 !include "FileFunc.nsh"
@@ -134,10 +133,6 @@ Section "!Main EXE" SecMain
     ; Libraries dependant on 2015 are: Python, Qt5
     File vc_redist_140.exe
     ExecWait "$INSTDIR\vc_redist_140.exe /q /norestart"
-
-    ; Install VLC
-    File "vlc-2.2.4-win${VLCBITVERSION}.exe"
-    ExecWait "$INSTDIR\vlc-2.2.4-win${VLCBITVERSION}.exe /language=en_GB /S"
 
     FileOpen $9 "$INSTDIR\tribler.exe.log" w
     FileWrite $9 ""

--- a/TriblerGUI/vlc.py
+++ b/TriblerGUI/vlc.py
@@ -152,8 +152,8 @@ def find_lib():
             pass
         if vlc_dir is None:
             # try some standard locations.
-            for p in ('Program Files\\VideoLAN\\', 'VideoLAN\\',
-                      'Program Files\\', 'Program Files (x86)\\VideoLAN\\', ''):
+            for p in ('Program Files\\Tribler\\', 'Program Files (x86)\\Tribler\\', 'Program Files\\VideoLAN\\',
+                      'VideoLAN\\', 'Program Files\\', 'Program Files (x86)\\VideoLAN\\', ''):
                 p = 'C:\\' + p + 'VLC\\libvlc.dll'
                 if os.path.exists(p):
                     vlc_dir = os.path.dirname(p)

--- a/doc/building/building_on_windows.rst
+++ b/doc/building/building_on_windows.rst
@@ -26,7 +26,7 @@ Next, create a ``build`` folder directly on your ``C:\`` drive.
 Inside the ``build`` folder, put the following items:
 
 1. A folder ``certs`` containing a ``.pfx`` key. In our case it's named ``swarmplayerprivatekey.pfx``. Make sure to rename paths in ``makedist_win.bat`` to match your file name.
-2. The VLC 2.2.4 installer (either 32 or 64-bit). This file must be named ``vlc-2.2.4-win64.exe`` (or ``vlc-2.2.4-win32.exe`` when building 32-bit).
+2. A folder ``vlc`` that contains ``libvlc.dll``, ``libvlccore.dll`` and a directory ``plugins`` that contain the VLC plugins.
 3. ``vc_redist_90.exe`` (Microsoft Visual C++ 2008 Redistributable Package), which is available `here <https://www.microsoft.com/en-us/download/details.aspx?id=15336>`_. In case you build 32 bit, get the x86 version `here <https://www.microsoft.com/en-us/download/details.aspx?id=29>`_. Don't forget to rename the file.
 4. ``vc_redist_110.exe`` (Visual C++ Redistributable for Visual Studio 2012), which is available `here <https://www.microsoft.com/en-us/download/details.aspx?id=30679>`_. In case you build 32 bit, get the x86 version. Once more, don't forget to rename the file.
 5. ``libsodium.dll`` which can be downloaded from `libsodium.org <https://download.libsodium.org/libsodium/releases/>`_ (as of writing version 1.0.8).

--- a/win/makedist_win.bat
+++ b/win/makedist_win.bat
@@ -55,8 +55,6 @@ REM copy Tribler\Main\Build\Win\tribler.exe.manifest dist\tribler
 type Tribler\LICENSE Tribler\binary-LICENSE-postfix.txt > Tribler\binary-LICENSE.txt
 copy Tribler\binary-LICENSE.txt dist\tribler
 
-REM copy C:\Build\ffmpeg\bin\ffmpeg.exe dist\tribler
-
 mkdir dist\tribler\tools
 copy win\tools\reset*.bat dist\tribler\tools
 
@@ -73,8 +71,8 @@ REM Copy missing dll files
 copy C:\build\missing_dlls\*.dll dist\tribler
 
 REM Copy VLC, different files based on 32-bit or 64-bit
-if %1==32 copy C:\build\vlc-2.2.4-win32.exe dist\tribler
-if %1==64 copy C:\build\vlc-2.2.4-win64.exe dist\tribler
+mkdir dist\tribler\VLC
+xcopy C:\build\vlc dist\tribler\VLC /s /e
 
 @echo Running NSIS
 cd dist\tribler


### PR DESCRIPTION
In this PR, I bundle the VLC media player with Tribler. I've modified the script to simply copy the necessary VLC files, instead of installing a stand-alone version of VLC, which pollutes the system of Windows users.

Note that if our shipped `libvlc.dll` does not load for any reason, it still attempts to use an installed VLC version.

I've tested this PR on Windows 32-bit and 64-bit systems. Playback seems to work fine.

Fixes #3545, fixes #2769