### PR TITLE
Add bootstrap override option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ cover/
 htmlcov/
 .coverage
 
+# Ignore nosetest output logs
+Tribler/Test/logs/
+
 # Android
 *.apk
 

--- a/Tribler/Core/APIImplementation/LaunchManyCore.py
+++ b/Tribler/Core/APIImplementation/LaunchManyCore.py
@@ -176,13 +176,13 @@ class TriblerLaunchMany(TaskManager):
                 from Tribler.pyipv8.ipv8.configuration import get_default_configuration
                 ipv8_config = get_default_configuration()
                 ipv8_config['port'] = self.session.config.get_dispersy_port()
+                ipv8_config['address'] = self.session.config.get_ipv8_address()
                 ipv8_config['overlays'] = []
                 ipv8_config['keys'] = []  # We load the keys ourselves
 
-                if self.session.config.get_ipv8_use_testnet():
-                    # Replace the default servers with our testnet server
+                if self.session.config.get_ipv8_bootstrap_override():
                     import Tribler.pyipv8.ipv8.deprecated.community as community_file
-                    community_file._DEFAULT_ADDRESSES = [("95.211.155.142", 7001)]
+                    community_file._DEFAULT_ADDRESSES = [self.session.config.get_ipv8_bootstrap_override()]
                     community_file._DNS_ADDRESSES = []
 
                 self.ipv8 = IPv8(ipv8_config)

--- a/Tribler/Core/Config/config.spec
+++ b/Tribler/Core/Config/config.spec
@@ -89,7 +89,8 @@ port = integer(min=-1, max=65536, default=-1)
 
 [ipv8]
 enabled = boolean(default=True)
-use_testnet = boolean(default=False)
+address = string(default='0.0.0.0')
+bootstrap_override = string(default='')
 
 [video_server]
 enabled = boolean(default=True)

--- a/Tribler/Core/Config/tribler_config.py
+++ b/Tribler/Core/Config/tribler_config.py
@@ -272,11 +272,17 @@ class TriblerConfig(object):
     def get_ipv8_enabled(self):
         return self.config['ipv8']['enabled']
 
-    def set_ipv8_use_testnet(self, value):
-        self.config['ipv8']['use_testnet'] = value
+    def set_ipv8_bootstrap_override(self, value):
+        self.config['ipv8']['bootstrap_override'] = value
 
-    def get_ipv8_use_testnet(self):
-        return self.config['ipv8']['use_testnet']
+    def get_ipv8_bootstrap_override(self):
+        return self.config['ipv8']['bootstrap_override']
+
+    def set_ipv8_address(self, value):
+        self.config['ipv8']['address'] = value
+
+    def get_ipv8_address(self):
+        return self.config['ipv8']['address']
 
     # Libtorrent
 

--- a/Tribler/Test/Core/Config/test_tribler_config.py
+++ b/Tribler/Test/Core/Config/test_tribler_config.py
@@ -157,8 +157,8 @@ class TestTriblerConfig(TriblerCoreTest):
         """
         self.tribler_config.set_ipv8_enabled(False)
         self.assertEqual(self.tribler_config.get_ipv8_enabled(), False)
-        self.tribler_config.set_ipv8_use_testnet(True)
-        self.assertEqual(self.tribler_config.get_ipv8_use_testnet(), True)
+        self.tribler_config.set_ipv8_bootstrap_override(("127.0.0.1", 12345))
+        self.assertEqual(self.tribler_config.get_ipv8_bootstrap_override(), ("127.0.0.1", 12345))
 
     def test_get_set_methods_libtorrent(self):
         """

--- a/Tribler/Test/Core/test_launch_many_cores.py
+++ b/Tribler/Test/Core/test_launch_many_cores.py
@@ -145,7 +145,7 @@ class TestLaunchManyCoreFullSession(TestAsServer):
         self.config.set_megacache_enabled(True)
         self.config.set_tunnel_community_socks5_listen_ports(self.get_socks5_ports())
         self.config.set_mainline_dht_enabled(True)
-        self.config.set_ipv8_use_testnet(True)
+        self.config.set_ipv8_bootstrap_override(("127.0.0.1", 12345))
 
     def get_community(self, community_cls):
         for community in self.session.get_dispersy_instance().get_communities():

--- a/twisted/plugins/tribler_plugin.py
+++ b/twisted/plugins/tribler_plugin.py
@@ -23,6 +23,8 @@ from Tribler.community.allchannel.community import AllChannelCommunity
 from Tribler.community.search.community import SearchCommunity
 from Tribler.dispersy.utils import twistd_yappi
 
+from .tunnel_helper_plugin import check_ipv8_bootstrap_override
+
 
 class Options(usage.Options):
     optParameters = [
@@ -31,11 +33,11 @@ class Options(usage.Options):
         ["restapi", "p", -1, "Use an alternate port for the REST API", int],
         ["dispersy", "d", -1, "Use an alternate port for Dispersy", int],
         ["libtorrent", "l", -1, "Use an alternate port for libtorrent", int],
+        ["ipv8_bootstrap_override", "b", "", "Force the usage of specific IPv8 bootstrap server (ip:port)", check_ipv8_bootstrap_override]
     ]
     optFlags = [
         ["auto-join-channel", "a", "Automatically join a channel when discovered"],
         ["log-incoming-searches", "i", "Write information about incoming remote searches to a file"],
-        ["testnet", "t", "Join the Tribler Testnet"]
     ]
 
 
@@ -106,8 +108,8 @@ class TriblerServiceMaker(object):
         if options["libtorrent"] != -1 and options["libtorrent"] > 0:
             config.set_libtorrent_port(options["libtorrent"])
 
-        if "testnet" in options and options["testnet"]:
-            config.set_ipv8_use_testnet(True)
+        if "ipv8_bootstrap_override" in options:
+            config.set_ipv8_bootstrap_override(options["ipv8_bootstrap_override"])
 
         self.session = Session(config)
         self.session.start().addErrback(lambda failure: self.shutdown_process(failure.getErrorMessage()))


### PR DESCRIPTION
This pull request removes `use_testnet` option and replaces it with more general `bootstrap_override` option, that allows to, well, override bootstrap servers list. It is very useful to build your own isolated testnets without hacking the code.
The corresponding new option is added to `tunnel_helper` and Tribler Twisted plugins (it seems not to have any effect for the latter, probably because of Dispersy endpoint interference).
Anyways, support for this option is required to proceed with building Jenkins performance tests.

p.s.
as a small bonus, there is a small change to `.gitignore` to ignore log file generated by `nosetests`.

p.p.s
monstrous regexp for checking IP addresses is a shameless copypaste from a popular Stackexchange answer.