### PR TITLE
Updated IPv8 pointer, fixed crash when downloading torrent with zero-byte files

### DIFF
--- a/Tribler/Core/DownloadState.py
+++ b/Tribler/Core/DownloadState.py
@@ -160,7 +160,8 @@ class DownloadState(object):
             files = self.download.get_def().get_files_with_length()
             progress = self.download.handle.file_progress(flags=1)
             for index, (path, size) in enumerate(files):
-                completion.append((path, float(progress[index]) / size))
+                completion_frac = (float(progress[index]) / size) if size > 0 else 1
+                completion.append((path, completion_frac))
 
         return completion
 

--- a/Tribler/Test/Core/test_downloadstate.py
+++ b/Tribler/Test/Core/test_downloadstate.py
@@ -117,6 +117,11 @@ class TestDownloadState(TriblerCoreTest):
         handle.file_progress = lambda **_: []
         self.assertEqual(download_state.get_files_completion(), [])
 
+        # Test a file with a length of zero
+        self.mocked_tdef.get_files_with_length = lambda: [("test.txt", 0)]
+        handle.file_progress = lambda **_: [0]
+        self.assertEqual(download_state.get_files_completion(), [('test.txt', 1.0)])
+
     def test_get_availability(self):
         """
         Testing whether the right availability of a file is returned


### PR DESCRIPTION
This PR also sanitizes the crawling process of TrustChain.

Fixes #3815 