### PR TITLE
Updated ipv8 pointer

### DIFF
--- a/Tribler/Core/APIImplementation/LaunchManyCore.py
+++ b/Tribler/Core/APIImplementation/LaunchManyCore.py
@@ -48,7 +48,7 @@ from Tribler.pyipv8.ipv8.dht.provider import DHTCommunityProvider
 from Tribler.pyipv8.ipv8.keyvault.private.m2crypto import M2CryptoSK
 from Tribler.pyipv8.ipv8.peer import Peer
 from Tribler.pyipv8.ipv8.peerdiscovery.churn import RandomChurn
-from Tribler.pyipv8.ipv8.peerdiscovery.deprecated.discovery import DiscoveryCommunity
+from Tribler.pyipv8.ipv8.peerdiscovery.community import DiscoveryCommunity
 from Tribler.pyipv8.ipv8.peerdiscovery.discovery import EdgeWalk, RandomWalk
 from Tribler.pyipv8.ipv8.taskmanager import TaskManager
 from Tribler.pyipv8.ipv8.util import blockingCallFromThread

--- a/Tribler/Test/Community/Tunnel/FullSession/test_tunnel_base.py
+++ b/Tribler/Test/Community/Tunnel/FullSession/test_tunnel_base.py
@@ -6,7 +6,7 @@ from twisted.internet.task import deferLater
 from Tribler.community.triblertunnel.community import TriblerTunnelCommunity
 from Tribler.pyipv8.ipv8.keyvault.crypto import ECCrypto
 from Tribler.pyipv8.ipv8.peer import Peer
-from Tribler.pyipv8.ipv8.peerdiscovery.deprecated.discovery import DiscoveryCommunity
+from Tribler.pyipv8.ipv8.peerdiscovery.community import DiscoveryCommunity
 from Tribler.pyipv8.ipv8.peerdiscovery.network import Network
 from twisted.internet.defer import returnValue, inlineCallbacks
 

--- a/Tribler/Test/Community/Tunnel/test_community.py
+++ b/Tribler/Test/Community/Tunnel/test_community.py
@@ -38,9 +38,6 @@ class TestTriblerTunnelCommunity(TestBase):
         super(TestTriblerTunnelCommunity, self).setUp()
         self.initialize(TriblerTunnelCommunity, 1)
 
-    def tearDown(self):
-        super(TestTriblerTunnelCommunity, self).tearDown()
-
     def create_node(self):
         mock_ipv8 = MockIPv8(u"curve25519", TriblerTunnelCommunity, socks_listen_ports=[],
                              exitnode_cache=join(mkdtemp(suffix="_tribler_test_cache"), 'cache.dat'))

--- a/Tribler/Test/Community/popularity/test_repository.py
+++ b/Tribler/Test/Community/popularity/test_repository.py
@@ -357,7 +357,7 @@ class TestContentRepositoryWithRealDatabase(TestBase):
     def tearDown(self):
         self.torrent_db.close()
         self.sqlitedb.close()
-        super(TestContentRepositoryWithRealDatabase, self).tearDown()
+        return super(TestContentRepositoryWithRealDatabase, self).tearDown()
 
     def test_update_db_from_search_results(self):
         """


### PR DESCRIPTION
This pointer update also requires references to `DiscoveryCommunity` to be refactored and `TestBase` subclasses to return the value of `super( ... , self).tearDown()`.