### PR TITLE
Fixed issue with removing temporary test directories

### DIFF
--- a/Tribler/Core/Modules/wallet/btc_wallet.py
+++ b/Tribler/Core/Modules/wallet/btc_wallet.py
@@ -53,6 +53,9 @@ class BitcoinWallet(Wallet):
 
         self._logger.info("Creating wallet in %s", self.wallet_dir)
         try:
+            if self.wallet:
+                raise WalletError("Wallet with name '%s' already created" % self.wallet_name)
+
             self.wallet = HDWallet.create(self.wallet_name, network=self.network, databasefile=self.db_path)
             self.wallet.new_key('tribler_payments')
             self.wallet.new_key('tribler_change', change=1)

--- a/Tribler/Test/Core/Modules/RestApi/Channels/test_channels_subscription_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/Channels/test_channels_subscription_endpoint.py
@@ -29,7 +29,6 @@ class TestChannelsSubscriptionEndpoint(AbstractTestChannelsEndpoint):
         fake_community = self.create_fake_allchannel_community()
         fake_community.disp_create_votecast = self.on_dispersy_create_votecast
         self.session.config.get_dispersy_enabled = lambda: True
-        self.session.lm.dispersy = Dispersy(ManualEnpoint(0), self.getStateDir())
         self.session.lm.dispersy.attach_community(fake_community)
         for i in xrange(0, 10):
             self.insert_channel_in_db('rand%d' % i, 42 + i, 'Test channel %d' % i, 'Test description %d' % i)

--- a/Tribler/Test/Core/Modules/test_tracker_manager.py
+++ b/Tribler/Test/Core/Modules/test_tracker_manager.py
@@ -21,6 +21,14 @@ class TestTrackerManager(TriblerCoreTest):
         self.session.start_database()
         self.tracker_manager = TrackerManager(self.session)
 
+    @inlineCallbacks
+    def tearDown(self):
+        if self.session is not None:
+            yield self.session.shutdown()
+            assert self.session.has_shutdown()
+            self.session = None
+        yield super(TestTrackerManager, self).tearDown()
+
     def test_add_tracker(self):
         """
         Test whether adding a tracker works correctly

--- a/Tribler/Test/Core/Upgrade/upgrade_base.py
+++ b/Tribler/Test/Core/Upgrade/upgrade_base.py
@@ -39,12 +39,11 @@ class AbstractUpgrader(TriblerCoreTest):
         if self.torrent_store:
             self.torrent_store.close()
 
-        super(AbstractUpgrader, self).tearDown()
-
         if self.sqlitedb:
             self.sqlitedb.close()
         self.sqlitedb = None
-        self.session = None
+
+        super(AbstractUpgrader, self).tearDown()
 
     def copy_and_initialize_upgrade_database(self, db_name):
 

--- a/Tribler/Test/Core/base_test_channel.py
+++ b/Tribler/Test/Core/base_test_channel.py
@@ -67,5 +67,8 @@ class BaseTestChannel(TestAsServer):
     @inlineCallbacks
     def tearDown(self):
         self.session.lm.dispersy.cancel_all_pending_tasks()
+        # Ugly way to check if database is open in Dispersy
+        if self.session.lm.dispersy._database._cursor:
+            yield self.session.lm.dispersy._database.close()
         self.session.lm.dispersy = None
         yield super(BaseTestChannel, self).tearDown()

--- a/Tribler/Test/test_as_server.py
+++ b/Tribler/Test/test_as_server.py
@@ -69,7 +69,7 @@ class BaseTestCase(unittest.TestCase):
         while self._tempdirs:
             temp_dir = self._tempdirs.pop()
             os.chmod(temp_dir, 0700)
-            shutil.rmtree(temp_dir, ignore_errors=False)
+            shutil.rmtree(unicode(temp_dir), ignore_errors=False)
 
     def temporary_directory(self, suffix=''):
         random_string = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(6))

--- a/Tribler/Test/test_as_server.py
+++ b/Tribler/Test/test_as_server.py
@@ -7,10 +7,11 @@ import functools
 import inspect
 import logging
 import os
+import random
 import re
 import shutil
+import string
 import time
-from tempfile import mkdtemp
 from threading import enumerate as enumerate_threads
 
 import twisted
@@ -45,6 +46,7 @@ class BaseTestCase(unittest.TestCase):
 
     def __init__(self, *args, **kwargs):
         super(BaseTestCase, self).__init__(*args, **kwargs)
+        self._tempdirs = []
         self.maxDiff = None  # So we see full diffs when using assertEquals
 
         def wrap(fun):
@@ -62,6 +64,19 @@ class BaseTestCase(unittest.TestCase):
         for name, method in inspect.getmembers(self, predicate=inspect.ismethod):
             if name.startswith("test_"):
                 setattr(self, name, wrap(method))
+
+    def tearDown(self):
+        while self._tempdirs:
+            temp_dir = self._tempdirs.pop()
+            os.chmod(temp_dir, 0700)
+            shutil.rmtree(temp_dir, ignore_errors=False)
+
+    def temporary_directory(self, suffix=''):
+        random_string = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(6))
+        temp = os.path.join(TESTS_DIR, "temp", self.__class__.__name__ + suffix + random_string)
+        self._tempdirs.append(temp)
+        os.makedirs(temp)
+        return temp
 
 
 class AbstractServer(BaseTestCase):
@@ -83,7 +98,7 @@ class AbstractServer(BaseTestCase):
     def setUp(self):
         self._logger = logging.getLogger(self.__class__.__name__)
 
-        self.session_base_dir = mkdtemp(suffix="_tribler_test_session")
+        self.session_base_dir = self.temporary_directory(suffix="_tribler_test_session_")
         self.state_dir = os.path.join(self.session_base_dir, u"dot.Tribler")
         self.dest_dir = os.path.join(self.session_base_dir, u"TriblerDownloads")
 
@@ -91,8 +106,6 @@ class AbstractServer(BaseTestCase):
         reactor_deferred = Deferred()
         reactor.callWhenRunning(reactor_deferred.callback, None)
 
-        self.setUpCleanup()
-        os.makedirs(self.session_base_dir)
         self.annotate_dict = {}
 
         self.file_server = None
@@ -101,11 +114,6 @@ class AbstractServer(BaseTestCase):
         self.annotate(self._testMethodName, start=True)
         self.watchdog.start()
         yield reactor_deferred
-
-    def setUpCleanup(self):
-        # Change to an existing dir before cleaning up.
-        os.chdir(TESTS_DIR)
-        shutil.rmtree(unicode(self.session_base_dir), ignore_errors=True)
 
     def setUpFileServer(self, port, path):
         # Create a local file server, can be used to serve local files. This is preferred over an external network
@@ -151,7 +159,6 @@ class AbstractServer(BaseTestCase):
 
     @inlineCallbacks
     def tearDown(self):
-        self.tearDownCleanup()
         self.annotate(self._testMethodName, start=False)
 
         process_unhandled_exceptions()
@@ -168,8 +175,7 @@ class AbstractServer(BaseTestCase):
         else:
             yield self.checkReactor("tearDown")
 
-    def tearDownCleanup(self):
-        self.setUpCleanup()
+        super(AbstractServer, self).tearDown()
 
     def getStateDir(self, nr=0):
         state_dir = self.state_dir + (str(nr) if nr else '')

--- a/Tribler/community/market/community.py
+++ b/Tribler/community/market/community.py
@@ -336,6 +336,7 @@ class MarketCommunity(Community, BlockListener):
         if self.is_matchmaker:
             self.order_book.save_to_database()
             self.order_book.shutdown_task_manager()
+        self.market_database.close()
         yield super(MarketCommunity, self).unload()
 
     def get_ipv8_address(self):


### PR DESCRIPTION
In windows the temporary session directories in tests were not being cleared. This was mostly because of improper tearDown and confusing hierarchy of tests. Read issue #3867.
Previously we were suppressing any OS error occurring on removing the temp session directories which is why we did not notice the issue until now. In this PR, OS error is raised and all the suppressed error are fixed.

Fixes #3867 