### PR TITLE
Fix ValueError for empty URLs

### DIFF
--- a/Tribler/Core/Utilities/utilities.py
+++ b/Tribler/Core/Utilities/utilities.py
@@ -275,7 +275,7 @@ def create_valid_metainfo(metainfo):
         raise ValueError('metainfo not dict')
 
     # some .torrent files have a dht:// url in the announce field.
-    if ('announce' in metainfo) \
+    if ('announce' in metainfo and metainfo['announce']) \
             and (not (is_valid_url(metainfo['announce']) or metainfo['announce'].startswith('dht:'))):
         raise ValueError('announce URL bad')
 


### PR DESCRIPTION
ValueError is only raised for non-empty announce URLs if they are invalid.

Fixes #3609 Tribler fails to chew a mega-torrent