### PR TITLE
Test for bytes, not str

### DIFF
--- a/Tribler/Test/Core/test_torrent_def.py
+++ b/Tribler/Test/Core/test_torrent_def.py
@@ -103,7 +103,7 @@ class TestTorrentDef(BaseTestCase):
         metainfo = t.get_metainfo()
         self.general_check(metainfo)
 
-        self.assertEqual(metainfo['info']['name'], 'dirintorrent')
+        self.assertEqual(metainfo['info']['name'], b'dirintorrent')
         reals = 0
         for file in metainfo['info']['files']:
             s = file['length']
@@ -137,7 +137,7 @@ class TestTorrentDef(BaseTestCase):
 
         metainfo = t.get_metainfo()
         self.general_check(metainfo)
-        self.assertEqual(metainfo['info']['name'], 'dirintorrent')
+        self.assertEqual(metainfo['info']['name'], b'dirintorrent')
 
         reals = 0
         for file in metainfo['info']['files']:

--- a/Tribler/Test/Core/test_torrent_def.py
+++ b/Tribler/Test/Core/test_torrent_def.py
@@ -5,11 +5,11 @@ import os
 import shutil
 from tempfile import mkdtemp
 
-import six
-
 from libtorrent import bdecode
 
 from nose.tools import raises
+
+import six
 
 from twisted.internet import reactor
 from twisted.internet.defer import inlineCallbacks

--- a/Tribler/Test/Core/test_torrent_def.py
+++ b/Tribler/Test/Core/test_torrent_def.py
@@ -1,13 +1,16 @@
 from __future__ import absolute_import
+
 import logging
 import os
 import shutil
 from tempfile import mkdtemp
 
 import six
+
 from libtorrent import bdecode
+
 from nose.tools import raises
-from Tribler.Test.tools import trial_timeout
+
 from twisted.internet import reactor
 from twisted.internet.defer import inlineCallbacks
 from twisted.web.server import Site
@@ -16,10 +19,11 @@ from twisted.web.static import File
 from Tribler.Core.TorrentDef import TorrentDef, TorrentDefNoMetainfo
 from Tribler.Core.Utilities.network_utils import get_random_port
 from Tribler.Core.Utilities.utilities import create_valid_metainfo, valid_torrent_file
-from Tribler.Core.exceptions import TorrentDefNotFinalizedException, HttpError
+from Tribler.Core.exceptions import HttpError, TorrentDefNotFinalizedException
 from Tribler.Core.simpledefs import INFOHASH_LENGTH
 from Tribler.Test.common import TESTS_DATA_DIR, TORRENT_UBUNTU_FILE
 from Tribler.Test.test_as_server import BaseTestCase
+from Tribler.Test.tools import trial_timeout
 
 TRACKER = 'http://www.tribler.org/announce'
 


### PR DESCRIPTION
```
FAIL: Add a single dir to a TorrentDef
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/defer.py", line 151, in maybeDeferred
    result = f(*args, **kw)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 201, in runWithWarningsSuppressed
    reraise(exc_info[1], exc_info[2])
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/python/compat.py", line 464, in reraise
    raise exception.with_traceback(traceback)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 197, in runWithWarningsSuppressed
    result = f(*a, **kw)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/test_as_server.py", line 62, in check
    result = fun(*argv, **kwargs)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/Core/test_torrent_def.py", line 106, in test_add_content_dir
    self.assertEqual(metainfo['info']['name'], 'dirintorrent')
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/trial/_synctest.py", line 432, in assertEqual
    super(_Assertions, self).assertEqual(first, second, msg)
  File "/usr/lib/python3.5/unittest/case.py", line 821, in assertEqual
    assertion_func(first, second, msg=msg)
  File "/usr/lib/python3.5/unittest/case.py", line 814, in _baseAssertEqual
    raise self.failureException(msg)
twisted.trial.unittest.FailTest: b'dirintorrent' != 'dirintorrent'
-------------------- >> begin captured logging << --------------------
Tribler.Core.Utilities.maketorrent: DEBUG: makeinfo: inpath=/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/data/contentdir, outpath=dirintorrent
TestTorrentDef: DEBUG: Expected size file.txt 29
TestTorrentDef: DEBUG: Expected size otherfile.txt 135
TestTorrentDef: DEBUG: Expected total size of files in torrent 164
--------------------- >> end captured logging << ---------------------

======================================================================
FAIL: Add a single dir and single file to a TorrentDef
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/defer.py", line 151, in maybeDeferred
    result = f(*args, **kw)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 201, in runWithWarningsSuppressed
    reraise(exc_info[1], exc_info[2])
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/python/compat.py", line 464, in reraise
    raise exception.with_traceback(traceback)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 197, in runWithWarningsSuppressed
    result = f(*a, **kw)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/test_as_server.py", line 62, in check
    result = fun(*argv, **kwargs)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/Core/test_torrent_def.py", line 140, in test_add_content_dir_and_file
    self.assertEqual(metainfo['info']['name'], 'dirintorrent')
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/trial/_synctest.py", line 432, in assertEqual
    super(_Assertions, self).assertEqual(first, second, msg)
  File "/usr/lib/python3.5/unittest/case.py", line 821, in assertEqual
    assertion_func(first, second, msg=msg)
  File "/usr/lib/python3.5/unittest/case.py", line 814, in _baseAssertEqual
    raise self.failureException(msg)
twisted.trial.unittest.FailTest: b'dirintorrent' != 'dirintorrent'
-------------------- >> begin captured logging << --------------------
Tribler.Core.Utilities.maketorrent: DEBUG: makeinfo: inpath=/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/data/contentdir, outpath=dirintorrent
Tribler.Core.Utilities.maketorrent: DEBUG: makeinfo: inpath=/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/data/video.avi, outpath=dirintorrent/video.avi
--------------------- >> end captured logging << ---------------------
```