### PR TITLE
Added price details to GUI list with asks/bids

### DIFF
--- a/TriblerGUI/widgets/marketpage.py
+++ b/TriblerGUI/widgets/marketpage.py
@@ -128,8 +128,10 @@ class MarketPage(QWidget):
         self.window().create_bid_button.setText("Buy %s for %s" % (self.chosen_wallets[0], self.chosen_wallets[1]))
 
         # Update headers of the tree widget
+        self.window().asks_list.headerItem().setText(0, 'Price (%s/%s)' % self.chosen_wallets[::-1])
         self.window().asks_list.headerItem().setText(1, '%s' % self.chosen_wallets[0])
         self.window().asks_list.headerItem().setText(2, 'Total (%s)' % self.chosen_wallets[0])
+        self.window().bids_list.headerItem().setText(2, 'Price (%s/%s)' % self.chosen_wallets[::-1])
         self.window().bids_list.headerItem().setText(1, '%s' % self.chosen_wallets[0])
         self.window().bids_list.headerItem().setText(0, 'Total (%s)' % self.chosen_wallets[0])
 


### PR DESCRIPTION
For clarity, I now show the details of the price of each market order.

Related to #4131 

![schermafbeelding 2018-12-22 om 21 01 55](https://user-images.githubusercontent.com/1707075/50378623-211c9500-0637-11e9-817e-b7a7199b8efe.png)
