### PR TITLE
Fixed double unicode encoding for Pony

### DIFF
--- a/Tribler/Core/Modules/MetadataStore/OrmBindings/torrent_metadata.py
+++ b/Tribler/Core/Modules/MetadataStore/OrmBindings/torrent_metadata.py
@@ -19,8 +19,8 @@ def define_binding(db):
 
         def get_magnet(self):
             return ("magnet:?xt=urn:btih:%s&dn=%s" %
-                    (str(self.infohash).encode('hex'), str(self.title).encode('utf8'))) + \
-                   ("&tr=%s" % (str(self.tracker_info).encode('utf8')) if self.tracker_info else "")
+                    (str(self.infohash).encode('hex'), self.title)) + \
+                   ("&tr=%s" % self.tracker_info if self.tracker_info else "")
 
         @classmethod
         def search_keyword(cls, query, entry_type=None, lim=100):

--- a/Tribler/Test/Core/Modules/MetadataStore/test_torrent_metadata.py
+++ b/Tribler/Test/Core/Modules/MetadataStore/test_torrent_metadata.py
@@ -47,6 +47,8 @@ class TestTorrentMetadata(TriblerCoreTest):
         """
         torrent_metadata = self.mds.TorrentMetadata.from_dict({})
         self.assertTrue(torrent_metadata.get_magnet())
+        torrent_metadata2 = self.mds.TorrentMetadata.from_dict({'title':u'\U0001f4a9'})
+        self.assertTrue(torrent_metadata2.get_magnet())
 
     @db_session
     def test_search_keyword(self):


### PR DESCRIPTION
By default, Pony[ converts everything into Unicode](https://docs.ponyorm.com/api_reference.html#attribute-types) when putting it into a database. Therefore, strings should not be `.encode('utf-8')`-ed when received from it.
Fixes #4023 