### PR TITLE
Fixed double logging

### DIFF
--- a/logger.conf
+++ b/logger.conf
@@ -19,7 +19,6 @@ keys=root,twisted,
     TrustChainCommunity,
     PopularityCommunity,
     DHTDiscoveryCommunity,
-    PreviewChannelCommunity,
     MarketCommunity,
     
     MetadataStore,
@@ -87,7 +86,7 @@ args=(4*1024,) # 4KB buffer
 
 [logger_root]
 level=INFO
-handlers=default,infoMemoryHandler,errorHandler,debugging
+handlers=default,infoMemoryHandler,errorHandler
 
 [logger_twisted]
 level=ERROR
@@ -185,12 +184,6 @@ propagate=0
 [logger_DHTDiscoveryCommunity]
 level=INFO
 qualname=DHTDiscoveryCommunity
-handlers=default
-propagate=0
-
-[logger_PreviewChannelCommunity]
-level=INFO
-qualname=PreviewChannelCommunity
 handlers=default
 propagate=0
 


### PR DESCRIPTION
Also removed an unused logger entry in `logger.conf`.

Fixes #4243 