### PR TITLE
str are already Unicode utf-8 by default in Python 3

### DIFF
--- a/Tribler/Core/Utilities/maketorrent.py
+++ b/Tribler/Core/Utilities/maketorrent.py
@@ -250,10 +250,7 @@ def filename2pathlist(path, skipfirst=False):
 
 def pathlist2filename(pathlist):
     """ Convert a multi-file torrent file 'path' entry to a filename. """
-    fullpath = ''
-    for elem in pathlist:
-        fullpath = os.path.join(fullpath, elem)
-
+    fullpath = os.path.join(*pathlist)
     try:
         return fullpath.decode('utf-8')
     except AttributeError:

--- a/Tribler/Core/Utilities/maketorrent.py
+++ b/Tribler/Core/Utilities/maketorrent.py
@@ -257,7 +257,7 @@ def pathlist2filename(pathlist):
     try:
         return fullpath.decode('utf-8')
     except AttributeError:
-        return fullpath  # Python 3: AttributeError: 'str' object has no attribute 'decode' 
+        return fullpath  # Python 3: AttributeError: 'str' object has no attribute 'decode'
     except UnicodeDecodeError:
         charenc = chardet.detect(fullpath)['encoding']
         if not charenc:

--- a/Tribler/Core/Utilities/maketorrent.py
+++ b/Tribler/Core/Utilities/maketorrent.py
@@ -256,6 +256,8 @@ def pathlist2filename(pathlist):
 
     try:
         return fullpath.decode('utf-8')
+    except AttributeError:
+        return fullpath  # Python 3: AttributeError: 'str' object has no attribute 'decode' 
     except UnicodeDecodeError:
         charenc = chardet.detect(fullpath)['encoding']
         if not charenc:

--- a/Tribler/Core/Utilities/maketorrent.py
+++ b/Tribler/Core/Utilities/maketorrent.py
@@ -5,6 +5,7 @@ Author(s): Arno Bakker, Bram Cohen
 """
 from __future__ import absolute_import
 
+import codecs
 import logging
 import os
 from copy import copy

--- a/Tribler/Core/Utilities/maketorrent.py
+++ b/Tribler/Core/Utilities/maketorrent.py
@@ -252,9 +252,9 @@ def pathlist2filename(pathlist):
     """ Convert a multi-file torrent file 'path' entry to a filename. """
     fullpath = os.path.join(*pathlist)
     try:
-        return fullpath.decode('utf-8')
-    except AttributeError:
-        return fullpath  # Python 3: AttributeError: 'str' object has no attribute 'decode'
+        return codecs.decode(fullpath, 'utf-8')
+    except TypeError:
+        return fullpath  # Python 3: a bytes-like object is required, not 'str'
     except UnicodeDecodeError:
         charenc = chardet.detect(fullpath)['encoding']
         if not charenc:


### PR DESCRIPTION
```
ERROR: test_get_index
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/defer.py", line 151, in maybeDeferred
    result = f(*args, **kw)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 201, in runWithWarningsSuppressed
    reraise(exc_info[1], exc_info[2])
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/python/compat.py", line 464, in reraise
    raise exception.with_traceback(traceback)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 197, in runWithWarningsSuppressed
    result = f(*a, **kw)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/test_as_server.py", line 62, in check
    result = fun(*argv, **kwargs)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/Core/test_torrent_def.py", line 445, in test_get_index
    self.assertEqual(t.get_index_of_file_in_files('a.txt'), 0)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Core/TorrentDef.py", line 790, in get_index_of_file_in_files
    intorrentpath = maketorrent.pathlist2filename(file_dict['path'])
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Core/Utilities/maketorrent.py", line 258, in pathlist2filename
    return fullpath.decode('utf-8')
AttributeError: 'str' object has no attribute 'decode'
```