### PR TITLE
from six.moves.urllib.request import pathname2url

### DIFF
--- a/Tribler/Test/Integration/test_live_downloads.py
+++ b/Tribler/Test/Integration/test_live_downloads.py
@@ -6,18 +6,21 @@ import sys
 import time
 import unittest
 from unittest import skipUnless
-from urllib import pathname2url
+
+from check_os import setup_gui_logging
+
+import matplotlib.pyplot as plot
 
 import numpy
+
 from PyQt5.QtCore import QPoint, Qt
 from PyQt5.QtGui import QPixmap, QRegion
 from PyQt5.QtTest import QTest
 from PyQt5.QtWidgets import QApplication, QListWidget, QTreeWidget
 
 import run_tribler
-from check_os import setup_gui_logging
 
-import matplotlib.pyplot as plot
+from six.moves.urllib.request import pathname2url
 
 import TriblerGUI
 from TriblerGUI.tribler_window import TriblerWindow

--- a/Tribler/Test/Integration/test_live_downloads.py
+++ b/Tribler/Test/Integration/test_live_downloads.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import glob
 import logging
 import os
@@ -7,16 +9,16 @@ import time
 import unittest
 from unittest import skipUnless
 
+from PyQt5.QtCore import QPoint, Qt
+from PyQt5.QtGui import QPixmap, QRegion
+from PyQt5.QtTest import QTest
+from PyQt5.QtWidgets import QApplication, QListWidget, QTreeWidget
+
 from check_os import setup_gui_logging
 
 import matplotlib.pyplot as plot
 
 import numpy
-
-from PyQt5.QtCore import QPoint, Qt
-from PyQt5.QtGui import QPixmap, QRegion
-from PyQt5.QtTest import QTest
-from PyQt5.QtWidgets import QApplication, QListWidget, QTreeWidget
 
 import run_tribler
 


### PR DESCRIPTION
```
ERROR: Failure: ImportError (cannot import name 'pathname2url')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/nose/failure.py", line 39, in runTest
    raise self.exc_val.with_traceback(self.tb)
  File "/usr/lib/python3/dist-packages/nose/loader.py", line 418, in loadTestsFromName
    addr.filename, addr.module)
  File "/usr/lib/python3/dist-packages/nose/importer.py", line 47, in importFromPath
    return self.importFromDir(dir_path, fqname)
  File "/usr/lib/python3/dist-packages/nose/importer.py", line 94, in importFromDir
    mod = load_module(part_fqname, fh, filename, desc)
  File "/usr/lib/python3.5/imp.py", line 234, in load_module
    return load_source(name, filename, file)
  File "/usr/lib/python3.5/imp.py", line 172, in load_source
    module = _load(spec)
  File "<frozen importlib._bootstrap>", line 693, in _load
  File "<frozen importlib._bootstrap>", line 673, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 673, in exec_module
  File "<frozen importlib._bootstrap>", line 222, in _call_with_frames_removed
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/Integration/test_live_downloads.py", line 9, in <module>
    from urllib import pathname2url
ImportError: cannot import name 'pathname2url'
```