### PR TITLE
Update unnamed torrents on metainfo check

### DIFF
--- a/Tribler/Core/CacheDB/SqliteCacheDBHandler.py
+++ b/Tribler/Core/CacheDB/SqliteCacheDBHandler.py
@@ -515,6 +515,23 @@ class TorrentDBHandler(BasicDBHandler):
         if notify:
             self.notifier.notify(NTFY_TORRENTS, NTFY_UPDATE, infohash)
 
+    def update_torrent_with_metainfo(self, infohash, metainfo):
+        """ Updates name, length and num files from metainfo if record does not exist in the database. """
+        torrent_id = self.getTorrentID(infohash)
+        name = self.getOne('name', torrent_id=torrent_id)
+        if not name:
+            num_files, length = 0, 0
+            if 'info' in metainfo:
+                info = metainfo['info']
+                name = info["name"] if "name" in info else ""
+                if 'files' in info:
+                    num_files = len(info['files'])
+                    for piece in info['files']:
+                        length += piece['length']
+
+            if name and num_files and length:
+                self.updateTorrent(infohash, notify=False, name=name, num_files=num_files, length=length)
+
     def on_torrent_collect_response(self, infohashes):
         infohash_list = [(bin2str(infohash)) for infohash in infohashes]
 

--- a/Tribler/Core/Modules/restapi/torrentinfo_endpoint.py
+++ b/Tribler/Core/Modules/restapi/torrentinfo_endpoint.py
@@ -1,6 +1,5 @@
 import logging
 import hashlib
-
 from urllib import url2pathname
 
 from libtorrent import bdecode, bencode
@@ -65,6 +64,10 @@ class TorrentInfoEndpoint(resource.Resource):
 
             # Check if the torrent is already in the downloads
             metainfo['download_exists'] = infohash in self.session.lm.downloads
+
+            # Update the torrent database with metainfo if it is an unnamed torrent
+            if self.session.lm.torrent_db:
+                self.session.lm.torrent_db.update_torrent_with_metainfo(infohash, metainfo)
 
             # Save the torrent to our store
             try:


### PR DESCRIPTION
Unnamed torrents are now updated on metainfo check.
Related #3759 