### PR TITLE
from six.moves.configparser import RawConfigParser

### DIFF
--- a/Tribler/Test/Core/Upgrade/test_config_upgrade_70_71.py
+++ b/Tribler/Test/Core/Upgrade/test_config_upgrade_70_71.py
@@ -1,6 +1,6 @@
 import os
 import shutil
-from ConfigParser import RawConfigParser
+from six.moves.configparser import RawConfigParser
 
 from Tribler.Core.simpledefs import STATEDIR_DLPSTATE_DIR
 from configobj import ConfigObj

--- a/Tribler/Test/Core/Upgrade/test_config_upgrade_70_71.py
+++ b/Tribler/Test/Core/Upgrade/test_config_upgrade_70_71.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import os
 import shutil
 from six.moves.configparser import RawConfigParser


### PR DESCRIPTION
For compatibility with both Python 2 and Python 3