### PR TITLE
Fixed a few bugs in the market, updated IPv8 pointer

### DIFF
--- a/Tribler/Core/APIImplementation/LaunchManyCore.py
+++ b/Tribler/Core/APIImplementation/LaunchManyCore.py
@@ -189,7 +189,7 @@ class TriblerLaunchMany(TaskManager):
                     community_file._DEFAULT_ADDRESSES = [self.session.config.get_ipv8_bootstrap_override()]
                     community_file._DNS_ADDRESSES = []
 
-                self.ipv8 = IPv8(ipv8_config)
+                self.ipv8 = IPv8(ipv8_config, enable_statistics=self.session.config.get_ipv8_statistics())
 
                 self.session.config.set_anon_proxy_settings(2, ("127.0.0.1",
                                                                 self.session.

--- a/Tribler/Core/Config/config.spec
+++ b/Tribler/Core/Config/config.spec
@@ -96,6 +96,7 @@ port = integer(min=-1, max=65536, default=-1)
 enabled = boolean(default=True)
 address = string(default='0.0.0.0')
 bootstrap_override = string(default='')
+statistics = boolean(default=False)
 
 [video_server]
 enabled = boolean(default=True)

--- a/Tribler/Core/Config/tribler_config.py
+++ b/Tribler/Core/Config/tribler_config.py
@@ -267,6 +267,12 @@ class TriblerConfig(object):
     def get_ipv8_address(self):
         return self.config['ipv8']['address']
 
+    def set_ipv8_statistics(self, value):
+        self.config['ipv8']['statistics'] = value
+
+    def get_ipv8_statistics(self):
+        return self.config['ipv8']['statistics']
+
     # Libtorrent
 
     def set_libtorrent_enabled(self, value):

--- a/Tribler/Test/Community/Market/test_community.py
+++ b/Tribler/Test/Community/Market/test_community.py
@@ -205,7 +205,7 @@ class TestMarketCommunity(TestMarketCommunityBase):
 
         self.nodes[0].overlay.cancel_order(ask_order.order_id)
 
-        yield self.deliver_messages()
+        yield self.sleep(0.5)
 
         self.assertTrue(self.nodes[0].overlay.order_manager.order_repository.find_by_id(ask_order.order_id).cancelled)
 

--- a/Tribler/Test/Community/Market/test_community.py
+++ b/Tribler/Test/Community/Market/test_community.py
@@ -345,8 +345,8 @@ class TestMarketCommunityTwoNodes(TestMarketCommunityBase):
         """
         yield self.introduce_nodes()
 
-        yield self.nodes[0].overlay.create_ask(AssetPair(AssetAmount(10, 'DUM1'), AssetAmount(13, 'DUM2')), 3600)
-        yield self.nodes[1].overlay.create_bid(AssetPair(AssetAmount(10, 'DUM1'), AssetAmount(13, 'DUM2')), 3600)
+        self.nodes[0].overlay.create_ask(AssetPair(AssetAmount(10, 'DUM1'), AssetAmount(13, 'DUM2')), 3600)
+        self.nodes[1].overlay.create_bid(AssetPair(AssetAmount(10, 'DUM1'), AssetAmount(13, 'DUM2')), 3600)
 
         yield self.sleep(0.5)
 
@@ -371,10 +371,8 @@ class TestMarketCommunityTwoNodes(TestMarketCommunityBase):
         """
         yield self.introduce_nodes()
 
-        ask_order = yield self.nodes[0].overlay.create_ask(
-            AssetPair(AssetAmount(10, 'DUM1'), AssetAmount(10, 'DUM2')), 3600)
-        yield self.nodes[1].overlay.create_bid(
-            AssetPair(AssetAmount(2, 'DUM1'), AssetAmount(2, 'DUM2')), 3600)
+        self.nodes[0].overlay.create_ask(AssetPair(AssetAmount(10, 'DUM1'), AssetAmount(10, 'DUM2')), 3600)
+        self.nodes[1].overlay.create_bid(AssetPair(AssetAmount(2, 'DUM1'), AssetAmount(2, 'DUM2')), 3600)
 
         yield self.sleep(0.5)
 
@@ -386,10 +384,12 @@ class TestMarketCommunityTwoNodes(TestMarketCommunityBase):
         self.assertEqual(len(transactions2), 1)
         self.assertEqual(len(transactions2[0].payments), 2)
 
-        # There should be no reserved quantity for the bid tick
+        # There should be no reserved quantity in the orderbook
+        ask_order_id = self.nodes[0].overlay.order_manager.order_repository.find_all()[0].order_id
         for node_nr in [0, 1]:
-            ask_tick_entry = self.nodes[node_nr].overlay.order_book.get_tick(ask_order.order_id)
-            self.assertEqual(ask_tick_entry.reserved_for_matching, 0)
+            ask_tick_entry = self.nodes[node_nr].overlay.order_book.get_tick(ask_order_id)
+            if ask_tick_entry:
+                self.assertEqual(ask_tick_entry.reserved_for_matching, 0)
 
         yield self.nodes[1].overlay.create_bid(AssetPair(AssetAmount(8, 'DUM1'), AssetAmount(8, 'DUM2')), 3600)
 

--- a/Tribler/Test/Community/Market/test_matching_engine.py
+++ b/Tribler/Test/Community/Market/test_matching_engine.py
@@ -225,7 +225,7 @@ class MatchingEngineTestSuite(AbstractServer):
         """
         Create a bid with a specific price and quantity
         """
-        new_bid = Bid(OrderId(TraderId('2'), OrderNumber(self.bid_count)),
+        new_bid = Bid(OrderId(TraderId('3'), OrderNumber(self.bid_count)),
                       AssetPair(AssetAmount(amount1, 'BTC'), AssetAmount(amount2, 'MB')), Timeout(30), Timestamp.now())
         self.bid_count += 1
         return new_bid

--- a/Tribler/Test/Core/Config/test_tribler_config.py
+++ b/Tribler/Test/Core/Config/test_tribler_config.py
@@ -178,6 +178,8 @@ class TestTriblerConfig(TriblerCoreTest):
         self.assertEqual(self.tribler_config.get_ipv8_enabled(), False)
         self.tribler_config.set_ipv8_bootstrap_override("127.0.0.1:12345")
         self.assertEqual(self.tribler_config.get_ipv8_bootstrap_override(), ("127.0.0.1", 12345))
+        self.tribler_config.set_ipv8_statistics(True)
+        self.assertTrue(self.tribler_config.get_ipv8_statistics())
 
     def test_get_set_methods_libtorrent(self):
         """

--- a/Tribler/Test/Core/Modules/Wallet/test_btc_wallet.py
+++ b/Tribler/Test/Core/Modules/Wallet/test_btc_wallet.py
@@ -22,7 +22,7 @@ class TestBtcWallet(AbstractServer):
             return wallet.monitor_transaction("abc")
 
         def on_wallet_balance(balance):
-            self.assertDictEqual(balance, {'available': 0, 'pending': 0, 'currency': 'BTC', 'precision': 8})
+            self.assertDictEqual(balance, {'available': 3, 'pending': 0, 'currency': 'BTC', 'precision': 8})
             return wallet.get_transactions().addCallback(on_wallet_transactions)
 
         def on_wallet_created(_):
@@ -33,6 +33,7 @@ class TestBtcWallet(AbstractServer):
             self.assertRaises(Exception, BitcoinTestnetWallet, self.session_base_dir, testnet=True)
 
             wallet.wallet.utxos_update = lambda **_: None  # We don't want to do an actual HTTP request here
+            wallet.wallet.balance = lambda **_: 3
             return wallet.get_balance().addCallback(on_wallet_balance)
 
         return wallet.create_wallet().addCallback(on_wallet_created)

--- a/Tribler/community/market/core/matching_engine.py
+++ b/Tribler/community/market/core/matching_engine.py
@@ -99,7 +99,8 @@ class PriceTimeStrategy(MatchingStrategy):
 
         # We now start to iterate through price levels and tick entries and match on the fly
         while cur_tick_entry and quantity_to_match > 0:
-            if cur_tick_entry.is_blocked_for_matching(order_id):
+            if cur_tick_entry.is_blocked_for_matching(order_id) or \
+                            order_id.trader_id == cur_tick_entry.order_id.trader_id:
                 cur_tick_entry = cur_tick_entry.next_tick
                 continue
 


### PR DESCRIPTION
In this PR, I fixed three bugs in the market:
- fixed a bug in the matching engine where two orders of the same trader could be matched
- fixed order cancellation test
- changed logic for simultaneous order creation. I made the tests more challenging by removing the `yield` statement before `create_ask`/`create_bid`, which always errors out without the new logic.

I also updated the IPv8 pointer, added a configuration option to toggle the IPv8 statistics and mocked the `balance` method of a BTC wallet during tests (so we don't make requests to external websites).