### PR TITLE
from six.moves.urllib.parse import unquote_plus

### DIFF
--- a/Tribler/Test/GUI/test_util.py
+++ b/Tribler/Test/GUI/test_util.py
@@ -1,5 +1,6 @@
 import unittest
-from urllib import unquote_plus
+
+from six.moves.urllib.parse import unquote_plus
 
 from TriblerGUI.utilities import unicode_quoter, quote_plus_unicode
 

--- a/Tribler/Test/GUI/test_util.py
+++ b/Tribler/Test/GUI/test_util.py
@@ -1,8 +1,10 @@
+from __future__ import absolute_import
+
 import unittest
 
 from six.moves.urllib.parse import unquote_plus
 
-from TriblerGUI.utilities import unicode_quoter, quote_plus_unicode
+from TriblerGUI.utilities import quote_plus_unicode, unicode_quoter
 
 
 class TestGUIUtilities(unittest.TestCase):


### PR DESCRIPTION
```
ERROR: Failure: ImportError (cannot import name 'unquote_plus')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/nose/failure.py", line 39, in runTest
    raise self.exc_val.with_traceback(self.tb)
  File "/usr/lib/python3/dist-packages/nose/loader.py", line 418, in loadTestsFromName
    addr.filename, addr.module)
  File "/usr/lib/python3/dist-packages/nose/importer.py", line 47, in importFromPath
    return self.importFromDir(dir_path, fqname)
  File "/usr/lib/python3/dist-packages/nose/importer.py", line 94, in importFromDir
    mod = load_module(part_fqname, fh, filename, desc)
  File "/usr/lib/python3.5/imp.py", line 234, in load_module
    return load_source(name, filename, file)
  File "/usr/lib/python3.5/imp.py", line 172, in load_source
    module = _load(spec)
  File "<frozen importlib._bootstrap>", line 693, in _load
  File "<frozen importlib._bootstrap>", line 673, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 673, in exec_module
  File "<frozen importlib._bootstrap>", line 222, in _call_with_frames_removed
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/GUI/test_util.py", line 2, in <module>
    from urllib import unquote_plus
ImportError: cannot import name 'unquote_plus'
```