### PR TITLE
Switched to register_anonymous_task where applicable

### DIFF
--- a/Tribler/Core/APIImplementation/LaunchManyCore.py
+++ b/Tribler/Core/APIImplementation/LaunchManyCore.py
@@ -1019,8 +1019,7 @@ class TriblerLaunchMany(TaskManager):
 
         self.downloads[infohash].pstate_for_restart = pstate
 
-        self.register_task("save_pstate %f" % timemod.clock(),
-                           self.downloads[infohash].save_resume_data())
+        self.register_anonymous_task("save_pstate", self.downloads[infohash].save_resume_data())
 
     def load_download_pstate(self, filename):
         """ Called by any thread """

--- a/Tribler/Core/Libtorrent/LibtorrentDownloadImpl.py
+++ b/Tribler/Core/Libtorrent/LibtorrentDownloadImpl.py
@@ -657,8 +657,7 @@ class LibtorrentDownloadImpl(DownloadConfigInterface, TaskManager):
                         return
                     if self.get_state().get_progress() == 1.0:
                         self.set_byte_priority([(self.get_vod_fileindex(), 0, -1)], 1)
-                random_id = ''.join(random.choice('0123456789abcdef') for _ in xrange(30))
-                self.register_task("reset_priorities_%s" % random_id, reactor.callLater(5, reset_priorities))
+                self.register_anonymous_task("reset_priorities", reactor.callLater(5, reset_priorities))
 
             if self.endbuffsize:
                 self.set_byte_priority([(self.get_vod_fileindex(), 0, -1)], 1)
@@ -923,8 +922,7 @@ class LibtorrentDownloadImpl(DownloadConfigInterface, TaskManager):
                     if when > 0.0 and not self.session.lm.shutdownstarttime:
                         # Schedule next invocation, either on general or DL specific
                         dc = reactor.callLater(when, lambda: self.network_get_state(usercallback))
-                        random_id = ''.join(random.choice('0123456789abcdef') for _ in xrange(30))
-                        self.register_task("downloads_cb_%s" % random_id, dc)
+                        self.register_anonymous_task("downloads_cb", dc)
             else:
                 return ds
 

--- a/Tribler/Core/Libtorrent/LibtorrentMgr.py
+++ b/Tribler/Core/Libtorrent/LibtorrentMgr.py
@@ -425,10 +425,10 @@ class LibtorrentMgr(TaskManager):
             self._logger.info("DHT not ready, rescheduling get_metainfo")
 
             def schedule_call():
-                random_id = ''.join(random.choice('0123456789abcdef') for _ in xrange(30))
-                self.register_task("schedule_metainfo_lookup_%s" % random_id,
-                                   reactor.callLater(5, lambda i=infohash_or_magnet, c=callback, t=timeout - 5,
-                                                  tcb=timeout_callback, n=notify: self.get_metainfo(i, c, t, tcb, n)))
+                self.register_anonymous_task("schedule_metainfo_lookup",
+                                             reactor.callLater(5, lambda i=infohash_or_magnet, c=callback, t=timeout-5,
+                                                                         tcb=timeout_callback,
+                                                                         n=notify: self.get_metainfo(i, c, t, tcb, n)))
 
             reactor.callFromThread(schedule_call)
             return
@@ -480,8 +480,7 @@ class LibtorrentMgr(TaskManager):
                     return
 
                 def schedule_call():
-                    random_id = ''.join(random.choice('0123456789abcdef') for _ in xrange(30))
-                    self.register_task("schedule_got_metainfo_lookup_%s" % random_id,
+                    self.register_anonymous_task("schedule_got_metainfo_lookup",
                                        reactor.callLater(timeout, lambda: self.got_metainfo(infohash, timeout=True)))
 
                 reactor.callFromThread(schedule_call)

--- a/Tribler/Test/Core/Modules/Wallet/test_trustchain_wallet.py
+++ b/Tribler/Test/Core/Modules/Wallet/test_trustchain_wallet.py
@@ -98,7 +98,7 @@ class TestTrustchainWallet(TestBase):
 
         yield tx_deferred
 
-    @twisted_wrapper
+    @twisted_wrapper(2)
     def test_monitor_tx_existing(self):
         """
         Test monitoring a transaction that already exists


### PR DESCRIPTION
This removes the need for custom random id creation.

Also switched away from `save_pstate` id based on time, which is unsafe.