### PR TITLE
Various fixes

### DIFF
--- a/Tribler/Core/TorrentChecker/session.py
+++ b/Tribler/Core/TorrentChecker/session.py
@@ -1,5 +1,6 @@
 import logging
 import random
+import socket
 import struct
 import time
 from abc import ABCMeta, abstractmethod, abstractproperty
@@ -370,7 +371,11 @@ class UdpSocketManager(DatagramProtocol):
 
     def send_request(self, data, tracker_session):
         self.tracker_sessions[tracker_session.transaction_id] = tracker_session
-        self.transport.write(data, (tracker_session.ip_address, tracker_session.port))
+        try:
+            self.transport.write(data, (tracker_session.ip_address, tracker_session.port))
+        except socket.error as exc:
+            self._logger.warning("Unable to write data to %s:%d - %s",
+                                 tracker_session.ip_address, tracker_session.port, exc)
 
     def datagramReceived(self, data, _):
         # Find the tracker session and give it the data

--- a/TriblerGUI/widgets/videoplayerpage.py
+++ b/TriblerGUI/widgets/videoplayerpage.py
@@ -42,12 +42,16 @@ class VideoPlayerPage(QWidget):
             os.environ['VLC_PLUGIN_PATH'] = vlc.plugin_path
 
         if not vlc_available:
-            # VLC is not available, we hide the video player button
             self.window().vlc_available = False
             self.window().left_menu_button_video_player.setHidden(True)
             return
 
         self.instance = vlc.Instance()
+        if not self.instance:
+            self.window().vlc_available = False
+            self.window().left_menu_button_video_player.setHidden(True)
+            return
+
         self.mediaplayer = self.instance.media_player_new()
         self.window().video_player_widget.should_hide_video_widgets.connect(self.hide_video_widgets)
         self.window().video_player_widget.should_show_video_widgets.connect(self.show_video_widgets)


### PR DESCRIPTION
In this PR, I fixed some stuff and improved the tribler.spec file to exclude `PyQt4`. This makes it possible to build Tribler on Linux (i.e. bundle all `.so` files together and create a Tribler executable file).

Fixes #3859 (not sure how to test this one properly).