### PR TITLE
Fix chant-related DHT timeout error handling in torrents endpoint

### DIFF
--- a/Tribler/Core/APIImplementation/LaunchManyCore.py
+++ b/Tribler/Core/APIImplementation/LaunchManyCore.py
@@ -526,6 +526,7 @@ class TriblerLaunchMany(TaskManager):
         else:
             # Add new channel object to DB
             channel = self.mds.ChannelMetadata.from_payload(payload)
+            channel.subscribed = True
 
         if channel.version > channel.local_version:
             self._logger.info("Downloading new channel version %s ver %i->%i", str(channel.public_key).encode("hex"),

--- a/Tribler/Core/Modules/restapi/torrentinfo_endpoint.py
+++ b/Tribler/Core/Modules/restapi/torrentinfo_endpoint.py
@@ -146,7 +146,7 @@ class TorrentInfoEndpoint(resource.Resource):
                 on_got_metainfo(tdef.get_metainfo())
                 return NOT_DONE_YET
 
-            self.session.lm.ltmgr.get_metainfo(uri, callback=metainfo_deferred.callback, timeout=20,
+            self.session.lm.ltmgr.get_metainfo(mlink or uri, callback=metainfo_deferred.callback, timeout=20,
                                                timeout_callback=on_metainfo_timeout, notify=True)
             return NOT_DONE_YET
 

--- a/Tribler/Test/Core/Modules/RestApi/test_torrents_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_torrents_endpoint.py
@@ -261,5 +261,5 @@ class TestTorrentHealthEndpoint(AbstractApiTest):
         # Left for compatibility with other tests in this object
         self.udp_tracker.start()
         self.http_tracker.start()
-
+        # TODO: add test for DHT timeout
         yield self.do_request(url, expected_code=200, request_type='GET').addCallback(verify_response_no_trackers)


### PR DESCRIPTION
And subscribe to the downloaded channel by default.