### PR TITLE
Fix bug 3675: bootstrap_override parsing in config

### DIFF
--- a/Tribler/Core/Config/config.spec
+++ b/Tribler/Core/Config/config.spec
@@ -90,7 +90,7 @@ port = integer(min=-1, max=65536, default=-1)
 [ipv8]
 enabled = boolean(default=True)
 address = string(default='0.0.0.0')
-bootstrap_override = string(default='')
+bootstrap_override = tuple(default=None)
 
 [video_server]
 enabled = boolean(default=True)

--- a/Tribler/Core/Config/tribler_config.py
+++ b/Tribler/Core/Config/tribler_config.py
@@ -276,7 +276,9 @@ class TriblerConfig(object):
         self.config['ipv8']['bootstrap_override'] = value
 
     def get_ipv8_bootstrap_override(self):
-        return self.config['ipv8']['bootstrap_override']
+        val = self.config['ipv8']['bootstrap_override']
+        ip_port_tuple = (val[0], int(val[1])) if val else None
+        return ip_port_tuple
 
     def set_ipv8_address(self, value):
         self.config['ipv8']['address'] = value


### PR DESCRIPTION
Tried a more general approach by writing a custom parser/checker for `<IP> : <port>` format. It failed because the `config` module writes the tuple back automatically in the form of tuple ` <IP> , <port>`.
Had to resort to this simple fix.

Fixes #3675