### PR TITLE
dict.iteritems() --> dict.items() for Python 3

### DIFF
--- a/Tribler/Core/Utilities/utilities.py
+++ b/Tribler/Core/Utilities/utilities.py
@@ -5,13 +5,15 @@ Author(s): Jie Yang
 """
 from __future__ import absolute_import
 
-from base64 import b32decode
 import binascii
 import logging
-import six
+from base64 import b32decode
 
-from libtorrent import bencode, bdecode
-from six.moves.urllib.parse import urlsplit, parse_qsl
+from libtorrent import bdecode, bencode
+
+import six
+from six.moves.urllib.parse import parse_qsl, urlsplit
+
 from twisted.internet import reactor
 from twisted.internet.defer import fail, succeed
 from twisted.internet.ssl import ClientContextFactory

--- a/Tribler/Core/Utilities/utilities.py
+++ b/Tribler/Core/Utilities/utilities.py
@@ -298,7 +298,7 @@ def create_valid_metainfo(metainfo):
         # disabling this check, modifying metainfo to allow for ill-formatted torrents
         metainfo_result['nodes'] = []
 
-    return dict((key, val) for key, val in metainfo_result.iteritems()
+    return dict((key, val) for key, val in metainfo_result.items()
                 if val or (metainfo[key] and metainfo[key] == val))
 
 


### PR DESCRIPTION
```
ERROR: test_valid_torrent_file_announce_list_empty
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/defer.py", line 1418, in _inlineCallbacks
    result = g.send(result)
StopIteration

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/defer.py", line 151, in maybeDeferred
    result = f(*args, **kw)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 201, in runWithWarningsSuppressed
    reraise(exc_info[1], exc_info[2])
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/python/compat.py", line 464, in reraise
    raise exception.with_traceback(traceback)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 197, in runWithWarningsSuppressed
    result = f(*a, **kw)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/test_as_server.py", line 62, in check
    result = fun(*argv, **kwargs)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/Core/test_utilities.py", line 191, in test_valid_torrent_file_announce_list_empty
    "length": 42}, "announce-list": []})
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Core/Utilities/utilities.py", line 301, in create_valid_metainfo
    return dict((key, val) for key, val in metainfo_result.iteritems()
AttributeError: 'dict' object has no attribute 'iteritems'
```