### PR TITLE
Insert a temporary try / except KeyError block

### DIFF
--- a/Tribler/Core/TorrentDef.py
+++ b/Tribler/Core/TorrentDef.py
@@ -485,7 +485,13 @@ class TorrentDef(object):
             self.infohash = infohash
             self.metainfo = metainfo
 
-            self.input['name'] = metainfo['info']['name']
+            try:
+                self.input['name'] = metainfo['info']['name']
+            except KeyError:  #TODO: Remove this tempoary try / except block leaving only the 1 line above
+                print(metainfo)
+                print("======")
+                print(metainfo['info'])
+                raise
             # May have been 0, meaning auto.
             self.input['piece length'] = metainfo['info']['piece length']
             self.metainfo_valid = True


### PR DESCRIPTION
```
======================================================================
ERROR: Add a single file with announce-list to a TorrentDef
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/defer.py", line 151, in maybeDeferred
    result = f(*args, **kw)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 201, in runWithWarningsSuppressed
    reraise(exc_info[1], exc_info[2])
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/python/compat.py", line 464, in reraise
    raise exception.with_traceback(traceback)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 197, in runWithWarningsSuppressed
    result = f(*a, **kw)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/test_as_server.py", line 62, in check
    result = fun(*argv, **kwargs)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/Core/test_torrent_def.py", line 192, in test_add_content_announce_list
    t.finalize()
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Core/TorrentDef.py", line 488, in finalize
    self.input['name'] = metainfo['info']['name']
KeyError: 'name'
-------------------- >> begin captured logging << --------------------
Tribler.Core.Utilities.maketorrent: DEBUG: makeinfo: inpath=/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/data/video.avi, outpath=None
--------------------- >> end captured logging << ---------------------

======================================================================
ERROR: Add a single dir to a TorrentDef
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/defer.py", line 151, in maybeDeferred
    result = f(*args, **kw)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 201, in runWithWarningsSuppressed
    reraise(exc_info[1], exc_info[2])
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/python/compat.py", line 464, in reraise
    raise exception.with_traceback(traceback)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 197, in runWithWarningsSuppressed
    result = f(*a, **kw)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/test_as_server.py", line 62, in check
    result = fun(*argv, **kwargs)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/Core/test_torrent_def.py", line 102, in test_add_content_dir
    t.finalize()
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Core/TorrentDef.py", line 488, in finalize
    self.input['name'] = metainfo['info']['name']
KeyError: 'name'
-------------------- >> begin captured logging << --------------------
Tribler.Core.Utilities.maketorrent: DEBUG: makeinfo: inpath=/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/data/contentdir, outpath=dirintorrent
--------------------- >> end captured logging << ---------------------

======================================================================
ERROR: Add a single dir and single file to a TorrentDef
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/defer.py", line 151, in maybeDeferred
    result = f(*args, **kw)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 201, in runWithWarningsSuppressed
    reraise(exc_info[1], exc_info[2])
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/python/compat.py", line 464, in reraise
    raise exception.with_traceback(traceback)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 197, in runWithWarningsSuppressed
    result = f(*a, **kw)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/test_as_server.py", line 62, in check
    result = fun(*argv, **kwargs)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/Core/test_torrent_def.py", line 140, in test_add_content_dir_and_file
    t.finalize()
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Core/TorrentDef.py", line 488, in finalize
    self.input['name'] = metainfo['info']['name']
KeyError: 'name'
-------------------- >> begin captured logging << --------------------
Tribler.Core.Utilities.maketorrent: DEBUG: makeinfo: inpath=/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/data/contentdir, outpath=dirintorrent
Tribler.Core.Utilities.maketorrent: DEBUG: makeinfo: inpath=/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/data/video.avi, outpath=dirintorrent/video.avi
--------------------- >> end captured logging << ---------------------

======================================================================
ERROR: Add a single file to a TorrentDef
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/defer.py", line 151, in maybeDeferred
    result = f(*args, **kw)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 201, in runWithWarningsSuppressed
    reraise(exc_info[1], exc_info[2])
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/python/compat.py", line 464, in reraise
    raise exception.with_traceback(traceback)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 197, in runWithWarningsSuppressed
    result = f(*a, **kw)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/test_as_server.py", line 62, in check
    result = fun(*argv, **kwargs)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/Core/test_torrent_def.py", line 70, in test_add_content_file_and_copy
    t.finalize()
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Core/TorrentDef.py", line 488, in finalize
    self.input['name'] = metainfo['info']['name']
KeyError: 'name'
-------------------- >> begin captured logging << --------------------
Tribler.Core.Utilities.maketorrent: DEBUG: makeinfo: inpath=/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/data/video.avi, outpath=None
--------------------- >> end captured logging << ---------------------

======================================================================
ERROR: Add a single file to a TorrentDef and save the latter
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/defer.py", line 151, in maybeDeferred
    result = f(*args, **kw)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 201, in runWithWarningsSuppressed
    reraise(exc_info[1], exc_info[2])
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/python/compat.py", line 464, in reraise
    raise exception.with_traceback(traceback)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 197, in runWithWarningsSuppressed
    result = f(*a, **kw)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/test_as_server.py", line 62, in check
    result = fun(*argv, **kwargs)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/Core/test_torrent_def.py", line 233, in test_add_content_file_save
    t.finalize()
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Core/TorrentDef.py", line 488, in finalize
    self.input['name'] = metainfo['info']['name']
KeyError: 'name'
-------------------- >> begin captured logging << --------------------
Tribler.Core.Utilities.maketorrent: DEBUG: makeinfo: inpath=/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/data/video.avi, outpath=None
--------------------- >> end captured logging << ---------------------

======================================================================
ERROR: Add a single file with BitTornado httpseeds to a TorrentDef
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/defer.py", line 151, in maybeDeferred
    result = f(*args, **kw)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 201, in runWithWarningsSuppressed
    reraise(exc_info[1], exc_info[2])
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/python/compat.py", line 464, in reraise
    raise exception.with_traceback(traceback)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 197, in runWithWarningsSuppressed
    result = f(*a, **kw)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/test_as_server.py", line 62, in check
    result = fun(*argv, **kwargs)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/Core/test_torrent_def.py", line 207, in test_add_content_httpseeds
    t.finalize()
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Core/TorrentDef.py", line 488, in finalize
    self.input['name'] = metainfo['info']['name']
KeyError: 'name'
-------------------- >> begin captured logging << --------------------
Tribler.Core.Utilities.maketorrent: DEBUG: makeinfo: inpath=/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/data/video.avi, outpath=None
--------------------- >> end captured logging << ---------------------

======================================================================
ERROR: Add a single file with piece length to a TorrentDef
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/defer.py", line 151, in maybeDeferred
    result = f(*args, **kw)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 201, in runWithWarningsSuppressed
    reraise(exc_info[1], exc_info[2])
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/python/compat.py", line 464, in reraise
    raise exception.with_traceback(traceback)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 197, in runWithWarningsSuppressed
    result = f(*a, **kw)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/test_as_server.py", line 62, in check
    result = fun(*argv, **kwargs)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/Core/test_torrent_def.py", line 221, in test_add_content_piece_length
    t.finalize()
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Core/TorrentDef.py", line 488, in finalize
    self.input['name'] = metainfo['info']['name']
KeyError: 'name'
-------------------- >> begin captured logging << --------------------
Tribler.Core.Utilities.maketorrent: DEBUG: makeinfo: inpath=/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/data/video.avi, outpath=None
--------------------- >> end captured logging << ---------------------
```