### PR TITLE
Fix basestring and unichr in Tribler/Test

### DIFF
--- a/Tribler/Test/Community/Search/FullSession/test_search_community.py
+++ b/Tribler/Test/Community/Search/FullSession/test_search_community.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+from six import unichr
 from twisted.internet import reactor
 from twisted.internet.defer import inlineCallbacks, Deferred
 

--- a/Tribler/Test/Core/Modules/RestApi/test_search_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_search_endpoint.py
@@ -1,4 +1,6 @@
 from __future__ import absolute_import
+
+from six import unichr
 from pony.orm import db_session
 from six.moves import xrange
 from twisted.internet.defer import inlineCallbacks

--- a/Tribler/Test/Core/Modules/RestApi/test_settings_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_settings_endpoint.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+from six import unichr
 from twisted.internet.defer import inlineCallbacks
 
 import Tribler.Core.Utilities.json_util as json

--- a/Tribler/Test/Core/test_sqlitecachedbhandler_preferences.py
+++ b/Tribler/Test/Core/test_sqlitecachedbhandler_preferences.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import
+
+from six import string_types
 from twisted.internet.defer import inlineCallbacks
 
 from Tribler.Core.CacheDB.SqliteCacheDBHandler import TorrentDBHandler, MyPreferenceDBHandler
@@ -65,7 +68,7 @@ class TestMyPreferenceDBHandler(AbstractDB):
         self.assertEqual(len(res), 12)
         for k in res:
             data = res[k]
-            self.assertIsInstance(data, basestring, "data is not destination_path: %s" % type(data))
+            self.assertIsInstance(data, string_types, "data is not destination_path: %s" % type(data))
 
         res = self.mdb.getMyPrefStats(torrent_id=126)
         self.assertEqual(len(res), 1)


### PR DESCRIPTION
In Tribler/Test:
* __from six import unichr__
* Change __basestring__ --> __six.string_types__
