### PR TITLE
Fixed TrustChain logging

### DIFF
--- a/logger.conf
+++ b/logger.conf
@@ -16,7 +16,6 @@ keys=root,twisted,
     DiscoveryCommunity,
     HiddenTunnelCommunity,
     TriblerTunnelCommunity,
-    TrustChainCommunity,
     PopularityCommunity,
     DHTDiscoveryCommunity,
     MarketCommunity,
@@ -166,12 +165,6 @@ propagate=0
 [logger_TriblerTunnelCommunity]
 level=ERROR
 qualname=TriblerTunnelCommunity
-handlers=default
-propagate=0
-
-[logger_TrustChainCommunity]
-level=ERROR
-qualname=TrustChainCommunity
 handlers=default
 propagate=0
 


### PR DESCRIPTION
The logger.conf specified that TrustChainCommunity logging is limited to ERROR logs.