### PR TITLE
Remove unused Edit Channel buttons from everywhere

### DIFF
--- a/TriblerGUI/qt_resources/mainwindow.ui
+++ b/TriblerGUI/qt_resources/mainwindow.ui
@@ -1050,7 +1050,7 @@ background-color: #e67300;
       <item>
        <widget class="QStackedWidget" name="stackedWidget">
         <property name="currentIndex">
-         <number>12</number>
+         <number>3</number>
         </property>
         <widget class="HomePage" name="home_page">
          <layout class="QVBoxLayout" name="verticalLayout">
@@ -4613,31 +4613,6 @@ background-color: transparent;
               </spacer>
              </item>
              <item>
-              <widget class="EllipseButton" name="edit_channel_button">
-               <property name="minimumSize">
-                <size>
-                 <width>45</width>
-                 <height>24</height>
-                </size>
-               </property>
-               <property name="maximumSize">
-                <size>
-                 <width>45</width>
-                 <height>24</height>
-                </size>
-               </property>
-               <property name="cursor">
-                <cursorShape>PointingHandCursor</cursorShape>
-               </property>
-               <property name="styleSheet">
-                <string notr="true"/>
-               </property>
-               <property name="text">
-                <string>EDIT</string>
-               </property>
-              </widget>
-             </item>
-             <item>
               <spacer name="horizontalSpacer_6">
                <property name="orientation">
                 <enum>Qt::Horizontal</enum>
@@ -5064,7 +5039,7 @@ border-top: 1px solid #555;
                <x>0</x>
                <y>0</y>
                <width>300</width>
-               <height>610</height>
+               <height>646</height>
               </rect>
              </property>
              <layout class="QVBoxLayout" name="verticalLayout_22">
@@ -8267,8 +8242,8 @@ QTabBar::tab:selected {
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>131</width>
-                       <height>260</height>
+                       <width>133</width>
+                       <height>246</height>
                       </rect>
                      </property>
                      <layout class="QFormLayout" name="formLayout_4">
@@ -12009,6 +11984,12 @@ color: #eee;</string>
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
+   <class>SubscriptionsWidget</class>
+   <extends>QWidget</extends>
+   <header>TriblerGUI.widgets.subscriptionswidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>EllipseButton</class>
    <extends>QToolButton</extends>
    <header>TriblerGUI.widgets.ellipsebutton.h</header>
@@ -12121,12 +12102,6 @@ color: #eee;</string>
    <class>LoadingPage</class>
    <extends>QWidget</extends>
    <header>TriblerGUI.widgets.loadingpage.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>SubscriptionsWidget</class>
-   <extends>QWidget</extends>
-   <header>TriblerGUI.widgets.subscriptionswidget.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -12380,22 +12355,6 @@ color: #eee;</string>
    <hints>
     <hint type="sourcelabel">
      <x>221</x>
-     <y>75</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>427</x>
-     <y>317</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>edit_channel_button</sender>
-   <signal>clicked()</signal>
-   <receiver>MainWindow</receiver>
-   <slot>on_edit_channel_clicked()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>834</x>
      <y>75</y>
     </hint>
     <hint type="destinationlabel">

--- a/TriblerGUI/widgets/channelpage.py
+++ b/TriblerGUI/widgets/channelpage.py
@@ -58,8 +58,6 @@ class ChannelPage(QWidget):
         self.window().num_subs_label.setText(str(channel_info['votes']))
         self.window().subscription_widget.initialize_with_channel(channel_info)
 
-        self.window().edit_channel_button.setHidden(True)
-
     def clicked_item(self):
         if len(self.window().channel_torrents_list.selectedItems()) != 1:
             self.window().channel_torrents_detail_widget.hide()
@@ -110,10 +108,3 @@ class ChannelPage(QWidget):
             self.playlists.append((PlaylistListItem, result))
         self.loaded_playlists = True
         self.update_result_list()
-
-    def on_edit_channel_clicked(self):
-        self.window().edit_channel_page.initialize_with_channel_overview(
-            {"channel":
-                 {"name": self.channel_info["name"],
-                  "description": self.channel_info["description"],
-                  "identifier": self.channel_info["dispersy_cid"]}})

--- a/TriblerGUI/widgets/editchannelpage.py
+++ b/TriblerGUI/widgets/editchannelpage.py
@@ -21,7 +21,7 @@ from TriblerGUI.utilities import get_image_path
 
 class EditChannelPage(QWidget):
     """
-    This class is responsible for managing lists and data on the your channel page, including torrents, playlists
+    This class is responsible for managing lists and data on your channel page, including torrents, playlists
     and rss feeds.
     """
     playlists_loaded = pyqtSignal(object)
@@ -34,7 +34,6 @@ class EditChannelPage(QWidget):
         self.playlists = None
         self.editing_playlist = None
         self.viewing_playlist = None
-        self.editing_own_channel = False
         self.dialog = None
         self.editchannel_request_mgr = None
 
@@ -86,34 +85,18 @@ class EditChannelPage(QWidget):
             return
         if 'error' in overview:
             self.window().edit_channel_stacked_widget.setCurrentIndex(0)
-        else:
-            if "mychannel" in overview:
-                self.channel_overview = overview["mychannel"]
-                self.set_editing_own_channel(True)
-                self.window().edit_channel_name_label.setText("My channel")
-            else:
-                self.channel_overview = overview["channel"]
-                self.set_editing_own_channel(False)
-                self.window().edit_channel_name_label.setText(self.channel_overview["name"])
 
-            self.window().edit_channel_overview_name_label.setText(self.channel_overview["name"])
-            self.window().edit_channel_description_label.setText(self.channel_overview["description"])
-            self.window().edit_channel_identifier_label.setText(self.channel_overview["identifier"])
+        self.channel_overview = overview["mychannel"]
+        self.window().edit_channel_name_label.setText("My channel")
 
-            self.window().edit_channel_name_edit.setText(self.channel_overview["name"])
-            self.window().edit_channel_description_edit.setText(self.channel_overview["description"])
+        self.window().edit_channel_overview_name_label.setText(self.channel_overview["name"])
+        self.window().edit_channel_description_label.setText(self.channel_overview["description"])
+        self.window().edit_channel_identifier_label.setText(self.channel_overview["identifier"])
 
-            self.window().edit_channel_stacked_widget.setCurrentIndex(1)
+        self.window().edit_channel_name_edit.setText(self.channel_overview["name"])
+        self.window().edit_channel_description_edit.setText(self.channel_overview["description"])
 
-    def set_editing_own_channel(self, edit_own):
-        self.editing_own_channel = edit_own
-
-        self.window().edit_channel_settings_button.setHidden(not edit_own)
-        self.window().edit_channel_rss_feeds_button.setHidden(not edit_own)
-        self.window().edit_channel_playlists_button.setHidden(not edit_own)
-
-        self.window().edit_channel_torrents_remove_all_button.setHidden(not edit_own)
-        self.window().edit_channel_torrents_remove_selected_button.setHidden(not edit_own)
+        self.window().edit_channel_stacked_widget.setCurrentIndex(1)
 
     def load_channel_torrents(self):
         self.window().edit_channel_torrents_list.set_data_items([(LoadingListItem, None)])


### PR DESCRIPTION
Remove hidden Edit Channel button from the GUI. The button's purpose was to be able to edit other people's Dispersy channels, but this never worked properly, so the button was hidden long time ago. And no one missed it.
Now it's gone for good.