### PR TITLE
Fix TorrentChecker timeout logging

### DIFF
--- a/Tribler/Core/Modules/MetadataStore/store.py
+++ b/Tribler/Core/Modules/MetadataStore/store.py
@@ -12,7 +12,7 @@ from pony.orm import db_session
 from Tribler.Core.Modules.MetadataStore.OrmBindings import channel_metadata, channel_node, misc, torrent_metadata, \
     torrent_state, tracker_state
 from Tribler.Core.Modules.MetadataStore.OrmBindings.channel_metadata import BLOB_EXTENSION
-from Tribler.Core.Modules.MetadataStore.serialization import CHANNEL_TORRENT, ChannelMetadataPayload, DELETED, \
+from Tribler.Core.Modules.MetadataStore.serialization import CHANNEL_TORRENT, DELETED, \
     REGULAR_TORRENT, read_payload_with_offset, time2int
 from Tribler.Core.exceptions import InvalidSignatureException
 
@@ -200,6 +200,7 @@ class MetadataStore(object):
 
         return (self.process_compressed_mdblob(serialized_data) if filepath.endswith('.lz4') else
                 self.process_squashed_mdblob(serialized_data))
+
     @db_session
     def process_compressed_mdblob(self, compressed_data):
         return self.process_squashed_mdblob(lz4.frame.decompress(compressed_data))

--- a/Tribler/Core/TorrentChecker/session.py
+++ b/Tribler/Core/TorrentChecker/session.py
@@ -263,7 +263,6 @@ class HttpTrackerSession(TrackerSession):
         Handles the case of an error during the request.
         :param failure: The failure object that is thrown by a deferred.
         """
-        self._logger.info("Error when querying http tracker: %s %s", str(failure), self.tracker_url)
         self.failed(msg=failure.getErrorMessage())
 
     def on_response(self, response):
@@ -425,7 +424,6 @@ class UdpTrackerSession(TrackerSession):
         Handles the case when resolving an ip address fails.
         :param failure: The failure object thrown by the deferred.
         """
-        self._logger.info("Error when querying UDP tracker: %s %s", str(failure), self.tracker_url)
         self.failed(msg=failure.getErrorMessage())
 
     def _on_cancel(self, _):

--- a/Tribler/Core/TorrentChecker/torrent_checker.py
+++ b/Tribler/Core/TorrentChecker/torrent_checker.py
@@ -8,7 +8,7 @@ from binascii import hexlify
 from pony.orm import db_session
 
 from twisted.internet import reactor
-from twisted.internet.defer import CancelledError, DeferredList, fail, maybeDeferred, succeed
+from twisted.internet.defer import CancelledError, DeferredList, maybeDeferred, succeed
 from twisted.internet.error import ConnectingCancelledError, ConnectionLost
 from twisted.python.failure import Failure
 from twisted.web.client import HTTPConnectionPool
@@ -264,7 +264,8 @@ class TorrentChecker(TaskManager):
         :param failure: The failure object raised by Twisted.
         """
         failure.trap(ValueError, CancelledError, ConnectingCancelledError, ConnectionLost, RuntimeError)
-        self._logger.warning(u"Got session error for URL %s: %s", session.tracker_url, failure)
+        self._logger.warning(u"Got session error for URL %s: %s", session.tracker_url,
+                             str(failure).replace(u'\n]', u']'))
 
         self.clean_session(session)
 


### PR DESCRIPTION
This PR solves #4228 by removing `INFO`-level logging with full tracebacks in the TorrentChecker, and fixing the single-line twisted tracebacks there to be really single-line, e.g.:
**Before:**
```
INFO    1551286977.55                   session:266  (HttpTrackerSession)  Error when querying http tracker: [Failure instance: Traceback: <class 'twisted.internet.error.DNSLookupError'>: DNS lookup failed: no results for hostname lookup: tracker.thepiratebay.org.
/home/vader/.local/lib/python2.7/site-packages/twisted/internet/_resolver.py:137:deliverResults
/home/vader/.local/lib/python2.7/site-packages/twisted/internet/endpoints.py:921:resolutionComplete
/home/vader/.local/lib/python2.7/site-packages/twisted/internet/defer.py:459:callback
/home/vader/.local/lib/python2.7/site-packages/twisted/internet/defer.py:567:_startRunCallbacks
--- <exception caught here> ---
/home/vader/.local/lib/python2.7/site-packages/twisted/internet/defer.py:653:_runCallbacks
/home/vader/.local/lib/python2.7/site-packages/twisted/internet/endpoints.py:975:startConnectionAttempts
] http://tracker.thepiratebay.org/announce
WARNING 1551286977.55           torrent_checker:267  (TorrentChecker)  Got session error for URL http://tracker.thepiratebay.org/announce: [Failure instance: Traceback (failure with no frames): <type 'exceptions.ValueError'>: HTTP tracker failed for url http://tracker.thepiratebay.org/announce (error: DNS lookup failed: no results for hostname lookup: tracker.thepiratebay.org.)
]
```
**After:**
```
WARNING 1551286977.55           torrent_checker:267  (TorrentChecker)  Got session error for URL http://tracker.thepiratebay.org/announce: [Failure instance: Traceback (failure with no frames): <type 'exceptions.ValueError'>: HTTP tracker failed for url http://tracker.thepiratebay.org/announce (error: DNS lookup failed: no results for hostname lookup: tracker.thepiratebay.org.)]
```