### PR TITLE
Fixed bug where torrent_info was removed in loop

### DIFF
--- a/Tribler/Core/Libtorrent/LibtorrentDownloadImpl.py
+++ b/Tribler/Core/Libtorrent/LibtorrentDownloadImpl.py
@@ -436,7 +436,7 @@ class LibtorrentDownloadImpl(DownloadConfigInterface, TaskManager):
             self._logger.info("LibtorrentDownloadImpl: could not get info from download handle")
 
         for fileindex, bytes_begin, bytes_end in byteranges:
-            if fileindex >= 0:
+            if fileindex >= 0 and torrent_info:
                 # Ensure the we remain within the file's boundaries
                 file_entry = torrent_info.file_at(fileindex)
                 bytes_begin = min(


### PR DESCRIPTION
[Caught by the application tester](https://jenkins-ci.tribler.org/job/Deployment-Tests/job/Run_Tribler_Release/job/Run_Win7_32bit/65/console). It seems that `torrent_info` is removed while the interpreter executes a for-loop. To solve this, I've added a check in every loop for the existence of torrent info.