### PR TITLE
Remove blocking_call_from_reactor_thread decorators

### DIFF
--- a/Tribler/Core/APIImplementation/LaunchManyCore.py
+++ b/Tribler/Core/APIImplementation/LaunchManyCore.py
@@ -41,7 +41,7 @@ from Tribler.pyipv8.ipv8.peerdiscovery.churn import RandomChurn
 from Tribler.pyipv8.ipv8.peerdiscovery.deprecated.discovery import DiscoveryCommunity
 from Tribler.pyipv8.ipv8.peerdiscovery.discovery import EdgeWalk, RandomWalk
 from Tribler.pyipv8.ipv8.taskmanager import TaskManager
-from Tribler.pyipv8.ipv8.util import blockingCallFromThread, blocking_call_on_reactor_thread
+from Tribler.pyipv8.ipv8.util import blockingCallFromThread
 from Tribler.pyipv8.ipv8_service import IPv8
 from twisted.internet import reactor
 from twisted.internet.defer import Deferred, inlineCallbacks, DeferredList, succeed

--- a/Tribler/Core/APIImplementation/LaunchManyCore.py
+++ b/Tribler/Core/APIImplementation/LaunchManyCore.py
@@ -234,7 +234,6 @@ class TriblerLaunchMany(TaskManager):
     def on_tribler_started(self, subject, changetype, objectID, *args):
         reactor.callFromThread(self.startup_deferred.callback, None)
 
-    @blocking_call_on_reactor_thread
     def load_ipv8_overlays(self):
         # Discovery Community
         with open(self.session.config.get_permid_keypair_filename(), 'r') as key_file:
@@ -330,7 +329,6 @@ class TriblerLaunchMany(TaskManager):
             for overlay in self.ipv8.overlays:
                 self.ipv8.endpoint.enable_community_statistics(overlay.get_prefix(), True)
 
-    @blocking_call_on_reactor_thread
     def load_dispersy_communities(self):
         self._logger.info("tribler: Preparing Dispersy communities...")
         now_time = timemod.time()
@@ -596,7 +594,6 @@ class TriblerLaunchMany(TaskManager):
         with self.session_lock:
             return infohash in self.downloads
 
-    @blocking_call_on_reactor_thread
     @inlineCallbacks
     def update_download_hops(self, download, new_hops):
         """

--- a/Tribler/Core/CacheDB/sqlitecachedb.py
+++ b/Tribler/Core/CacheDB/sqlitecachedb.py
@@ -75,7 +75,6 @@ class SQLiteCacheDB(TaskManager):
         """
         return self._connection
 
-    @blocking_call_on_reactor_thread
     def initialize(self):
         """ Initializes the database. If the database doesn't exist, we create a new one. Otherwise, we check the
             version and upgrade to the latest version.
@@ -84,7 +83,6 @@ class SQLiteCacheDB(TaskManager):
         # open a connection to the database
         self._open_connection()
 
-    @blocking_call_on_reactor_thread
     def close(self):
         """
         Cancels all pending tasks and closes all cursors. Then, it closes the connection.
@@ -207,7 +205,6 @@ class SQLiteCacheDB(TaskManager):
                 self._cursor_table[thread_name] = self._connection.cursor()
             return self._cursor_table[thread_name]
 
-    @blocking_call_on_reactor_thread
     def initial_begin(self):
         try:
             self._logger.info(u"Beginning the first transaction...")
@@ -218,7 +215,6 @@ class SQLiteCacheDB(TaskManager):
             raise
         self._should_commit = False
 
-    @blocking_call_on_reactor_thread
     def write_version(self, version):
         assert isinstance(version, int), u"Invalid version type: %s is not int" % type(version)
         assert version <= LATEST_DB_VERSION, u"Invalid version value: %s > the latest %s" % (version, LATEST_DB_VERSION)
@@ -228,7 +224,6 @@ class SQLiteCacheDB(TaskManager):
         self.commit_now()
         self._version = version
 
-    @blocking_call_on_reactor_thread
     def commit_now(self, vacuum=False, exiting=False):
         if self._should_commit and isInIOThread():
             try:
@@ -269,7 +264,6 @@ class SQLiteCacheDB(TaskManager):
 
     # --------- generic functions -------------
 
-    @blocking_call_on_reactor_thread
     def execute(self, sql, args=None):
         cur = self.get_cursor()
 
@@ -294,7 +288,6 @@ class SQLiteCacheDB(TaskManager):
 
             raise msg
 
-    @blocking_call_on_reactor_thread
     def executemany(self, sql, args=None):
         self._should_commit = True
 
@@ -388,7 +381,6 @@ class SQLiteCacheDB(TaskManager):
         result = self.fetchone(num_rec_sql)
         return result
 
-    @blocking_call_on_reactor_thread
     def fetchone(self, sql, args=None):
         find = self.execute_read(sql, args)
         if not find:
@@ -407,7 +399,6 @@ class SQLiteCacheDB(TaskManager):
         else:
             return find[0]
 
-    @blocking_call_on_reactor_thread
     def fetchall(self, sql, args=None):
         res = self.execute_read(sql, args)
         if res is not None:

--- a/Tribler/Core/CreditMining/CreditMiningSource.py
+++ b/Tribler/Core/CreditMining/CreditMiningSource.py
@@ -7,7 +7,6 @@ from Tribler.community.allchannel.community import AllChannelCommunity
 from Tribler.community.channel.community import ChannelCommunity
 from Tribler.Core.simpledefs import NTFY_DISCOVERED, NTFY_TORRENT, NTFY_CHANNELCAST
 from Tribler.pyipv8.ipv8.taskmanager import TaskManager
-from Tribler.pyipv8.ipv8.util import blocking_call_on_reactor_thread
 
 
 class BaseSource(TaskManager):

--- a/Tribler/Core/CreditMining/CreditMiningSource.py
+++ b/Tribler/Core/CreditMining/CreditMiningSource.py
@@ -56,7 +56,6 @@ class ChannelSource(BaseSource):
         self.community = None
         self.channelcast_db = self.session.open_dbhandler(NTFY_CHANNELCAST)
 
-    @blocking_call_on_reactor_thread
     def start(self):
         super(ChannelSource, self).start()
 

--- a/Tribler/Core/Libtorrent/LibtorrentMgr.py
+++ b/Tribler/Core/Libtorrent/LibtorrentMgr.py
@@ -85,7 +85,6 @@ class LibtorrentMgr(TaskManager):
                                   lt.alert.category_t.tracker_notification | lt.alert.category_t.debug_notification
         self.alert_callback = None
 
-    @blocking_call_on_reactor_thread
     def initialize(self):
         # start upnp
         self.get_session().start_upnp()
@@ -103,7 +102,6 @@ class LibtorrentMgr(TaskManager):
         self.register_task(u'task_cleanup_metacache',
                            LoopingCall(self._task_cleanup_metainfo_cache)).start(60, now=True)
 
-    @blocking_call_on_reactor_thread
     def shutdown(self):
         self.shutdown_task_manager()
 
@@ -594,7 +592,6 @@ class LibtorrentMgr(TaskManager):
             self.notifier.notify(NTFY_REACHABLE, NTFY_INSERT, None, '')
             self.check_reachability_lc.stop()
 
-    @blocking_call_on_reactor_thread
     def _schedule_next_check(self, delay, retries_left):
         if not self.tribler_session.config.get_libtorrent_dht_enabled():
             self.dht_ready = True
@@ -637,7 +634,6 @@ class LibtorrentMgr(TaskManager):
 
         return fail(Failure(Exception("invalid uri")))
 
-    @blocking_call_on_reactor_thread
     def start_download_from_url(self, url, dconfig=None):
 
         def _on_loaded(tdef):

--- a/Tribler/Core/Libtorrent/LibtorrentMgr.py
+++ b/Tribler/Core/Libtorrent/LibtorrentMgr.py
@@ -31,7 +31,6 @@ from Tribler.Core.simpledefs import (NTFY_INSERT, NTFY_MAGNET_CLOSE, NTFY_MAGNET
                                      NTFY_REACHABLE, NTFY_TORRENTS)
 from Tribler.Core.version import version_id
 from Tribler.pyipv8.ipv8.taskmanager import TaskManager
-from Tribler.pyipv8.ipv8.util import blocking_call_on_reactor_thread
 
 LTSTATE_FILENAME = "lt.state"
 METAINFO_CACHE_PERIOD = 5 * 60

--- a/Tribler/Core/Modules/channel/channel.py
+++ b/Tribler/Core/Modules/channel/channel.py
@@ -10,7 +10,6 @@ from Tribler.Core.Modules.channel.channel_rss import ChannelRssParser
 import Tribler.Core.Utilities.json_util as json
 from Tribler.Core.simpledefs import SIGNAL_CHANNEL, SIGNAL_ON_CREATED, SIGNAL_RSS_FEED, SIGNAL_ON_UPDATED
 from Tribler.pyipv8.ipv8.taskmanager import TaskManager
-from Tribler.pyipv8.ipv8.util import blocking_call_on_reactor_thread
 
 
 class ChannelObject(TaskManager):

--- a/Tribler/Core/Modules/channel/channel.py
+++ b/Tribler/Core/Modules/channel/channel.py
@@ -50,7 +50,6 @@ class ChannelObject(TaskManager):
         deferreds = [feed.parse_feed() for feed in self._rss_feed_dict.itervalues()]
         return DeferredList(deferreds, consumeErrors=True)
 
-    @blocking_call_on_reactor_thread
     def initialize(self):
         # load existing rss_feeds
         if os.path.exists(self._rss_file_path):
@@ -71,7 +70,6 @@ class ChannelObject(TaskManager):
             # subscribe to the channel creation event
             self._session.add_observer(self._on_channel_created, SIGNAL_CHANNEL, [SIGNAL_ON_CREATED])
 
-    @blocking_call_on_reactor_thread
     def shutdown(self):
         self.shutdown_task_manager()
         for key, rss_parser in self._rss_feed_dict.iteritems():
@@ -99,7 +97,6 @@ class ChannelObject(TaskManager):
         task_name = u'create_rss_%s' % hexlify(channel_data[u'channel'].cid)
         self.register_task(task_name, reactor.callLater(0, _create_rss_feed, channel_data))
 
-    @blocking_call_on_reactor_thread
     def create_rss_feed(self, rss_feed_url):
         if rss_feed_url in self._rss_feed_dict:
             self._logger.warn(u"skip existing rss feed: %s", repr(rss_feed_url))
@@ -119,7 +116,6 @@ class ChannelObject(TaskManager):
             rss_list = [rss_url for rss_url in self._rss_feed_dict.iterkeys()]
             json.dump(rss_list, f)
 
-    @blocking_call_on_reactor_thread
     def remove_rss_feed(self, rss_feed_url):
         if rss_feed_url not in self._rss_feed_dict:
             self._logger.warn(u"skip existing rss feed: %s", repr(rss_feed_url))

--- a/Tribler/Core/Modules/channel/channel_manager.py
+++ b/Tribler/Core/Modules/channel/channel_manager.py
@@ -27,7 +27,6 @@ class ChannelManager(TaskManager):
 
         self._channel_list = []
 
-    @blocking_call_on_reactor_thread
     def initialize(self):
         self.dispersy = self.session.get_dispersy_instance()
 
@@ -41,7 +40,6 @@ class ChannelManager(TaskManager):
 
                 self._logger.debug(u"loaded channel '%s', %s", channel_obj.name, hexlify(community.cid))
 
-    @blocking_call_on_reactor_thread
     def shutdown(self):
         self.shutdown_task_manager()
         self._channel_mode_map = None
@@ -53,7 +51,6 @@ class ChannelManager(TaskManager):
         self.dispersy = None
         self.session = None
 
-    @blocking_call_on_reactor_thread
     def create_channel(self, name, description, mode, rss_url=None):
         """
         Creates a new Channel.

--- a/Tribler/Core/Modules/channel/channel_manager.py
+++ b/Tribler/Core/Modules/channel/channel_manager.py
@@ -5,7 +5,6 @@ from Tribler.Core.Modules.channel.channel import ChannelObject
 from Tribler.Core.exceptions import DuplicateChannelNameError
 from Tribler.community.channel.community import ChannelCommunity
 from Tribler.pyipv8.ipv8.taskmanager import TaskManager
-from Tribler.pyipv8.ipv8.util import blocking_call_on_reactor_thread
 
 
 class ChannelManager(TaskManager):

--- a/Tribler/Core/Modules/channel/channel_rss.py
+++ b/Tribler/Core/Modules/channel/channel_rss.py
@@ -17,7 +17,6 @@ from Tribler.Core.Utilities.utilities import http_get
 from Tribler.Core.simpledefs import (SIGNAL_CHANNEL_COMMUNITY, SIGNAL_ON_TORRENT_UPDATED, SIGNAL_RSS_FEED,
                                      SIGNAL_ON_UPDATED)
 from Tribler.pyipv8.ipv8.taskmanager import TaskManager
-from Tribler.pyipv8.ipv8.util import blocking_call_on_reactor_thread
 
 DEFAULT_CHECK_INTERVAL = 1800  # half an hour
 

--- a/Tribler/Core/Modules/channel/channel_rss.py
+++ b/Tribler/Core/Modules/channel/channel_rss.py
@@ -41,7 +41,6 @@ class ChannelRssParser(TaskManager):
 
         self.running = False
 
-    @blocking_call_on_reactor_thread
     def initialize(self):
         # initialize URL cache
         # use the SHA1 of channel cid + rss_url as key
@@ -70,7 +69,6 @@ class ChannelRssParser(TaskManager):
         self.session.notifier.notify(SIGNAL_RSS_FEED, SIGNAL_ON_UPDATED, None, rss_feed_data)
         self.running = True
 
-    @blocking_call_on_reactor_thread
     def shutdown(self):
         self._to_stop = True
         self.shutdown_task_manager()

--- a/Tribler/Core/Modules/restapi/channels/channels_torrents_endpoint.py
+++ b/Tribler/Core/Modules/restapi/channels/channels_torrents_endpoint.py
@@ -10,7 +10,6 @@ from Tribler.Core.TorrentDef import TorrentDef
 from Tribler.Core.exceptions import DuplicateTorrentFileError, HttpError
 import Tribler.Core.Utilities.json_util as json
 from Tribler.Core.Utilities.utilities import http_get
-from Tribler.pyipv8.ipv8.util import blocking_call_on_reactor_thread
 
 UNKNOWN_TORRENT_MSG = "this torrent is not found in the specified channel"
 UNKNOWN_COMMUNITY_MSG = "the community for the specified channel cannot be found"

--- a/Tribler/Core/Modules/restapi/channels/channels_torrents_endpoint.py
+++ b/Tribler/Core/Modules/restapi/channels/channels_torrents_endpoint.py
@@ -191,7 +191,6 @@ class ChannelModifyTorrentEndpoint(BaseChannelsEndpoint):
         def _on_magnet_fetched(meta_info):
             return TorrentDef.load_from_dict(meta_info)
 
-        @blocking_call_on_reactor_thread
         def _on_torrent_def_loaded(torrent_def):
             self.session.add_torrent_def_to_channel(channel[0], torrent_def, extra_info, forward=True)
             return self.path

--- a/Tribler/Core/Modules/search_manager.py
+++ b/Tribler/Core/Modules/search_manager.py
@@ -7,7 +7,6 @@ from Tribler.Core.simpledefs import (SIGNAL_SEARCH_COMMUNITY, SIGNAL_ALLCHANNEL_
 from Tribler.community.allchannel.community import AllChannelCommunity
 from Tribler.community.search.community import SearchCommunity
 from Tribler.pyipv8.ipv8.taskmanager import TaskManager
-from Tribler.pyipv8.ipv8.util import blocking_call_on_reactor_thread
 
 
 class SearchManager(TaskManager):

--- a/Tribler/Core/Modules/search_manager.py
+++ b/Tribler/Core/Modules/search_manager.py
@@ -30,14 +30,12 @@ class SearchManager(TaskManager):
         self.session.add_observer(self._on_channel_search_results,
                                   SIGNAL_ALLCHANNEL_COMMUNITY, [SIGNAL_ON_SEARCH_RESULTS])
 
-    @blocking_call_on_reactor_thread
     def shutdown(self):
         self.shutdown_task_manager()
         self.channelcast_db = None
         self.dispersy = None
         self.session = None
 
-    @blocking_call_on_reactor_thread
     def search_for_torrents(self, keywords):
         """
         Searches for torrents using SearchCommunity with the given keywords.
@@ -62,7 +60,6 @@ class SearchManager(TaskManager):
 
         return nr_requests_made
 
-    @blocking_call_on_reactor_thread
     def _on_torrent_search_results(self, subject, change_type, object_id, search_results):
         """
         The callback function handles the search results from SearchCommunity.
@@ -173,7 +170,6 @@ class SearchManager(TaskManager):
         # inform other components about the results
         self.session.notifier.notify(SIGNAL_TORRENT, SIGNAL_ON_SEARCH_RESULTS, None, results_data)
 
-    @blocking_call_on_reactor_thread
     def search_for_channels(self, keywords):
         """
         Searches for channels using AllChannelCommunity with the given keywords.
@@ -188,7 +184,6 @@ class SearchManager(TaskManager):
                 community.create_channelsearch(keywords)
                 break
 
-    @blocking_call_on_reactor_thread
     def _on_channel_search_results(self, subject, change_type, object_id, search_results):
         """
         The callback function handles the search results from AllChannelCommunity.

--- a/Tribler/Core/Modules/tracker_manager.py
+++ b/Tribler/Core/Modules/tracker_manager.py
@@ -14,7 +14,6 @@ class TrackerManager(object):
         self._logger = logging.getLogger(self.__class__.__name__)
         self._session = session
 
-    @blocking_call_on_reactor_thread
     def get_tracker_info(self, tracker_url):
         """
         Gets the tracker information with the given tracker URL.
@@ -30,7 +29,6 @@ class TrackerManager(object):
 
         return {u'id': result[0], u'last_check': result[2], u'failures': result[3], u'is_alive': bool(result[4])}
 
-    @blocking_call_on_reactor_thread
     def add_tracker(self, tracker_url):
         """
         Adds a new tracker into the tracker info dict and the database.
@@ -100,7 +98,6 @@ class TrackerManager(object):
                        tracker_info[u'id'])
         self._session.sqlite_db.execute(sql_stmt, value_tuple)
 
-    @blocking_call_on_reactor_thread
     def get_next_tracker_for_auto_check(self):
         """
         Gets the next tracker for automatic tracker-checking.

--- a/Tribler/Core/Modules/tracker_manager.py
+++ b/Tribler/Core/Modules/tracker_manager.py
@@ -2,7 +2,6 @@ import logging
 import time
 
 from Tribler.Core.Utilities.tracker_utils import get_uniformed_tracker_url
-from Tribler.pyipv8.ipv8.util import blocking_call_on_reactor_thread
 
 MAX_TRACKER_FAILURES = 5  # if a tracker fails this amount of times in a row, its 'is_alive' will be marked as 0 (dead).
 TRACKER_RETRY_INTERVAL = 60    # A "dead" tracker will be retired every 60 seconds

--- a/Tribler/Core/Modules/wallet/tc_wallet.py
+++ b/Tribler/Core/Modules/wallet/tc_wallet.py
@@ -161,7 +161,6 @@ class TrustchainWallet(Wallet, BlockListener):
                 peers_helped_you.add(block.link_public_key)
         return len(peers_you_helped), len(peers_helped_you)
 
-    @blocking_call_on_reactor_thread
     def get_statistics(self, public_key=None):
         """
         Returns a dictionary with some statistics regarding the local trustchain database

--- a/Tribler/Core/Modules/wallet/tc_wallet.py
+++ b/Tribler/Core/Modules/wallet/tc_wallet.py
@@ -5,7 +5,6 @@ from Tribler.Core.Modules.wallet.wallet import Wallet, InsufficientFunds
 from Tribler.pyipv8.ipv8.attestation.trustchain.listener import BlockListener
 from Tribler.pyipv8.ipv8.keyvault.crypto import ECCrypto
 from Tribler.pyipv8.ipv8.peer import Peer
-from Tribler.pyipv8.ipv8.util import blocking_call_on_reactor_thread
 from twisted.internet.defer import succeed, fail, Deferred
 from twisted.internet.task import LoopingCall
 

--- a/Tribler/Core/RemoteTorrentHandler.py
+++ b/Tribler/Core/RemoteTorrentHandler.py
@@ -81,11 +81,9 @@ class RemoteTorrentHandler(TaskManager):
             requester.stop()
         self.shutdown_task_manager()
 
-    @blocking_call_on_reactor_thread
     def set_max_num_torrents(self, max_num_torrents):
         self.max_num_torrents = max_num_torrents
 
-    @blocking_call_on_reactor_thread
     def __check_overflow(self):
         def clean_until_done(num_delete, deletions_per_step):
             """
@@ -117,7 +115,6 @@ class RemoteTorrentHandler(TaskManager):
     def schedule_task(self, name, task, delay_time=0.0, *args, **kwargs):
         self.register_task(name, reactor.callLater(delay_time, task, *args, **kwargs))
 
-    @blocking_call_on_reactor_thread
     def download_torrent(self, candidate, infohash, user_callback=None, priority=1, timeout=None):
         assert isinstance(infohash, str), u"infohash has invalid type: %s" % type(infohash)
         assert len(infohash) == INFOHASH_LENGTH, u"infohash has invalid length: %s" % len(infohash)
@@ -135,7 +132,6 @@ class RemoteTorrentHandler(TaskManager):
             callback = lambda ih = infohash: user_callback(ih)
             self.torrent_callbacks.setdefault(infohash, set()).add(callback)
 
-    @blocking_call_on_reactor_thread
     def save_torrent(self, tdef, callback=None):
         infohash = tdef.get_infohash()
         infohash_str = hexlify(infohash)
@@ -173,7 +169,6 @@ class RemoteTorrentHandler(TaskManager):
         # notify all
         self.notify_possible_torrent_infohash(infohash)
 
-    @blocking_call_on_reactor_thread
     def download_torrentmessage(self, candidate, infohash, user_callback=None, priority=1):
         assert isinstance(infohash, str), u"infohash has invalid type: %s" % type(infohash)
         assert len(infohash) == INFOHASH_LENGTH, u"infohash has invalid length: %s" % len(infohash)
@@ -196,7 +191,6 @@ class RemoteTorrentHandler(TaskManager):
         thumb_hash_str = hexlify(thumb_hash)
         return self.session.lm.metadata_store[thumb_hash_str]
 
-    @blocking_call_on_reactor_thread
     def download_metadata(self, candidate, thumb_hash, usercallback=None, timeout=None):
         if self.has_metadata(thumb_hash):
             return
@@ -208,7 +202,6 @@ class RemoteTorrentHandler(TaskManager):
 
         self._logger.debug(u"added metadata request: %s %s", hexlify(thumb_hash), candidate)
 
-    @blocking_call_on_reactor_thread
     def save_metadata(self, thumb_hash, data):
         # save data to a temporary tarball and extract it to the torrent collecting directory
         thumb_hash_str = hexlify(thumb_hash)
@@ -461,7 +454,6 @@ class MagnetRequester(Requester):
                                                 timeout=self.TIMEOUT, timeout_callback=self._failure_callback)
             self._running_requests.append(infohash)
 
-    @blocking_call_on_reactor_thread
     def _success_callback(self, meta_info):
         """
         The callback that will be called by LibtorrentMgr when a download was successful.
@@ -480,7 +472,6 @@ class MagnetRequester(Requester):
 
         self._start_pending_requests()
 
-    @blocking_call_on_reactor_thread
     def _failure_callback(self, infohash):
         """
         The callback that will be called by LibtorrentMgr when a download failed.
@@ -578,7 +569,6 @@ class TftpRequester(Requester):
         del self._tried_sources[key]
         self._active_request_list.remove(key)
 
-    @blocking_call_on_reactor_thread
     def _on_download_successful(self, address, file_name, file_data, extra_info):
         self._logger.debug(u"successfully downloaded %s from %s:%s", file_name, address[0], address[1])
 
@@ -608,7 +598,6 @@ class TftpRequester(Requester):
             self._clear_active_request(key)
             self._start_pending_requests()
 
-    @blocking_call_on_reactor_thread
     def _on_download_failed(self, address, file_name, error_msg, extra_info):
         self._logger.debug(u"failed to download %s from %s:%s: %s", file_name, address[0], address[1], error_msg)
 

--- a/Tribler/Core/RemoteTorrentHandler.py
+++ b/Tribler/Core/RemoteTorrentHandler.py
@@ -18,7 +18,6 @@ from Tribler.Core.TFTP.handler import METADATA_PREFIX
 from Tribler.Core.TorrentDef import TorrentDef
 from Tribler.Core.simpledefs import INFOHASH_LENGTH, NTFY_TORRENTS
 from Tribler.pyipv8.ipv8.taskmanager import TaskManager
-from Tribler.pyipv8.ipv8.util import blocking_call_on_reactor_thread
 
 TORRENT_OVERFLOW_CHECKING_INTERVAL = 30 * 60
 LOW_PRIO_COLLECTING = 0

--- a/Tribler/Core/Session.py
+++ b/Tribler/Core/Session.py
@@ -453,7 +453,6 @@ class Session(object):
         """
         self.lm.checkpoint_downloads()
 
-    @blocking_call_on_reactor_thread
     def start_database(self):
         """
         Start the SQLite database.
@@ -465,7 +464,6 @@ class Session(object):
         self.sqlite_db.initialize()
         self.sqlite_db.initial_begin()
 
-    @blocking_call_on_reactor_thread
     def start(self):
         """
         Start a Tribler session by initializing the LaunchManyCore class, opening the database and running the upgrader.
@@ -494,7 +492,6 @@ class Session(object):
 
         return startup_deferred.addCallback(load_checkpoint)
 
-    @blocking_call_on_reactor_thread
     def shutdown(self):
         """
         Checkpoints the session and closes it, stopping the download engine.

--- a/Tribler/Core/Session.py
+++ b/Tribler/Core/Session.py
@@ -32,7 +32,6 @@ from Tribler.Core.simpledefs import (NTFY_CHANNELCAST, NTFY_DELETE, NTFY_INSERT,
                                      STATEDIR_WALLET_DIR, STATE_OPEN_DB, STATE_START_API, STATE_UPGRADING_READABLE,
                                      STATE_LOAD_CHECKPOINTS, STATE_READABLE_STARTED)
 from Tribler.Core.statistics import TriblerStatistics
-from Tribler.pyipv8.ipv8.util import blocking_call_on_reactor_thread
 
 if sys.platform == 'win32':
     SOCKET_BLOCK_ERRORCODE = 10035  # WSAEWOULDBLOCK

--- a/Tribler/Core/TFTP/handler.py
+++ b/Tribler/Core/TFTP/handler.py
@@ -11,8 +11,7 @@ from twisted.internet import reactor
 from twisted.internet.task import LoopingCall
 
 from Tribler.dispersy.candidate import Candidate
-from Tribler.dispersy.util import (call_on_reactor_thread, blocking_call_on_reactor_thread, attach_runtime_statistics,
-                                   is_valid_address)
+from Tribler.dispersy.util import (call_on_reactor_thread, attach_runtime_statistics, is_valid_address)
 from Tribler.pyipv8.ipv8.taskmanager import TaskManager
 
 from .exception import InvalidPacketException, FileNotFound

--- a/Tribler/Core/TFTP/handler.py
+++ b/Tribler/Core/TFTP/handler.py
@@ -75,7 +75,6 @@ class TftpHandler(TaskManager):
                            LoopingCall(self._task_check_timeout)).start(self._timeout_check_interval, now=True)
         self._is_running = True
 
-    @blocking_call_on_reactor_thread
     def shutdown(self):
         """ Shuts down the TFTP service.
         """

--- a/Tribler/Core/TorrentChecker/torrent_checker.py
+++ b/Tribler/Core/TorrentChecker/torrent_checker.py
@@ -49,7 +49,6 @@ class TorrentChecker(TaskManager):
         self.socket_mgr = self.udp_port = None
         self.connection_pool = None
 
-    @blocking_call_on_reactor_thread
     def initialize(self):
         self._torrent_db = self.tribler_session.open_dbhandler(NTFY_TORRENTS)
         self._reschedule_tracker_select()
@@ -204,7 +203,6 @@ class TorrentChecker(TaskManager):
 
         return final_response
 
-    @blocking_call_on_reactor_thread
     def add_gui_request(self, infohash, timeout=20, scrape_now=False):
         """
         Public API for adding a GUI request.

--- a/Tribler/Core/TorrentChecker/torrent_checker.py
+++ b/Tribler/Core/TorrentChecker/torrent_checker.py
@@ -15,7 +15,6 @@ from Tribler.Core.Utilities.tracker_utils import MalformedTrackerURLException
 from Tribler.Core.simpledefs import NTFY_TORRENTS
 from Tribler.community.popularity.repository import TYPE_TORRENT_HEALTH
 from Tribler.pyipv8.ipv8.taskmanager import TaskManager
-from Tribler.pyipv8.ipv8.util import blocking_call_on_reactor_thread
 
 # some settings
 DEFAULT_TORRENT_SELECTION_INTERVAL = 20  # every 20 seconds, the thread will select torrents to check

--- a/Tribler/Core/TorrentDef.py
+++ b/Tribler/Core/TorrentDef.py
@@ -18,7 +18,6 @@ from Tribler.Core.Utilities.utilities import parse_magnetlink, http_get
 from Tribler.Core.defaults import TDEF_DEFAULTS
 from Tribler.Core.exceptions import TorrentDefNotFinalizedException, NotYetImplementedException
 from Tribler.Core.simpledefs import INFOHASH_LENGTH
-from Tribler.pyipv8.ipv8.util import blocking_call_on_reactor_thread
 
 
 def escape_as_utf8(string, encoding='utf8'):

--- a/Tribler/Core/TorrentDef.py
+++ b/Tribler/Core/TorrentDef.py
@@ -161,7 +161,6 @@ class TorrentDef(object):
     _create = staticmethod(_create)
 
     @staticmethod
-    @blocking_call_on_reactor_thread
     def load_from_url(url):
         """
         Load a BT .torrent or Tribler .tstream file from the URL and

--- a/Tribler/Core/Upgrade/upgrade.py
+++ b/Tribler/Core/Upgrade/upgrade.py
@@ -9,7 +9,6 @@ from Tribler.Core.Upgrade.db_upgrader import DBUpgrader
 from Tribler.Core.Upgrade.pickle_converter import PickleConverter
 from Tribler.Core.Upgrade.torrent_upgrade65 import TorrentMigrator65
 from Tribler.Core.simpledefs import NTFY_UPGRADER, NTFY_FINISHED, NTFY_STARTED, NTFY_UPGRADER_TICK
-from Tribler.pyipv8.ipv8.util import blocking_call_on_reactor_thread
 
 
 # Database versions:

--- a/Tribler/Core/Upgrade/upgrade.py
+++ b/Tribler/Core/Upgrade/upgrade.py
@@ -83,7 +83,6 @@ class TriblerUpgrader(object):
         """
         self.session.notifier.notify(NTFY_UPGRADER, NTFY_FINISHED, None)
 
-    @blocking_call_on_reactor_thread
     def check_should_upgrade_database(self):
         self.failed = True
         should_upgrade = False
@@ -105,7 +104,6 @@ class TriblerUpgrader(object):
 
         return (self.failed, should_upgrade)
 
-    @blocking_call_on_reactor_thread
     @inlineCallbacks
     def upgrade_database_to_current_version(self):
         """ Checks the database version and upgrade if it is not the latest version.
@@ -136,7 +134,6 @@ class TriblerUpgrader(object):
         except Exception as e:
             self._logger.exception(u"failed to upgrade: %s", e)
 
-    @blocking_call_on_reactor_thread
     def stash_database(self):
         self.db.close()
         old_dir = os.path.dirname(self.db.sqlite_db_path)


### PR DESCRIPTION
Remove `@blocking_call_from_reactor_thread` decorators from everything. Because these are obsolete.