### PR TITLE
Fixes endpoint issue with tunnel community

### DIFF
--- a/Tribler/Core/APIImplementation/LaunchManyCore.py
+++ b/Tribler/Core/APIImplementation/LaunchManyCore.py
@@ -936,8 +936,12 @@ class TriblerLaunchMany(TaskManager):
 
         if self.tunnel_community and self.trustchain_community:
             # We unload these overlays manually since the TrustChain has to be unloaded after the tunnel overlay.
-            yield self.ipv8.unload_overlay(self.tunnel_community)
-            yield self.ipv8.unload_overlay(self.trustchain_community)
+            tunnel_community = self.tunnel_community
+            self.tunnel_community = None
+            yield self.ipv8.unload_overlay(tunnel_community)
+            trustchain_community = self.trustchain_community
+            self.trustchain_community = None
+            yield self.ipv8.unload_overlay(trustchain_community)
 
         if self.dispersy:
             self._logger.info("lmc: Shutting down Dispersy...")

--- a/Tribler/Core/Libtorrent/LibtorrentDownloadImpl.py
+++ b/Tribler/Core/Libtorrent/LibtorrentDownloadImpl.py
@@ -263,7 +263,7 @@ class LibtorrentDownloadImpl(DownloadConfigInterface, TaskManager):
                     if not self.ltmgr or not dht_ok or tunnels_ready < 1:
                         self._logger.info(u"LTMGR/DHT/session not ready, rescheduling create_engine_wrapper")
 
-                        if tunnels_ready < 1:
+                        if tunnel_community and tunnels_ready < 1:
                             tunnel_community.build_tunnels(self.get_hops())
 
                         # Schedule this function call to be called again in 5 seconds


### PR DESCRIPTION
Potentially fixes #3905 

The reference to tunnel and TrustChain are cleared when these communities are unloaded and the existence of tunnel community is checked before trying to build tunnels.