### PR TITLE
mid.encode('hex') --> hexlify(mid) for Python 3

### DIFF
--- a/Tribler/Core/Libtorrent/LibtorrentMgr.py
+++ b/Tribler/Core/Libtorrent/LibtorrentMgr.py
@@ -5,13 +5,12 @@ Author(s): Egbert Bouman
 """
 from __future__ import absolute_import
 
-import binascii
 import logging
 import os
 import tempfile
 import threading
 import time
-from binascii import hexlify
+from binascii import hexlify, unhexlify
 from copy import deepcopy
 from distutils.version import LooseVersion
 from shutil import rmtree
@@ -181,7 +180,7 @@ class LibtorrentMgr(TaskManager):
 
             mid = self.tribler_session.trustchain_keypair.key_to_hash()
             settings['peer_fingerprint'] = mid
-            settings['handshake_client_version'] = 'Tribler/' + version_id + '/' + mid.encode('hex')
+            settings['handshake_client_version'] = 'Tribler/' + version_id + '/' + hexlify(mid)
         else:
             settings['enable_outgoing_utp'] = True
             settings['enable_incoming_utp'] = True
@@ -332,7 +331,7 @@ class LibtorrentMgr(TaskManager):
             if 'ti' in atp:
                 infohash = str(atp['ti'].info_hash())
             elif 'url' in atp:
-                infohash = binascii.hexlify(parse_magnetlink(atp['url'])[1])
+                infohash = hexlify(parse_magnetlink(atp['url'])[1])
             else:
                 raise ValueError('No ti or url key in add_torrent_params')
 
@@ -464,7 +463,7 @@ class LibtorrentMgr(TaskManager):
 
         magnet = infohash_or_magnet if infohash_or_magnet.startswith('magnet') else None
         infohash_bin = infohash_or_magnet if not magnet else parse_magnetlink(magnet)[1]
-        infohash = binascii.hexlify(infohash_bin)
+        infohash = hexlify(infohash_bin)
 
         if infohash in self.torrents:
             return
@@ -523,7 +522,7 @@ class LibtorrentMgr(TaskManager):
 
     def got_metainfo(self, infohash, timeout=False):
         with self.metainfo_lock:
-            infohash_bin = binascii.unhexlify(infohash)
+            infohash_bin = unhexlify(infohash)
 
             if infohash in self.metainfo_requests:
                 request_dict = self.metainfo_requests.pop(infohash)

--- a/Tribler/Core/Libtorrent/LibtorrentMgr.py
+++ b/Tribler/Core/Libtorrent/LibtorrentMgr.py
@@ -180,7 +180,7 @@ class LibtorrentMgr(TaskManager):
 
             mid = self.tribler_session.trustchain_keypair.key_to_hash()
             settings['peer_fingerprint'] = mid
-            settings['handshake_client_version'] = 'Tribler/' + version_id + '/' + hexlify(mid)
+            settings['handshake_client_version'] = b'Tribler/' + version_id + b'/' + hexlify(mid)
         else:
             settings['enable_outgoing_utp'] = True
             settings['enable_incoming_utp'] = True

--- a/Tribler/Core/Libtorrent/LibtorrentMgr.py
+++ b/Tribler/Core/Libtorrent/LibtorrentMgr.py
@@ -180,7 +180,8 @@ class LibtorrentMgr(TaskManager):
 
             mid = self.tribler_session.trustchain_keypair.key_to_hash()
             settings['peer_fingerprint'] = mid
-            settings['handshake_client_version'] = b'Tribler/' + version_id + b'/' + hexlify(mid)
+            settings['handshake_client_version'] = ('Tribler/' + version_id + '/' +
+                                                    codecs.decode(mid, 'raw_unicode_escape'))
         else:
             settings['enable_outgoing_utp'] = True
             settings['enable_incoming_utp'] = True

--- a/Tribler/Core/Libtorrent/LibtorrentMgr.py
+++ b/Tribler/Core/Libtorrent/LibtorrentMgr.py
@@ -5,6 +5,7 @@ Author(s): Egbert Bouman
 """
 from __future__ import absolute_import
 
+import codecs
 import logging
 import os
 import tempfile


### PR DESCRIPTION
```
ERROR: Testing whether some errors are ignored (like socket errors)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/defer.py", line 1416, in _inlineCallbacks
    result = result.throwExceptionIntoGenerator(g)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/python/failure.py", line 491, in throwExceptionIntoGenerator
    return g.throw(self.type, self.value, self.tb)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/Core/test_session.py", line 23, in setUp
    yield super(TestSessionAsServer, self).setUp()
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/defer.py", line 1418, in _inlineCallbacks
    result = g.send(result)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/test_as_server.py", line 278, in setUp
    self.tribler_started_deferred = self.session.start()
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Core/Session.py", line 409, in start
    startup_deferred = self.lm.register(self, self.session_lock)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Core/APIImplementation/LaunchManyCore.py", line 153, in register
    self.init()
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Core/APIImplementation/LaunchManyCore.py", line 308, in init
    self.ltmgr.initialize()
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Core/Libtorrent/LibtorrentMgr.py", line 98, in initialize
    self.get_session().start_upnp()
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Core/Libtorrent/LibtorrentMgr.py", line 248, in get_session
    self.ltsessions[hops] = self.create_session(hops)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Core/Libtorrent/LibtorrentMgr.py", line 184, in create_session
    settings['handshake_client_version'] = 'Tribler/' + version_id + '/' + mid.encode('hex')
AttributeError: 'bytes' object has no attribute 'encode'
```