### PR TITLE
Generalized testnet configuration options

### DIFF
--- a/Tribler/Core/Config/config.spec
+++ b/Tribler/Core/Config/config.spec
@@ -5,6 +5,7 @@ ec_keypair_filename = string(default='')
 megacache = boolean(default=True)
 videoanalyserpath = string(default='')
 log_dir = string(default=None)
+testnet = boolean(default=False)
 
 [allchannel_community]
 enabled = boolean(default=True)
@@ -31,8 +32,8 @@ ec_keypair_filename = string(default='')
 [trustchain]
 enabled = boolean(default=True)
 ec_keypair_filename = string(default='')
+testnet_keypair_filename = string(default='')
 live_edges_enabled = boolean(default=True)
-testnet = boolean(default=False)
 
 [wallets]
 btc_testnet = boolean(default=False)

--- a/Tribler/Core/Config/tribler_config.py
+++ b/Tribler/Core/Config/tribler_config.py
@@ -187,14 +187,24 @@ class TriblerConfig(object):
             self.set_permid_keypair_filename(file_name)
         return file_name
 
-    def set_trustchain_permid_keypair_filename(self, keypairfilename):
+    def set_trustchain_keypair_filename(self, keypairfilename):
         self.config['trustchain']['ec_keypair_filename'] = keypairfilename
 
-    def get_trustchain_permid_keypair_filename(self):
+    def get_trustchain_keypair_filename(self):
         file_name = self.config['trustchain']['ec_keypair_filename']
         if not file_name:
             file_name = os.path.join(self.get_state_dir(), 'ec_multichain.pem')
-            self.set_trustchain_permid_keypair_filename(file_name)
+            self.set_trustchain_keypair_filename(file_name)
+        return file_name
+
+    def set_trustchain_testnet_keypair_filename(self, keypairfilename):
+        self.config['trustchain']['testnet_keypair_filename'] = keypairfilename
+
+    def get_trustchain_testnet_keypair_filename(self):
+        file_name = self.config['trustchain']['testnet_keypair_filename']
+        if not file_name:
+            file_name = os.path.join(self.get_state_dir(), 'ec_trustchain_testnet.pem')
+            self.set_trustchain_testnet_keypair_filename(file_name)
         return file_name
 
     def set_trustchain_enabled(self, value):
@@ -208,12 +218,6 @@ class TriblerConfig(object):
 
     def get_trustchain_live_edges_enabled(self):
         return self.config['trustchain']['live_edges_enabled']
-
-    def set_trustchain_testnet(self, value):
-        self.config['trustchain']['testnet'] = value
-
-    def get_trustchain_testnet(self):
-        return self.config['trustchain']['testnet']
 
     def set_megacache_enabled(self, value):
         self.config['general']['megacache'] = value
@@ -233,6 +237,12 @@ class TriblerConfig(object):
     def get_log_dir(self):
         log_dir = self.config['general']['log_dir']
         return os.path.join(self.get_state_dir(), 'logs') if (not log_dir or log_dir == 'None') else log_dir
+
+    def set_testnet(self, value):
+        self.config['general']['testnet'] = value
+
+    def get_testnet(self):
+        return self.config['general']['testnet']
 
     # Torrent checking
 

--- a/Tribler/Core/Session.py
+++ b/Tribler/Core/Session.py
@@ -134,8 +134,7 @@ class Session(object):
             permid_module.save_keypair(self.keypair, pair_filename)
             permid_module.save_pub_key(self.keypair, public_key_filename)
 
-        trustchain_pairfilename = self.config.get_trustchain_permid_keypair_filename()
-
+        trustchain_pairfilename = self.config.get_trustchain_keypair_filename()
         if os.path.exists(trustchain_pairfilename):
             self.trustchain_keypair = permid_module.read_keypair_trustchain(trustchain_pairfilename)
         else:
@@ -145,6 +144,17 @@ class Session(object):
             trustchain_pubfilename = os.path.join(self.config.get_state_dir(), 'ecpub_multichain.pem')
             permid_module.save_keypair_trustchain(self.trustchain_keypair, trustchain_pairfilename)
             permid_module.save_pub_key_trustchain(self.trustchain_keypair, trustchain_pubfilename)
+
+        trustchain_testnet_pairfilename = self.config.get_trustchain_testnet_keypair_filename()
+        if os.path.exists(trustchain_testnet_pairfilename):
+            self.trustchain_testnet_keypair = permid_module.read_keypair_trustchain(trustchain_testnet_pairfilename)
+        else:
+            self.trustchain_testnet_keypair = permid_module.generate_keypair_trustchain()
+
+            # Save keypair
+            trustchain_testnet_pubfilename = os.path.join(self.config.get_state_dir(), 'ecpub_trustchain_testnet.pem')
+            permid_module.save_keypair_trustchain(self.trustchain_testnet_keypair, trustchain_testnet_pairfilename)
+            permid_module.save_pub_key_trustchain(self.trustchain_testnet_keypair, trustchain_testnet_pubfilename)
 
     def unhandled_error_observer(self, event):
         """

--- a/Tribler/Core/Upgrade/config_converter.py
+++ b/Tribler/Core/Upgrade/config_converter.py
@@ -152,7 +152,7 @@ def add_libtribler_config(new_config, old_config):
             elif section == "tunnel_community" and name == "exitnode_enabled":
                 temp_config.set_tunnel_community_exitnode_enabled(value)
             elif section == "general" and name == "ec_keypair_filename_multichain":
-                temp_config.set_trustchain_permid_keypair_filename(value)
+                temp_config.set_trustchain_keypair_filename(value)
             elif section == "metadata" and name == "enabled":
                 temp_config.set_metadata_enabled(value)
             elif section == "metadata" and name == "store_dir":

--- a/Tribler/Test/Core/Config/test_tribler_config.py
+++ b/Tribler/Test/Core/Config/test_tribler_config.py
@@ -114,17 +114,26 @@ class TestTriblerConfig(TriblerCoreTest):
         self.tribler_config.set_permid_keypair_filename("TEST")
         self.assertEqual(self.tribler_config.get_permid_keypair_filename(), "TEST")
 
-        self.tribler_config.set_trustchain_permid_keypair_filename(None)
-        self.assertEqual(self.tribler_config.get_trustchain_permid_keypair_filename(),
+        self.tribler_config.set_trustchain_keypair_filename(None)
+        self.assertEqual(self.tribler_config.get_trustchain_keypair_filename(),
                          os.path.join("TEST", "ec_multichain.pem"))
-        self.tribler_config.set_trustchain_permid_keypair_filename("TEST")
-        self.assertEqual(self.tribler_config.get_trustchain_permid_keypair_filename(), "TEST")
+        self.tribler_config.set_trustchain_keypair_filename("TEST")
+        self.assertEqual(self.tribler_config.get_trustchain_keypair_filename(), "TEST")
+
+        self.tribler_config.set_trustchain_testnet_keypair_filename(None)
+        self.assertEqual(self.tribler_config.get_trustchain_testnet_keypair_filename(),
+                         os.path.join("TEST", "ec_trustchain_testnet.pem"))
+        self.tribler_config.set_trustchain_testnet_keypair_filename("TEST")
+        self.assertEqual(self.tribler_config.get_trustchain_testnet_keypair_filename(), "TEST")
 
         self.tribler_config.set_megacache_enabled(True)
         self.assertEqual(self.tribler_config.get_megacache_enabled(), True)
 
         self.tribler_config.set_video_analyser_path(True)
         self.assertEqual(self.tribler_config.get_video_analyser_path(), True)
+
+        self.tribler_config.set_testnet(True)
+        self.assertTrue(self.tribler_config.get_testnet())
 
     def test_get_set_methods_torrent_checking(self):
         """

--- a/Tribler/community/market/community.py
+++ b/Tribler/community/market/community.py
@@ -129,6 +129,7 @@ class MarketCommunity(Community, BlockListener):
                        "85e3cd472537c49f5744abb74bde47801ca4fb28bf97c4019681497238f34".decode('hex'))
     PROTOCOL_VERSION = 1
     BLOCK_CLASS = MarketBlock
+    DB_NAME = 'market'
 
     def __init__(self, *args, **kwargs):
         self.is_matchmaker = kwargs.pop('is_matchmaker', True)
@@ -147,7 +148,7 @@ class MarketCommunity(Community, BlockListener):
         self.mid = self.my_peer.mid.encode('hex')
         self.mid_register = {}
         self.order_book = None
-        self.market_database = MarketDB(db_working_dir, 'market')
+        self.market_database = MarketDB(db_working_dir, self.DB_NAME)
         self.matching_engine = None
         self.incoming_match_messages = {}  # Map of TraderId -> Message (we save all incoming matches)
         self.transaction_manager = None
@@ -1597,3 +1598,14 @@ class MarketCommunity(Community, BlockListener):
         """
         rep_manager = TemporalPagerankReputationManager(self.trustchain.persistence.get_all_blocks())
         self.reputation_dict = rep_manager.compute(self.my_peer.public_key.key_to_bin())
+
+
+class MarketTestnetCommunity(MarketCommunity):
+    """
+    This community defines a testnet for the market.
+    """
+    master_peer = Peer("3081a7301006072a8648ce3d020106052b81040027038192000406aeac19f997920c42f80455aeccfb9a60eba6c"
+                       "f09dfa7dc747efe9a74e85552f656bb918b0000c13cf2ad39cdec3e950bd011657fd49dcf5af2273f3ed09019fc"
+                       "443ad5d2ecc41f02f88458880e0ce680b34367ee68d708b873d60f994a0d3c97585d3d4dd489a8071ebb89acdac"
+                       "67107726b87135169d94909885ae4057c32b974de000d8e875a43d413d685079178".decode('hex'))
+    DB_NAME = 'market_testnet'

--- a/Tribler/community/triblertunnel/community.py
+++ b/Tribler/community/triblertunnel/community.py
@@ -24,6 +24,10 @@ from Tribler.pyipv8.ipv8.peer import Peer
 
 
 class TriblerTunnelCommunity(HiddenTunnelCommunity):
+    """
+    This community is built upon the anonymous messaging layer in IPv8.
+    It adds support for libtorrent anonymous downloads and bandwidth token payout when closing circuits.
+    """
     master_peer = Peer("3081a7301006072a8648ce3d020106052b81040027038192000407df3e6d69794baa5590617b729ebea421d82bb02"
                        "e70fb2dcc91111f636a591d37a5af44becae32467e840be09e7a85d28e4ec4074776d97a1cf479eeff7f040a6852a"
                        "bddbe275a1047614ee9b4a74c172b1ab454f4b26119fa3207914b018d7379d0b8beef96625a41327450d51aa63a2b"
@@ -508,3 +512,13 @@ class TriblerTunnelCommunity(HiddenTunnelCommunity):
             yield socks_server.stop()
 
         super(TriblerTunnelCommunity, self).unload()
+
+
+class TriblerTunnelTestnetCommunity(TriblerTunnelCommunity):
+    """
+    This community defines a testnet for the anonymous tunnels.
+    """
+    master_peer = Peer("3081a7301006072a8648ce3d020106052b810400270381920004002831990fc973aaf5a8f5bd401f8771fd411d763"
+                       "0ccc4a61c4147a1200135023a2397006e0acb215783cc0245bbc69ebe66abdd13f1fa3434c630604ef2c0d99e5f98"
+                       "727e75ae7901529ba5a2dd875bab582f3f508aa7b675c9d9bd7fd6c2e2684c7fc71b72f007e080634cecf007b718f"
+                       "5cf24d24821cd08feb30d3f3059c7702615ea6f8b23823415bd1673c406e1".decode('hex'))

--- a/twisted/plugins/tribler_plugin.py
+++ b/twisted/plugins/tribler_plugin.py
@@ -56,6 +56,7 @@ class Options(usage.Options):
     optFlags = [
         ["auto-join-channel", "a", "Automatically join a channel when discovered"],
         ["log-incoming-searches", "i", "Write information about incoming remote searches to a file"],
+        ["testnet", "t", "Join the testnet"]
     ]
 
 
@@ -128,6 +129,9 @@ class TriblerServiceMaker(object):
 
         if options["ipv8_bootstrap_override"] is not None:
             config.set_ipv8_bootstrap_override(options["ipv8_bootstrap_override"])
+
+        if "testnet" in options and options["testnet"]:
+            config.set_testnet(True)
 
         self.session = Session(config)
         self.session.start().addErrback(lambda failure: self.shutdown_process(failure.getErrorMessage()))

--- a/twisted/plugins/tunnel_helper_plugin.py
+++ b/twisted/plugins/tunnel_helper_plugin.py
@@ -83,7 +83,7 @@ check_ipv8_bootstrap_override.coerceDoc = "IPv8 bootstrap server address must be
 class Options(usage.Options):
     optFlags = [
         ["exit", "x", "Allow being an exit-node"],
-        ["testnet", "t", "Join the TrustChain testnet"]
+        ["testnet", "t", "Join the testnet"]
     ]
 
     optParameters = [
@@ -177,7 +177,7 @@ class Tunnel(object):
         config.set_market_community_enabled(False)
         config.set_mainline_dht_enabled(False)
         config.set_tunnel_community_exitnode_enabled(bool(self.options["exit"]))
-        config.set_trustchain_testnet(bool(self.options["testnet"]))
+        config.set_testnet(bool(self.options["testnet"]))
 
         if self.options["restapi"] is not None:
             config.set_http_api_enabled(True)


### PR DESCRIPTION
In this PR, I changed the testnet option to generalize it. When enabling the testnet option in the Tribler config file, other (testnet) communities for the market, trustchain and tunnel community will be loaded and used instead. These communities will also be joined with a different identity.