### PR TITLE
print() is a function in Python 3

### DIFF
--- a/Tribler/Core/Utilities/instrumentation.py
+++ b/Tribler/Core/Utilities/instrumentation.py
@@ -3,13 +3,14 @@ instrumentation.
 
 Author(s): Elric Milon
 """
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
 import threading
-from decorator import decorator
 from os import sys
 from threading import Lock, RLock, Thread
 from time import sleep, time
+
+from decorator import decorator
 
 MAX_SAME_STACK_TIME = 60
 
@@ -99,7 +100,7 @@ class WatchDog(Thread):
         self._registered_events.pop(name, None)
 
     def printe(self, line):
-            print(line, file=sys.stderr)
+        print(line, file=sys.stderr)
 
     def run(self):
         events_to_unregister = []

--- a/Tribler/Core/Utilities/instrumentation.py
+++ b/Tribler/Core/Utilities/instrumentation.py
@@ -3,6 +3,8 @@ instrumentation.
 
 Author(s): Elric Milon
 """
+from __future__ import print_function
+
 import threading
 from decorator import decorator
 from os import sys
@@ -97,7 +99,7 @@ class WatchDog(Thread):
         self._registered_events.pop(name, None)
 
     def printe(self, line):
-            print >> sys.stderr, line
+            print(line, file=sys.stderr)
 
     def run(self):
         events_to_unregister = []


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.