### PR TITLE
Version checker in config

### DIFF
--- a/Tribler/Core/Config/config.spec
+++ b/Tribler/Core/Config/config.spec
@@ -2,6 +2,7 @@
 state_dir = string(default='')
 log_dir = string(default=None)
 testnet = boolean(default=False)
+version_checker_enabled = boolean(default=True)
 
 [tunnel_community]
 enabled = boolean(default=True)


### PR DESCRIPTION
We had not defined boolean spec for version checker which is why version checked seemed to be always enabled in dev mode.