### PR TITLE
Added the Yappi profiler to the core and GUI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ twistd.pid
 # PyInstaller
 build/
 dist/
+
+# Annotation files
+annotations.txt

--- a/Tribler/Core/Modules/resource_monitor.py
+++ b/Tribler/Core/Modules/resource_monitor.py
@@ -81,8 +81,12 @@ class ResourceMonitor(TaskManager):
         yappi_stats = yappi.get_func_stats()
         yappi_stats.sort("tsub")
 
-        file_path = os.path.join(self.session.config.get_state_dir(), 'logs',
-                                 'yappi_%s.stats' % self.profiler_start_time)
+        log_dir = os.path.join(self.session.config.get_state_dir(), 'logs')
+        file_path = os.path.join(log_dir, 'yappi_%s.stats' % self.profiler_start_time)
+        # Make the log directory if it does not exist
+        if not os.path.exists(log_dir):
+            os.makedirs(log_dir)
+
         yappi_stats.save(file_path, type='callgrind')
         yappi.clear_stats()
         self.profiler_running = False

--- a/Tribler/Test/Core/Modules/test_resource_monitor.py
+++ b/Tribler/Test/Core/Modules/test_resource_monitor.py
@@ -76,9 +76,17 @@ class TestResourceMonitor(TriblerCoreTest):
             self.assertEquals(changeType, SIGNAL_LOW_SPACE)
 
         self.resource_monitor.get_free_disk_space = fake_get_free_disk_space
-        self.resource_monitor.session = MockObject()
-        self.resource_monitor.session.config = MockObject()
-        self.resource_monitor.session.config.get_state_dir = lambda: "."
-        self.resource_monitor.session.notifier = MockObject()
         self.resource_monitor.session.notifier.notify = on_notify
         self.resource_monitor.check_resources()
+
+    def test_profiler(self):
+        """
+        Test the profiler functionality
+        """
+        self.resource_monitor.start_profiler()
+        self.assertTrue(self.resource_monitor.profiler_running)
+        self.assertRaises(RuntimeError, self.resource_monitor.start_profiler)
+
+        self.resource_monitor.stop_profiler()
+        self.assertFalse(self.resource_monitor.profiler_running)
+        self.assertRaises(RuntimeError, self.resource_monitor.stop_profiler)

--- a/TriblerGUI/qt_resources/debugwindow.ui
+++ b/TriblerGUI/qt_resources/debugwindow.ui
@@ -358,7 +358,7 @@
         <item>
          <widget class="QTabWidget" name="system_tab_widget">
           <property name="currentIndex">
-           <number>0</number>
+           <number>5</number>
           </property>
           <widget class="QWidget" name="tab_9">
            <attribute name="title">
@@ -704,6 +704,57 @@
                 <number>0</number>
                </property>
               </layout>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+          <widget class="QWidget" name="tab_12">
+           <attribute name="title">
+            <string>Profiler</string>
+           </attribute>
+           <layout class="QVBoxLayout" name="verticalLayout">
+            <property name="spacing">
+             <number>0</number>
+            </property>
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
+             <number>0</number>
+            </property>
+            <item>
+             <widget class="QPushButton" name="toggle_profiler_button">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>Start profiler</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="label">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>Warning: enabling the profiler might decrease the performance of Tribler!</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignCenter</set>
+              </property>
              </widget>
             </item>
            </layout>


### PR DESCRIPTION
I've added the Yappi profiler to the core and the GUI. The profiler itself can be started from the HTTP API with requests to `/debug/profiler`. I've also added an additional tab in the debug panel where the profiler can be enabled and disabled.

When the profiler is stopped, the data file is written to the `logs` directory in the state dir of Tribler. The filename contains the timestamp when the profiler was started. When shutting down Tribler while the profiler is still running, this file is also written to the disk.