### PR TITLE
debian: return to previous dir after running the tribler script

### DIFF
--- a/debian/bin/tribler
+++ b/debian/bin/tribler
@@ -3,5 +3,6 @@
 
 echo "Starting Tribler..."
 
-cd "/usr/share/tribler"
+pushd "/usr/share/tribler"
 exec /usr/bin/python2.7 run_tribler.py "$@" > `mktemp /tmp/$USER-tribler-XXXXXXXX.log` 2>&1
+popd


### PR DESCRIPTION
RIght now, after running tribler via terminal, we stay in `/usr/share/tribler`. Depending on your environment you may not experience this issue. I changed the script to use `pushd` and `popd` instead of `cd`.