### PR TITLE
Error dialog now shows the actual error as well if the directory is not writable

### DIFF
--- a/TriblerGUI/dialogs/startdownloaddialog.py
+++ b/TriblerGUI/dialogs/startdownloaddialog.py
@@ -158,12 +158,12 @@ class StartDownloadDialog(DialogContainer):
         if len(chosen_dir) != 0:
             self.dialog_widget.destination_input.setCurrentText(chosen_dir)
 
-        if not is_dir_writable(chosen_dir):
-            ConfirmationDialog.show_message(self.dialog_widget, "Insufficient Permissions",
-                                            "Tribler cannot download to <i>%s</i> directory. "
-                                            "Please add proper write permissions to the directory "
-                                            "or choose another download directory." % chosen_dir,
-                                            "OK")
+        is_writable, error = is_dir_writable(chosen_dir)
+        if not is_writable:
+            gui_error_message = "Tribler cannot download to <i>%s</i> directory. Please add proper write " \
+                                "permissions to the directory or choose another download directory. [%s]" \
+                                % (chosen_dir, error)
+            ConfirmationDialog.show_message(self.dialog_widget, "Insufficient Permissions", gui_error_message, "OK")
 
     def on_anon_download_state_changed(self, _):
         if self.dialog_widget.anon_download_checkbox.isChecked():
@@ -176,12 +176,12 @@ class StartDownloadDialog(DialogContainer):
                                           "Please select at least one file to download.")
         else:
             download_dir = self.dialog_widget.destination_input.currentText()
-            if not is_dir_writable(download_dir):
-                ConfirmationDialog.show_message(self.dialog_widget, "Insufficient Permissions",
-                                                "Tribler cannot download to <i>%s</i> directory. "
-                                                "Please add proper write permissions to the directory "
-                                                "or choose another download directory and try to download again." %
-                                                download_dir, "OK")
+            is_writable, error = is_dir_writable(download_dir)
+            if not is_writable:
+                gui_error_message = "Tribler cannot download to <i>%s</i> directory. Please add proper write " \
+                                    "permissions to the directory or choose another download directory and try " \
+                                    "to download again. [%s]" % (download_dir, error)
+                ConfirmationDialog.show_message(self.dialog_widget, "Insufficient Permissions", gui_error_message, "OK")
             else:
                 self.button_clicked.emit(1)
 

--- a/TriblerGUI/tribler_window.py
+++ b/TriblerGUI/tribler_window.py
@@ -390,11 +390,12 @@ class TriblerWindow(QMainWindow):
     def perform_start_download_request(self, uri, anon_download, safe_seeding, destination, selected_files,
                                        total_files=0, callback=None):
         # Check if destination directory is writable
-        if not is_dir_writable(destination):
-            ConfirmationDialog.show_message(self.window(), "Download error <i>%s</i>" % uri,
-                                            "Insufficient write permissions to <i>%s</i> directory. "
-                                            "Please add proper write permissions on the directory and "
-                                            "add the torrent again." % destination, "OK")
+        is_writable, error = is_dir_writable(destination)
+        if not is_writable:
+            gui_error_message = "Insufficient write permissions to <i>%s</i> directory. Please add proper " \
+                                "write permissions on the directory and add the torrent again. %s" \
+                                % (destination, error)
+            ConfirmationDialog.show_message(self.window(), "Download error <i>%s</i>" % uri, gui_error_message, "OK")
             return
 
         selected_files_uri = ""

--- a/TriblerGUI/utilities.py
+++ b/TriblerGUI/utilities.py
@@ -217,13 +217,13 @@ def is_dir_writable(path):
         if not os.path.exists(path):
             os.makedirs(path)
         open(os.path.join(path, 'temp'), 'w')
-    except IOError:
-        return False
-    except OSError:
-        return False
+    except IOError as io_error:
+        return False, io_error
+    except OSError as os_error:
+        return False, os_error
     else:
         os.remove(os.path.join(path, 'temp'))
-        return True
+        return True, None
 
 
 def unicode_quoter(c):

--- a/TriblerGUI/widgets/settingspage.py
+++ b/TriblerGUI/widgets/settingspage.py
@@ -199,9 +199,10 @@ class SettingsPage(QWidget):
         if not log_dir or log_dir == previous_log_dir:
             return
 
-        if not is_dir_writable(log_dir):
-            ConfirmationDialog.show_message(self.window(), "Insufficient Permissions",
-                                            "<i>%s</i> is not writable. " % log_dir, "OK")
+        is_writable, error = is_dir_writable(log_dir)
+        if not is_writable:
+            gui_error_message = "<i>%s</i> is not writable. [%s]" % (log_dir, error)
+            ConfirmationDialog.show_message(self.window(), "Insufficient Permissions", gui_error_message, "OK")
         else:
             self.window().log_location_input.setText(log_dir)
 


### PR DESCRIPTION
Error dialog now shows the actual error as well if the directory is not writable.
With this PR the user can report the actual error in #3862.

This PR will close this issue for now. When we get the report of the actual issue, we can create a new issue.
Fixes #3862 