### PR TITLE
Hide torrent info on channel torrent deselect

### DIFF
--- a/TriblerGUI/widgets/channelpage.py
+++ b/TriblerGUI/widgets/channelpage.py
@@ -64,8 +64,11 @@ class ChannelPage(QWidget):
         list_widget = item.listWidget()
         list_item = list_widget.itemWidget(item)
         if isinstance(list_item, ChannelTorrentListItem):
-            self.window().channel_torrents_detail_widget.update_with_torrent(list_item.torrent_info)
-            self.window().channel_torrents_detail_widget.show()
+            if not self.window().channel_torrents_list.selectedItems():
+                self.window().channel_torrents_detail_widget.hide()
+            else:
+                self.window().channel_torrents_detail_widget.update_with_torrent(list_item.torrent_info)
+                self.window().channel_torrents_detail_widget.show()
 
     def update_result_list(self):
         if self.loaded_channels and self.loaded_playlists:


### PR DESCRIPTION
If a torrent is deselected in a discovered channel, the torrent info is now hidden.