### PR TITLE
READY: unicode(s, enc) --> ensure_unicode(s, enc)

### DIFF
--- a/Tribler/Core/Modules/restapi/create_torrent_endpoint.py
+++ b/Tribler/Core/Modules/restapi/create_torrent_endpoint.py
@@ -7,9 +7,9 @@ import logging
 from twisted.web import http, resource
 from twisted.web.server import NOT_DONE_YET
 
+import Tribler.Core.Utilities.json_util as json
 from Tribler.Core.DownloadConfig import DownloadStartupConfig
 from Tribler.Core.Modules.restapi.util import return_handled_exception
-import Tribler.Core.Utilities.json_util as json
 from Tribler.Core.Utilities.unicode import ensure_text
 from Tribler.Core.exceptions import DuplicateDownloadException
 

--- a/Tribler/Core/Modules/restapi/create_torrent_endpoint.py
+++ b/Tribler/Core/Modules/restapi/create_torrent_endpoint.py
@@ -6,6 +6,7 @@ from twisted.web.server import NOT_DONE_YET
 
 from Tribler.Core.DownloadConfig import DownloadStartupConfig
 from Tribler.Core.Modules.restapi.util import return_handled_exception
+from Tribler.Core.Utilities.unicode import ensure_text
 from Tribler.Core.exceptions import DuplicateDownloadException
 import Tribler.Core.Utilities.json_util as json
 
@@ -57,7 +58,7 @@ class CreateTorrentEndpoint(resource.Resource):
         params = {}
 
         if 'files[]' in parameters and len(parameters['files[]']) > 0:
-            file_path_list = [unicode(f, 'utf-8') for f in parameters['files[]']]
+            file_path_list = [ensure_text(f, 'utf-8') for f in parameters['files[]']]
         else:
             request.setResponseCode(http.BAD_REQUEST)
             return json.dumps({"error": "files parameter missing"})

--- a/Tribler/Core/Modules/restapi/create_torrent_endpoint.py
+++ b/Tribler/Core/Modules/restapi/create_torrent_endpoint.py
@@ -10,7 +10,7 @@ from twisted.web.server import NOT_DONE_YET
 import Tribler.Core.Utilities.json_util as json
 from Tribler.Core.DownloadConfig import DownloadStartupConfig
 from Tribler.Core.Modules.restapi.util import return_handled_exception
-from Tribler.Core.Utilities.unicode import ensure_text
+from Tribler.Core.Utilities.unicode import ensure_unicode
 from Tribler.Core.exceptions import DuplicateDownloadException
 
 
@@ -61,7 +61,7 @@ class CreateTorrentEndpoint(resource.Resource):
         params = {}
 
         if 'files[]' in parameters and len(parameters['files[]']) > 0:
-            file_path_list = [ensure_text(f, 'utf-8') for f in parameters['files[]']]
+            file_path_list = [ensure_unicode(f, 'utf-8') for f in parameters['files[]']]
         else:
             request.setResponseCode(http.BAD_REQUEST)
             return json.dumps({"error": "files parameter missing"})

--- a/Tribler/Core/Modules/restapi/create_torrent_endpoint.py
+++ b/Tribler/Core/Modules/restapi/create_torrent_endpoint.py
@@ -1,14 +1,17 @@
+from __future__ import absolute_import
+
 import base64
 import json
 import logging
+
 from twisted.web import http, resource
 from twisted.web.server import NOT_DONE_YET
 
 from Tribler.Core.DownloadConfig import DownloadStartupConfig
 from Tribler.Core.Modules.restapi.util import return_handled_exception
+import Tribler.Core.Utilities.json_util as json
 from Tribler.Core.Utilities.unicode import ensure_text
 from Tribler.Core.exceptions import DuplicateDownloadException
-import Tribler.Core.Utilities.json_util as json
 
 
 class CreateTorrentEndpoint(resource.Resource):

--- a/Tribler/Core/TorrentDef.py
+++ b/Tribler/Core/TorrentDef.py
@@ -13,7 +13,7 @@ from hashlib import sha1
 from libtorrent import bdecode, bencode
 
 import six
-from six import text_type
+from six import ensure_text, text_type
 
 from Tribler.Core.Utilities import maketorrent
 from Tribler.Core.Utilities.unicode import dunno2unicode
@@ -549,7 +549,7 @@ class TorrentDef(object):
             # There is an utf-8 encoded name.  We assume that it is
             # correctly encoded and use it normally
             try:
-                return unicode(self.metainfo["info"]["name.utf-8"], "UTF-8")
+                return ensure_text(self.metainfo["info"]["name.utf-8"], "UTF-8")
             except UnicodeError:
                 pass
 
@@ -558,7 +558,7 @@ class TorrentDef(object):
             # should contain something like 'utf-8'
             if "encoding" in self.metainfo:
                 try:
-                    return unicode(self.metainfo["info"]["name"], self.metainfo["encoding"])
+                    return ensure_text(self.metainfo["info"]["name"], self.metainfo["encoding"])
                 except UnicodeError:
                     pass
                 except LookupError:
@@ -577,7 +577,7 @@ class TorrentDef(object):
             # Try to convert the names in path to unicode, assuming
             # that it was encoded as utf-8
             try:
-                return unicode(self.metainfo["info"]["name"], "UTF-8")
+                return ensure_text(self.metainfo["info"]["name"], "UTF-8")
             except UnicodeError:
                 pass
 
@@ -648,7 +648,8 @@ class TorrentDef(object):
                     # We assume that it is correctly encoded and use
                     # it normally
                     try:
-                        yield join(*[unicode(element, "UTF-8") for element in file_dict["path.utf-8"]]), file_dict["length"]
+                        yield (join(*[ensure_text(element, "UTF-8") for element in file_dict["path.utf-8"]]),
+                               file_dict["length"])
                         continue
                     except UnicodeError:
                         pass
@@ -659,7 +660,8 @@ class TorrentDef(object):
                     if "encoding" in self.metainfo:
                         encoding = self.metainfo["encoding"]
                         try:
-                            yield join(*[unicode(element, encoding) for element in file_dict["path"]]), file_dict["length"]
+                            yield (join(*[ensure_text(element, encoding) for element in file_dict["path"]]),
+                                   file_dict["length"])
                             continue
                         except UnicodeError:
                             pass
@@ -681,7 +683,8 @@ class TorrentDef(object):
                     # Try to convert the names in path to unicode,
                     # assuming that it was encoded as utf-8
                     try:
-                        yield join(*[unicode(element, "UTF-8") for element in file_dict["path"]]), file_dict["length"]
+                        yield (join(*[ensure_text(element, "UTF-8") for element in file_dict["path"]]),
+                               file_dict["length"])
                         continue
                     except UnicodeError:
                         pass

--- a/Tribler/Core/TorrentDef.py
+++ b/Tribler/Core/TorrentDef.py
@@ -13,7 +13,7 @@ from hashlib import sha1
 from libtorrent import bdecode, bencode
 
 import six
-from six import ensure_text, text_type
+from six import binary_type, text_type  # ensure_text
 
 from Tribler.Core.Utilities import maketorrent
 from Tribler.Core.Utilities.unicode import dunno2unicode
@@ -21,6 +21,17 @@ from Tribler.Core.Utilities.utilities import create_valid_metainfo, http_get, is
 from Tribler.Core.defaults import TDEF_DEFAULTS
 from Tribler.Core.exceptions import NotYetImplementedException, TorrentDefNotFinalizedException
 from Tribler.Core.simpledefs import INFOHASH_LENGTH
+
+
+def ensure_text(s, encoding='utf-8', errors='strict'):
+    """Copied from https://github.com/benjaminp/six/blob/master/six.py
+    """
+    if isinstance(s, binary_type):
+        return s.decode(encoding, errors)
+    elif isinstance(s, text_type):
+        return s
+    else:
+        raise TypeError("not expecting type '%s'" % type(s))
 
 
 def escape_as_utf8(string, encoding='utf8'):

--- a/Tribler/Core/TorrentDef.py
+++ b/Tribler/Core/TorrentDef.py
@@ -13,25 +13,14 @@ from hashlib import sha1
 from libtorrent import bdecode, bencode
 
 import six
-from six import binary_type, text_type  # ensure_text
+from six import text_type
 
 from Tribler.Core.Utilities import maketorrent
-from Tribler.Core.Utilities.unicode import dunno2unicode
+from Tribler.Core.Utilities.unicode import dunno2unicode, ensure_text
 from Tribler.Core.Utilities.utilities import create_valid_metainfo, http_get, is_valid_url, parse_magnetlink
 from Tribler.Core.defaults import TDEF_DEFAULTS
 from Tribler.Core.exceptions import NotYetImplementedException, TorrentDefNotFinalizedException
 from Tribler.Core.simpledefs import INFOHASH_LENGTH
-
-
-def ensure_text(s, encoding='utf-8', errors='strict'):
-    """Copied from https://github.com/benjaminp/six/blob/master/six.py
-    """
-    if isinstance(s, binary_type):
-        return s.decode(encoding, errors)
-    elif isinstance(s, text_type):
-        return s
-    else:
-        raise TypeError("not expecting type '%s'" % type(s))
 
 
 def escape_as_utf8(string, encoding='utf8'):

--- a/Tribler/Core/TorrentDef.py
+++ b/Tribler/Core/TorrentDef.py
@@ -16,7 +16,7 @@ import six
 from six import text_type
 
 from Tribler.Core.Utilities import maketorrent
-from Tribler.Core.Utilities.unicode import dunno2unicode, ensure_text
+from Tribler.Core.Utilities.unicode import dunno2unicode, ensure_unicode
 from Tribler.Core.Utilities.utilities import create_valid_metainfo, http_get, is_valid_url, parse_magnetlink
 from Tribler.Core.defaults import TDEF_DEFAULTS
 from Tribler.Core.exceptions import NotYetImplementedException, TorrentDefNotFinalizedException
@@ -549,7 +549,7 @@ class TorrentDef(object):
             # There is an utf-8 encoded name.  We assume that it is
             # correctly encoded and use it normally
             try:
-                return ensure_text(self.metainfo["info"]["name.utf-8"], "UTF-8")
+                return ensure_unicode(self.metainfo["info"]["name.utf-8"], "UTF-8")
             except UnicodeError:
                 pass
 
@@ -558,7 +558,7 @@ class TorrentDef(object):
             # should contain something like 'utf-8'
             if "encoding" in self.metainfo:
                 try:
-                    return ensure_text(self.metainfo["info"]["name"], self.metainfo["encoding"])
+                    return ensure_unicode(self.metainfo["info"]["name"], self.metainfo["encoding"])
                 except UnicodeError:
                     pass
                 except LookupError:
@@ -577,7 +577,7 @@ class TorrentDef(object):
             # Try to convert the names in path to unicode, assuming
             # that it was encoded as utf-8
             try:
-                return ensure_text(self.metainfo["info"]["name"], "UTF-8")
+                return ensure_unicode(self.metainfo["info"]["name"], "UTF-8")
             except UnicodeError:
                 pass
 
@@ -648,7 +648,7 @@ class TorrentDef(object):
                     # We assume that it is correctly encoded and use
                     # it normally
                     try:
-                        yield (join(*[ensure_text(element, "UTF-8") for element in file_dict["path.utf-8"]]),
+                        yield (join(*[ensure_unicode(element, "UTF-8") for element in file_dict["path.utf-8"]]),
                                file_dict["length"])
                         continue
                     except UnicodeError:
@@ -660,7 +660,7 @@ class TorrentDef(object):
                     if "encoding" in self.metainfo:
                         encoding = self.metainfo["encoding"]
                         try:
-                            yield (join(*[ensure_text(element, encoding) for element in file_dict["path"]]),
+                            yield (join(*[ensure_unicode(element, encoding) for element in file_dict["path"]]),
                                    file_dict["length"])
                             continue
                         except UnicodeError:
@@ -683,7 +683,7 @@ class TorrentDef(object):
                     # Try to convert the names in path to unicode,
                     # assuming that it was encoded as utf-8
                     try:
-                        yield (join(*[ensure_text(element, "UTF-8") for element in file_dict["path"]]),
+                        yield (join(*[ensure_unicode(element, "UTF-8") for element in file_dict["path"]]),
                                file_dict["length"])
                         continue
                     except UnicodeError:

--- a/Tribler/Core/Utilities/torrent_utils.py
+++ b/Tribler/Core/Utilities/torrent_utils.py
@@ -7,7 +7,7 @@ import libtorrent
 
 from six import text_type
 
-from Tribler.Core.Utilities.unicode import ensure_text
+from Tribler.Core.Utilities.unicode import ensure_unicode
 
 logger = logging.getLogger(__name__)
 
@@ -112,10 +112,10 @@ def create_torrent_file(file_path_list, params):
 
     if params.get('name'):
         if not isinstance(params['name'], text_type):
-            params['name'] = ensure_text(params['name'], 'utf-8')
+            params['name'] = ensure_unicode(params['name'], 'utf-8')
         torrent_file_name = os.path.join(base_path, params['name'] + postfix)
     else:
-        torrent_file_name = os.path.join(base_path, ensure_text(t1['info']['name'], 'utf-8') + postfix)
+        torrent_file_name = os.path.join(base_path, ensure_unicode(t1['info']['name'], 'utf-8') + postfix)
     with open(torrent_file_name, 'wb') as f:
         f.write(torrent)
 

--- a/Tribler/Core/Utilities/torrent_utils.py
+++ b/Tribler/Core/Utilities/torrent_utils.py
@@ -4,7 +4,10 @@ import logging
 import os
 
 import libtorrent
+
 from six import text_type
+
+from Tribler.Core.Utilities.unicode import ensure_text
 
 logger = logging.getLogger(__name__)
 
@@ -109,10 +112,10 @@ def create_torrent_file(file_path_list, params):
 
     if params.get('name'):
         if not isinstance(params['name'], text_type):
-            params['name'] = unicode(params['name'], 'utf-8')
+            params['name'] = ensure_text(params['name'], 'utf-8')
         torrent_file_name = os.path.join(base_path, params['name'] + postfix)
     else:
-        torrent_file_name = os.path.join(base_path, unicode(t1['info']['name'], 'utf-8') + postfix)
+        torrent_file_name = os.path.join(base_path, ensure_text(t1['info']['name'], 'utf-8') + postfix)
     with open(torrent_file_name, 'wb') as f:
         f.write(torrent)
 

--- a/Tribler/Core/Utilities/unicode.py
+++ b/Tribler/Core/Utilities/unicode.py
@@ -7,7 +7,18 @@ from __future__ import absolute_import
 
 import sys
 
-from six import text_type
+from six import binary_type, text_type
+
+
+def ensure_text(s, encoding='utf-8', errors='strict'):
+    """Copied from https://github.com/benjaminp/six/blob/master/six.py
+    """
+    if isinstance(s, binary_type):
+        return s.decode(encoding, errors)
+    elif isinstance(s, text_type):
+        return s
+    else:
+        raise TypeError("not expecting type '%s'" % type(s))
 
 
 def bin2unicode(bin, possible_encoding='utf_8'):
@@ -40,7 +51,7 @@ def str2unicode(s):
     except UnicodeDecodeError:
         for encoding in [sys.getfilesystemencoding(), 'utf_8', 'iso-8859-1']:
             try:
-                return unicode(s, encoding)
+                return ensure_text(s, encoding)
             except UnicodeDecodeError:
                 pass
     return None

--- a/Tribler/Core/Utilities/unicode.py
+++ b/Tribler/Core/Utilities/unicode.py
@@ -51,7 +51,7 @@ def str2unicode(s):
     except UnicodeDecodeError:
         for encoding in [sys.getfilesystemencoding(), 'utf_8', 'iso-8859-1']:
             try:
-                return ensure_text(s, encoding)
+                return ensure_unicode(s, encoding)
             except UnicodeDecodeError:
                 pass
     return None

--- a/Tribler/Core/Utilities/unicode.py
+++ b/Tribler/Core/Utilities/unicode.py
@@ -10,8 +10,8 @@ import sys
 from six import binary_type, text_type
 
 
-def ensure_text(s, encoding='utf-8', errors='strict'):
-    """Copied from https://github.com/benjaminp/six/blob/master/six.py
+def ensure_unicode(s, encoding, errors='strict'):
+    """Similar to six.ensure_text() except that the encoding parameter is *not* optional
     """
     if isinstance(s, binary_type):
         return s.decode(encoding, errors)


### PR DESCRIPTION
As discussed in https://github.com/Tribler/tribler/issues/3883

In _Tribler/Core/Utilities/unicode.py_, __ensure_unicode()__ is defined to be like [__six.ensure_text()__](https://six.readthedocs.io/#six.ensure_text) except that encoding parameter is not optional.  See [__six>=1.12.0__](https://github.com/benjaminp/six/blob/master/CHANGES).