### PR TITLE
Various improvement/fixes

### DIFF
--- a/Tribler/Core/Config/config.spec
+++ b/Tribler/Core/Config/config.spec
@@ -72,6 +72,7 @@ max_connections_download = integer(default=-1)
 max_download_rate = integer(default=0)
 max_upload_rate = integer(default=0)
 utp = boolean(default=True)
+dht = boolean(default=True)
 
 anon_listen_port = integer(min=-1, max=65536, default=-1)
 anon_proxy_type = integer(min=0, max=5, default=0)

--- a/Tribler/Core/Config/tribler_config.py
+++ b/Tribler/Core/Config/tribler_config.py
@@ -447,6 +447,12 @@ class TriblerConfig(object):
         """
         return self.config['libtorrent'].as_int('max_download_rate')
 
+    def set_libtorrent_dht_enabled(self, value):
+        self.config['libtorrent']['dht'] = value
+
+    def get_libtorrent_dht_enabled(self):
+        return self.config['libtorrent']['dht']
+
     # Mainline DHT
 
     def set_mainline_dht_enabled(self, value):

--- a/Tribler/Core/Libtorrent/LibtorrentDownloadImpl.py
+++ b/Tribler/Core/Libtorrent/LibtorrentDownloadImpl.py
@@ -243,7 +243,6 @@ class LibtorrentDownloadImpl(DownloadConfigInterface, TaskManager):
 
         except Exception as e:
             self.error = e
-            print_exc()
 
     def can_create_engine_wrapper(self):
         """

--- a/Tribler/Core/Modules/restapi/debug_endpoint.py
+++ b/Tribler/Core/Modules/restapi/debug_endpoint.py
@@ -48,6 +48,8 @@ class DebugCircuitsEndpoint(resource.Resource):
         resource.Resource.__init__(self)
         self.session = session
 
+        self.putChild("slots", DebugCircuitSlotsEndpoint(session))
+
     def render_GET(self, request):
         """
         .. http:get:: /debug/circuits
@@ -98,6 +100,46 @@ class DebugCircuitsEndpoint(resource.Resource):
             circuits_json.append(item)
 
         return json.dumps({'circuits': circuits_json})
+
+
+class DebugCircuitSlotsEndpoint(resource.Resource):
+    """
+    This class handles requests for information about slots in the tunnel overlay.
+    """
+
+    def __init__(self, session):
+        resource.Resource.__init__(self)
+        self.session = session
+
+    def render_GET(self, request):
+        """
+        .. http:get:: /debug/circuits/slots
+
+        A GET request to this endpoint returns information about the slots in the tunnel overlay.
+
+            **Example request**:
+
+            .. sourcecode:: none
+
+                curl -X GET http://localhost:8085/debug/circuits/slots
+
+            **Example response**:
+
+            .. sourcecode:: javascript
+
+                {
+                    "open_files": [{
+                        "path": "path/to/open/file.txt",
+                        "fd": 33,
+                    }, ...]
+                }
+        """
+        return json.dumps({
+            "slots": {
+                "random": self.session.lm.tunnel_community.random_slots,
+                "competing": self.session.lm.tunnel_community.competing_slots
+            }
+        })
 
 
 class DebugOpenFilesEndpoint(resource.Resource):

--- a/Tribler/Core/Modules/restapi/statistics_endpoint.py
+++ b/Tribler/Core/Modules/restapi/statistics_endpoint.py
@@ -11,8 +11,12 @@ class StatisticsEndpoint(resource.Resource):
     def __init__(self, session):
         resource.Resource.__init__(self)
 
-        child_handler_dict = {"tribler": StatisticsTriblerEndpoint, "dispersy": StatisticsDispersyEndpoint,
-                              "communities": StatisticsCommunitiesEndpoint}
+        child_handler_dict = {
+            "tribler": StatisticsTriblerEndpoint,
+            "dispersy": StatisticsDispersyEndpoint,
+            "ipv8": StatisticsIPv8Endpoint,
+            "communities": StatisticsCommunitiesEndpoint
+        }
 
         for path, child_cls in child_handler_dict.iteritems():
             self.putChild(path, child_cls(session))
@@ -103,6 +107,43 @@ class StatisticsDispersyEndpoint(resource.Resource):
                 }
         """
         return json.dumps({'dispersy_statistics': self.session.get_dispersy_statistics()})
+
+
+class StatisticsIPv8Endpoint(resource.Resource):
+    """
+    This class handles requests regarding IPv8 statistics.
+    """
+
+    def __init__(self, session):
+        resource.Resource.__init__(self)
+        self.session = session
+
+    def render_GET(self, request):
+        """
+        .. http:get:: /statistics/ipv8
+
+        A GET request to this endpoint returns general statistics of IPv8.
+
+            **Example request**:
+
+            .. sourcecode:: none
+
+                curl -X GET http://localhost:8085/statistics/ipv8
+
+            **Example response**:
+
+            .. sourcecode:: javascript
+
+                {
+                    "ipv8_statistics": {
+                        "total_up": 3424324,
+                        "total_down": 859484
+                    }
+                }
+        """
+        return json.dumps({
+            'ipv8_statistics': self.session.get_ipv8_statistics()
+        })
 
 
 class StatisticsCommunitiesEndpoint(resource.Resource):

--- a/Tribler/Core/Session.py
+++ b/Tribler/Core/Session.py
@@ -426,6 +426,10 @@ class Session(object):
         """Return a dictionary with Dispersy communities statistics."""
         return TriblerStatistics(self).get_dispersy_community_statistics()
 
+    def get_ipv8_statistics(self):
+        """Return a dictionary with IPv8 statistics."""
+        return TriblerStatistics(self).get_ipv8_statistics()
+
     def get_ipv8_overlay_statistics(self):
         """Return a dictionary with IPv8 overlay statistics."""
         return TriblerStatistics(self).get_ipv8_overlays_statistics()

--- a/Tribler/Core/statistics.py
+++ b/Tribler/Core/statistics.py
@@ -120,6 +120,20 @@ class TriblerStatistics(object):
 
         return communities_stats
 
+    def get_ipv8_statistics(self):
+        """
+        Return generic IPv8 statistics.
+        """
+        try:
+            ipv8 = self.session.get_ipv8_instance()
+        except OperationNotEnabledByConfigurationException:
+            return {}
+
+        return {
+            "total_up": ipv8.endpoint.bytes_up,
+            "total_down": ipv8.endpoint.bytes_down
+        }
+
     def get_ipv8_overlays_statistics(self):
         """
         Return a dictionary with IPv8 overlay statistics.

--- a/Tribler/Test/Core/Config/test_tribler_config.py
+++ b/Tribler/Test/Core/Config/test_tribler_config.py
@@ -208,6 +208,8 @@ class TestTriblerConfig(TriblerCoreTest):
         self.assertEqual(self.tribler_config.get_libtorrent_max_upload_rate(), True)
         self.tribler_config.set_libtorrent_max_download_rate(True)
         self.assertEqual(self.tribler_config.get_libtorrent_max_download_rate(), True)
+        self.tribler_config.set_libtorrent_dht_enabled(False)
+        self.assertFalse(self.tribler_config.get_libtorrent_dht_enabled())
 
     def test_get_set_methods_mainline_dht(self):
         """

--- a/Tribler/Test/Core/Libtorrent/test_libtorrent_mgr.py
+++ b/Tribler/Test/Core/Libtorrent/test_libtorrent_mgr.py
@@ -44,6 +44,7 @@ class TestLibtorrentMgr(AbstractServer):
         self.tribler_session.config.set_listen_port_runtime = lambda: None
         self.tribler_session.config.get_libtorrent_max_upload_rate = lambda: 100
         self.tribler_session.config.get_libtorrent_max_download_rate = lambda: 120
+        self.tribler_session.config.get_libtorrent_dht_enabled = lambda: False
 
         self.ltmgr = LibtorrentMgr(self.tribler_session)
 

--- a/Tribler/Test/Core/Modules/RestApi/test_debug_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_debug_endpoint.py
@@ -54,6 +54,22 @@ class TestCircuitDebugEndpoint(AbstractApiTest):
         return self.do_request('debug/circuits', expected_code=200).addCallback(verify_response)
 
     @deferred(timeout=10)
+    def test_get_slots(self):
+        """
+        Test whether we can get slot information from the API
+        """
+        self.session.lm.tunnel_community = MockObject()
+        self.session.lm.tunnel_community.random_slots = [None, None, None, 12345]
+        self.session.lm.tunnel_community.competing_slots = [(0, None), (12345, 12345)]
+
+        def verify_response(response):
+            response_json = json.loads(response)
+            self.assertEqual(len(response_json["slots"]["random"]), 4)
+
+        self.should_check_equality = False
+        return self.do_request('debug/circuits/slots', expected_code=200).addCallback(verify_response)
+
+    @deferred(timeout=10)
     def test_get_open_files(self):
         """
         Test whether the API returns open files

--- a/Tribler/Test/Core/Modules/RestApi/test_statistics_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_statistics_endpoint.py
@@ -18,6 +18,8 @@ class TestStatisticsEndpoint(AbstractApiTest):
                                   TrustChainCommunity,
                                   working_directory=self.session.config.get_state_dir())
         self.mock_ipv8.overlays = [self.mock_ipv8.overlay]
+        self.mock_ipv8.endpoint.bytes_up = 100
+        self.mock_ipv8.endpoint.bytes_down = 20
         self.session.lm.ipv8 = self.mock_ipv8
         self.session.config.set_ipv8_enabled(True)
 
@@ -54,6 +56,30 @@ class TestStatisticsEndpoint(AbstractApiTest):
 
         self.should_check_equality = False
         return self.do_request('statistics/dispersy', expected_code=200).addCallback(verify_dict)
+
+    @deferred(timeout=10)
+    def test_get_ipv8_statistics(self):
+        """
+        Testing whether the API returns a correct Dispersy statistics dictionary when requested
+        """
+        def verify_dict(data):
+            self.assertTrue(json.loads(data)["ipv8_statistics"])
+
+        self.should_check_equality = False
+        return self.do_request('statistics/ipv8', expected_code=200).addCallback(verify_dict)
+
+    @deferred(timeout=10)
+    def test_get_ipv8_statistics_unavailable(self):
+        """
+        Testing whether the API returns error 500 if IPv8 is not available
+        """
+        self.session.config.set_ipv8_enabled(False)
+
+        def verify_dict(data):
+            self.assertFalse(json.loads(data)["ipv8_statistics"])
+
+        self.should_check_equality = False
+        return self.do_request('statistics/ipv8', expected_code=200).addCallback(verify_dict)
 
     @deferred(timeout=10)
     def test_get_community_statistics(self):

--- a/Tribler/Test/GUI/test_gui.py
+++ b/Tribler/Test/GUI/test_gui.py
@@ -138,7 +138,7 @@ class AbstractTriblerGUITest(unittest.TestCase):
             if isinstance(llist, QListWidget) and llist.count() >= num_items:
                 if not isinstance(llist.itemWidget(llist.item(0)), LoadingListItem):
                     return
-            elif isinstance(llist, QTreeWidget) and llist.topLevelItemCount() > num_items:
+            elif isinstance(llist, QTreeWidget) and llist.topLevelItemCount() >= num_items:
                 if not isinstance(llist.topLevelItem(0), LoadingListItem):
                     return
 

--- a/Tribler/Test/GUI/test_gui.py
+++ b/Tribler/Test/GUI/test_gui.py
@@ -545,10 +545,10 @@ class TriblerGUITest(AbstractTriblerGUITest):
         self.screenshot(window.debug_window, name="debug_panel_trustchain_tab")
 
         window.debug_window.debug_tab_widget.setCurrentIndex(3)
-        self.wait_for_list_populated(window.debug_window.dispersy_general_tree_widget)
-        self.screenshot(window.debug_window, name="debug_panel_dispersy_tab")
+        self.wait_for_list_populated(window.debug_window.ipv8_general_tree_widget)
+        self.screenshot(window.debug_window, name="debug_panel_ipv8_tab")
 
-        window.debug_window.dispersy_tab_widget.setCurrentIndex(1)
+        window.debug_window.ipv8_tab_widget.setCurrentIndex(1)
         self.wait_for_list_populated(window.debug_window.communities_tree_widget)
         self.screenshot(window.debug_window, name="debug_panel_communities_tab")
 

--- a/Tribler/Test/test_as_server.py
+++ b/Tribler/Test/test_as_server.py
@@ -301,6 +301,7 @@ class TestAsServer(AbstractServer):
         self.config.set_popularity_community_enabled(False)
         self.config.set_dht_enabled(False)
         self.config.set_version_checker_enabled(False)
+        self.config.set_libtorrent_dht_enabled(False)
 
     @blocking_call_on_reactor_thread
     @inlineCallbacks

--- a/TriblerGUI/debug_window.py
+++ b/TriblerGUI/debug_window.py
@@ -106,7 +106,7 @@ class MemoryPlotMplCanvas(MplCanvas):
 
 class DebugWindow(QMainWindow):
     """
-    The debug window shows various statistics about Tribler such as performed requests, Dispersy statistics and
+    The debug window shows various statistics about Tribler such as performed requests, IPv8 statistics and
     community information.
     """
     resize_event = pyqtSignal()
@@ -133,10 +133,10 @@ class DebugWindow(QMainWindow):
         self.window().toggle_profiler_button.clicked.connect(self.on_toggle_profiler_button_clicked)
 
         self.window().debug_tab_widget.setCurrentIndex(0)
-        self.window().dispersy_tab_widget.setCurrentIndex(0)
+        self.window().ipv8_tab_widget.setCurrentIndex(0)
         self.window().system_tab_widget.setCurrentIndex(0)
         self.window().debug_tab_widget.currentChanged.connect(self.tab_changed)
-        self.window().dispersy_tab_widget.currentChanged.connect(self.dispersy_tab_changed)
+        self.window().ipv8_tab_widget.currentChanged.connect(self.ipv8_tab_changed)
         self.window().events_tree_widget.itemClicked.connect(self.on_event_clicked)
         self.window().system_tab_widget.currentChanged.connect(self.system_tab_changed)
         self.load_general_tab()
@@ -145,7 +145,7 @@ class DebugWindow(QMainWindow):
 
         # Enable/disable tabs, based on settings
         self.window().debug_tab_widget.setTabEnabled(2, settings and settings['trustchain']['enabled'])
-        self.window().debug_tab_widget.setTabEnabled(3, settings and settings['dispersy']['enabled'])
+        self.window().debug_tab_widget.setTabEnabled(3, settings and settings['ipv8']['enabled'])
         self.window().system_tab_widget.setTabEnabled(3, settings and settings['resource_monitor']['enabled'])
         self.window().system_tab_widget.setTabEnabled(4, settings and settings['resource_monitor']['enabled'])
 
@@ -168,7 +168,7 @@ class DebugWindow(QMainWindow):
         elif index == 2:
             self.load_trustchain_tab()
         elif index == 3:
-            self.dispersy_tab_changed(self.window().dispersy_tab_widget.currentIndex())
+            self.ipv8_tab_changed(self.window().ipv8_tab_widget.currentIndex())
         elif index == 4:
             self.load_events_tab()
         elif index == 5:
@@ -176,11 +176,11 @@ class DebugWindow(QMainWindow):
         elif index == 6:
             self.load_logs_tab()
 
-    def dispersy_tab_changed(self, index):
+    def ipv8_tab_changed(self, index):
         if index == 0:
-            self.load_dispersy_general_tab()
+            self.load_ipv8_general_tab()
         elif index == 1:
-            self.load_dispersy_communities_tab()
+            self.load_ipv8_communities_tab()
 
     def system_tab_changed(self, index):
         if index == 0:
@@ -252,31 +252,31 @@ class DebugWindow(QMainWindow):
         for key, value in data["statistics"].iteritems():
             self.create_and_add_widget_item(key, value, self.window().trustchain_tree_widget)
 
-    def load_dispersy_general_tab(self):
+    def load_ipv8_general_tab(self):
         self.request_mgr = TriblerRequestManager()
-        self.request_mgr.perform_request("statistics/dispersy", self.on_dispersy_general_stats)
+        self.request_mgr.perform_request("statistics/ipv8", self.on_ipv8_general_stats)
 
-    def on_dispersy_general_stats(self, data):
+    def on_ipv8_general_stats(self, data):
         if not data:
             return
-        self.window().dispersy_general_tree_widget.clear()
-        for key, value in data["dispersy_statistics"].iteritems():
-            self.create_and_add_widget_item(key, value, self.window().dispersy_general_tree_widget)
+        self.window().ipv8_general_tree_widget.clear()
+        for key, value in data["ipv8_statistics"].iteritems():
+            self.create_and_add_widget_item(key, value, self.window().ipv8_general_tree_widget)
 
-    def load_dispersy_communities_tab(self):
+    def load_ipv8_communities_tab(self):
         self.request_mgr = TriblerRequestManager()
-        self.request_mgr.perform_request("statistics/communities", self.on_dispersy_community_stats)
+        self.request_mgr.perform_request("statistics/communities", self.on_ipv8_community_stats)
 
-    def on_dispersy_community_stats(self, data):
+    def on_ipv8_community_stats(self, data):
         if not data:
             return
         self.window().communities_tree_widget.clear()
-        for community in data["dispersy_community_statistics"]:
+        for overlay in data["ipv8_overlay_statistics"]:
             item = QTreeWidgetItem(self.window().communities_tree_widget)
-            item.setText(0, community["classification"])
-            item.setText(1, community["identifier"][:6])
-            item.setText(2, community["member"][:6])
-            item.setText(3, "%s" % community["candidates"])
+            item.setText(0, overlay["overlay_name"])
+            item.setText(1, overlay["master_peer"][:6])
+            item.setText(2, overlay["my_peer"][:6])
+            item.setText(3, "%s" % len(overlay["peers"]))
             self.window().communities_tree_widget.addTopLevelItem(item)
 
     def on_event_clicked(self, item):

--- a/TriblerGUI/qt_resources/debugwindow.ui
+++ b/TriblerGUI/qt_resources/debugwindow.ui
@@ -21,7 +21,7 @@
     <item>
      <widget class="QTabWidget" name="debug_tab_widget">
       <property name="currentIndex">
-       <number>5</number>
+       <number>3</number>
       </property>
       <widget class="QWidget" name="tab">
        <attribute name="title">
@@ -156,7 +156,7 @@
       </widget>
       <widget class="QWidget" name="tab_4">
        <attribute name="title">
-        <string>Dispersy</string>
+        <string>IPv8</string>
        </attribute>
        <layout class="QVBoxLayout" name="verticalLayout">
         <property name="spacing">
@@ -175,9 +175,9 @@
          <number>0</number>
         </property>
         <item>
-         <widget class="QTabWidget" name="dispersy_tab_widget">
+         <widget class="QTabWidget" name="ipv8_tab_widget">
           <property name="currentIndex">
-           <number>0</number>
+           <number>1</number>
           </property>
           <widget class="QWidget" name="tab_6">
            <attribute name="title">
@@ -200,7 +200,7 @@
              <number>0</number>
             </property>
             <item>
-             <widget class="QTreeWidget" name="dispersy_general_tree_widget">
+             <widget class="QTreeWidget" name="ipv8_general_tree_widget">
               <property name="indentation">
                <number>0</number>
               </property>
@@ -223,7 +223,7 @@
           </widget>
           <widget class="QWidget" name="tab_7">
            <attribute name="title">
-            <string>Communities</string>
+            <string>Overlays</string>
            </attribute>
            <layout class="QVBoxLayout" name="verticalLayout">
             <property name="spacing">
@@ -251,22 +251,22 @@
               </attribute>
               <column>
                <property name="text">
-                <string>Classification</string>
+                <string>Name</string>
                </property>
               </column>
               <column>
                <property name="text">
-                <string>Identifier</string>
+                <string>Master peer</string>
                </property>
               </column>
               <column>
                <property name="text">
-                <string>Member</string>
+                <string>My peer</string>
                </property>
               </column>
               <column>
                <property name="text">
-                <string>Candidates</string>
+                <string>Peers</string>
                </property>
               </column>
              </widget>


### PR DESCRIPTION
In this PR, I did the following:
- added option to disable the libtorrent DHT, I enabled it in the tests by default. Fixes #3790 
- added an endpoint to fetch general statistics about IPv8
- replaced Dispersy statistics with IPv8 statistics
- added endpoint to fetch info about filled slots (this should help me to debug the tunnel helpers)