### PR TITLE
PROPOSAL: Default anon downloads use two hops now

### DIFF
--- a/Tribler/Core/Config/config.spec
+++ b/Tribler/Core/Config/config.spec
@@ -76,7 +76,7 @@ anon_proxy_auth = string(default='')
 
 [download_defaults]
 anonymity_enabled = boolean(default=True)
-number_hops = integer(min=0, max=3, default=1)
+number_hops = integer(min=0, max=3, default=2)
 safeseeding_enabled = boolean(default=True)
 saveas = string(default=None)
 seeding_mode = string(default='ratio')


### PR DESCRIPTION
I propose to change the default anonymous download hop count to two. Currently, it is set to one, which means that users will directly connect to the exit nodes to download torrents. When we increase it to two, people will use an intermediary relay which is now able to earn tokens. While this will slow down downloads, it will help people earn bandwidth tokens by just running Tribler.