### PR TITLE
Properly disable rtorrent_checker if Dispersy is disabled

### DIFF
--- a/Tribler/Core/APIImplementation/LaunchManyCore.py
+++ b/Tribler/Core/APIImplementation/LaunchManyCore.py
@@ -147,7 +147,7 @@ class TriblerLaunchMany(TaskManager):
                     raise RuntimeError("Metadata store (leveldb) is None which should not normally happen")
 
             # torrent collecting: RemoteTorrentHandler
-            if self.session.config.get_torrent_collecting_enabled():
+            if self.session.config.get_torrent_collecting_enabled() and self.session.config.get_dispersy_enabled():
                 from Tribler.Core.RemoteTorrentHandler import RemoteTorrentHandler
                 self.rtorrent_handler = RemoteTorrentHandler(self.session)
 


### PR DESCRIPTION
rtorrent_handler initialization is split into two parts in `LaunchManyCores`: first `init` creates the object, than `register` runs `rtorrent_handler.initialize()`. The second part checks that Dispersy is enabled, and the first one does not.
This patch fixes that.