### PR TITLE
Disabled version checker in seeder session

### DIFF
--- a/Tribler/Test/test_as_server.py
+++ b/Tribler/Test/test_as_server.py
@@ -359,6 +359,7 @@ class TestAsServer(AbstractServer):
         self.seed_config.set_market_community_enabled(False)
         self.seed_config.set_dht_enabled(False)
         self.seed_config.set_state_dir(self.getStateDir(2))
+        self.seed_config.set_version_checker_enabled(False)
 
         def start_seed_download(_):
             self.dscfg_seed = DownloadStartupConfig()


### PR DESCRIPTION
It messed up the tests on Mac since that machine has an older version of OpenSSL (and therefore is unable to establish a secure connection to github.com).