### PR TITLE
Add some commit_now() statements in important points

### DIFF
--- a/Tribler/Core/APIImplementation/LaunchManyCore.py
+++ b/Tribler/Core/APIImplementation/LaunchManyCore.py
@@ -610,6 +610,7 @@ class TriblerLaunchMany(TaskManager):
             if isinstance(tdef, TorrentDefNoMetainfo):
                 self.torrent_db.addOrGetTorrentID(tdef.get_infohash())
                 self.torrent_db.updateTorrent(tdef.get_infohash(), name=tdef.get_name_as_unicode())
+                self.torrent_db._db.commit_now()
                 write_my_pref()
             elif self.rtorrent_handler:
                 self.rtorrent_handler.save_torrent(tdef, write_my_pref)

--- a/Tribler/Core/Modules/restapi/torrentinfo_endpoint.py
+++ b/Tribler/Core/Modules/restapi/torrentinfo_endpoint.py
@@ -70,6 +70,7 @@ class TorrentInfoEndpoint(resource.Resource):
             # Update the torrent database with metainfo if it is an unnamed torrent
             if self.session.lm.torrent_db:
                 self.session.lm.torrent_db.update_torrent_with_metainfo(infohash, metainfo)
+                self.session.lm.torrent_db._db.commit_now()
 
             # Save the torrent to our store
             try:

--- a/Tribler/Test/Community/popularity/test_repository.py
+++ b/Tribler/Test/Community/popularity/test_repository.py
@@ -313,6 +313,9 @@ class TestContentRepository(unittest.TestCase):
         self.content_repository.has_torrent = lambda infohash: False
         self.content_repository.get_torrent = lambda infohash: None
 
+        self.content_repository.torrent_db._db = MockObject()
+        self.content_repository.torrent_db._db.commit_now = lambda x=None: None
+
         self.content_repository.called_update_torrent = False
         self.content_repository.update_from_torrent_search_results(search_results.values())
         self.assertTrue(self.content_repository.called_update_torrent)

--- a/Tribler/community/popularity/repository.py
+++ b/Tribler/community/popularity/repository.py
@@ -162,6 +162,7 @@ class ContentRepository(object):
             else:
                 self.logger.debug("Adding new torrent from search results to database")
                 self.torrent_db.addOrGetTorrentID(infohash)
+                self.torrent_db._db.commit_now()
 
             # Update local database
             self.torrent_db.updateTorrent(infohash, notify=False, name=torrent_item.name,


### PR DESCRIPTION
Resolves https://github.com/Tribler/tribler/issues/3985 (at least partially).
Adds some commit statements in higher-level functions, so data would be safe and immediately available from DB even when Dispersy is not around. We don't add them to low-level functions because we don't want to interfere with Dispersy commit patterns too much.