### PR TITLE
Fixed bug on adding torrent from HTTP URL that resolves to a magnet link

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -51,8 +51,7 @@ Depends: ${misc:Depends},
          python-requests,
          python-twisted,
          vlc (>= 1.1.0),
-Recommends: python-treq,
-            python-faulthandler,
+Recommends: python-faulthandler,
             python-tk,
 Description: Python based Bittorrent/Internet TV application
  It allows you to watch videos and download content. Tribler aims to combine


### PR DESCRIPTION
Fixes #3828 

With previous PR #3795 Twisted agent now supports HTTPS so we no longer need treq.
Therefore, I'm removing this dependency.