### PR TITLE
Fixed LevelDB issue

### DIFF
--- a/Tribler/Core/leveldbstore.py
+++ b/Tribler/Core/leveldbstore.py
@@ -132,13 +132,22 @@ class LevelDbStore(MutableMapping, TaskManager):
         else:
             return self._db.RangeIter(key_from=start, key_to=end)
 
-    def flush(self):
-        if self._pending_torrents:
+    def flush(self, retry=3, write_batch=None):
+        if not write_batch and self._pending_torrents:
             write_batch = self._writebatch(self._db)
             for k, v in self._pending_torrents.iteritems():
                 write_batch.Put(k, v)
             self._pending_torrents.clear()
-            return self._db.Write(write_batch)
+
+        if write_batch:
+            if not retry:
+                self._logger.error("Failed to flush LevelDB cache. Max retry done.")
+                return
+            try:
+                self._db.Write(write_batch)
+            except Exception as ex:
+                self._logger.error("Failed to flush LevelDB cache. Will retry %s times. Error:%s", retry-1, ex)
+                self.flush(retry=retry-1, write_batch=write_batch)
 
     def close(self):
         self.shutdown_task_manager()

--- a/Tribler/Core/plyveladapter.py
+++ b/Tribler/Core/plyveladapter.py
@@ -1,5 +1,6 @@
 import plyvel
 
+
 class LevelDB(object):
 
     def __init__(self, store_dir, create_if_missing=True):
@@ -31,7 +32,8 @@ class LevelDB(object):
 class WriteBatch(object):
 
     def __init__(self, db):
-        self._batch = db._db.write_batch()
+        # Using transaction and sync in Windows to prevent CorruptionError
+        self._batch = db._db.write_batch(transaction=True, sync=True)
 
     def Put(self, key, value):
         self._batch.put(key, value)


### PR DESCRIPTION
Fixes https://github.com/Tribler/tribler/issues/3955

Two important changes in this PR:
1. sync and transaction parameters in write_batch are set to True for Windows. This helps in preventing corruption.
2. Retry mechanism for up to 3 times is implemented. In windows, there could be the case where index file is not available during read operation because it is being merged. In such case, retry helps.