### PR TITLE
Fixed e2e payout test

### DIFF
--- a/Tribler/Test/Community/Tunnel/test_community.py
+++ b/Tribler/Test/Community/Tunnel/test_community.py
@@ -292,7 +292,7 @@ class TestTriblerTunnelCommunity(TestBase):
 
         # Verify whether the downloader (node 0) correctly paid the subsequent nodes.
         self.assertTrue(self.nodes[0].overlay.bandwidth_wallet.get_bandwidth_tokens() < 0)
-        self.assertTrue(self.nodes[1].overlay.bandwidth_wallet.get_bandwidth_tokens() > 0)
+        self.assertTrue(self.nodes[1].overlay.bandwidth_wallet.get_bandwidth_tokens() >= 0)
         self.assertTrue(self.nodes[2].overlay.bandwidth_wallet.get_bandwidth_tokens() > 0)
 
     @inlineCallbacks


### PR DESCRIPTION
After the change that randomly picks the first relay node, it is possible to have an e2e circuit that goes like 0 (downloader) -> 2 -> 0 -> 2 (seeder). In this case, node 1 will remain with a balance of zero after payouts.