### PR TITLE
Market timeout fix

### DIFF
--- a/Tribler/Test/Community/Market/test_block.py
+++ b/Tribler/Test/Community/Market/test_block.py
@@ -1,5 +1,8 @@
+from __future__ import absolute_import
+
 from twisted.internet.defer import inlineCallbacks
 
+from Tribler.Test.test_as_server import AbstractServer
 from Tribler.community.market.block import MarketBlock
 from Tribler.community.market.core.assetamount import AssetAmount
 from Tribler.community.market.core.assetpair import AssetPair
@@ -9,7 +12,6 @@ from Tribler.community.market.core.tick import Ask
 from Tribler.community.market.core.timeout import Timeout
 from Tribler.community.market.core.timestamp import Timestamp
 from Tribler.community.market.core.transaction import Transaction, TransactionId, TransactionNumber
-from Tribler.Test.test_as_server import AbstractServer
 
 
 class TestMarketBlock(AbstractServer):
@@ -71,6 +73,10 @@ class TestMarketBlock(AbstractServer):
         Test whether a tick block can be correctly verified
         """
         self.assertTrue(self.tick_block.is_valid_tick_block())
+
+        self.tick_block.transaction['tick']['timeout'] = -1
+        self.assertFalse(self.tick_block.is_valid_tick_block())
+        self.tick_block.transaction['tick']['timeout'] = 3600
 
         self.tick_block.type = 'test'
         self.assertFalse(self.tick_block.is_valid_tick_block())

--- a/Tribler/Test/Community/Market/test_community.py
+++ b/Tribler/Test/Community/Market/test_community.py
@@ -1,22 +1,26 @@
+from __future__ import absolute_import
+
+from nose.tools import raises
+
+from twisted.internet.defer import fail, inlineCallbacks
 from twisted.python.failure import Failure
 
 from Tribler.Core.Modules.wallet.dummy_wallet import DummyWallet1, DummyWallet2
 from Tribler.Core.Modules.wallet.tc_wallet import TrustchainWallet
 from Tribler.Test.Core.base_test import MockObject
+from Tribler.Test.tools import trial_timeout
 from Tribler.community.market.block import MarketBlock
-from Tribler.community.market.community import MarketCommunity, PingRequestCache
+from Tribler.community.market.community import MarketCommunity
 from Tribler.community.market.core.assetamount import AssetAmount
 from Tribler.community.market.core.assetpair import AssetPair
 from Tribler.community.market.core.message import TraderId
-from Tribler.community.market.core.order import OrderId, OrderNumber, Order
+from Tribler.community.market.core.order import Order, OrderId, OrderNumber
 from Tribler.community.market.core.tick import Ask, Bid
 from Tribler.community.market.core.timeout import Timeout
 from Tribler.community.market.core.timestamp import Timestamp
-from Tribler.community.market.core.transaction import TransactionId, TransactionNumber, Transaction
+from Tribler.community.market.core.transaction import Transaction, TransactionId, TransactionNumber
 from Tribler.pyipv8.ipv8.test.base import TestBase
 from Tribler.pyipv8.ipv8.test.mocking.ipv8 import MockIPv8
-from Tribler.Test.tools import trial_timeout
-from twisted.internet.defer import fail, succeed, inlineCallbacks
 
 
 class TestMarketCommunityBase(TestBase):
@@ -515,3 +519,10 @@ class TestMarketCommunitySingle(TestMarketCommunityBase):
         self.nodes[0].overlay.received_block(tx_done)
         self.assertEqual(len(self.nodes[0].overlay.order_book.asks), 0)
         self.assertEqual(len(self.nodes[0].overlay.order_book.bids), 0)
+
+    @raises(RuntimeError)
+    def test_order_invalid_timeout(self):
+        """
+        Test whether we cannot create an order with an invalid timeout
+        """
+        self.nodes[0].overlay.create_ask(AssetPair(AssetAmount(10, 'DUM1'), AssetAmount(10, 'DUM2')), 3600 * 1000)

--- a/Tribler/community/market/block.py
+++ b/Tribler/community/market/block.py
@@ -1,3 +1,7 @@
+from __future__ import absolute_import
+
+from six import integer_types
+
 from Tribler.pyipv8.ipv8.attestation.trustchain.block import TrustChainBlock
 
 
@@ -30,9 +34,9 @@ class MarketBlock(TrustChainBlock):
         if 'amount' not in assets_dict['second'] or 'type' not in assets_dict['second']:
             return False
 
-        if not MarketBlock.has_required_types([('amount', (int, long)), ('type', str)], assets_dict['first']):
+        if not MarketBlock.has_required_types([('amount', integer_types), ('type', str)], assets_dict['first']):
             return False
-        if not MarketBlock.has_required_types([('amount', (int, long)), ('type', str)], assets_dict['second']):
+        if not MarketBlock.has_required_types([('amount', integer_types), ('type', str)], assets_dict['second']):
             return False
 
         if amount_positive and (assets_dict['first']['amount'] <= 0 or assets_dict['second']['amount'] <= 0):
@@ -68,6 +72,8 @@ class MarketBlock(TrustChainBlock):
         if not MarketBlock.is_valid_asset_pair(tick['assets']):
             return False
         if not MarketBlock.has_required_types(required_types, tick):
+            return False
+        if tick['timeout'] < 0 or tick['timeout'] > 3600 * 24:
             return False
 
         return True

--- a/Tribler/community/market/core/wallet_address.py
+++ b/Tribler/community/market/core/wallet_address.py
@@ -10,7 +10,7 @@ class WalletAddress(object):
         super(WalletAddress, self).__init__()
 
         if not isinstance(wallet_address, str):
-            raise ValueError("Wallet address must be a string")
+            raise ValueError("Wallet address must be a string, found %s instead" % type(wallet_address))
 
         self._wallet_address = wallet_address
 


### PR DESCRIPTION
The timeout can now be at most one day, which I think is reasonable. Orders with a negative timeout, or a timeout that is higher than one day will be considered invalid and not be added to the orderbook.

@MattSkala I also added some more information when the initialization of a `WalletAddress` is failing. This might help you to debug #4148.

Fixes #4147 