### PR TITLE
Removed non-existing directory from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ data_dirs = [
     'Tribler.Test.Core.data',
     'Tribler.Test.Core.data.config_files',
     'Tribler.Test.Core.data.libtorrent',
-    'Tribler.Test.Core.data.sqlite_scripts',
     'Tribler.Test.Core.data.torrent_creation_files',
     'Tribler.Test.Core.data.upgrade_databases',
 ]


### PR DESCRIPTION
This fixes the build on Debian and Arch, see https://jenkins-ci.tribler.org/job/Build-Tribler_release/job/Build-Custom/