### PR TITLE
Explaning bandwidth tokens in the GUI

### DIFF
--- a/Tribler/Core/Modules/wallet/tc_wallet.py
+++ b/Tribler/Core/Modules/wallet/tc_wallet.py
@@ -10,7 +10,7 @@ from twisted.internet.defer import succeed, fail, Deferred
 from twisted.internet.task import LoopingCall
 
 
-MEGA_DIV = 1024 * 1024
+MEGA_DIV = 1024.0 * 1024.0
 MIN_TRANSACTION_SIZE = 1024 * 1024
 
 
@@ -72,7 +72,7 @@ class TrustchainWallet(Wallet, BlockListener):
 
     def get_balance(self):
         return succeed({
-            'available': self.get_bandwidth_tokens() / MEGA_DIV,
+            'available': int(self.get_bandwidth_tokens() / MEGA_DIV),
             'pending': 0,
             'currency': self.get_identifier(),
             'precision': self.precision()

--- a/TriblerGUI/dialogs/trustexplanationdialog.py
+++ b/TriblerGUI/dialogs/trustexplanationdialog.py
@@ -1,0 +1,22 @@
+from PyQt5 import uic
+from PyQt5.QtWidgets import QSizePolicy
+
+from TriblerGUI.dialogs.dialogcontainer import DialogContainer
+from TriblerGUI.utilities import get_ui_file_path
+
+
+class TrustExplanationDialog(DialogContainer):
+
+    def __init__(self, parent):
+        DialogContainer.__init__(self, parent)
+
+        uic.loadUi(get_ui_file_path('trustexplanation.ui'), self.dialog_widget)
+
+        self.dialog_widget.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Expanding)
+        self.dialog_widget.close_button.clicked.connect(self.close_dialog)
+
+        self.update_window()
+
+    def update_window(self):
+        self.dialog_widget.adjustSize()
+        self.on_main_window_resize()

--- a/TriblerGUI/qt_resources/mainwindow.ui
+++ b/TriblerGUI/qt_resources/mainwindow.ui
@@ -1050,7 +1050,7 @@ background-color: #e67300;
       <item>
        <widget class="QStackedWidget" name="stackedWidget">
         <property name="currentIndex">
-         <number>2</number>
+         <number>12</number>
         </property>
         <widget class="HomePage" name="home_page">
          <layout class="QVBoxLayout" name="verticalLayout">
@@ -5063,7 +5063,7 @@ border-top: 1px solid #555;
               <rect>
                <x>0</x>
                <y>0</y>
-               <width>661</width>
+               <width>300</width>
                <height>610</height>
               </rect>
              </property>
@@ -9371,7 +9371,7 @@ border-top: 1px solid #555;
              <item>
               <widget class="QLabel" name="subscribed_channels_header_label">
                <property name="sizePolicy">
-                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
                  <horstretch>0</horstretch>
                  <verstretch>0</verstretch>
                 </sizepolicy>
@@ -9393,10 +9393,45 @@ border-top: 1px solid #555;
                                             background-color: transparent;
                                             font-size: 20px;
                                             font-weight: bold;
-                                            margin: 10px;</string>
+                                            margin: 10px;
+margin-right: 4px;
+margin-top: 9px;</string>
                </property>
                <property name="text">
                 <string>Trust statistics</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QToolButton" name="trust_explain_button">
+               <property name="minimumSize">
+                <size>
+                 <width>20</width>
+                 <height>20</height>
+                </size>
+               </property>
+               <property name="maximumSize">
+                <size>
+                 <width>20</width>
+                 <height>20</height>
+                </size>
+               </property>
+               <property name="font">
+                <font>
+                 <pointsize>14</pointsize>
+                </font>
+               </property>
+               <property name="cursor">
+                <cursorShape>PointingHandCursor</cursorShape>
+               </property>
+               <property name="styleSheet">
+                <string notr="true">border: 1px solid white;
+color: white;
+border-radius: 10px;
+</string>
+               </property>
+               <property name="text">
+                <string>i</string>
                </property>
               </widget>
              </item>
@@ -9406,7 +9441,7 @@ border-top: 1px solid #555;
                 <enum>Qt::Horizontal</enum>
                </property>
                <property name="sizeType">
-                <enum>QSizePolicy::Fixed</enum>
+                <enum>QSizePolicy::Expanding</enum>
                </property>
                <property name="sizeHint" stdset="0">
                 <size>
@@ -9479,7 +9514,7 @@ border-top: 1px solid #555;
              <string notr="true">padding-left: 10px; padding-right: 10px;</string>
             </property>
             <property name="text">
-             <string>You can build trust by contributing to the Tribler network. This is done by exchanging data anonymously or by letting Tribler run idle.</string>
+             <string>You can build trust by contributing bandwidth to the Tribler network. This is done by letting Tribler run idle, or by mining tokens.</string>
             </property>
             <property name="wordWrap">
              <bool>true</bool>

--- a/TriblerGUI/qt_resources/trustexplanation.ui
+++ b/TriblerGUI/qt_resources/trustexplanation.ui
@@ -1,0 +1,279 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>538</width>
+    <height>335</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>0</width>
+    <height>0</height>
+   </size>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>16777215</width>
+    <height>16777215</height>
+   </size>
+  </property>
+  <property name="cursor">
+   <cursorShape>ArrowCursor</cursorShape>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <property name="autoFillBackground">
+   <bool>false</bool>
+  </property>
+  <property name="styleSheet">
+   <string notr="true">QWidget {
+background-color: #333333;
+border-radius: 2px;
+}
+QToolButton {
+border: 1px solid #B5B5B5;
+border-radius: 12px;
+color: white;
+padding-left: 4px;
+padding-right: 4px;
+}
+QToolButton::hover {
+border: 1px solid white;
+color: white;
+}
+QLineEdit, QTextEdit {
+background-color: #444;
+border: none;
+color: #C0C0C0;
+padding: 4px;
+margin-top: 4px;
+}</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="spacing">
+    <number>0</number>
+   </property>
+   <property name="sizeConstraint">
+    <enum>QLayout::SetMinimumSize</enum>
+   </property>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QWidget" name="dialog_main_container" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">color: white;</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <property name="spacing">
+       <number>0</number>
+      </property>
+      <property name="sizeConstraint">
+       <enum>QLayout::SetMinimumSize</enum>
+      </property>
+      <property name="leftMargin">
+       <number>12</number>
+      </property>
+      <property name="topMargin">
+       <number>12</number>
+      </property>
+      <property name="rightMargin">
+       <number>12</number>
+      </property>
+      <property name="bottomMargin">
+       <number>12</number>
+      </property>
+      <item>
+       <widget class="QLabel" name="new_order_title_label">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>20</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>16777215</width>
+          <height>20</height>
+         </size>
+        </property>
+        <property name="styleSheet">
+         <string notr="true">font-size: 16px; font-weight: bold;</string>
+        </property>
+        <property name="text">
+         <string>Bandwidth Tokens</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="verticalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::Fixed</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>10</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QLabel" name="error_text_label">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="styleSheet">
+         <string notr="true">color: white;</string>
+        </property>
+        <property name="text">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;In Tribler, you compensate other users for the bandwidth you use when downloading with anonymity. When uploading content to other (Tribler) users, you earn &lt;span style=&quot; font-style:italic;&quot;&gt;bandwidth tokens&lt;/span&gt;. If you accumulate more bandwidth tokens, you get preferential treatment when downloading anonymously, which results in higher download speeds.&lt;/p&gt;&lt;p&gt;The exact amount of bandwidth tokens you pay to others, depends on the level of anonymity. This is the number of other users, or &lt;span style=&quot; font-style:italic;&quot;&gt;hops&lt;/span&gt;, you use during a download. If you download with three hop anonymity, your encrypted data is sent through the machines of three other Tribler users. Increasing the number of hops benefits anonymity but costs you more bandwidth tokens.&lt;/p&gt;&lt;p&gt;For example, if you download a &lt;span style=&quot; font-weight:600;&quot;&gt;1 Gigabyte&lt;/span&gt; video with one hop anonymity, you pay &lt;span style=&quot; font-weight:600;&quot;&gt;1 Gigabyte&lt;/span&gt; worth of bandwidth tokens. Each additional hop increases the amount of bandwidth tokens you have to pay. When downloading the same file using three hops, you pay &lt;span style=&quot; font-weight:600;&quot;&gt;3 Gigabyte&lt;/span&gt; of bandwidth tokens instead.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QWidget" name="dialog_button_container" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>50</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>50</height>
+      </size>
+     </property>
+     <property name="styleSheet">
+      <string notr="true"/>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <property name="leftMargin">
+       <number>12</number>
+      </property>
+      <property name="topMargin">
+       <number>12</number>
+      </property>
+      <property name="rightMargin">
+       <number>12</number>
+      </property>
+      <property name="bottomMargin">
+       <number>12</number>
+      </property>
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QToolButton" name="close_button">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>24</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>16777215</width>
+          <height>24</height>
+         </size>
+        </property>
+        <property name="cursor">
+         <cursorShape>PointingHandCursor</cursorShape>
+        </property>
+        <property name="text">
+         <string>CLOSE</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/TriblerGUI/widgets/trustpage.py
+++ b/TriblerGUI/widgets/trustpage.py
@@ -1,11 +1,11 @@
 import matplotlib
 
 from TriblerGUI.defs import PAGE_MARKET
+from TriblerGUI.dialogs.trustexplanationdialog import TrustExplanationDialog
 
 matplotlib.use('Qt5Agg')
 
 import datetime
-from PyQt5.QtCore import QTimer
 from PyQt5.QtWidgets import QSizePolicy
 from PyQt5.QtWidgets import QWidget
 from matplotlib.backends.backend_qt5agg import FigureCanvas
@@ -85,6 +85,7 @@ class TrustPage(QWidget):
         self.request_mgr = None
         self.blocks = None
         self.byte_scale = 1024 * 1024
+        self.dialog = None
 
     def initialize_trust_page(self):
         vlayout = self.window().plot_widget.layout()
@@ -92,11 +93,16 @@ class TrustPage(QWidget):
         vlayout.addWidget(self.trust_plot)
 
         self.window().trade_button.clicked.connect(self.on_trade_button_clicked)
+        self.window().trust_explain_button.clicked.connect(self.on_info_button_clicked)
 
     def on_trade_button_clicked(self):
         self.window().market_page.initialize_market_page()
         self.window().navigation_stack.append(self.window().stackedWidget.currentIndex())
         self.window().stackedWidget.setCurrentIndex(PAGE_MARKET)
+
+    def on_info_button_clicked(self):
+        self.dialog = TrustExplanationDialog(self.window())
+        self.dialog.show()
 
     def load_blocks(self):
         self.request_mgr = TriblerRequestManager()


### PR DESCRIPTION
Since there has been quite some confusion regarding the bandwidth token functionality, I've added a small explanation to the GUI. I will write a more extensive explanation in the FAQ on the website, which should address the questions asked in #3657.

Also fixed a minor rounding issue, causing incompatibilities between the balance as reported by the wallet and TrustChain.

![trust_explain](https://user-images.githubusercontent.com/1707075/46525928-30d4da80-c88d-11e8-84b1-32f058ad568d.png)
