### PR TITLE
Reuse pstate when changing hop count

### DIFF
--- a/Tribler/Core/APIImplementation/LaunchManyCore.py
+++ b/Tribler/Core/APIImplementation/LaunchManyCore.py
@@ -593,6 +593,8 @@ class TriblerLaunchMany(TaskManager):
         """
         infohash = binascii.hexlify(download.tdef.get_infohash())
         self._logger.info("Updating the amount of hops of download %s", infohash)
+        pstate = download.get_persistent_download_config()
+        pstate.set('state', 'engineresumedata', (yield download.save_resume_data()))
         yield self.session.remove_download(download)
 
         # copy the old download_config and change the hop count
@@ -601,7 +603,7 @@ class TriblerLaunchMany(TaskManager):
         # If the user wants to change the hop count to 0, don't automatically bump this up to 1 anymore
         dscfg.set_safe_seeding(False)
 
-        self.session.start_download_from_tdef(download.tdef, dscfg)
+        self.session.start_download_from_tdef(download.tdef, dscfg, pstate=pstate)
 
     def update_trackers(self, infohash, trackers):
         """ Update the trackers for a download.

--- a/Tribler/Core/Session.py
+++ b/Tribler/Core/Session.py
@@ -225,7 +225,7 @@ class Session(object):
             return self.lm.ltmgr.start_download_from_uri(uri, dconfig=download_config)
         raise OperationNotEnabledByConfigurationException()
 
-    def start_download_from_tdef(self, torrent_definition, download_startup_config=None, hidden=False):
+    def start_download_from_tdef(self, torrent_definition, download_startup_config=None, pstate=None, hidden=False):
         """
         Creates a Download object and adds it to the session. The passed
         ContentDef and DownloadStartupConfig are copied into the new Download
@@ -244,7 +244,7 @@ class Session(object):
         :return: a Download
         """
         if self.config.get_libtorrent_enabled():
-            return self.lm.add(torrent_definition, download_startup_config, hidden=hidden)
+            return self.lm.add(torrent_definition, download_startup_config, pstate=pstate, hidden=hidden)
         raise OperationNotEnabledByConfigurationException()
 
     def resume_download_from_file(self, filename):


### PR DESCRIPTION
Fixes https://github.com/Tribler/tribler/issues/3805, https://github.com/Tribler/tribler/issues/3173,  https://github.com/Tribler/tribler/issues/3199.
Also fixes LibtorrentDownloadImpl.setup not correctly handling the pstate argument.