### PR TITLE
Fixed logging message that still used relay.mid

### DIFF
--- a/Tribler/community/triblertunnel/community.py
+++ b/Tribler/community/triblertunnel/community.py
@@ -204,7 +204,7 @@ class TriblerTunnelCommunity(HiddenTunnelCommunity):
             relay = self.relay_from_to[payload.circuit_id]
             circuit_peer = self.get_peer_from_address(relay.peer.address)
             if not circuit_peer:
-                self.logger.warning("%s Unable to find next peer %s for payout!", self.my_peer, relay.mid.encode('hex'))
+                self.logger.warning("%s Unable to find next peer %s for payout!", self.my_peer, relay.peer)
                 return
 
             self.do_payout(circuit_peer, relay.circuit_id, block.transaction['down'] - payload.base_amount * 2,


### PR DESCRIPTION
This crashed on the exit nodes.