### PR TITLE
Trap SchemeNotSupported twisted error on creating discovered channel

### DIFF
--- a/Tribler/Core/Modules/restapi/channels/channels_torrents_endpoint.py
+++ b/Tribler/Core/Modules/restapi/channels/channels_torrents_endpoint.py
@@ -1,4 +1,5 @@
 import base64
+from twisted.web.error import SchemeNotSupported
 
 from twisted.internet.defer import Deferred
 from twisted.web import http
@@ -199,7 +200,7 @@ class ChannelModifyTorrentEndpoint(BaseChannelsEndpoint):
             request.finish()
 
         def _on_add_failed(failure):
-            failure.trap(ValueError, DuplicateTorrentFileError)
+            failure.trap(ValueError, DuplicateTorrentFileError, SchemeNotSupported)
             self._logger.exception(failure.value)
             request.write(BaseChannelsEndpoint.return_500(self, request, failure.value))
             request.finish()


### PR DESCRIPTION
SchemeNotSupported twisted error on creating a discovered channel is trapped.
Fixes #3970