### PR TITLE
Fixed crash on torrents with exotic names

### DIFF
--- a/Tribler/Core/Modules/restapi/downloads_endpoint.py
+++ b/Tribler/Core/Modules/restapi/downloads_endpoint.py
@@ -213,7 +213,7 @@ class DownloadsEndpoint(DownloadBaseEndpoint):
 
             num_seeds, num_peers = state.get_num_seeds_peers()
 
-            download_json = {"name": tdef.get_name(), "progress": state.get_progress(),
+            download_json = {"name": tdef.get_name_utf8(), "progress": state.get_progress(),
                              "infohash": tdef.get_infohash().encode('hex'),
                              "speed_down": state.get_current_speed(DOWNLOAD),
                              "speed_up": state.get_current_speed(UPLOAD),

--- a/Tribler/Core/TorrentDef.py
+++ b/Tribler/Core/TorrentDef.py
@@ -502,6 +502,24 @@ class TorrentDef(object):
         else:
             raise TorrentDefNotFinalizedException()
 
+    def get_name_utf8(self):
+        """
+        Not all names are utf-8, attempt to construct it as utf-8 anyway.
+        """
+        out = self.get_name()
+        try:
+            # Try seeing if the delivered encoding is correct and we
+            # can convert to utf8 without any issues.
+            return out.decode(self.get_encoding()).encode('utf8').decode('utf8')
+        except (LookupError, TypeError, ValueError):
+            try:
+                # The delivered encoding is incorrect, cast it to
+                # latin1 and hope for the best (minor corruption).
+                return out.decode('latin1').encode('utf8', 'ignore').decode('utf8')
+            except (TypeError, ValueError):
+                # This is a very nasty string (e.g. u'\u266b'), remove the illegal entries.
+                return out.encode('utf8', 'ignore').decode('utf8')
+
     def set_name(self, name):
         """ Set the name of this torrent
         @param name name of torrent as String

--- a/Tribler/Test/Core/test_torrent_def.py
+++ b/Tribler/Test/Core/test_torrent_def.py
@@ -145,6 +145,25 @@ class TestTorrentDef(BaseTestCase):
             reals += file['length']
         self.assertEqual(exps, reals)
 
+    def test_get_name_utf8(self):
+        """ Add a TorrentDef with non-utf8 encoding"""
+        t = TorrentDef()
+        t.set_name('\xA1\xC0')
+        t.set_encoding('euc_kr')
+        t.set_tracker(TRACKER)
+        t.finalize()
+
+        self.assertEqual(t.get_name_utf8(), u'\xf7')
+
+    def test_get_name_utf8_unknown(self):
+        """ Add a TorrentDef with non-utf8 encoding"""
+        t = TorrentDef()
+        t.set_name('\xA1\xC0')
+        t.set_tracker(TRACKER)
+        t.finalize()
+
+        self.assertEqual(t.get_name_utf8(), u'\xa1\xc0')
+
     def test_add_content_announce_list(self):
         """ Add a single file with announce-list to a TorrentDef """
         t = TorrentDef()


### PR DESCRIPTION
Fixes #3599 

This adds a method for getting a utf8 safe torrent name from a `TorrentDef`.