### PR TITLE
Fixed upgrade from 7.0 to 7.1

### DIFF
--- a/Tribler/Test/Core/data/config_files/download_pstate_70.state
+++ b/Tribler/Test/Core/data/config_files/download_pstate_70.state
@@ -1,0 +1,19 @@
+[downloadconfig]
+version = 16
+saveas = /Users/randomuser/downloads
+max_upload_rate = 0
+max_download_rate = 0
+mode = 0
+hops = 0
+selected_files = []
+correctedfilename = None
+safe_seeding = False
+seeding_mode = ratio
+seeding_ratio = 2.0
+seeding_time = 60
+user_stopped = False
+time_added = 1527601394
+
+[state]
+version = 5
+dlstate = {'status': 4, 'progress': 1.0, 'swarmcache': None}


### PR DESCRIPTION
We forgot to upgrade the existing .state files for downloads that have already been added to Tribler. By renaming the downloadconfig section to download_defaults, the upgrade from 7.0 to 7.1 should not mess up the downloads anymore.

Fixes #3645, fixes #3556