### PR TITLE
Properly fixed tray icon + small market fix

### DIFF
--- a/Tribler/Test/Community/Market/test_community.py
+++ b/Tribler/Test/Community/Market/test_community.py
@@ -24,7 +24,7 @@ class TestMarketCommunityBase(TestBase):
         super(TestMarketCommunityBase, self).setUp()
         self.initialize(MarketCommunity, self.NUM_NODES)
         for node in self.nodes:
-            node.overlay._use_main_thread = False
+            node.overlay._use_main_thread = True
 
     def create_node(self):
         dum1_wallet = DummyWallet1()

--- a/Tribler/community/market/community.py
+++ b/Tribler/community/market/community.py
@@ -1113,7 +1113,8 @@ class MarketCommunity(Community, BlockListener):
 
         proposed_trade = ProposedTrade.from_network(payload)
 
-        self.logger.debug("Proposed trade received from trader %s", str(proposed_trade.trader_id))
+        self.logger.debug("Proposed trade received from trader %s for order %s",
+                          str(proposed_trade.trader_id), str(proposed_trade.recipient_order_id))
 
         # Update the known IP address of the sender of this proposed trade
         self.update_ip(proposed_trade.trader_id, peer.address)
@@ -1155,8 +1156,6 @@ class MarketCommunity(Community, BlockListener):
                               order.traded_quantity, decline_reason)
             self.send_declined_trade(declined_trade)
         else:
-            self.logger.debug("Proposed trade received for order with id: %s", str(order.order_id))
-
             if order.available_quantity >= proposed_trade.assets.first.amount:  # Enough quantity left
                 order.reserve_quantity_for_tick(proposed_trade.order_id, proposed_trade.assets.first.amount)
                 self.order_manager.order_repository.update(order)

--- a/Tribler/community/market/core/order_repository.py
+++ b/Tribler/community/market/core/order_repository.py
@@ -78,8 +78,6 @@ class MemoryOrderRepository(OrderRepository):
         :return: The order or null if it cannot be found
         :rtype: Order
         """
-        self._logger.debug("Order with the id: " + str(order_id) + " was searched for in the order repository")
-
         return self._orders.get(order_id)
 
     def add(self, order):
@@ -147,8 +145,6 @@ class DatabaseOrderRepository(OrderRepository):
         :return: The order or null if it cannot be found
         :rtype: Order
         """
-        self._logger.debug("Order with the id: " + str(order_id) + " was searched for in the order repository")
-
         return self.persistence.get_order(order_id)
 
     def add(self, order):

--- a/Tribler/community/market/core/transaction_repository.py
+++ b/Tribler/community/market/core/transaction_repository.py
@@ -73,9 +73,6 @@ class MemoryTransactionRepository(TransactionRepository):
         :return: The transaction or null if it cannot be found
         :rtype: Transaction
         """
-        self._logger.debug(
-            "Transaction with the id: " + str(transaction_id) + " was searched for in the transaction repository")
-
         return self._transactions.get(transaction_id)
 
     def add(self, transaction):
@@ -141,9 +138,6 @@ class DatabaseTransactionRepository(TransactionRepository):
         :return: The transaction or null if it cannot be found
         :rtype: Transaction
         """
-        self._logger.debug("Transaction with the id: %s was searched for in the transaction repository",
-                           str(transaction_id))
-
         return self.persistence.get_transaction(transaction_id)
 
     def add(self, transaction):

--- a/TriblerGUI/tribler_window.py
+++ b/TriblerGUI/tribler_window.py
@@ -1,7 +1,6 @@
 import glob
 import logging
 import os
-import sip
 import sys
 import traceback
 from urllib import pathname2url, unquote
@@ -302,7 +301,7 @@ class TriblerWindow(QMainWindow):
         close_dialog.show()
 
     def on_torrent_finished(self, torrent_info):
-        if self.tray_icon and not sip.isdeleted(self.tray_icon):
+        if self.tray_icon:
             self.window().tray_icon.showMessage("Download finished",
                                                 "Download of %s has finished." % torrent_info["name"])
 

--- a/TriblerGUI/widgets/downloadspage.py
+++ b/TriblerGUI/widgets/downloadspage.py
@@ -71,32 +71,6 @@ class DownloadsPage(QWidget):
         if not self.window().vlc_available:
             self.window().play_download_button.setHidden(True)
 
-    def tray_set_tooltip(self, message):
-        """
-        Set a tooltip message for the tray icon, if possible.
-
-        :param message: the message to display on hover
-        """
-        if self.window().tray_icon:
-            try:
-                self.window().tray_icon.setToolTip(message)
-            except RuntimeError as e:
-                logging.error("Failed to set tray tooltip: %s", str(e))
-
-    def tray_show_message(self, title, message):
-        """
-        Show a message at the tray icon, if possible.
-
-        :param title: the title of the message
-        :param message: the message to display
-        """
-        if self.window().tray_icon:
-            try:
-                self.window().tray_icon.showMessage(title, message)
-            except RuntimeError as e:
-                logging.error("Failed to set tray message: %s", str(e))
-
-
     def on_filter_text_changed(self, text):
         self.window().downloads_list.clearSelection()
         self.window().download_details_widget.hide()
@@ -196,7 +170,7 @@ class DownloadsPage(QWidget):
                 self.window().downloads_list.takeTopLevelItem(index)
                 del self.download_widgets[infohash]
 
-        self.tray_set_tooltip("Down: %s, Up: %s" % (format_speed(self.total_download), format_speed(self.total_upload)))
+        self.window().tray_set_tooltip("Down: %s, Up: %s" % (format_speed(self.total_download), format_speed(self.total_upload)))
         self.update_download_visibility()
         self.schedule_downloads_timer()
 
@@ -430,7 +404,7 @@ class DownloadsPage(QWidget):
                                           "Error when exporting file",
                                           "An error occurred when exporting the torrent file: %s" % str(exc))
         else:
-            self.tray_show_message("Torrent file exported", "Torrent file exported to %s" % dest_path)
+            self.window().tray_show_message("Torrent file exported", "Torrent file exported to %s" % dest_path)
 
     def on_right_click_item(self, pos):
         item_clicked = self.window().downloads_list.itemAt(pos)

--- a/TriblerGUI/widgets/marketpage.py
+++ b/TriblerGUI/widgets/marketpage.py
@@ -374,7 +374,7 @@ class MarketPage(QWidget):
         if not payment["success"]:
             # Error occurred during payment
             main_text = "Transaction with id %s failed." % payment["transaction_number"]
-            self.window().tray_icon.showMessage("Transaction failed", main_text)
+            self.window().tray_show_message("Transaction failed", main_text)
             ConfirmationDialog.show_error(self.window(), "Transaction failed", main_text)
             self.window().hide_status_bar()
         else:


### PR DESCRIPTION
The calls for showing notifications/removing the tray icon is now wrapped in a try/except block.

Next to fixing the tray icon in the GUI, I'm also running the market tests on the reactor thread now. They consistently pass on Linux now (I've tested and verified this on bbq).

Fixes #3843