### PR TITLE
Minimal changes to pass the imports on Python 3

### DIFF
--- a/Tribler/Core/APIImplementation/LaunchManyCore.py
+++ b/Tribler/Core/APIImplementation/LaunchManyCore.py
@@ -3,6 +3,8 @@ LaunchManyCore
 
 Author(s): Arno Bakker, Niels Zeilemaker
 """
+from __future__ import absolute_import
+
 import binascii
 import logging
 import os

--- a/Tribler/Core/APIImplementation/LaunchManyCore.py
+++ b/Tribler/Core/APIImplementation/LaunchManyCore.py
@@ -23,7 +23,6 @@ from twisted.internet.threads import deferToThread
 from twisted.python.threadable import isInIOThread
 
 from Tribler.Core.CacheDB.sqlitecachedb import forceDBThread
-from Tribler.Core.DecentralizedTracking.dht_provider import MainlineDHTProvider
 from Tribler.Core.DownloadConfig import DownloadStartupConfig, DefaultDownloadStartupConfig
 from Tribler.Core.Modules.MetadataStore.serialization import ChannelMetadataPayload, float2time
 from Tribler.Core.Modules.MetadataStore.store import MetadataStore
@@ -296,6 +295,7 @@ class TriblerLaunchMany(TaskManager):
             competing_slots = self.session.config.get_tunnel_community_competing_slots()
 
             if self.mainline_dht:
+                from Tribler.Core.DecentralizedTracking.dht_provider import MainlineDHTProvider
                 dht_provider = MainlineDHTProvider(self.mainline_dht, self.session.config.get_dispersy_port())
             else:
                 dht_provider = DHTCommunityProvider(self.dht_community, self.session.config.get_dispersy_port())

--- a/Tribler/Core/Category/Category.py
+++ b/Tribler/Core/Category/Category.py
@@ -3,10 +3,12 @@ Category.
 
 Author(s):  Yuan Yuan, Jelle Roozenburg
 """
+from __future__ import absolute_import
+
 import logging
 import os
 import re
-from ConfigParser import MissingSectionHeaderError, ParsingError
+from six.moves.configparser import MissingSectionHeaderError, ParsingError
 
 from Tribler.Core.Category.FamilyFilter import XXXFilter
 from Tribler.Core.Category.init_category import getCategoryInfo

--- a/Tribler/Core/Category/init_category.py
+++ b/Tribler/Core/Category/init_category.py
@@ -3,7 +3,9 @@ Give the initial category information.
 
 Author(s): Yuan Yuan
 """
-import ConfigParser
+from __future__ import absolute_import
+
+from six.moves import configparser
 
 
 def __split_list(string):
@@ -38,7 +40,7 @@ def __get_default():
 
 
 def getCategoryInfo(filename):
-    config = ConfigParser.ConfigParser()
+    config = configparser.ConfigParser()
     config.readfp(open(filename))
 
     cate_list = []

--- a/Tribler/Core/CreditMining/CreditMiningSource.py
+++ b/Tribler/Core/CreditMining/CreditMiningSource.py
@@ -5,8 +5,6 @@ import logging
 from binascii import hexlify, unhexlify
 
 from Tribler.dispersy.exception import CommunityNotFoundException
-from Tribler.community.allchannel.community import AllChannelCommunity
-from Tribler.community.channel.community import ChannelCommunity
 from Tribler.Core.simpledefs import NTFY_DISCOVERED, NTFY_TORRENT, NTFY_CHANNELCAST
 from Tribler.pyipv8.ipv8.taskmanager import TaskManager
 
@@ -65,6 +63,9 @@ class ChannelSource(BaseSource):
         try:
             self.community = dispersy.get_community(unhexlify(self.source), True)
         except CommunityNotFoundException:
+            from Tribler.community.allchannel.community import AllChannelCommunity
+            from Tribler.community.channel.community import ChannelCommunity
+
             allchannelcommunity = None
             for community in dispersy.get_communities():
                 if isinstance(community, AllChannelCommunity):

--- a/Tribler/Core/CreditMining/CreditMiningSource.py
+++ b/Tribler/Core/CreditMining/CreditMiningSource.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import logging
 
 from binascii import hexlify, unhexlify

--- a/Tribler/Core/DownloadConfig.py
+++ b/Tribler/Core/DownloadConfig.py
@@ -3,12 +3,12 @@ Controls how a TorrentDef is downloaded (rate, where on disk, etc.).
 
 Author(s): Arno Bakker, Egbert Bouman
 """
+from __future__ import absolute_import
+
 import copy
 import logging
 import os
-from ConfigParser import ParsingError, MissingSectionHeaderError
-
-from types import StringType
+from six.moves.configparser import MissingSectionHeaderError, ParsingError
 
 from Tribler.Core.Utilities.configparser import CallbackConfigParser
 from Tribler.Core.defaults import dldefaults
@@ -154,7 +154,7 @@ class DownloadConfigInterface(object):
         ['harry.avi','sjaak.avi']). Not Unicode strings!
         """
         # TODO: can't check if files exists, don't have tdef here.... bugger
-        if isinstance(files, StringType):  # convenience
+        if isinstance(files, str):  # convenience
             files = [files]
 
         if self.get_mode() == DLMODE_VOD and len(files) > 1:
@@ -203,7 +203,7 @@ class DownloadStartupConfig(DownloadConfigInterface):
         dlconfig = CallbackConfigParser()
         try:
             dlconfig.read_file(filename)
-        except (ParsingError, IOError, MissingSectionHeaderError):
+        except (ParsingError, MissingSectionHeaderError, IOError):
             logger.error("Failed to open download config file: %s", filename)
             raise
 

--- a/Tribler/Core/Modules/restapi/channels/base_channels_endpoint.py
+++ b/Tribler/Core/Modules/restapi/channels/base_channels_endpoint.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import logging
 import time
 from twisted.web import http, resource

--- a/Tribler/Core/Modules/restapi/channels/base_channels_endpoint.py
+++ b/Tribler/Core/Modules/restapi/channels/base_channels_endpoint.py
@@ -6,7 +6,6 @@ from twisted.web import http, resource
 
 from Tribler.Core.simpledefs import NTFY_CHANNELCAST
 import Tribler.Core.Utilities.json_util as json
-from Tribler.community.allchannel.community import AllChannelCommunity
 from Tribler.dispersy.exception import CommunityNotFoundException
 
 UNKNOWN_CHANNEL_RESPONSE_MSG = "the channel with the provided cid is not known"
@@ -71,6 +70,8 @@ class BaseChannelsEndpoint(resource.Resource):
         """
         Make a vote in the channel specified by the cid. Returns a deferred that fires when the vote is done.
         """
+        # TODO remove when we remove Dispersy
+        from Tribler.community.allchannel.community import AllChannelCommunity
         for community in self.session.get_dispersy_instance().get_communities():
             if isinstance(community, AllChannelCommunity):
                 return community.disp_create_votecast(cid, vote, int(time.time()))

--- a/Tribler/Core/Modules/restapi/debug_endpoint.py
+++ b/Tribler/Core/Modules/restapi/debug_endpoint.py
@@ -6,12 +6,17 @@ import sys
 
 import datetime
 import psutil
-from meliae import scanner
 from six import StringIO
 from twisted.web import http, resource
 
 from Tribler.Core.Utilities.instrumentation import WatchDog
 import Tribler.Core.Utilities.json_util as json
+
+HAS_MELIAE = True
+try:
+    from meliae import scanner
+except ImportError:
+    HAS_MELIAE = False
 
 
 class MemoryDumpBuffer(StringIO):
@@ -322,7 +327,8 @@ class DebugMemoryEndpoint(resource.Resource):
     def __init__(self, session):
         resource.Resource.__init__(self)
         self.putChild("history", DebugMemoryHistoryEndpoint(session))
-        self.putChild("dump", DebugMemoryDumpEndpoint(session))
+        if HAS_MELIAE:
+            self.putChild("dump", DebugMemoryDumpEndpoint(session))
 
 
 class DebugMemoryHistoryEndpoint(resource.Resource):

--- a/Tribler/Core/Modules/restapi/debug_endpoint.py
+++ b/Tribler/Core/Modules/restapi/debug_endpoint.py
@@ -1,11 +1,13 @@
+from __future__ import absolute_import
+
 import logging
 import os
-from StringIO import StringIO
 import sys
 
 import datetime
 import psutil
 from meliae import scanner
+from six import StringIO
 from twisted.web import http, resource
 
 from Tribler.Core.Utilities.instrumentation import WatchDog

--- a/Tribler/Core/Modules/restapi/downloads_endpoint.py
+++ b/Tribler/Core/Modules/restapi/downloads_endpoint.py
@@ -1,6 +1,9 @@
-import logging
-from urllib import unquote_plus, url2pathname
+from __future__ import absolute_import
 
+import logging
+
+from six.moves.urllib.parse import unquote_plus
+from six.moves.urllib.request import url2pathname
 from twisted.web import http, resource
 from twisted.web.server import NOT_DONE_YET
 
@@ -11,6 +14,8 @@ from Tribler.Core.Utilities.utilities import unichar_string
 from Tribler.Core.exceptions import InvalidSignatureException
 from Tribler.Core.simpledefs import DOWNLOAD, UPLOAD, dlstatus_strings, DLMODE_VOD
 import Tribler.Core.Utilities.json_util as json
+from Tribler.pyipv8.ipv8.util import is_unicode
+from Tribler.util import cast_to_unicode_utf8
 
 
 def _safe_extended_peer_info(ext_peer_info):
@@ -320,7 +325,7 @@ class DownloadsEndpoint(DownloadBaseEndpoint):
         uri = parameters['uri'][0]
         if uri.startswith("file:"):
             if uri.endswith(".mdblob"):
-                filename = url2pathname(uri[5:].encode('utf-8') if isinstance(uri, unicode) else uri[5:])
+                filename = url2pathname(uri[5:].encode('utf-8') if is_unicode(uri) else uri[5:])
                 try:
                     payload = ChannelMetadataPayload.from_file(filename)
                 except IOError:
@@ -335,7 +340,7 @@ class DownloadsEndpoint(DownloadBaseEndpoint):
             else:
                 download_uri = u"file:%s" % url2pathname(uri[5:]).decode('utf-8')
         else:
-            download_uri = unquote_plus(unicode(uri, 'utf-8'))
+            download_uri = unquote_plus(cast_to_unicode_utf8(uri))
         download_deferred = self.session.start_download_from_uri(download_uri, download_config)
         download_deferred.addCallback(download_added)
         download_deferred.addErrback(on_error)

--- a/Tribler/Core/Modules/restapi/torrentinfo_endpoint.py
+++ b/Tribler/Core/Modules/restapi/torrentinfo_endpoint.py
@@ -1,8 +1,10 @@
+from __future__ import absolute_import
+
 import hashlib
 import logging
 from libtorrent import bdecode, bencode
-from urllib import url2pathname
 
+from six.moves.urllib.request import url2pathname
 from twisted.internet.defer import Deferred
 from twisted.internet.error import DNSLookupError, ConnectError, ConnectionLost
 from twisted.web import http, resource
@@ -15,6 +17,7 @@ from Tribler.Core.Modules.MetadataStore.serialization import CHANNEL_TORRENT, \
 from Tribler.Core.TorrentDef import TorrentDef
 from Tribler.Core.Utilities.utilities import fix_torrent, http_get, parse_magnetlink, unichar_string
 from Tribler.Core.exceptions import HttpError, InvalidSignatureException
+from Tribler.pyipv8.ipv8.util import is_unicode
 
 
 class TorrentInfoEndpoint(resource.Resource):
@@ -122,7 +125,7 @@ class TorrentInfoEndpoint(resource.Resource):
 
         def on_file():
             try:
-                filename = url2pathname(uri[5:].encode('utf-8') if isinstance(uri, unicode) else uri[5:])
+                filename = url2pathname(uri[5:].encode('utf-8') if is_unicode(uri) else uri[5:])
                 if filename.endswith(BLOB_EXTENSION):
                     return on_mdblob(filename)
                 metainfo_deferred.callback(bdecode(fix_torrent(filename)))

--- a/Tribler/Core/Modules/search_manager.py
+++ b/Tribler/Core/Modules/search_manager.py
@@ -6,8 +6,6 @@ import os
 from Tribler.Core.Utilities.search_utils import split_into_keywords
 from Tribler.Core.simpledefs import (SIGNAL_SEARCH_COMMUNITY, SIGNAL_ALLCHANNEL_COMMUNITY, SIGNAL_ON_SEARCH_RESULTS,
                                      NTFY_CHANNELCAST, SIGNAL_TORRENT, SIGNAL_CHANNEL)
-from Tribler.community.allchannel.community import AllChannelCommunity
-from Tribler.community.search.community import SearchCommunity
 from Tribler.pyipv8.ipv8.taskmanager import TaskManager
 
 
@@ -46,6 +44,8 @@ class SearchManager(TaskManager):
         if self.dispersy is None:
             return nr_requests_made
 
+        # TODO remove when we remove Dispersy
+        from Tribler.community.search.community import SearchCommunity
         for community in self.dispersy.get_communities():
             if isinstance(community, SearchCommunity):
                 self._current_keywords = keywords
@@ -179,6 +179,8 @@ class SearchManager(TaskManager):
         if self.dispersy is None:
             return
 
+        #TODO remove when we remove Dispersy
+        from Tribler.community.allchannel.community import AllChannelCommunity
         for community in self.dispersy.get_communities():
             if isinstance(community, AllChannelCommunity):
                 self._current_keywords = keywords

--- a/Tribler/Core/Modules/search_manager.py
+++ b/Tribler/Core/Modules/search_manager.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import logging
 import os
 

--- a/Tribler/Core/TorrentDef.py
+++ b/Tribler/Core/TorrentDef.py
@@ -6,9 +6,9 @@ Author(s): Arno Bakker
 from __future__ import absolute_import
 import logging
 import os
+import six
 import sys
 from hashlib import sha1
-from types import StringType, ListType, IntType, LongType
 
 from libtorrent import bencode, bdecode
 
@@ -276,10 +276,10 @@ class TorrentDef(object):
         """
         # TODO: check input, in particular remove / at end
         newhier = []
-        if not isinstance(hier, ListType):
+        if not isinstance(hier, list):
             raise ValueError("hierarchy is not a list")
         for tier in hier:
-            if not isinstance(tier, ListType):
+            if not isinstance(tier, list):
                 raise ValueError("tier is not a list")
             newtier = []
             for url in tier:
@@ -327,15 +327,15 @@ class TorrentDef(object):
         @param nodes A list of [hostname,port] lists.
         """
         # Check input
-        if not isinstance(nodes, ListType):
+        if not isinstance(nodes, list):
             raise ValueError("nodes not a list")
         else:
             for node in nodes:
-                if not isinstance(node, ListType) or len(node) != 2:
+                if not isinstance(node, list) or len(node) != 2:
                     raise ValueError("node in nodes not a 2-item list: " + repr(node))
-                if not isinstance(node[0], StringType):
+                if not isinstance(node[0], str):
                     raise ValueError("host in node is not string:" + repr(node))
-                if not isinstance(node[1], IntType):
+                if not isinstance(node[1], six.integer_types):
                     raise ValueError("port in node is not int:" + repr(node))
 
         self.input['nodes'] = nodes
@@ -417,7 +417,7 @@ class TorrentDef(object):
         (value 0).
         @param value A number of bytes as per the text.
         """
-        if not (isinstance(value, IntType) or isinstance(value, LongType)):
+        if not isinstance(value, six.integer_types):
             raise ValueError("Piece length not an int/long")
 
         self.input['piece length'] = value

--- a/Tribler/Core/Upgrade/config_converter.py
+++ b/Tribler/Core/Upgrade/config_converter.py
@@ -1,13 +1,16 @@
+from __future__ import absolute_import
+
 import ast
 import os
-from ConfigParser import RawConfigParser, DuplicateSectionError, NoSectionError, MissingSectionHeaderError
 import logging
 from glob import iglob
-
-from Tribler.Core.simpledefs import STATEDIR_DLPSTATE_DIR
+from six.moves.configparser import DuplicateSectionError, MissingSectionHeaderError, NoSectionError, ParsingError, \
+    RawConfigParser
 
 from Tribler.Core.Config.tribler_config import TriblerConfig
 from Tribler.Core.exceptions import InvalidConfigException
+from Tribler.Core.simpledefs import STATEDIR_DLPSTATE_DIR
+
 logger = logging.getLogger(__name__)
 
 

--- a/Tribler/Core/Upgrade/pickle_converter.py
+++ b/Tribler/Core/Upgrade/pickle_converter.py
@@ -1,8 +1,9 @@
-import cPickle
+from __future__ import absolute_import
+
 import glob
 import os
 import pickle
-from ConfigParser import RawConfigParser
+from six.moves.configparser import RawConfigParser
 
 from Tribler.Core.simpledefs import PERSISTENTSTATE_CURRENTVERSION
 
@@ -71,7 +72,7 @@ class PickleConverter(object):
         udcfilename = os.path.join(self.session.config.get_state_dir(), 'user_download_choice.pickle')
         if os.path.exists(udcfilename):
             with open(udcfilename, "r") as udc_file:
-                choices = cPickle.Unpickler(udc_file).load()
+                choices = pickle.Unpickler(udc_file).load()
                 choices = dict([(k.encode('hex'), v) for k, v in choices["download_state"].iteritems()])
                 new_config.config['user_download_states'] = choices
                 new_config.write()

--- a/Tribler/Core/Utilities/configparser.py
+++ b/Tribler/Core/Utilities/configparser.py
@@ -3,11 +3,13 @@ A configparser.
 
 Author(s): Egbert Bouman
 """
+from __future__ import absolute_import
+
 import ast
 import codecs
-import StringIO
 
-from ConfigParser import DEFAULTSECT, RawConfigParser
+from six import StringIO
+from six.moves.configparser import DEFAULTSECT, RawConfigParser
 from threading import RLock
 
 from Tribler.Core.exceptions import OperationNotPossibleAtRuntimeException
@@ -31,7 +33,7 @@ class CallbackConfigParser(RawConfigParser):
         # (e.g. when loading resumedata). Please do not remove.
         with codecs.open(filename, 'rb', encoding) as fp:
             buff = fp.read()
-        self.readfp(StringIO.StringIO(buff))
+        self.readfp(StringIO(buff))
 
     def set(self, section, option, new_value):
         with self.lock:
@@ -42,8 +44,8 @@ class CallbackConfigParser(RawConfigParser):
             RawConfigParser.set(self, section, option, new_value)
 
     def get(self, section, option, literal_eval=True):
-        value = RawConfigParser.get(self, section, option) if RawConfigParser.has_option(
-            self, section, option) else None
+        value = RawConfigParser.get(self, section, option) if \
+            RawConfigParser.has_option(self, section, option) else None
         if literal_eval:
             return CallbackConfigParser.get_literal_value(value)
         return value

--- a/Tribler/Core/Utilities/instrumentation.py
+++ b/Tribler/Core/Utilities/instrumentation.py
@@ -106,7 +106,7 @@ class WatchDog(Thread):
             with self._synchronized_lock:
                 if self.check_for_deadlocks:
                     self.look_for_deadlocks()
-                for name, event in self._registered_events.iteritems():
+                for name, event in self._registered_events.items():
                     if event.is_set():
                         event.clear()
                         self.event_timestamps[name] = time()

--- a/Tribler/Core/Utilities/tracker_utils.py
+++ b/Tribler/Core/Utilities/tracker_utils.py
@@ -1,5 +1,7 @@
-from httplib import HTTP_PORT
-from urlparse import urlparse
+from __future__ import absolute_import
+
+from six.moves.http_client import HTTP_PORT
+from six.moves.urllib.parse import urlparse
 
 
 class MalformedTrackerURLException(Exception):

--- a/Tribler/Core/Video/VideoServer.py
+++ b/Tribler/Core/Video/VideoServer.py
@@ -3,16 +3,18 @@ Video server.
 
 Author(s): Jan David Mol, Arno Bakker, Egbert Bouman
 """
+from __future__ import absolute_import
+
 import logging
 import mimetypes
 import os
 import socket
 import time
-from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
-from SocketServer import ThreadingMixIn
 from binascii import unhexlify
 from cherrypy.lib.httputil import get_ranges
 from collections import defaultdict
+from six.moves.BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
+from six.moves.socketserver import ThreadingMixIn
 from threading import Event, Thread, RLock
 from traceback import print_exc
 

--- a/Tribler/Test/test_as_server.py
+++ b/Tribler/Test/test_as_server.py
@@ -15,9 +15,10 @@ import string
 import time
 from threading import enumerate as enumerate_threads
 
-import twisted
 from configobj import ConfigObj
+import six
 from six.moves import xrange
+import twisted
 from twisted.internet import interfaces
 from twisted.internet import reactor
 from twisted.internet.base import BasePort
@@ -71,7 +72,7 @@ class BaseTestCase(unittest.TestCase):
         while self._tempdirs:
             temp_dir = self._tempdirs.pop()
             os.chmod(temp_dir, 0o700)
-            shutil.rmtree(unicode(temp_dir), ignore_errors=False)
+            shutil.rmtree(six.text_type(temp_dir), ignore_errors=False)
 
     def temporary_directory(self, suffix=''):
         random_string = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(6))

--- a/Tribler/community/market/community.py
+++ b/Tribler/community/market/community.py
@@ -1,4 +1,7 @@
+from __future__ import absolute_import
+
 from base64 import b64decode
+from binascii import unhexlify
 
 from twisted.internet import reactor
 from twisted.internet.defer import inlineCallbacks, succeed, Deferred
@@ -122,10 +125,11 @@ class MarketCommunity(Community, BlockListener):
     """
     Community for general asset trading.
     """
-    master_peer = Peer("3081a7301006072a8648ce3d020106052b81040027038192000403225c5011b442e40d36c3918d1ee12729f95e11"
-                       "f0f0f3a517b858d4ca093faa35cc92f6a152152312398e5ec87cb636818020812a04667d7c174d9b1303a6183dcd"
-                       "2c8f72d98f9f04988c299e01ed65ef65d5f413c22ea836eade5d7c5762fb816043f9cf82166d5d8fe558afa4e7b2"
-                       "c252374e589d6033908138c95c9145d603074aa81bff0055006f9ca430f28b82".decode('hex'))
+    master_peer = Peer(unhexlify("3081a7301006072a8648ce3d020106052b81040027038192000403225c5011b442e40d36c3918d1ee12"
+                                 "729f95e11f0f0f3a517b858d4ca093faa35cc92f6a152152312398e5ec87cb636818020812a04667d7c"
+                                 "174d9b1303a6183dcd2c8f72d98f9f04988c299e01ed65ef65d5f413c22ea836eade5d7c5762fb81604"
+                                 "3f9cf82166d5d8fe558afa4e7b2c252374e589d6033908138c95c9145d603074aa81bff0055006f9ca4"
+                                 "30f28b82"))
     PROTOCOL_VERSION = 2
     BLOCK_CLASS = MarketBlock
     DB_NAME = 'market'
@@ -1556,8 +1560,9 @@ class MarketTestnetCommunity(MarketCommunity):
     """
     This community defines a testnet for the market.
     """
-    master_peer = Peer("3081a7301006072a8648ce3d020106052b81040027038192000401c7bdfc0069db5849a1fa3b3ef09e26828ae4a34"
-                       "4cfd8d042533988d50a4860edfdf4f71bccdc6dc1e76df1741a22546774d9a24162fd8e06e41a6fb3fc730fbc49c4"
-                       "502b4416b407fd2216f5a25efb87307dd83225c76cea762b098e51788cb42d4baa5c00487627bb9617bf40eea9ccb"
-                       "b16dfa88d2d3944c202e024d34ddd4e5b21ae7390622260f5551ef7cf99c9".decode('hex'))
+    master_peer = Peer(unhexlify("3081a7301006072a8648ce3d020106052b81040027038192000401c7bdfc0069db5849a1fa3b3ef09e2"
+                                 "6828ae4a344cfd8d042533988d50a4860edfdf4f71bccdc6dc1e76df1741a22546774d9a24162fd8e06"
+                                 "e41a6fb3fc730fbc49c4502b4416b407fd2216f5a25efb87307dd83225c76cea762b098e51788cb42d4"
+                                 "baa5c00487627bb9617bf40eea9ccbb16dfa88d2d3944c202e024d34ddd4e5b21ae7390622260f5551e"
+                                 "f7cf99c9"))
     DB_NAME = 'market_testnet'

--- a/Tribler/community/market/community.py
+++ b/Tribler/community/market/community.py
@@ -585,7 +585,8 @@ class MarketCommunity(Community, BlockListener):
         # Create the tick
         tick = Tick.from_order(order)
 
-        def on_block_created(block):
+        def on_block_created(blocks):
+            block, _ = blocks
             self.trustchain.send_block(block, ttl=2)
             if self.is_matchmaker:
                 tick.block_hash = block.hash
@@ -596,7 +597,7 @@ class MarketCommunity(Community, BlockListener):
             self.logger.info("Ask created with asset pair %s", assets)
             return order
 
-        return self.create_new_tick_block(tick).addCallback(lambda (blk, _): on_block_created(blk))
+        return self.create_new_tick_block(tick).addCallback(on_block_created)
 
     def create_bid(self, assets, timeout):
         """
@@ -619,7 +620,8 @@ class MarketCommunity(Community, BlockListener):
         # Create the tick
         tick = Tick.from_order(order)
 
-        def on_block_created(block):
+        def on_block_created(blocks):
+            block, _ = blocks
             self.trustchain.send_block(block, ttl=2)
             if self.is_matchmaker:
                 tick.block_hash = block.hash
@@ -630,7 +632,7 @@ class MarketCommunity(Community, BlockListener):
             self.logger.info("Bid created with asset pair %s", assets)
             return order
 
-        return self.create_new_tick_block(tick).addCallback(lambda (blk, _): on_block_created(blk))
+        return self.create_new_tick_block(tick).addCallback(on_block_created)
 
     def received_block(self, block):
         """
@@ -716,7 +718,7 @@ class MarketCommunity(Community, BlockListener):
         }
         deferred = self.trustchain.sign_block(peer, peer.public_key.key_to_bin(),
                                               block_type='tx_init', transaction=tx_dict)
-        return addCallback(deferred, lambda (blk1, blk2): blk1)
+        return addCallback(deferred, lambda blocks: blocks[0])
 
     @synchronized
     def create_new_tx_payment_block(self, peer, payment):
@@ -736,7 +738,7 @@ class MarketCommunity(Community, BlockListener):
         }
         deferred = self.trustchain.sign_block(peer, peer.public_key.key_to_bin(),
                                               block_type='tx_payment', transaction=tx_dict)
-        return addCallback(deferred, lambda (blk1, blk2): blk1)
+        return addCallback(deferred, lambda blocks: blocks[0])
 
     @synchronized
     def create_new_tx_done_block(self, peer, ask_order_dict, bid_order_dict, transaction):
@@ -762,7 +764,7 @@ class MarketCommunity(Community, BlockListener):
         }
         deferred = self.trustchain.sign_block(peer, peer.public_key.key_to_bin(),
                                               block_type='tx_done', transaction=tx_dict)
-        return addCallback(deferred, lambda (blk1, blk2): blk1)
+        return addCallback(deferred, lambda blocks: blocks[0])
 
     def on_tick(self, tick):
         """
@@ -1005,7 +1007,7 @@ class MarketCommunity(Community, BlockListener):
 
             if order.verified:
                 return self.create_new_cancel_order_block(order)\
-                    .addCallback(lambda (blk, _): self.trustchain.send_block(blk, ttl=2))
+                    .addCallback(lambda blocks: self.trustchain.send_block(blocks[0], ttl=2))
 
         return succeed(None)
 

--- a/Tribler/util.py
+++ b/Tribler/util.py
@@ -1,0 +1,11 @@
+"""
+This file contains various utility methods.
+"""
+from __future__ import absolute_import
+
+import sys
+
+if sys.version_info.major > 2:
+    cast_to_unicode_utf8 = lambda x: "".join([chr(c) for c in x]) if isinstance(x, bytes) else str(x)
+else:
+    cast_to_unicode_utf8 = lambda x: x.decode('utf-8')


### PR DESCRIPTION
In this PR, I made the minimal required changes to at least start executing the nosetests on Python 3. These changes should not break compatibility with the old Python 2 code. If the tests in this PR pass, this will give @cclauss a stable basis to work on.

I made a few changes to prevent us from porting Dispersy/pymdht. In particular, I made the imports that import either Dispersy or pymdht local. There were only a few of these and I think this is acceptable to do so we do not have to wait for these submodules to be removed.

All dependencies except for Meliae are available for Python 3, either via `pip` or `apt`.

Fixes #4092 

Related to #3883 