### PR TITLE
Update logger default formatter to include the logger name

### DIFF
--- a/logger.conf
+++ b/logger.conf
@@ -87,7 +87,7 @@ formatter=debugging
 args=(sys.stderr,)
 
 [formatter_debugging]
-format=%(levelname)-7s %(created).2f %(module)15s:%(lineno)-4d  %(message)s
+format=%(levelname)-7s %(created).2f %(module)25s:%(lineno)-4d (%(name)s)  %(message)s
 class=logging.Formatter
 
 [handler_infoHandler]


### PR DESCRIPTION
Update logger default formatter to include the logger name