### PR TITLE
Validating payout block when receiving it

### DIFF
--- a/Tribler/Core/Modules/wallet/bandwidth_block.py
+++ b/Tribler/Core/Modules/wallet/bandwidth_block.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
-from Tribler.pyipv8.ipv8.attestation.trustchain.block import TrustChainBlock, EMPTY_SIG, ValidationResult,\
-    GENESIS_SEQ, GENESIS_HASH
+from Tribler.pyipv8.ipv8.attestation.trustchain.block import EMPTY_SIG, GENESIS_HASH, GENESIS_SEQ, TrustChainBlock, \
+    ValidationResult
 from Tribler.pyipv8.ipv8.messaging.deprecated.encoding import encode
 
 
@@ -60,7 +60,6 @@ class TriblerBandwidthBlock(TrustChainBlock):
     def validate_transaction(self, database):
         """
         Validates this transaction
-        :param transaction the transaction to validate
         :param database: the database to check against
         :return: A tuple consisting of a ValidationResult and a list of user string errors
         """

--- a/Tribler/community/triblertunnel/community.py
+++ b/Tribler/community/triblertunnel/community.py
@@ -211,6 +211,11 @@ class TriblerTunnelCommunity(HiddenTunnelCommunity):
         block = TriblerBandwidthBlock.from_payload(payload, self.serializer)
         self.bandwidth_wallet.trustchain.process_half_block(block, peer)
 
+        # Check whether the block has been added to the database and has been verified
+        if not self.bandwidth_wallet.trustchain.persistence.contains(block):
+            self.logger.warning("Not proceeding with payout - received payout block is not valid")
+            return
+
         # Send the next payout
         if payload.circuit_id in self.relay_from_to and block.transaction['down'] > payload.base_amount:
             relay = self.relay_from_to[payload.circuit_id]


### PR DESCRIPTION
Not validating this block could lead to bandwidth being transferred by a relay while not counter-signing a payout block they received.

Fixes #4247 