### PR TITLE
Fix Wallet shutdown in TriblerTunnel community

### DIFF
--- a/Tribler/Test/Core/Modules/Wallet/test_btc_wallet.py
+++ b/Tribler/Test/Core/Modules/Wallet/test_btc_wallet.py
@@ -1,9 +1,11 @@
 import datetime
+
+from twisted.internet.defer import succeed, Deferred
+
 from Tribler.Core.Modules.wallet.btc_wallet import BitcoinTestnetWallet, BitcoinWallet
 from Tribler.Test.Core.base_test import MockObject
 from Tribler.Test.test_as_server import AbstractServer
 from Tribler.Test.twisted_thread import deferred
-from twisted.internet.defer import succeed, Deferred
 
 
 class TestBtcWallet(AbstractServer):

--- a/Tribler/community/triblertunnel/community.py
+++ b/Tribler/community/triblertunnel/community.py
@@ -538,6 +538,8 @@ class TriblerTunnelCommunity(HiddenTunnelCommunity):
 
     @inlineCallbacks
     def unload(self):
+        if self.bandwidth_wallet:
+            self.bandwidth_wallet.shutdown_task_manager()
         for socks_server in self.socks_servers:
             yield socks_server.stop()
 


### PR DESCRIPTION
This patch adds calls to correctly tear down bandwidth wallet on shutdown of TriblerTunnel community.

Related to #3876 