### PR TITLE
Python3 fixes in miscellaneous Tribler/Core files

### DIFF
--- a/Tribler/Core/APIImplementation/LaunchManyCore.py
+++ b/Tribler/Core/APIImplementation/LaunchManyCore.py
@@ -15,6 +15,7 @@ from glob import iglob
 from threading import Event, enumerate as enumerate_threads
 from traceback import print_exc
 
+from six import text_type
 from pony.orm import db_session
 from twisted.internet import reactor
 from twisted.internet.defer import Deferred, inlineCallbacks, DeferredList, succeed
@@ -218,7 +219,7 @@ class TriblerLaunchMany(TaskManager):
                 else:
                     dispersy_endpoint = MIMEndpoint(self.session.config.get_dispersy_port())
 
-                working_directory = unicode(self.session.config.get_state_dir())
+                working_directory = text_type(self.session.config.get_state_dir())
                 self.dispersy = Dispersy(dispersy_endpoint, working_directory)
                 self.dispersy.statistics.enable_debug_statistics(False)
 

--- a/Tribler/Core/Config/tribler_config.py
+++ b/Tribler/Core/Config/tribler_config.py
@@ -1,8 +1,12 @@
 """
 Configuration object for the Tribler Core.
 """
+from __future__ import absolute_import
+
 import logging
 import os
+
+from six import text_type
 
 from configobj import ConfigObj
 from validate import Validator
@@ -479,7 +483,7 @@ class TriblerConfig(object):
     def get_tunnel_community_socks5_listen_ports(self):
         ports = self.config['tunnel_community']['socks5_listen_ports']
         path = u'tunnel_community~socks5_listen_ports~'
-        return [self._get_random_port(path + unicode(index))
+        return [self._get_random_port(path + text_type(index))
                 if int(port) < 0 else int(port) for index, port in enumerate(ports)]
 
     def set_tunnel_community_exitnode_enabled(self, value):

--- a/Tribler/Core/CreditMining/CreditMiningManager.py
+++ b/Tribler/Core/CreditMining/CreditMiningManager.py
@@ -1,9 +1,12 @@
+from __future__ import absolute_import
+
 import os
 import psutil
 import logging
 
 from glob import glob
 from binascii import unhexlify, hexlify
+from six import string_types
 from twisted.internet.task import LoopingCall
 from twisted.internet.defer import Deferred, DeferredList, succeed
 
@@ -139,7 +142,7 @@ class CreditMiningManager(TaskManager):
         if source_str not in self.sources:
             num_torrents = len(self.torrents)
 
-            if isinstance(source_str, basestring) and len(source_str) == 40:
+            if isinstance(source_str, string_types) and len(source_str) == 40:
                 source = ChannelSource(self.session, source_str, self.on_torrent_insert)
             else:
                 self._logger.error('Cannot add unknown source %s', source_str)

--- a/Tribler/Core/DownloadConfig.py
+++ b/Tribler/Core/DownloadConfig.py
@@ -8,6 +8,8 @@ from __future__ import absolute_import
 import copy
 import logging
 import os
+
+from six import string_types
 from six.moves.configparser import MissingSectionHeaderError, ParsingError
 
 from Tribler.Core.Utilities.configparser import CallbackConfigParser
@@ -56,7 +58,7 @@ class DownloadConfigInterface(object):
         """ Sets the directory where to save this Download.
         @param path A path of a directory.
         """
-        assert isinstance(path, basestring), path
+        assert isinstance(path, string_types), path
         self.dlconfig.set('download_defaults', 'saveas', path)
 
     def get_dest_dir(self):

--- a/Tribler/Core/Session.py
+++ b/Tribler/Core/Session.py
@@ -33,6 +33,11 @@ from Tribler.Core.simpledefs import (NTFY_CHANNELCAST, NTFY_DELETE, NTFY_INSERT,
                                      STATE_LOAD_CHECKPOINTS, STATE_READABLE_STARTED, NTFY_TRIBLER, STATE_SHUTDOWN)
 from Tribler.Core.statistics import TriblerStatistics
 
+try:
+    long        # pylint: disable=long-builtin
+except NameError:
+    long = int  # pylint: disable=redefined-builtin
+
 if sys.platform == 'win32':
     SOCKET_BLOCK_ERRORCODE = 10035  # WSAEWOULDBLOCK
 else:

--- a/Tribler/Core/Upgrade/torrent_upgrade64.py
+++ b/Tribler/Core/Upgrade/torrent_upgrade64.py
@@ -3,12 +3,15 @@ Migration scripts for migrating to 6.4
 
 Author(s): Elric Milon
 """
+from __future__ import absolute_import
+
 import logging
 import os
 from binascii import hexlify
 from shutil import rmtree, move
 from sqlite3 import Connection
 
+from six.moves import xrange
 from Tribler.Core.TorrentDef import TorrentDef
 
 

--- a/Tribler/Core/__init__.py
+++ b/Tribler/Core/__init__.py
@@ -6,6 +6,11 @@ Author(s): Arno Bakker
 import logging
 from threading import RLock
 
+try:
+    long        # pylint: disable=long-builtin
+except NameError:
+    long = int  # pylint: disable=redefined-builtin
+
 logger = logging.getLogger(__name__)
 
 

--- a/Tribler/Core/osutils.py
+++ b/Tribler/Core/osutils.py
@@ -6,10 +6,14 @@ The function get_home_dir returns CSIDL_APPDATA i.e. App data directory on win32
 Author(s): Arno Bakker
 """
 
+from __future__ import absolute_import
+
 import logging
 import os
 import subprocess
 import sys
+
+from six import text_type
 
 logger = logging.getLogger(__name__)
 
@@ -54,6 +58,7 @@ if sys.platform == "win32":
 
     except ImportError:
         def get_home_dir():
+            unicode_error = None  # forward declare for Python 3 scoping rules
             try:
                 # when there are special unicode characters in the username,
                 # the following will fail on python 2.4, 2.5, 2.x this will
@@ -62,12 +67,12 @@ if sys.platform == "win32":
             except Exception as unicode_error:
                 pass
 
-            # non-unicode home
+            # non-Unicode home
             home = os.path.expanduser("~")
             head, tail = os.path.split(home)
 
             dirs = os.listdir(head)
-            udirs = os.listdir(unicode(head))
+            udirs = os.listdir(text_type(head))
 
             # the character set may be different, but the string length is
             # still the same
@@ -77,7 +82,7 @@ if sys.platform == "win32":
             if len(dirs) == 1 and len(udirs) == 1:
                 return os.path.join(head, udirs[0])
 
-            # remove all dirs that are equal in unicode and non-unicode. we
+            # remove all dirs that are equal in Unicode and non-Unicode. we
             # know that we don't need these dirs because the initial
             # expandusers would not have failed on them
             for dir in dirs[:]:
@@ -126,10 +131,10 @@ if sys.platform == "win32":
 elif is_android():
 
     def get_home_dir():
-        return os.path.realpath(unicode(os.environ['EXTERNAL_STORAGE']))
+        return os.path.realpath(text_type(os.environ['EXTERNAL_STORAGE']))
 
     def get_appstate_dir():
-        return os.path.realpath(os.path.join(unicode(os.environ['ANDROID_PRIVATE']), u'../.Tribler'))
+        return os.path.realpath(os.path.join(text_type(os.environ['ANDROID_PRIVATE']), u'../.Tribler'))
 
     def get_picture_dir():
         return os.path.join(get_home_dir(), u'DCIM')

--- a/Tribler/Core/statistics.py
+++ b/Tribler/Core/statistics.py
@@ -1,5 +1,9 @@
+from __future__ import absolute_import
+
 import os
 import time
+
+from six import text_type
 
 from Tribler.Core.CacheDB.sqlitecachedb import DB_FILE_RELATIVE_PATH
 from Tribler.Core.exceptions import OperationNotEnabledByConfigurationException
@@ -56,7 +60,7 @@ class TriblerStatistics(object):
         return {
             "wan_address": "%s:%d" % stats.wan_address,
             "lan_address": "%s:%d" % stats.lan_address,
-            "connection": unicode(stats.connection_type),
+            "connection": text_type(stats.connection_type),
             "runtime": stats.timestamp - stats.start,
             "total_downloaded": stats.total_down,
             "total_uploaded": stats.total_up,


### PR DESCRIPTION
This PR proposes fixes to files in Tribler/Core that are _not_ contained in:
* Tribler/Core/CacheDB
* Tribler/Core/Modules
* Tribler/Core/Libtorrent + TorrentChecker + TorrentDef.py
* Tribler/Core/Utilities --> #4115