### PR TITLE
binascii.b2a_uu() requires bytes, not str

### DIFF
--- a/Tribler/Test/Core/test_unicode.py
+++ b/Tribler/Test/Core/test_unicode.py
@@ -26,7 +26,7 @@ class TriblerCoreTestUnicode(TriblerCoreTest):
         self.assertIsInstance(data, six.text_type)
 
     def test_unicode_binary_3(self):
-        data = binascii.b2a_uu("test")
+        data = binascii.b2a_uu(b"test")
         data = bin2unicode(data, 'bla')
         self.assertIsInstance(data, six.text_type)
 

--- a/Tribler/Test/Core/test_unicode.py
+++ b/Tribler/Test/Core/test_unicode.py
@@ -3,11 +3,11 @@ from __future__ import absolute_import
 import binascii
 import sys
 
+from nose.tools import raises
+
 import six
 
-from nose.tools import raises
-from Tribler.Core.Utilities.unicode import (bin2unicode, dunno2unicode,
-                                            str2unicode)
+from Tribler.Core.Utilities.unicode import bin2unicode, dunno2unicode, str2unicode
 from Tribler.Test.Core.base_test import TriblerCoreTest
 
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/defer.py", line 151, in maybeDeferred
    result = f(*args, **kw)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 201, in runWithWarningsSuppressed
    reraise(exc_info[1], exc_info[2])
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/python/compat.py", line 464, in reraise
    raise exception.with_traceback(traceback)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 197, in runWithWarningsSuppressed
    result = f(*a, **kw)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/test_as_server.py", line 62, in check
    result = fun(*argv, **kwargs)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/Core/test_unicode.py", line 24, in test_unicode_binary_2
    data = binascii.b2a_uu("test")
TypeError: a bytes-like object is required, not 'str'
```