### PR TITLE
self._interrupt_socket.sendto() requires bytes, not str

### DIFF
--- a/Tribler/Core/Utilities/network_utils.py
+++ b/Tribler/Core/Utilities/network_utils.py
@@ -179,7 +179,7 @@ class InterruptSocket(object):
 
     def interrupt(self):
         if not self._has_interrupted:
-            self._interrupt_socket.sendto('+', (self._ip, self._port))
+            self._interrupt_socket.sendto(b'+', (self._ip, self._port))
             self._has_interrupted = True
 
     def close(self):


### PR DESCRIPTION
```
ERROR: test_interrupt_socket
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/defer.py", line 1418, in _inlineCallbacks
    result = g.send(result)
StopIteration

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/defer.py", line 151, in maybeDeferred
    result = f(*args, **kw)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 201, in runWithWarningsSuppressed
    reraise(exc_info[1], exc_info[2])
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/python/compat.py", line 464, in reraise
    raise exception.with_traceback(traceback)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 197, in runWithWarningsSuppressed
    result = f(*a, **kw)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/test_as_server.py", line 62, in check
    result = fun(*argv, **kwargs)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/Core/test_network_utils.py", line 47, in test_interrupt_socket
    interrupt_socket.interrupt()
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Core/Utilities/network_utils.py", line 182, in interrupt
    self._interrupt_socket.sendto('+', (self._ip, self._port))
TypeError: a bytes-like object is required, not 'str'
```