### PR TITLE
state_file.write() requires bytes, not str

### DIFF
--- a/Tribler/Test/Core/test_launch_many_cores.py
+++ b/Tribler/Test/Core/test_launch_many_cores.py
@@ -145,7 +145,7 @@ class TestLaunchManyCore(TriblerCoreTest):
         self.lm.session.get_downloads_pstate_dir = lambda: self.session_base_dir
 
         with open(os.path.join(self.lm.session.get_downloads_pstate_dir(), 'abcd.state'), 'wb') as state_file:
-            state_file.write("hi")
+            state_file.write(b"hi")
 
         self.lm.initComplete = True
         self.lm.resume_download = mocked_resume_download


### PR DESCRIPTION
```
ERROR: Test whether we are resuming downloads after loading checkpoint
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/defer.py", line 151, in maybeDeferred
    result = f(*args, **kw)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 201, in runWithWarningsSuppressed
    reraise(exc_info[1], exc_info[2])
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/python/compat.py", line 464, in reraise
    raise exception.with_traceback(traceback)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 197, in runWithWarningsSuppressed
    result = f(*a, **kw)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/test_as_server.py", line 62, in check
    result = fun(*argv, **kwargs)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/Core/test_launch_many_cores.py", line 148, in test_load_checkpoint
    state_file.write("hi")
TypeError: a bytes-like object is required, not 'str'
```