### PR TITLE
Retrying REST API initialization on failure

### DIFF
--- a/Tribler/Core/Config/config.spec
+++ b/Tribler/Core/Config/config.spec
@@ -117,6 +117,7 @@ directory = string(default='')
 [http_api]
 enabled = boolean(default=False)
 port = integer(min=-1, max=65536, default=-1)
+retry_port = boolean(default=False)
 
 [resource_monitor]
 enabled = boolean(default=True)

--- a/Tribler/Core/Config/tribler_config.py
+++ b/Tribler/Core/Config/tribler_config.py
@@ -248,6 +248,12 @@ class TriblerConfig(object):
     def get_http_api_port(self):
         return self._obtain_port('http_api', 'port')
 
+    def set_http_api_retry_port(self, retry_port):
+        self.config['http_api']['retry_port'] = retry_port
+
+    def get_http_api_retry_port(self):
+        return self.config['http_api']['retry_port']
+
     # Dispersy
 
     def set_dispersy_enabled(self, value):

--- a/Tribler/Test/Core/Config/test_tribler_config.py
+++ b/Tribler/Test/Core/Config/test_tribler_config.py
@@ -159,6 +159,8 @@ class TestTriblerConfig(TriblerCoreTest):
         self.assertEqual(self.tribler_config.get_http_api_enabled(), True)
         self.tribler_config.set_http_api_port(True)
         self.assertEqual(self.tribler_config.get_http_api_port(), True)
+        self.tribler_config.set_http_api_retry_port(True)
+        self.assertTrue(self.tribler_config.get_http_api_retry_port())
 
     def test_get_set_methods_dispersy(self):
         """

--- a/Tribler/Test/Core/Modules/RestApi/base_api_test.py
+++ b/Tribler/Test/Core/Modules/RestApi/base_api_test.py
@@ -59,6 +59,7 @@ class AbstractBaseApiTest(TestAsServer):
     def setUpPreSession(self):
         super(AbstractBaseApiTest, self).setUpPreSession()
         self.config.set_http_api_enabled(True)
+        self.config.set_http_api_retry_port(True)
         self.config.set_megacache_enabled(True)
         self.config.set_tunnel_community_enabled(False)
 

--- a/TriblerGUI/code_executor.py
+++ b/TriblerGUI/code_executor.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import
+
+from base64 import b64encode
 import binascii
 import code
 import io
@@ -51,6 +54,7 @@ class CodeExecutor(object):
         self.logger.info("Code execution with task %s finished:", task_id)
         self.logger.info("Stdout of task %s: %s", task_id, stdout)
         if ('Traceback' in stderr or 'SyntaxError' in stderr) and 'SystemExit' not in stderr:
+            self.logger.info("Executed code with failure: %s", b64encode(code))
             raise RuntimeError("Error during remote code execution! %s" % stderr)
 
         # Determine the return value


### PR DESCRIPTION
This should fix the nasty win64 error we occasionally observe when running unit tests.

I also log the code being executed when the remote code execution unit fails. This should help me to debug errors like in https://jenkins-ci.tribler.org/job/Deployment-Tests/job/Run_Tribler_Release/job/Run_Win7_64bit/68/.