### PR TITLE
Added VLC 3.0.6 bindings

### DIFF
--- a/TriblerGUI/vlc.py
+++ b/TriblerGUI/vlc.py
@@ -53,10 +53,10 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-__version__ = "3.0.2102"
-__libvlc_version__ = "3.0.2"
-__generator_version__ = "1.2"
-build_date = "Fri May 11 18:17:40 2018 3.0.2"
+__version__ = "3.0.6108"
+__libvlc_version__ = "3.0.6"
+__generator_version__ = "1.8"
+build_date = "Sun Feb 24 16:20:25 2019 3.0.6"
 
 # The libvlc doc states that filenames are expected to be in UTF8, do
 # not rely on sys.getfilesystemencoding() which will be confused,
@@ -239,11 +239,25 @@ def find_lib():
                 if os.path.isdir(p):
                     plugin_path = p
                     break
-        else:  # hope, some [DY]LD_LIBRARY_PATH is set...
-            # pre-load libvlccore VLC 2.2.8+
-            logger.info("VLC libs not found/bundled. Trying from system library path.")
-            ctypes.CDLL('libvlccore.dylib')
-            dll = ctypes.CDLL('libvlc.dylib')
+        else:
+            # hope, some [DY]LD_LIBRARY_PATH is set...
+            d = '/Applications/VLC.app/Contents/MacOS/'
+            c = d + 'lib/libvlccore.dylib'
+            p = d + 'lib/libvlc.dylib'
+            if os.path.exists(p) and os.path.exists(c):
+                logger.info("Loading VLC dylibs from %s", d)
+                # pre-load libvlccore VLC 2.2.8+
+                ctypes.CDLL(c)
+                dll = ctypes.CDLL(p)
+                for p in ('modules', 'plugins'):
+                    p = d + p
+                    if os.path.isdir(p):
+                        plugin_path = p
+                        break
+            else:
+                logger.info("VLC libs not found/bundled. Trying from system library path.")
+                ctypes.CDLL('libvlccore.dylib')
+                dll = ctypes.CDLL('libvlc.dylib')
 
     else:
         raise NotImplementedError('%s: %s not supported' % (sys.argv[0], sys.platform))
@@ -465,8 +479,8 @@ else:
     PyFile_AsFile.restype = FILE_ptr
     PyFile_AsFile.argtypes = [ctypes.py_object]
 
-    # Generated enum types #
 
+# Generated enum types #
 
 class _Enum(ctypes.c_uint):
     '''(INTERNAL) Base class
@@ -1155,7 +1169,7 @@ class Callback(ctypes.c_void_p):
 class LogCb(ctypes.c_void_p):
     """Callback prototype for LibVLC log message handler.
     @param data: data pointer as given to L{libvlc_log_set}().
-    @param level: message level (@ref libvlc_log_level).
+    @param level: message level (@ref L{LogLevel}).
     @param ctx: message context (meta-information about the message).
     @param fmt: printf() format string (as defined by ISO C11).
     @param args: variable argument list for the format @note Log message handlers B{must} be thread-safe. @warning The message context pointer, the format string parameters and the variable arguments are only valid until the callback returns.
@@ -1361,7 +1375,7 @@ class CallbackDecorators(object):
     LogCb = ctypes.CFUNCTYPE(ctypes.c_void_p, ctypes.c_void_p, ctypes.c_int, Log_ptr, ctypes.c_char_p, ctypes.c_void_p)
     LogCb.__doc__ = '''Callback prototype for LibVLC log message handler.
         @param data: data pointer as given to L{libvlc_log_set}().
-        @param level: message level (@ref libvlc_log_level).
+        @param level: message level (@ref L{LogLevel}).
         @param ctx: message context (meta-information about the message).
         @param fmt: printf() format string (as defined by ISO C11).
         @param args: variable argument list for the format @note Log message handlers B{must} be thread-safe. @warning The message context pointer, the format string parameters and the variable arguments are only valid until the callback returns.
@@ -1518,6 +1532,7 @@ cb = CallbackDecorators
 # From libvlc_structures.h
 
 class AudioOutput(_Cstruct):
+
     def __str__(self):
         return '%s(%s:%s)' % (self.__class__.__name__, self.name, self.description)
 
@@ -1682,6 +1697,7 @@ class Rectangle(_Cstruct):
 
 
 class TrackDescription(_Cstruct):
+
     def __str__(self):
         return '%s(%d:%s)' % (self.__class__.__name__, self.id, self.name)
 
@@ -1744,6 +1760,7 @@ class Event(_Cstruct):
 
 
 class ModuleDescription(_Cstruct):
+
     def __str__(self):
         return '%s %s (%s)' % (self.__class__.__name__, self.shortname, self.name)
 
@@ -1772,6 +1789,7 @@ def module_description_list(head):
 
 
 class AudioOutputDevice(_Cstruct):
+
     def __str__(self):
         return '%s(%d:%s)' % (self.__class__.__name__, self.id, self.name)
 
@@ -1784,7 +1802,7 @@ AudioOutputDevice._fields_ = [  # recursive struct
 
 
 class TitleDescription(_Cstruct):
-    _fields = [
+    _fields_ = [
         ('duration', ctypes.c_longlong),
         ('name', ctypes.c_char_p),
         ('menu', ctypes.c_bool),
@@ -1792,7 +1810,7 @@ class TitleDescription(_Cstruct):
 
 
 class ChapterDescription(_Cstruct):
-    _fields = [
+    _fields_ = [
         ('time_offset', ctypes.c_longlong),
         ('duration', ctypes.c_longlong),
         ('name', ctypes.c_char_p),
@@ -1800,7 +1818,7 @@ class ChapterDescription(_Cstruct):
 
 
 class VideoViewpoint(_Cstruct):
-    _fields = [
+    _fields_ = [
         ('yaw', ctypes.c_float),
         ('pitch', ctypes.c_float),
         ('roll', ctypes.c_float),
@@ -1808,11 +1826,22 @@ class VideoViewpoint(_Cstruct):
     ]
 
 
+class MediaDiscovererDescription(_Cstruct):
+    _fields_ = [
+        ('name', ctypes.c_char_p),
+        ('longname', ctypes.c_char_p),
+        ('cat', MediaDiscovererCategory),
+    ]
+
+    def __str__(self):
+        return '%s %s (%d) - %s' % (self.__class__.__name__, self.name, self.cat, self.longname)
+
+
 # This struct depends on the MediaSlaveType enum that is defined only
 # in > 2.2
 if 'MediaSlaveType' in locals():
     class MediaSlave(_Cstruct):
-        _fields = [
+        _fields_ = [
             ('psz_uri', ctypes.c_char_p),
             ('i_type', MediaSlaveType),
             ('i_priority', ctypes.c_uint)
@@ -1820,13 +1849,81 @@ if 'MediaSlaveType' in locals():
 
 
 class RDDescription(_Cstruct):
-    _fields = [
+    _fields_ = [
         ('name', ctypes.c_char_p),
         ('longname', ctypes.c_char_p)
     ]
 
 
+class MediaThumbnailRequest:
+    def __new__(cls, *args):
+        if len(args) == 1 and isinstance(args[0], _Ints):
+            return _Constructor(cls, args[0])
+
+
 # End of header.py #
+class AudioEqualizer(_Ctype):
+    '''Create a new default equalizer, with all frequency values zeroed.
+
+    The new equalizer can subsequently be applied to a media player by invoking
+    L{MediaPlayer.set_equalizer}.
+    The returned handle should be freed via libvlc_audio_equalizer_release() when
+    it is no longer needed.
+    '''
+
+    def __new__(cls, *args):
+        if len(args) == 1 and isinstance(args[0], _Ints):
+            return _Constructor(cls, args[0])
+        return libvlc_audio_equalizer_new()
+
+    def release(self):
+        '''Release a previously created equalizer instance.
+        The equalizer was previously created by using L{new}() or
+        L{new_from_preset}().
+        It is safe to invoke this method with a None p_equalizer parameter for no effect.
+        @version: LibVLC 2.2.0 or later.
+        '''
+        return libvlc_audio_equalizer_release(self)
+
+    def set_preamp(self, f_preamp):
+        '''Set a new pre-amplification value for an equalizer.
+        The new equalizer settings are subsequently applied to a media player by invoking
+        L{media_player_set_equalizer}().
+        The supplied amplification value will be clamped to the -20.0 to +20.0 range.
+        @param f_preamp: preamp value (-20.0 to 20.0 Hz).
+        @return: zero on success, -1 on error.
+        @version: LibVLC 2.2.0 or later.
+        '''
+        return libvlc_audio_equalizer_set_preamp(self, f_preamp)
+
+    def get_preamp(self):
+        '''Get the current pre-amplification value from an equalizer.
+        @return: preamp value (Hz).
+        @version: LibVLC 2.2.0 or later.
+        '''
+        return libvlc_audio_equalizer_get_preamp(self)
+
+    def set_amp_at_index(self, f_amp, u_band):
+        '''Set a new amplification value for a particular equalizer frequency band.
+        The new equalizer settings are subsequently applied to a media player by invoking
+        L{media_player_set_equalizer}().
+        The supplied amplification value will be clamped to the -20.0 to +20.0 range.
+        @param f_amp: amplification value (-20.0 to 20.0 Hz).
+        @param u_band: index, counting from zero, of the frequency band to set.
+        @return: zero on success, -1 on error.
+        @version: LibVLC 2.2.0 or later.
+        '''
+        return libvlc_audio_equalizer_set_amp_at_index(self, f_amp, u_band)
+
+    def get_amp_at_index(self, u_band):
+        '''Get the amplification value for a particular equalizer frequency band.
+        @param u_band: index, counting from zero, of the frequency band to get.
+        @return: amplification value (Hz); NaN if there is no such frequency band.
+        @version: LibVLC 2.2.0 or later.
+        '''
+        return libvlc_audio_equalizer_get_amp_at_index(self, u_band)
+
+
 class EventManager(_Ctype):
     '''Create an event manager with callback handler.
 
@@ -1871,7 +1968,7 @@ class EventManager(_Ctype):
             raise VLCException("%s required: %r" % ('EventType', eventtype))
         if not hasattr(callback, '__call__'):  # callable()
             raise VLCException("%s required: %r" % ('callable', callback))
-            # check that the callback expects arguments
+        # check that the callback expects arguments
         if not any(getargspec(callback)[:2]):  # list(...)
             raise VLCException("%s required: %r" % ('argument', callback))
 
@@ -2028,10 +2125,7 @@ class Instance(_Ctype):
             i = head
             while i:
                 i = i.contents
-                d = [{'id': libvlc_audio_output_device_id(self, i.name, d),
-                      'longname': libvlc_audio_output_device_longname(self, i.name, d)}
-                     for d in range(libvlc_audio_output_device_count(self, i.name))]
-                r.append({'name': i.name, 'description': i.description, 'devices': d})
+                r.append({'name': i.name, 'description': i.description})
                 i = i.next
             libvlc_audio_output_list_release(head)
         return r
@@ -2651,7 +2745,7 @@ class Media(_Ctype):
         return libvlc_media_add_option_flag(self, str_to_bytes(psz_options), i_flags)
 
     def retain(self):
-        '''Retain a reference to a media descriptor object (libvlc_media_t). Use
+        '''Retain a reference to a media descriptor object (L{Media}). Use
         L{release}() to decrement the reference count of a
         media descriptor object.
         '''
@@ -2706,7 +2800,7 @@ class Media(_Ctype):
         '''Get current state of media descriptor object. Possible media states are
         libvlc_NothingSpecial=0, libvlc_Opening, libvlc_Playing, libvlc_Paused,
         libvlc_Stopped, libvlc_Ended, libvlc_Error.
-        See libvlc_state_t.
+        See L{State}.
         @return: state of media descriptor object.
         '''
         return libvlc_media_get_state(self)
@@ -2747,7 +2841,7 @@ class Media(_Ctype):
         To track when this is over you can listen to libvlc_MediaParsedChanged
         event. However if this functions returns an error, you will not receive any
         events.
-        It uses a flag to specify parse options (see libvlc_media_parse_flag_t). All
+        It uses a flag to specify parse options (see L{MediaParseFlag}). All
         these flags can be combined. By default, media is parsed if it's a local
         file.
         @note: Parsing can be aborted with L{parse_stop}().
@@ -2755,7 +2849,7 @@ class Media(_Ctype):
         See L{get_meta}
         See L{tracks_get}
         See L{get_parsed_status}
-        See libvlc_media_parse_flag_t.
+        See L{MediaParseFlag}.
         @param parse_flag: parse options:
         @param timeout: maximum time allowed to preparse the media. If -1, the default "preparse-timeout" option will be used as a timeout. If 0, it will wait indefinitely. If > 0, the timeout will be used (in milliseconds).
         @return: -1 in case of error, 0 otherwise.
@@ -2775,8 +2869,8 @@ class Media(_Ctype):
     def get_parsed_status(self):
         '''Get Parsed status for media descriptor object.
         See libvlc_MediaParsedChanged
-        See libvlc_media_parsed_status_t.
-        @return: a value of the libvlc_media_parsed_status_t enum.
+        See L{MediaParsedStatus}.
+        @return: a value of the L{MediaParsedStatus} enum.
         @version: LibVLC 3.0.0 or later.
         '''
         return libvlc_media_get_parsed_status(self)
@@ -2799,7 +2893,7 @@ class Media(_Ctype):
     def get_type(self):
         '''Get the media type of the media descriptor object.
         @return: media type.
-        @version: LibVLC 3.0.0 and later. See libvlc_media_type_t.
+        @version: LibVLC 3.0.0 and later. See L{MediaType}.
         '''
         return libvlc_media_get_type(self)
 
@@ -3218,7 +3312,7 @@ class MediaListPlayer(_Ctype):
 
     def get_state(self):
         '''Get current libvlc_state of media list player.
-        @return: libvlc_state_t for media list player.
+        @return: L{State} for media list player.
         '''
         return libvlc_media_list_player_get_state(self)
 
@@ -3316,18 +3410,6 @@ class MediaPlayer(_Ctype):
         """
         return track_description_list(libvlc_video_get_spu_description(self))
 
-    def video_get_title_description(self):
-        """Get the description of available titles.
-        """
-        return track_description_list(libvlc_video_get_title_description(self))
-
-    def video_get_chapter_description(self, title):
-        """Get the description of available chapters for specific title.
-
-        @param title: selected title (int)
-        """
-        return track_description_list(libvlc_video_get_chapter_description(self, title))
-
     def video_get_track_description(self):
         """Get the description of available video tracks.
         """
@@ -3345,8 +3427,14 @@ class MediaPlayer(_Ctype):
         '''
         titleDescription_pp = ctypes.POINTER(TitleDescription)()
         n = libvlc_media_player_get_full_title_descriptions(self, ctypes.byref(titleDescription_pp))
-        info = ctypes.cast(ctypes.titleDescription_pp, ctypes.POINTER(ctypes.POINTER(TitleDescription) * n))
-        return info
+        info = ctypes.cast(titleDescription_pp, ctypes.POINTER(ctypes.POINTER(TitleDescription) * n))
+        try:
+            contents = info.contents
+        except ValueError:
+            # Media not parsed, no info.
+            return None
+        descr = (contents[i].contents for i in range(len(contents)))
+        return descr
 
     def get_full_chapter_descriptions(self, i_chapters_of_title):
         '''Get the full description of available chapters.
@@ -3356,8 +3444,14 @@ class MediaPlayer(_Ctype):
         '''
         chapterDescription_pp = ctypes.POINTER(ChapterDescription)()
         n = libvlc_media_player_get_full_chapter_descriptions(self, ctypes.byref(chapterDescription_pp))
-        info = ctypes.cast(ctypes.chapterDescription_pp, ctypes.POINTER(ctypes.POINTER(ChapterDescription) * n))
-        return info
+        info = ctypes.cast(chapterDescription_pp, ctypes.POINTER(ctypes.POINTER(ChapterDescription) * n))
+        try:
+            contents = info.contents
+        except ValueError:
+            # Media not parsed, no info.
+            return None
+        descr = (contents[i].contents for i in range(len(contents)))
+        return descr
 
     def video_get_size(self, num=0):
         """Get the video size in pixels as 2-tuple (width, height).
@@ -3440,6 +3534,19 @@ class MediaPlayer(_Ctype):
         '''\deprecated Use L{get_nsobject}() instead.
         '''
         return libvlc_media_player_get_agl(self)
+
+    def video_get_title_description(self):
+        '''Get the description of available titles.
+        @return: list containing description of available titles. It must be freed with L{track_description_list_release}().
+        '''
+        return libvlc_video_get_title_description(self)
+
+    def video_get_chapter_description(self, i_title):
+        '''Get the description of available chapters for specific title.
+        @param i_title: selected title.
+        @return: list containing description of available chapter for title i_title. It must be freed with L{track_description_list_release}().
+        '''
+        return libvlc_video_get_chapter_description(self, i_title)
 
     def video_set_subtitle_file(self, psz_subtitle):
         '''Set new video subtitle file.
@@ -3827,7 +3934,7 @@ class MediaPlayer(_Ctype):
 
     def get_state(self):
         '''Get current movie state.
-        @return: the current state of the media player (playing, paused, ...) See libvlc_state_t.
+        @return: the current state of the media player (playing, paused, ...) See L{State}.
         '''
         return libvlc_media_player_get_state(self)
 
@@ -4036,7 +4143,7 @@ class MediaPlayer(_Ctype):
     def video_set_teletext(self, i_page):
         '''Set new teletext page to retrieve.
         This function can also be used to send a teletext key.
-        @param i_page: teletex page number requested. This value can be 0 to disable teletext, a number in the range ]0;1000[ to show the requested page, or a \ref libvlc_teletext_key_t. 100 is the default teletext page.
+        @param i_page: teletex page number requested. This value can be 0 to disable teletext, a number in the range ]0;1000[ to show the requested page, or a \ref L{TeletextKey}. 100 is the default teletext page.
         '''
         return libvlc_video_set_teletext(self, i_page)
 
@@ -4107,7 +4214,7 @@ class MediaPlayer(_Ctype):
 
     def video_get_logo_int(self, option):
         '''Get integer logo option.
-        @param option: logo option to get, values of libvlc_video_logo_option_t.
+        @param option: logo option to get, values of L{VideoLogoOption}.
         '''
         return libvlc_video_get_logo_int(self, option)
 
@@ -4116,7 +4223,7 @@ class MediaPlayer(_Ctype):
         are ignored.
         Passing libvlc_logo_enable as option value has the side effect of
         starting (arg !0) or stopping (arg 0) the logo filter.
-        @param option: logo option to set, values of libvlc_video_logo_option_t.
+        @param option: logo option to set, values of L{VideoLogoOption}.
         @param value: logo option value.
         '''
         return libvlc_video_set_logo_int(self, option, value)
@@ -4124,14 +4231,14 @@ class MediaPlayer(_Ctype):
     def video_set_logo_string(self, option, psz_value):
         '''Set logo option as string. Options that take a different type value
         are ignored.
-        @param option: logo option to set, values of libvlc_video_logo_option_t.
+        @param option: logo option to set, values of L{VideoLogoOption}.
         @param psz_value: logo option value.
         '''
         return libvlc_video_set_logo_string(self, option, str_to_bytes(psz_value))
 
     def video_get_adjust_int(self, option):
         '''Get integer adjust option.
-        @param option: adjust option to get, values of libvlc_video_adjust_option_t.
+        @param option: adjust option to get, values of L{VideoAdjustOption}.
         @version: LibVLC 1.1.1 and later.
         '''
         return libvlc_video_get_adjust_int(self, option)
@@ -4141,7 +4248,7 @@ class MediaPlayer(_Ctype):
         are ignored.
         Passing libvlc_adjust_enable as option value has the side effect of
         starting (arg !0) or stopping (arg 0) the adjust filter.
-        @param option: adust option to set, values of libvlc_video_adjust_option_t.
+        @param option: adust option to set, values of L{VideoAdjustOption}.
         @param value: adjust option value.
         @version: LibVLC 1.1.1 and later.
         '''
@@ -4149,7 +4256,7 @@ class MediaPlayer(_Ctype):
 
     def video_get_adjust_float(self, option):
         '''Get float adjust option.
-        @param option: adjust option to get, values of libvlc_video_adjust_option_t.
+        @param option: adjust option to get, values of L{VideoAdjustOption}.
         @version: LibVLC 1.1.1 and later.
         '''
         return libvlc_video_get_adjust_float(self, option)
@@ -4157,7 +4264,7 @@ class MediaPlayer(_Ctype):
     def video_set_adjust_float(self, option, value):
         '''Set adjust option as float. Options that take a different type value
         are ignored.
-        @param option: adust option to set, values of libvlc_video_adjust_option_t.
+        @param option: adust option to set, values of L{VideoAdjustOption}.
         @param value: adjust option value.
         @version: LibVLC 1.1.1 and later.
         '''
@@ -4281,13 +4388,13 @@ class MediaPlayer(_Ctype):
 
     def audio_get_channel(self):
         '''Get current audio channel.
-        @return: the audio channel See libvlc_audio_output_channel_t.
+        @return: the audio channel See L{AudioOutputChannel}.
         '''
         return libvlc_audio_get_channel(self)
 
     def audio_set_channel(self, channel):
         '''Set current audio channel.
-        @param channel: the audio channel, See libvlc_audio_output_channel_t.
+        @param channel: the audio channel, See L{AudioOutputChannel}.
         @return: 0 on success, -1 on error.
         '''
         return libvlc_audio_set_channel(self, channel)
@@ -4344,8 +4451,112 @@ class MediaPlayer(_Ctype):
         return libvlc_media_player_set_role(self, role)
 
 
-        # LibVLC __version__ functions #
+class Renderer(_Ctype):
+    '''N/A
+    '''
 
+    def __new__(cls, ptr=_internal_guard):
+        '''(INTERNAL) ctypes wrapper constructor.
+        '''
+        return _Constructor(cls, ptr)
+
+    def hold(self):
+        '''Hold a renderer item, i.e. creates a new reference
+        This functions need to called from the libvlc_RendererDiscovererItemAdded
+        callback if the libvlc user wants to use this item after. (for display or
+        for passing it to the mediaplayer for example).
+        @return: the current item.
+        @version: LibVLC 3.0.0 or later.
+        '''
+        return libvlc_renderer_item_hold(self)
+
+    def release(self):
+        '''Releases a renderer item, i.e. decrements its reference counter.
+        @version: LibVLC 3.0.0 or later.
+        '''
+        return libvlc_renderer_item_release(self)
+
+    def name(self):
+        '''Get the human readable name of a renderer item.
+        @return: the name of the item (can't be None, must *not* be freed).
+        @version: LibVLC 3.0.0 or later.
+        '''
+        return libvlc_renderer_item_name(self)
+
+    def type(self):
+        '''Get the type (not translated) of a renderer item. For now, the type can only
+        be "chromecast" ("upnp", "airplay" may come later).
+        @return: the type of the item (can't be None, must *not* be freed).
+        @version: LibVLC 3.0.0 or later.
+        '''
+        return libvlc_renderer_item_type(self)
+
+    def icon_uri(self):
+        '''Get the icon uri of a renderer item.
+        @return: the uri of the item's icon (can be None, must *not* be freed).
+        @version: LibVLC 3.0.0 or later.
+        '''
+        return libvlc_renderer_item_icon_uri(self)
+
+    def flags(self):
+        '''Get the flags of a renderer item
+        See LIBVLC_RENDERER_CAN_AUDIO
+        See LIBVLC_RENDERER_CAN_VIDEO.
+        @return: bitwise flag: capabilities of the renderer, see.
+        @version: LibVLC 3.0.0 or later.
+        '''
+        return libvlc_renderer_item_flags(self)
+
+
+class RendererDiscoverer(_Ctype):
+    '''N/A
+    '''
+
+    def __new__(cls, ptr=_internal_guard):
+        '''(INTERNAL) ctypes wrapper constructor.
+        '''
+        return _Constructor(cls, ptr)
+
+    def release(self):
+        '''Release a renderer discoverer object.
+        @version: LibVLC 3.0.0 or later.
+        '''
+        return libvlc_renderer_discoverer_release(self)
+
+    def start(self):
+        '''Start renderer discovery
+        To stop it, call L{stop}() or
+        L{release}() directly.
+        See L{stop}().
+        @return: -1 in case of error, 0 otherwise.
+        @version: LibVLC 3.0.0 or later.
+        '''
+        return libvlc_renderer_discoverer_start(self)
+
+    def stop(self):
+        '''Stop renderer discovery.
+        See L{start}().
+        @version: LibVLC 3.0.0 or later.
+        '''
+        return libvlc_renderer_discoverer_stop(self)
+
+    @memoize_parameterless
+    def event_manager(self):
+        '''Get the event manager of the renderer discoverer
+        The possible events to attach are @ref libvlc_RendererDiscovererItemAdded
+        and @ref libvlc_RendererDiscovererItemDeleted.
+        The @ref L{Renderer} struct passed to event callbacks is owned by
+        VLC, users should take care of holding/releasing this struct for their
+        internal usage.
+        See libvlc_event_t.u.renderer_discoverer_item_added.item
+        See libvlc_event_t.u.renderer_discoverer_item_removed.item.
+        @return: a valid event manager (can't fail).
+        @version: LibVLC 3.0.0 or later.
+        '''
+        return libvlc_renderer_discoverer_event_manager(self)
+
+
+# LibVLC __version__ functions #
 
 def libvlc_clearerr():
     '''Clears the LibVLC error status for the current thread. This is optional.
@@ -5380,7 +5591,7 @@ def libvlc_media_add_option_flag(p_md, psz_options, i_flags):
 
 
 def libvlc_media_retain(p_md):
-    '''Retain a reference to a media descriptor object (libvlc_media_t). Use
+    '''Retain a reference to a media descriptor object (L{Media}). Use
     L{libvlc_media_release}() to decrement the reference count of a
     media descriptor object.
     @param p_md: the media descriptor.
@@ -5470,7 +5681,7 @@ def libvlc_media_get_state(p_md):
     '''Get current state of media descriptor object. Possible media states are
     libvlc_NothingSpecial=0, libvlc_Opening, libvlc_Playing, libvlc_Paused,
     libvlc_Stopped, libvlc_Ended, libvlc_Error.
-    See libvlc_state_t.
+    See L{State}.
     @param p_md: a media descriptor object.
     @return: state of media descriptor object.
     '''
@@ -5535,7 +5746,7 @@ def libvlc_media_parse_with_options(p_md, parse_flag, timeout):
     To track when this is over you can listen to libvlc_MediaParsedChanged
     event. However if this functions returns an error, you will not receive any
     events.
-    It uses a flag to specify parse options (see libvlc_media_parse_flag_t). All
+    It uses a flag to specify parse options (see L{MediaParseFlag}). All
     these flags can be combined. By default, media is parsed if it's a local
     file.
     @note: Parsing can be aborted with L{libvlc_media_parse_stop}().
@@ -5543,7 +5754,7 @@ def libvlc_media_parse_with_options(p_md, parse_flag, timeout):
     See L{libvlc_media_get_meta}
     See L{libvlc_media_tracks_get}
     See L{libvlc_media_get_parsed_status}
-    See libvlc_media_parse_flag_t.
+    See L{MediaParseFlag}.
     @param p_md: media descriptor object.
     @param parse_flag: parse options:
     @param timeout: maximum time allowed to preparse the media. If -1, the default "preparse-timeout" option will be used as a timeout. If 0, it will wait indefinitely. If > 0, the timeout will be used (in milliseconds).
@@ -5573,9 +5784,9 @@ def libvlc_media_parse_stop(p_md):
 def libvlc_media_get_parsed_status(p_md):
     '''Get Parsed status for media descriptor object.
     See libvlc_MediaParsedChanged
-    See libvlc_media_parsed_status_t.
+    See L{MediaParsedStatus}.
     @param p_md: media descriptor object.
-    @return: a value of the libvlc_media_parsed_status_t enum.
+    @return: a value of the L{MediaParsedStatus} enum.
     @version: LibVLC 3.0.0 or later.
     '''
     f = _Cfunctions.get('libvlc_media_get_parsed_status', None) or \
@@ -5654,7 +5865,7 @@ def libvlc_media_get_type(p_md):
     '''Get the media type of the media descriptor object.
     @param p_md: media descriptor object.
     @return: media type.
-    @version: LibVLC 3.0.0 and later. See libvlc_media_type_t.
+    @version: LibVLC 3.0.0 and later. See L{MediaType}.
     '''
     f = _Cfunctions.get('libvlc_media_get_type', None) or \
         _Cfunction('libvlc_media_get_type', ((1,),), None,
@@ -5731,8 +5942,8 @@ def libvlc_renderer_item_hold(p_item):
     @version: LibVLC 3.0.0 or later.
     '''
     f = _Cfunctions.get('libvlc_renderer_item_hold', None) or \
-        _Cfunction('libvlc_renderer_item_hold', ((1,),), None,
-                   ctypes.c_void_p, ctypes.c_void_p)
+        _Cfunction('libvlc_renderer_item_hold', ((1,),), class_result(Renderer),
+                   ctypes.c_void_p, Renderer)
     return f(p_item)
 
 
@@ -5742,7 +5953,7 @@ def libvlc_renderer_item_release(p_item):
     '''
     f = _Cfunctions.get('libvlc_renderer_item_release', None) or \
         _Cfunction('libvlc_renderer_item_release', ((1,),), None,
-                   None, ctypes.c_void_p)
+                   None, Renderer)
     return f(p_item)
 
 
@@ -5753,7 +5964,7 @@ def libvlc_renderer_item_name(p_item):
     '''
     f = _Cfunctions.get('libvlc_renderer_item_name', None) or \
         _Cfunction('libvlc_renderer_item_name', ((1,),), None,
-                   ctypes.c_char_p, ctypes.c_void_p)
+                   ctypes.c_char_p, Renderer)
     return f(p_item)
 
 
@@ -5765,7 +5976,7 @@ def libvlc_renderer_item_type(p_item):
     '''
     f = _Cfunctions.get('libvlc_renderer_item_type', None) or \
         _Cfunction('libvlc_renderer_item_type', ((1,),), None,
-                   ctypes.c_char_p, ctypes.c_void_p)
+                   ctypes.c_char_p, Renderer)
     return f(p_item)
 
 
@@ -5776,7 +5987,7 @@ def libvlc_renderer_item_icon_uri(p_item):
     '''
     f = _Cfunctions.get('libvlc_renderer_item_icon_uri', None) or \
         _Cfunction('libvlc_renderer_item_icon_uri', ((1,),), None,
-                   ctypes.c_char_p, ctypes.c_void_p)
+                   ctypes.c_char_p, Renderer)
     return f(p_item)
 
 
@@ -5789,7 +6000,7 @@ def libvlc_renderer_item_flags(p_item):
     '''
     f = _Cfunctions.get('libvlc_renderer_item_flags', None) or \
         _Cfunction('libvlc_renderer_item_flags', ((1,),), None,
-                   ctypes.c_int, ctypes.c_void_p)
+                   ctypes.c_int, Renderer)
     return f(p_item)
 
 
@@ -5807,7 +6018,7 @@ def libvlc_renderer_discoverer_new(p_inst, psz_name):
     @version: LibVLC 3.0.0 or later.
     '''
     f = _Cfunctions.get('libvlc_renderer_discoverer_new', None) or \
-        _Cfunction('libvlc_renderer_discoverer_new', ((1,), (1,),), None,
+        _Cfunction('libvlc_renderer_discoverer_new', ((1,), (1,),), class_result(RendererDiscoverer),
                    ctypes.c_void_p, Instance, ctypes.c_char_p)
     return f(p_inst, psz_name)
 
@@ -5819,7 +6030,7 @@ def libvlc_renderer_discoverer_release(p_rd):
     '''
     f = _Cfunctions.get('libvlc_renderer_discoverer_release', None) or \
         _Cfunction('libvlc_renderer_discoverer_release', ((1,),), None,
-                   None, ctypes.c_void_p)
+                   None, RendererDiscoverer)
     return f(p_rd)
 
 
@@ -5834,7 +6045,7 @@ def libvlc_renderer_discoverer_start(p_rd):
     '''
     f = _Cfunctions.get('libvlc_renderer_discoverer_start', None) or \
         _Cfunction('libvlc_renderer_discoverer_start', ((1,),), None,
-                   ctypes.c_int, ctypes.c_void_p)
+                   ctypes.c_int, RendererDiscoverer)
     return f(p_rd)
 
 
@@ -5846,7 +6057,7 @@ def libvlc_renderer_discoverer_stop(p_rd):
     '''
     f = _Cfunctions.get('libvlc_renderer_discoverer_stop', None) or \
         _Cfunction('libvlc_renderer_discoverer_stop', ((1,),), None,
-                   None, ctypes.c_void_p)
+                   None, RendererDiscoverer)
     return f(p_rd)
 
 
@@ -5854,7 +6065,7 @@ def libvlc_renderer_discoverer_event_manager(p_rd):
     '''Get the event manager of the renderer discoverer
     The possible events to attach are @ref libvlc_RendererDiscovererItemAdded
     and @ref libvlc_RendererDiscovererItemDeleted.
-    The @ref libvlc_renderer_item_t struct passed to event callbacks is owned by
+    The @ref L{Renderer} struct passed to event callbacks is owned by
     VLC, users should take care of holding/releasing this struct for their
     internal usage.
     See libvlc_event_t.u.renderer_discoverer_item_added.item
@@ -5864,7 +6075,7 @@ def libvlc_renderer_discoverer_event_manager(p_rd):
     '''
     f = _Cfunctions.get('libvlc_renderer_discoverer_event_manager', None) or \
         _Cfunction('libvlc_renderer_discoverer_event_manager', ((1,),), class_result(EventManager),
-                   ctypes.c_void_p, ctypes.c_void_p)
+                   ctypes.c_void_p, RendererDiscoverer)
     return f(p_rd)
 
 
@@ -6614,7 +6825,7 @@ def libvlc_media_player_set_renderer(p_mi, p_item):
     '''
     f = _Cfunctions.get('libvlc_media_player_set_renderer', None) or \
         _Cfunction('libvlc_media_player_set_renderer', ((1,), (1,),), None,
-                   ctypes.c_int, MediaPlayer, ctypes.c_void_p)
+                   ctypes.c_int, MediaPlayer, Renderer)
     return f(p_mi, p_item)
 
 
@@ -7085,7 +7296,7 @@ def libvlc_media_player_set_rate(p_mi, rate):
 def libvlc_media_player_get_state(p_mi):
     '''Get current movie state.
     @param p_mi: the Media Player.
-    @return: the current state of the media player (playing, paused, ...) See libvlc_state_t.
+    @return: the current state of the media player (playing, paused, ...) See L{State}.
     '''
     f = _Cfunctions.get('libvlc_media_player_get_state', None) or \
         _Cfunction('libvlc_media_player_get_state', ((1,),), None,
@@ -7547,7 +7758,7 @@ def libvlc_video_set_teletext(p_mi, i_page):
     '''Set new teletext page to retrieve.
     This function can also be used to send a teletext key.
     @param p_mi: the media player.
-    @param i_page: teletex page number requested. This value can be 0 to disable teletext, a number in the range ]0;1000[ to show the requested page, or a \ref libvlc_teletext_key_t. 100 is the default teletext page.
+    @param i_page: teletex page number requested. This value can be 0 to disable teletext, a number in the range ]0;1000[ to show the requested page, or a \ref L{TeletextKey}. 100 is the default teletext page.
     '''
     f = _Cfunctions.get('libvlc_video_set_teletext', None) or \
         _Cfunction('libvlc_video_set_teletext', ((1,), (1,),), None,
@@ -7679,7 +7890,7 @@ def libvlc_video_set_marquee_string(p_mi, option, psz_text):
 def libvlc_video_get_logo_int(p_mi, option):
     '''Get integer logo option.
     @param p_mi: libvlc media player instance.
-    @param option: logo option to get, values of libvlc_video_logo_option_t.
+    @param option: logo option to get, values of L{VideoLogoOption}.
     '''
     f = _Cfunctions.get('libvlc_video_get_logo_int', None) or \
         _Cfunction('libvlc_video_get_logo_int', ((1,), (1,),), None,
@@ -7693,7 +7904,7 @@ def libvlc_video_set_logo_int(p_mi, option, value):
     Passing libvlc_logo_enable as option value has the side effect of
     starting (arg !0) or stopping (arg 0) the logo filter.
     @param p_mi: libvlc media player instance.
-    @param option: logo option to set, values of libvlc_video_logo_option_t.
+    @param option: logo option to set, values of L{VideoLogoOption}.
     @param value: logo option value.
     '''
     f = _Cfunctions.get('libvlc_video_set_logo_int', None) or \
@@ -7706,7 +7917,7 @@ def libvlc_video_set_logo_string(p_mi, option, psz_value):
     '''Set logo option as string. Options that take a different type value
     are ignored.
     @param p_mi: libvlc media player instance.
-    @param option: logo option to set, values of libvlc_video_logo_option_t.
+    @param option: logo option to set, values of L{VideoLogoOption}.
     @param psz_value: logo option value.
     '''
     f = _Cfunctions.get('libvlc_video_set_logo_string', None) or \
@@ -7718,7 +7929,7 @@ def libvlc_video_set_logo_string(p_mi, option, psz_value):
 def libvlc_video_get_adjust_int(p_mi, option):
     '''Get integer adjust option.
     @param p_mi: libvlc media player instance.
-    @param option: adjust option to get, values of libvlc_video_adjust_option_t.
+    @param option: adjust option to get, values of L{VideoAdjustOption}.
     @version: LibVLC 1.1.1 and later.
     '''
     f = _Cfunctions.get('libvlc_video_get_adjust_int', None) or \
@@ -7733,7 +7944,7 @@ def libvlc_video_set_adjust_int(p_mi, option, value):
     Passing libvlc_adjust_enable as option value has the side effect of
     starting (arg !0) or stopping (arg 0) the adjust filter.
     @param p_mi: libvlc media player instance.
-    @param option: adust option to set, values of libvlc_video_adjust_option_t.
+    @param option: adust option to set, values of L{VideoAdjustOption}.
     @param value: adjust option value.
     @version: LibVLC 1.1.1 and later.
     '''
@@ -7746,7 +7957,7 @@ def libvlc_video_set_adjust_int(p_mi, option, value):
 def libvlc_video_get_adjust_float(p_mi, option):
     '''Get float adjust option.
     @param p_mi: libvlc media player instance.
-    @param option: adjust option to get, values of libvlc_video_adjust_option_t.
+    @param option: adjust option to get, values of L{VideoAdjustOption}.
     @version: LibVLC 1.1.1 and later.
     '''
     f = _Cfunctions.get('libvlc_video_get_adjust_float', None) or \
@@ -7759,7 +7970,7 @@ def libvlc_video_set_adjust_float(p_mi, option, value):
     '''Set adjust option as float. Options that take a different type value
     are ignored.
     @param p_mi: libvlc media player instance.
-    @param option: adust option to set, values of libvlc_video_adjust_option_t.
+    @param option: adust option to set, values of L{VideoAdjustOption}.
     @param value: adjust option value.
     @version: LibVLC 1.1.1 and later.
     '''
@@ -8012,7 +8223,7 @@ def libvlc_audio_set_track(p_mi, i_track):
 def libvlc_audio_get_channel(p_mi):
     '''Get current audio channel.
     @param p_mi: media player.
-    @return: the audio channel See libvlc_audio_output_channel_t.
+    @return: the audio channel See L{AudioOutputChannel}.
     '''
     f = _Cfunctions.get('libvlc_audio_get_channel', None) or \
         _Cfunction('libvlc_audio_get_channel', ((1,),), None,
@@ -8023,7 +8234,7 @@ def libvlc_audio_get_channel(p_mi):
 def libvlc_audio_set_channel(p_mi, channel):
     '''Set current audio channel.
     @param p_mi: media player.
-    @param channel: the audio channel, See libvlc_audio_output_channel_t.
+    @param channel: the audio channel, See L{AudioOutputChannel}.
     @return: 0 on success, -1 on error.
     '''
     f = _Cfunctions.get('libvlc_audio_set_channel', None) or \
@@ -8117,7 +8328,7 @@ def libvlc_audio_equalizer_new():
     @version: LibVLC 2.2.0 or later.
     '''
     f = _Cfunctions.get('libvlc_audio_equalizer_new', None) or \
-        _Cfunction('libvlc_audio_equalizer_new', (), None,
+        _Cfunction('libvlc_audio_equalizer_new', (), class_result(AudioEqualizer),
                    ctypes.c_void_p)
     return f()
 
@@ -8134,7 +8345,7 @@ def libvlc_audio_equalizer_new_from_preset(u_index):
     @version: LibVLC 2.2.0 or later.
     '''
     f = _Cfunctions.get('libvlc_audio_equalizer_new_from_preset', None) or \
-        _Cfunction('libvlc_audio_equalizer_new_from_preset', ((1,),), None,
+        _Cfunction('libvlc_audio_equalizer_new_from_preset', ((1,),), class_result(AudioEqualizer),
                    ctypes.c_void_p, ctypes.c_uint)
     return f(u_index)
 
@@ -8149,7 +8360,7 @@ def libvlc_audio_equalizer_release(p_equalizer):
     '''
     f = _Cfunctions.get('libvlc_audio_equalizer_release', None) or \
         _Cfunction('libvlc_audio_equalizer_release', ((1,),), None,
-                   None, ctypes.c_void_p)
+                   None, AudioEqualizer)
     return f(p_equalizer)
 
 
@@ -8165,7 +8376,7 @@ def libvlc_audio_equalizer_set_preamp(p_equalizer, f_preamp):
     '''
     f = _Cfunctions.get('libvlc_audio_equalizer_set_preamp', None) or \
         _Cfunction('libvlc_audio_equalizer_set_preamp', ((1,), (1,),), None,
-                   ctypes.c_int, ctypes.c_void_p, ctypes.c_float)
+                   ctypes.c_int, AudioEqualizer, ctypes.c_float)
     return f(p_equalizer, f_preamp)
 
 
@@ -8177,7 +8388,7 @@ def libvlc_audio_equalizer_get_preamp(p_equalizer):
     '''
     f = _Cfunctions.get('libvlc_audio_equalizer_get_preamp', None) or \
         _Cfunction('libvlc_audio_equalizer_get_preamp', ((1,),), None,
-                   ctypes.c_float, ctypes.c_void_p)
+                   ctypes.c_float, AudioEqualizer)
     return f(p_equalizer)
 
 
@@ -8194,7 +8405,7 @@ def libvlc_audio_equalizer_set_amp_at_index(p_equalizer, f_amp, u_band):
     '''
     f = _Cfunctions.get('libvlc_audio_equalizer_set_amp_at_index', None) or \
         _Cfunction('libvlc_audio_equalizer_set_amp_at_index', ((1,), (1,), (1,),), None,
-                   ctypes.c_int, ctypes.c_void_p, ctypes.c_float, ctypes.c_uint)
+                   ctypes.c_int, AudioEqualizer, ctypes.c_float, ctypes.c_uint)
     return f(p_equalizer, f_amp, u_band)
 
 
@@ -8207,7 +8418,7 @@ def libvlc_audio_equalizer_get_amp_at_index(p_equalizer, u_band):
     '''
     f = _Cfunctions.get('libvlc_audio_equalizer_get_amp_at_index', None) or \
         _Cfunction('libvlc_audio_equalizer_get_amp_at_index', ((1,), (1,),), None,
-                   ctypes.c_float, ctypes.c_void_p, ctypes.c_uint)
+                   ctypes.c_float, AudioEqualizer, ctypes.c_uint)
     return f(p_equalizer, u_band)
 
 
@@ -8234,7 +8445,7 @@ def libvlc_media_player_set_equalizer(p_mi, p_equalizer):
     '''
     f = _Cfunctions.get('libvlc_media_player_set_equalizer', None) or \
         _Cfunction('libvlc_media_player_set_equalizer', ((1,), (1,),), None,
-                   ctypes.c_int, MediaPlayer, ctypes.c_void_p)
+                   ctypes.c_int, MediaPlayer, AudioEqualizer)
     return f(p_mi, p_equalizer)
 
 
@@ -8388,7 +8599,7 @@ def libvlc_media_list_player_is_playing(p_mlp):
 def libvlc_media_list_player_get_state(p_mlp):
     '''Get current libvlc_state of media list player.
     @param p_mlp: media list player instance.
-    @return: libvlc_state_t for media list player.
+    @return: L{State} for media list player.
     '''
     f = _Cfunctions.get('libvlc_media_list_player_get_state', None) or \
         _Cfunction('libvlc_media_list_player_get_state', ((1,),), None,
@@ -8470,18 +8681,13 @@ def libvlc_media_list_player_set_playback_mode(p_mlp, e_mode):
 #  libvlc_printerr
 #  libvlc_set_exit_handler
 
-# 54 function(s) not wrapped as methods:
-#  libvlc_audio_equalizer_get_amp_at_index
+# 39 function(s) not wrapped as methods:
 #  libvlc_audio_equalizer_get_band_count
 #  libvlc_audio_equalizer_get_band_frequency
-#  libvlc_audio_equalizer_get_preamp
 #  libvlc_audio_equalizer_get_preset_count
 #  libvlc_audio_equalizer_get_preset_name
 #  libvlc_audio_equalizer_new
 #  libvlc_audio_equalizer_new_from_preset
-#  libvlc_audio_equalizer_release
-#  libvlc_audio_equalizer_set_amp_at_index
-#  libvlc_audio_equalizer_set_preamp
 #  libvlc_audio_output_device_list_release
 #  libvlc_audio_output_list_release
 #  libvlc_chapter_descriptions_release
@@ -8509,17 +8715,7 @@ def libvlc_media_list_player_set_playback_mode(p_mlp, e_mode):
 #  libvlc_media_tracks_release
 #  libvlc_module_description_list_release
 #  libvlc_new
-#  libvlc_renderer_discoverer_event_manager
 #  libvlc_renderer_discoverer_list_release
-#  libvlc_renderer_discoverer_release
-#  libvlc_renderer_discoverer_start
-#  libvlc_renderer_discoverer_stop
-#  libvlc_renderer_item_flags
-#  libvlc_renderer_item_hold
-#  libvlc_renderer_item_icon_uri
-#  libvlc_renderer_item_name
-#  libvlc_renderer_item_release
-#  libvlc_renderer_item_type
 #  libvlc_title_descriptions_release
 #  libvlc_track_description_list_release
 #  libvlc_track_description_release
@@ -8562,7 +8758,10 @@ def _dot2int(v):
     '''
     t = [int(i) for i in v.split('.')]
     if len(t) == 3:
-        t.append(0)
+        if t[2] < 100:
+            t.append(0)
+        else:  # 100 is arbitrary
+            t[2:4] = divmod(t[2], 100)
     elif len(t) != 4:
         raise ValueError('"i.i.i[.i]": %r' % (v,))
     if min(t) < 0 or max(t) > 255:
@@ -8638,20 +8837,51 @@ if __name__ == '__main__':
             sys.stdout.flush()
 
 
+    def print_python():
+        from platform import architecture, mac_ver, uname, win32_ver
+        if 'intelpython' in sys.executable:
+            t = 'Intel-'
+        # elif 'PyPy ' in sys.version:
+        #     t = 'PyPy-'
+        else:
+            t = ''
+        t = '%sPython: %s (%s)' % (t, sys.version.split()[0], architecture()[0])
+        if win32_ver()[0]:
+            t = t, 'Windows', win32_ver()[0]
+        elif mac_ver()[0]:
+            t = t, ('iOS' if sys.platform == 'ios' else 'macOS'), mac_ver()[0]
+        else:
+            try:
+                import distro  # <http://GitHub.com/nir0s/distro>
+                t = t, bytes_to_str(distro.name()), bytes_to_str(distro.version())
+            except ImportError:
+                t = (t,) + uname()[0:3:2]
+        print(' '.join(t))
+
+
     def print_version():
         """Print version of this vlc.py and of the libvlc"""
         try:
-            print('Build date: %s (%#x)' % (build_date, hex_version()))
+            print('%s: %s (%s)' % (os.path.basename(__file__), __version__, build_date))
             print('LibVLC version: %s (%#x)' % (bytes_to_str(libvlc_get_version()), libvlc_hex_version()))
             print('LibVLC compiler: %s' % bytes_to_str(libvlc_get_compiler()))
             if plugin_path:
                 print('Plugin path: %s' % plugin_path)
-        except:
+        except Exception:
             print('Error: %s' % sys.exc_info()[1])
 
 
-    if sys.argv[1:] and '-h' not in sys.argv[1:] and '--help' not in sys.argv[1:]:
+    if '-h' in sys.argv[:2] or '--help' in sys.argv[:2]:
+        print('Usage: %s [options] <movie_filename>' % sys.argv[0])
+        print('Once launched, type ? for help.')
+        print('')
 
+    elif '-v' in sys.argv[:2] or '--version' in sys.argv[:2]:
+        print_version()
+        print_python()
+        print('')
+
+    else:
         movie = os.path.expanduser(sys.argv.pop())
         if not os.access(movie, os.R_OK):
             print('Error: %s file not readable' % movie)
@@ -8714,7 +8944,7 @@ if __name__ == '__main__':
                 print('Video size: %s' % str(player.video_get_size(0)))  # num=0
                 print('Scale: %s' % player.video_get_scale())
                 print('Aspect ratio: %s' % player.video_get_aspect_ratio())
-                # print('Window:' % player.get_hwnd()
+            # print('Window:' % player.get_hwnd()
             except Exception:
                 print('Error: %s' % sys.exc_info()[1])
 
@@ -8781,9 +9011,3 @@ if __name__ == '__main__':
             elif k.isdigit():
                 # jump to fraction of the movie.
                 player.set_position(float('0.' + k))
-
-    else:
-        print('Usage: %s [options] <movie_filename>' % sys.argv[0])
-        print('Once launched, type ? for help.')
-        print('')
-        print_version()


### PR DESCRIPTION
This will replace the current VLC bindings with the generated ones from upstream. Partially addresses #3883. I copied over the (heavily modified) `find_lib` method from our old `vlc.py` and added some code so Tribler is able to find VLC in a Mac developer environment.

Fixes #4093