### PR TITLE
Add periodic and shutdown commits to MegaCache DBs

### DIFF
--- a/Tribler/Core/CacheDB/SqliteCacheDBHandler.py
+++ b/Tribler/Core/CacheDB/SqliteCacheDBHandler.py
@@ -517,7 +517,7 @@ class TorrentDBHandler(BasicDBHandler):
 
     def update_torrent_with_metainfo(self, infohash, metainfo):
         """ Updates name, length and num files from metainfo if record does not exist in the database. """
-        torrent_id = self.getTorrentID(infohash)
+        torrent_id = self.addOrGetTorrentID(infohash)
         name = self.getOne('name', torrent_id=torrent_id)
         if not name:
             num_files, length = 0, 0


### PR DESCRIPTION
This PR partially resolves https://github.com/Tribler/tribler/issues/3985 by adding a LoopingCall to commit MegaCache DB at 10 seconds intervals, and commit and properly close the DB at Tribler shutdown.

I wonder why it was not there for all this years...