### PR TITLE
Refactored VoD logic

### DIFF
--- a/Tribler/Test/Core/Modules/RestApi/test_downloads_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_downloads_endpoint.py
@@ -475,6 +475,31 @@ class TestDownloadsEndpoint(AbstractApiTest):
         return self.do_request('downloads/%s/torrent' % video_tdef.get_infohash().encode('hex'),
                                expected_code=200, request_type='GET').addCallback(verify_exported_data)
 
+    @deferred(timeout=10)
+    def test_get_files_unknown_download(self):
+        """
+        Testing whether the API returns error 404 if the files of a non-existent download are requested
+        """
+        self.should_check_equality = False
+        return self.do_request('downloads/abcd/files', expected_code=404, request_type='GET')
+
+    @deferred(timeout=10)
+    def test_get_download_files(self):
+        """
+        Testing whether the API returns file information of a specific download when requested
+        """
+        video_tdef, _ = self.create_local_torrent(os.path.join(TESTS_DATA_DIR, 'video.avi'))
+        self.session.start_download_from_tdef(video_tdef, DownloadStartupConfig())
+
+        def verify_files_data(response):
+            json_response = json.loads(response)
+            self.assertIn('files', json_response)
+            self.assertTrue(json_response['files'])
+
+        self.should_check_equality = False
+        return self.do_request('downloads/%s/files' % video_tdef.get_infohash().encode('hex'),
+                               expected_code=200, request_type='GET').addCallback(verify_files_data)
+
 
 class TestDownloadsDispersyEndpoint(AbstractApiTest):
 

--- a/Tribler/Test/GUI/test_gui.py
+++ b/Tribler/Test/GUI/test_gui.py
@@ -32,7 +32,10 @@ if os.environ.get("TEST_GUI") == "yes":
 else:
     window = None
 
-sys.excepthook = sys.__excepthook__
+
+def no_abort(*args, **kwargs):
+    sys.__excepthook__(*args, **kwargs)
+sys.excepthook = no_abort
 
 
 class TimeoutException(Exception):

--- a/Tribler/Test/GUI/test_gui.py
+++ b/Tribler/Test/GUI/test_gui.py
@@ -175,6 +175,7 @@ class AbstractTriblerGUITest(unittest.TestCase):
         # QTextEdit was not populated in time, fail the test
         raise TimeoutException("QTextEdit was not populated within 10 seconds")
 
+
 @skipUnless(os.environ.get("TEST_GUI") == "yes", "Not testing the GUI by default")
 class TriblerGUITest(AbstractTriblerGUITest):
     """
@@ -437,17 +438,13 @@ class TriblerGUITest(AbstractTriblerGUITest):
         self.assertEqual(window.downloads_list.topLevelItemCount(), old_count + 1)
 
     def test_video_player_page(self):
-        QTest.mouseClick(window.left_menu_button_video_player, Qt.LeftButton)
+        self.go_to_and_wait_for_downloads()
+        QTest.mouseClick(window.downloads_list.topLevelItem(0).progress_slider, Qt.LeftButton)
+        QTest.mouseClick(window.play_download_button, Qt.LeftButton)
         self.screenshot(window, name="video_player_page")
 
-        # Some actions for the left menu playlist
-        window.left_menu_playlist.set_loading()
-        self.screenshot(window, name="video_player_page_playlist_loading")
-        window.left_menu_playlist.set_files([{'name': 'video.avi', 'index': 0},
-                                             {'name': 'test.txt', 'index': 1}])
-        self.screenshot(window, name="video_player_page_playlist_items")
-        window.left_menu_playlist.set_active_index(0)
-        self.screenshot(window, name="video_player_page_playlist_focus")
+        self.wait_for_signal(window.left_menu_playlist.list_loaded, no_args=True)
+        self.screenshot(window, name="video_player_left_menu_loaded")
 
     def test_feedback_dialog(self):
         def screenshot_dialog():

--- a/TriblerGUI/tribler_window.py
+++ b/TriblerGUI/tribler_window.py
@@ -509,6 +509,9 @@ class TriblerWindow(QMainWindow):
         self.request_mgr.perform_request("trustchain/statistics", self.received_token_balance, capture_errors=False)
 
     def received_token_balance(self, statistics):
+        if not statistics:
+            return
+
         statistics = statistics["statistics"]
         if 'latest_block' in statistics:
             balance = (statistics["latest_block"]["transaction"]["total_up"] - \

--- a/TriblerGUI/widgets/channel_torrent_list_item.py
+++ b/TriblerGUI/widgets/channel_torrent_list_item.py
@@ -80,8 +80,7 @@ class ChannelTorrentListItem(QWidget, fc_channel_torrent_list_item):
         if not self:
             return
         self.window().left_menu_button_video_player.click()
-        self.window().video_player_page.set_torrent_infohash(self.torrent_info["infohash"])
-        self.window().left_menu_playlist.set_loading()
+        self.window().video_player_page.play_media_item(self.torrent_info["infohash"], -1)
 
     def show_buttons(self):
         if not self.show_controls:

--- a/TriblerGUI/widgets/downloadsdetailstabwidget.py
+++ b/TriblerGUI/widgets/downloadsdetailstabwidget.py
@@ -209,10 +209,7 @@ class DownloadsDetailsTabWidget(QTabWidget):
 
     def on_play_file(self, file_info):
         self.window().left_menu_button_video_player.click()
-        self.window().video_player_page.set_torrent_infohash(self.current_download["infohash"])
-        self.window().video_player_page.change_playing_index(file_info["index"], file_info["name"])
-        self.window().left_menu_playlist.set_files(self.current_download["files"])
-        self.window().left_menu_playlist.set_active_index(file_info["index"])
+        self.window().video_player_page.play_media_item(self.current_download["infohash"], file_info["index"])
 
     def set_included_files(self, files):
         data_str = ''.join("selected_files[]=%s&" % ind for ind in files)[:-1]

--- a/TriblerGUI/widgets/downloadspage.py
+++ b/TriblerGUI/widgets/downloadspage.py
@@ -273,8 +273,8 @@ class DownloadsPage(QWidget):
 
     def on_play_download_clicked(self):
         self.window().left_menu_button_video_player.click()
-        self.window().video_player_page.set_torrent_infohash(self.selected_item.download_info["infohash"])
-        self.window().left_menu_playlist.set_loading()
+        if self.window().video_player_page.active_infohash != self.selected_item.download_info["infohash"]:
+            self.window().video_player_page.play_media_item(self.selected_item.download_info["infohash"], -1)
 
     def on_download_stopped(self, json_result):
         if json_result and "modified" in json_result:

--- a/TriblerGUI/widgets/leftmenuplaylist.py
+++ b/TriblerGUI/widgets/leftmenuplaylist.py
@@ -1,5 +1,7 @@
+from PyQt5.QtCore import QTimer
 from PyQt5.QtCore import pyqtSignal
 from PyQt5.QtWidgets import QListWidget
+from TriblerGUI.tribler_request_manager import TriblerRequestManager
 from TriblerGUI.utilities import is_video_file
 
 
@@ -9,7 +11,8 @@ class LeftMenuPlaylist(QListWidget):
     Only shows when a video is playing.
     """
 
-    playing_item_change = pyqtSignal(int, str)  # file index, name of file
+    playing_item_change = pyqtSignal(int)  # file index
+    list_loaded = pyqtSignal()
     item_should_play = pyqtSignal()  # no info required, a double click always follow a click event
 
     def __init__(self, parent):
@@ -17,14 +20,57 @@ class LeftMenuPlaylist(QListWidget):
 
         self.files_data = []
         self.loaded_list = False
+        self.loading_list = False
         self.active_index = -1
+        self.infohash = None
         self.itemClicked.connect(self.on_item_clicked)
         self.itemDoubleClicked.connect(self.on_item_double_clicked)
+
+        self.files_request_mgr = None
+        self.files_request_timer = None
 
     def set_loading(self):
         self.clear()
         self.addItem("Loading...")
         self.loaded_list = False
+        self.loading_list = True
+
+    def load_list(self, infohash):
+        self.infohash = infohash
+        self.set_loading()
+
+        if self.files_request_timer:
+            self.files_request_timer.invalidate()
+
+        self.files_request_timer = QTimer()
+        self.files_request_timer.timeout.connect(self.perform_get_files_request)
+        self.files_request_timer.start(1000)
+
+    def perform_get_files_request(self):
+        self.files_request_mgr = TriblerRequestManager()
+        self.files_request_mgr.perform_request("downloads/%s/files" % self.infohash, self.on_received_files)
+
+    def on_received_files(self, files):
+        if "files" not in files or not files["files"]:
+            return
+
+        self.files_request_timer.stop()
+        self.files_request_timer = None
+
+        self.set_files(files["files"])
+        self.loaded_list = True
+        self.loading_list = False
+        self.list_loaded.emit()
+
+    def get_largest_file(self):
+        largest_file = None
+        largest_index = None
+        for index, file_info in enumerate(self.files_data):
+            if is_video_file(file_info["name"]) and \
+                    (largest_file is None or file_info["size"] > largest_file["size"]):
+                largest_file = file_info
+                largest_index = index
+        return largest_index, largest_file
 
     def set_files(self, files):
         self.clear()
@@ -33,22 +79,27 @@ class LeftMenuPlaylist(QListWidget):
         for file_info in files:
             if is_video_file(file_info['name']):
                 self.addItem(file_info['name'])
-                self.files_data.append((file_info['index'], file_info['name']))
-        self.loaded_list = True
+                self.files_data.append(file_info)
 
     def set_active_index(self, file_index):
         cur_ind = 0
-        for index, _ in self.files_data:
-            if index == file_index:
+        for ind, file_info in enumerate(self.files_data):
+            if ind == file_index:
                 self.item(cur_ind).setSelected(True)
                 self.setFocus()
                 break
             cur_ind += 1
 
+    def get_file_info(self, menu_index):
+        """
+        Get the file info, based on the menu index
+        """
+        return self.files_data[menu_index] if menu_index < len(self.files_data) else None
+
     def on_item_clicked(self, item):
         item_ind = self.row(item)
         if self.loaded_list:
-            self.playing_item_change.emit(*self.files_data[item_ind])
+            self.playing_item_change.emit(item_ind)
 
     def on_item_double_clicked(self, item):
         self.item_should_play.emit()


### PR DESCRIPTION
In this PR, I refactored the VoD logic. Currently, the code that manages the VoD, is fragmented into several classes. I tried to make the logic a bit better by giving the `VideoPage` class more responsibilities. Note that this is only a minor step and more work should be done eventually.

I also added an endpoint to fetch files and the status of files in a specific download. Also, I've modified the GUI tests so the files are fetched from the fake core when starting a VoD session.

Finally, I fixed the annoying issue where a crash during the GUI tests would lead to a segmentation fault (or abort trap on MacOS). When an error occurs during the GUI tests, the test will now fail and provide us with debug output 👍 

Fixes #3546