### PR TITLE
Performing direct payouts to other Tribler clients

### DIFF
--- a/Tribler/Core/Libtorrent/LibtorrentMgr.py
+++ b/Tribler/Core/Libtorrent/LibtorrentMgr.py
@@ -158,6 +158,10 @@ class LibtorrentMgr(TaskManager):
                 pe_settings = lt.pe_settings()
                 pe_settings.prefer_rc4 = True
                 ltsession.set_pe_settings(pe_settings)
+
+            mid = self.tribler_session.trustchain_keypair.key_to_hash()
+            settings['peer_fingerprint'] = mid
+            settings['handshake_client_version'] = 'Tribler/' + version_id + '/' + mid.encode('hex')
         else:
             settings['enable_outgoing_utp'] = True
             settings['enable_incoming_utp'] = True

--- a/Tribler/Core/Modules/payout_manager.py
+++ b/Tribler/Core/Modules/payout_manager.py
@@ -1,0 +1,54 @@
+import logging
+
+from Tribler.Core.Modules.wallet.tc_wallet import TrustchainWallet
+
+
+class PayoutManager(object):
+    """
+    This manager is responsible for keeping track of known Tribler peers and doing (zero-hop) payouts.
+    """
+
+    def __init__(self, trustchain, dht):
+        self.logger = logging.getLogger(self.__class__.__name__)
+        self.bandwidth_wallet = TrustchainWallet(trustchain)
+        self.dht = dht
+        self.tribler_peers = {}
+
+    def do_payout(self, mid):
+        """
+        Perform a payout to a given mid. First, determine the outstanding balance. Then resolve the node in the DHT.
+        """
+        if mid not in self.tribler_peers:
+            self.logger.warning("Mid %s not found in known peers, not doing payout!", mid.encode('hex'))
+            return
+
+        total_bytes = 0
+        for balance in self.tribler_peers[mid].itervalues():
+            total_bytes += balance
+
+        def on_nodes(nodes):
+            self.logger.debug("Received %d nodes for DHT lookup", len(nodes))
+            if nodes:
+                self.bandwidth_wallet.trustchain.sign_block(nodes[0],
+                                                            public_key=nodes[0].public_key.key_to_bin(),
+                                                            block_type='tribler_bandwidth',
+                                                            transaction={'up': 0, 'down': total_bytes})
+
+        if total_bytes >= 1024 * 1024:  # Do at least 1MB payouts
+            self.logger.info("Doing direct payout to %s (%d bytes)", mid.encode('hex'), total_bytes)
+            self.dht.connect_peer(mid).addCallback(on_nodes)
+
+        # Remove the outstanding bytes; otherwise we will payout again
+        self.tribler_peers.pop(mid, None)
+
+    def update_peer(self, mid, infohash, balance):
+        """
+        Update a peer with a specific mid for a specific infohash.
+        """
+        self.logger.debug("Updating peer with mid %s and ih %s (balance: %d)", mid.encode('hex'),
+                          infohash.encode('hex'), balance)
+
+        if mid not in self.tribler_peers:
+            self.tribler_peers[mid] = {}
+
+        self.tribler_peers[mid][infohash] = balance

--- a/Tribler/Core/Modules/wallet/bandwidth_block.py
+++ b/Tribler/Core/Modules/wallet/bandwidth_block.py
@@ -8,7 +8,7 @@ class TriblerBandwidthBlock(TrustChainBlock):
     """
 
     @classmethod
-    def create(cls, block_type, transaction, database, public_key, link=None, link_pk=None):
+    def create(cls, block_type, transaction, database, public_key, link=None, link_pk=None, additional_info=None):
         """
         Create an empty next block.
         :param block_type: the type of the block to be created
@@ -17,6 +17,8 @@ class TriblerBandwidthBlock(TrustChainBlock):
         :param public_key: the public key to use for this block
         :param link: optionally create the block as a linked block to this block
         :param link_pk: the public key of the counterparty in this transaction
+        :param additional_info: additional information, which has a higher priority than the
+               transaction when link exists
         :return: A newly created block
         """
         latest_bw_block = database.get_latest(public_key, block_type='tribler_bandwidth')

--- a/Tribler/Test/Community/popularity/test_payload.py
+++ b/Tribler/Test/Community/popularity/test_payload.py
@@ -24,7 +24,7 @@ class TestSerializer(TestCase):
         subscribe = True
         identifier = 123123
         subscription = ContentSubscription(identifier, subscribe)
-        serialized = self.serializer.pack_multiple(subscription.to_pack_list())
+        serialized = self.serializer.pack_multiple(subscription.to_pack_list())[0]
 
         # Deserialize and test it
         (deserialized, _) = self.serializer.unpack_multiple(ContentSubscription.format_list, serialized)
@@ -41,7 +41,7 @@ class TestSerializer(TestCase):
         timestamp = 123123123
 
         health_payload = TorrentHealthPayload(infohash, num_seeders, num_leechers, timestamp)
-        serialized = self.serializer.pack_multiple(health_payload.to_pack_list())
+        serialized = self.serializer.pack_multiple(health_payload.to_pack_list())[0]
 
         # Deserialize and test it
         (deserialized, _) = self.serializer.unpack_multiple(TorrentHealthPayload.format_list, serialized)
@@ -61,7 +61,7 @@ class TestSerializer(TestCase):
         timestamp = 123123123
 
         health_payload = ChannelHealthPayload(channel_id, num_votes, num_torrents, swarm_size_sum, timestamp)
-        serialized = self.serializer.pack_multiple(health_payload.to_pack_list())
+        serialized = self.serializer.pack_multiple(health_payload.to_pack_list())[0]
 
         # Deserialize and test it
         (deserialized, _) = self.serializer.unpack_multiple(ChannelHealthPayload.format_list, serialized)
@@ -83,7 +83,7 @@ class TestSerializer(TestCase):
         comment = None
 
         health_payload = TorrentInfoResponsePayload(infohash, name, length, creation_date, num_files, comment)
-        serialized = self.serializer.pack_multiple(health_payload.to_pack_list())
+        serialized = self.serializer.pack_multiple(health_payload.to_pack_list())[0]
 
         # Deserialize and test it
         (deserialized, _) = self.serializer.unpack_multiple(TorrentInfoResponsePayload.format_list, serialized)
@@ -121,9 +121,9 @@ class TestSerializer(TestCase):
         # Serialize the results
         results = ''
         for item in sample_items:
-            results += self.serializer.pack_multiple(item.to_pack_list())
+            results += self.serializer.pack_multiple(item.to_pack_list())[0]
         serialized_results = self.serializer.pack_multiple(
-            SearchResponsePayload(identifier, response_type, results).to_pack_list())
+            SearchResponsePayload(identifier, response_type, results).to_pack_list())[0]
 
         # De-serialize the response payload and check the identifier and get the results
         response_format = SearchResponsePayload.format_list
@@ -172,7 +172,7 @@ class TestSerializer(TestCase):
 
         # Serialize request
         in_request = ContentInfoRequest(identifier, content_type, query_list, limit)
-        serialized_request = self.serializer.pack_multiple(in_request.to_pack_list())
+        serialized_request = self.serializer.pack_multiple(in_request.to_pack_list())[0]
 
         # Deserialize request and test it
         (deserialized_request, _) = self.serializer.unpack_multiple(ContentInfoRequest.format_list, serialized_request)
@@ -192,7 +192,7 @@ class TestSerializer(TestCase):
 
         # Serialize request
         in_response = ContentInfoResponse(identifier, content_type, response, pagination)
-        serialized_response = self.serializer.pack_multiple(in_response.to_pack_list())
+        serialized_response = self.serializer.pack_multiple(in_response.to_pack_list())[0]
 
         # Deserialize request and test it
         (deserialized_response, _) = self.serializer.unpack_multiple(ContentInfoResponse.format_list,

--- a/Tribler/Test/Core/Libtorrent/test_libtorrent_mgr.py
+++ b/Tribler/Test/Core/Libtorrent/test_libtorrent_mgr.py
@@ -28,6 +28,7 @@ class TestLibtorrentMgr(AbstractServer):
         yield super(TestLibtorrentMgr, self).setUp(annotate)
 
         self.tribler_session = MockObject()
+        self.tribler_session.lm = MockObject()
         self.tribler_session.notifier = Notifier()
         self.tribler_session.state_dir = self.session_base_dir
         self.tribler_session.trustchain_keypair = MockObject()
@@ -437,3 +438,26 @@ class TestLibtorrentMgr(AbstractServer):
         self.ltmgr.initialize()
         self.ltmgr._task_process_alerts()
         return test_deferred
+
+    def test_payout_on_disconnect(self):
+        """
+        Test whether a payout is initialized when a peer disconnects
+        """
+        class peer_disconnected_alert(object):
+            def __init__(self):
+                self.pid = MockObject()
+                self.pid.to_string = lambda: 'a' * 20
+
+        def mocked_do_payout(mid):
+            self.assertEqual(mid, 'a' * 20)
+            mocked_do_payout.called = True
+        mocked_do_payout.called = False
+
+        disconnect_alert = peer_disconnected_alert()
+        self.ltmgr.tribler_session.lm.payout_manager = MockObject()
+        self.ltmgr.tribler_session.lm.payout_manager.do_payout = mocked_do_payout
+        self.ltmgr.initialize()
+        self.ltmgr.get_session(0).pop_alerts = lambda: [disconnect_alert]
+        self.ltmgr._task_process_alerts()
+
+        self.assertTrue(mocked_do_payout.called)

--- a/Tribler/Test/Core/Modules/test_payout_manager.py
+++ b/Tribler/Test/Core/Modules/test_payout_manager.py
@@ -1,0 +1,54 @@
+from twisted.internet.defer import inlineCallbacks, succeed
+
+from Tribler.Core.Modules.payout_manager import PayoutManager
+from Tribler.Test.Core.base_test import TriblerCoreTest, MockObject
+from Tribler.pyipv8.ipv8.util import blocking_call_on_reactor_thread
+
+
+class TestPayoutManager(TriblerCoreTest):
+    """
+    This class contains various tests for the payout manager.
+    """
+
+    @blocking_call_on_reactor_thread
+    @inlineCallbacks
+    def setUp(self, annotate=True):
+        yield super(TestPayoutManager, self).setUp(annotate=annotate)
+
+        fake_tc = MockObject()
+        fake_tc.add_listener = lambda *_: None
+
+        fake_response_peer = MockObject()
+        fake_response_peer.public_key = MockObject()
+        fake_response_peer.public_key.key_to_bin = lambda: 'a' * 64
+        fake_dht = MockObject()
+        fake_dht.connect_peer = lambda *_: succeed([fake_response_peer])
+
+        self.payout_manager = PayoutManager(fake_tc, fake_dht)
+
+    def test_do_payout(self):
+        """
+        Test doing a payout
+        """
+        self.payout_manager.do_payout('a')  # Does not exist
+        self.payout_manager.update_peer('b', 'c', 10 * 1024 * 1024)
+        self.payout_manager.update_peer('b', 'd', 1337)
+
+        def mocked_sign_block(*_, **kwargs):
+            tx = kwargs.pop('transaction')
+            self.assertEqual(tx['down'], 10 * 1024 * 1024 + 1337)
+
+        self.payout_manager.bandwidth_wallet.trustchain.sign_block = mocked_sign_block
+        self.payout_manager.do_payout('b')
+
+    def test_update_peer(self):
+        """
+        Test the updating of a specific peer
+        """
+        self.payout_manager.update_peer('a', 'b', 1337)
+        self.assertIn('a', self.payout_manager.tribler_peers)
+        self.assertIn('b', self.payout_manager.tribler_peers['a'])
+        self.assertEqual(self.payout_manager.tribler_peers['a']['b'], 1337)
+
+        self.payout_manager.update_peer('a', 'b', 1338)
+        self.assertEqual(self.payout_manager.tribler_peers['a']['b'], 1338)

--- a/Tribler/community/popularity/pubsub.py
+++ b/Tribler/community/popularity/pubsub.py
@@ -221,7 +221,7 @@ class PubSubCommunity(Community):
         num_payloads = len(payload_list)
         while current_index < num_payloads:
             item = payload_list[current_index]
-            packed_item = self.serializer.pack_multiple(item.to_pack_list())
+            packed_item = self.serializer.pack_multiple(item.to_pack_list())[0]
             packed_item_length = len(packed_item)
             if size + packed_item_length > fit_size:
                 break


### PR DESCRIPTION
This PR implements direct payouts between Tribler instances (zero-hop downloads).

TODO:
- [x] write unit tests
- [x] test the implementation with 100+ Tribler instances and varying download sizes (done: https://jenkins-ci.tribler.org/job/pers/job/direct_download_devos50/96/)

Fixes #3718 