### PR TITLE
Point docs to jenkins-ci instead of jenkins

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,8 +83,8 @@ Submodule notes
 - Take care of not accidentally committing a submodule revision change with ``git commit -a``.
 - Do not commit a submodule update without running all the tests first and making sure the new code is not breaking Tribler.
 
-.. |jenkins_build| image:: http://jenkins.tribler.org/job/Test_tribler_devel/badge/icon
-    :target: http://jenkins.tribler.org/job/Test_tribler_devel/
+.. |jenkins_build| image:: http://jenkins-ci.tribler.org/job/Test_tribler_next/badge/icon
+    :target: http://jenkins-ci.tribler.org/job/Test_tribler_next/
     :alt: Build status on Jenkins
 
 .. |pr_closed| image:: https://img.shields.io/github/issues-pr-closed/tribler/tribler.svg?style=flat

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -12,7 +12,7 @@ The stabilization branch ``next`` contains the most up to date bugfixes. If your
 To backup your Tribler installation and checkout the latest version of the stabilization branch, please perform the following steps.
 * Copy the ``.Tribler`` folder to a safe location on your system (for instance the desktop) Make sure to leave the original folder on its original location. This folder is located at ``~/.Tribler/`` (Linux/OS X) or ``%APPDATA\.Tribler`` (Windows).
 * Remove the ``tribler`` installation folder.
-* Go to `the latest tested version of Tribler <https://jenkins.tribler.org/job/Publish_tribler_next/lastStableBuild/>`_ and under 'Build Artifacts', download the package appropriate to your operating system.
+* Go to `the latest tested version of Tribler <https://jenkins-ci.tribler.org/job/Build_Tribler_next/lastStableBuild/>`_ and under 'Build Artifacts', download the package appropriate to your operating system.
 * Install/unzip this package.
 
 To revert back to your original version of Tribler, `download the installer again <https://github.com/Tribler/tribler/releases>`_ and install it. Afterwards you can restore your backed up Tribler data folder.
@@ -28,7 +28,7 @@ Reporting bugs
     * The OS and version you are running.
     * Step by step instructions to reproduce the issue in case it's a bug.
 * Attach Tribler's log file. On Windows, these are found in ``%APPDATA%``. On Linux distributions, the log file is located in ``~/.Tribler/``. On OS X, the crash logs can be found in ``~/Library/Logs/DiagnosticReports`` and logger output can be found in the ``syslog``. The location of this log is ``/var/log/system.log``. You can use the following command to extract Tribler-related lines from the syslog: ``syslog -C |grep -i tribler > ~/tribler.log``. Please have a look at the content of the log files before posting it in case you want to edit out something.
-    * Does it still happen if you move ``%APPDATA\.Tribler`` away temporarily? (Do **not** delete it!)
+    * Does it still happen if you move ``%APPDATA%\.Tribler`` away temporarily? (Do **not** delete it!)
     * Do you have any other software installed that might interfere with Tribler?
 
 Pull requests

--- a/doc/development/development_on_linux.rst
+++ b/doc/development/development_on_linux.rst
@@ -9,7 +9,7 @@ First, install the required dependencies by executing the following command in y
 
     sudo apt-get install libav-tools libsodium18 libx11-6 python-apsw python-cherrypy3 python-cryptography python-datrie python-decorator python-dnspython python-ecdsa python-feedparser python-jsonrpclib python-keyring python-keyrings.alt python-leveldb python-libtorrent python-matplotlib python-meliae python-m2crypto python-netifaces python-pbkdf2 python-pil python-protobuf python-pyasn1 python-pysocks python-requests python-scipy python-twisted python2.7 vlc python-chardet python-configobj python-pyqt5 python-pyqt5.qtsvg python-libnacl
 
-Next, download the latest .deb file from `here <https://jenkins.tribler.org/job/Build-Tribler_Ubuntu-64_devel/lastStableBuild/>`_.
+Next, download the latest .deb file from `here <https://jenkins-ci.tribler.org/job/Build-Tribler_Ubuntu-64_devel/lastStableBuild/>`_.
 
 Installing the python-socks on Ubuntu >= 16.10
 --------------------------------------------------------------

--- a/doc/development_methodology.rst
+++ b/doc/development_methodology.rst
@@ -64,7 +64,7 @@ For bug fixes:
 
 3. Create a `Pull Request <https://github.com/Tribler/tribler/compare>`_.
 
-It is usually a good idea to create a pull request for a branch even if it's a work in progress. Doing so will make our `Jenkins instance <https://jenkins.tribler.org>`_ run all the checks, tests and experiments every time you push a change so you can have continuous feedback on the state of your branch.
+It is usually a good idea to create a pull request for a branch even if it's a work in progress. Doing so will make our `Jenkins instance <https://jenkins-ci.tribler.org>`_ run all the checks, tests and experiments every time you push a change so you can have continuous feedback on the state of your branch.
 
 When creating a PR, always prepend the PR title with **WIP** until it's ready for the final round of reviews. More about this on the next section.
 


### PR DESCRIPTION
Fixes #3749

Also, the label on the README now points to `next` instead of `devel`.