### PR TITLE
Move channel dir processing to a separate thread

### DIFF
--- a/Tribler/Core/Modules/MetadataStore/OrmBindings/channel_metadata.py
+++ b/Tribler/Core/Modules/MetadataStore/OrmBindings/channel_metadata.py
@@ -448,7 +448,7 @@ def define_binding(db):
                 "id": self.rowid,
                 "public_key": hexlify(self.public_key),
                 "name": self.title,
-                "torrents": self.contents_len,
+                "torrents": self.num_entries,
                 "subscribed": self.subscribed,
                 "votes": self.votes,
                 "status": self.status,

--- a/Tribler/Core/Modules/MetadataStore/store.py
+++ b/Tribler/Core/Modules/MetadataStore/store.py
@@ -331,7 +331,7 @@ class MetadataStore(object):
                                                    infohash=database_blob(payload.infohash))
         if node and node.timestamp < payload.timestamp:
             node.delete()
-            result.append((node, DELETED_METADATA))
+            result.append((None, DELETED_METADATA))
 
         # Check for the older version of the same node
         node = self.TorrentMetadata.get_for_update(public_key=database_blob(payload.public_key), id_=payload.id_)

--- a/Tribler/Core/Modules/MetadataStore/store.py
+++ b/Tribler/Core/Modules/MetadataStore/store.py
@@ -7,7 +7,6 @@ from datetime import datetime, timedelta
 from time import sleep
 
 import lz4.frame
-
 from pony import orm
 from pony.orm import db_session
 
@@ -281,7 +280,8 @@ class MetadataStore(object):
                 elif target_coeff > 1.0:
                     self.batch_size = int(float(self.batch_size) / target_coeff)
                 self.batch_size += 1  # we want to guarantee that at least something will go through
-            self._logger.debug(("Added payload batch to DB (entries, seconds): %i %f", self.batch_size, batch_end_time))
+            self._logger.debug(("Added payload batch to DB (entries, seconds): %i %f", (self.batch_size,
+                                float(batch_end_time.total_seconds()))))
             start = end
         return result
 

--- a/Tribler/Core/Modules/MetadataStore/store.py
+++ b/Tribler/Core/Modules/MetadataStore/store.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 import logging
 import os
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta
 from time import sleep
 
 import lz4.frame
+
 from pony import orm
 from pony.orm import db_session
 
@@ -280,8 +281,8 @@ class MetadataStore(object):
                 elif target_coeff > 1.0:
                     self.batch_size = int(float(self.batch_size) / target_coeff)
                 self.batch_size += 1  # we want to guarantee that at least something will go through
-            self._logger.debug(("Added payload batch to DB (entries, seconds): %i %f", (self.batch_size,
-                                float(batch_end_time.total_seconds()))))
+            self._logger.debug(("Added payload batch to DB (entries, seconds): %i %f",
+                                (self.batch_size, float(batch_end_time.total_seconds()))))
             start = end
         return result
 

--- a/Tribler/Core/Modules/gigachannel_manager.py
+++ b/Tribler/Core/Modules/gigachannel_manager.py
@@ -4,6 +4,7 @@ import os
 from binascii import hexlify
 
 from pony.orm import db_session
+
 from twisted.internet.task import LoopingCall
 from twisted.internet.threads import deferToThread
 
@@ -169,11 +170,11 @@ class GigaChannelManager(TaskManager):
             self.session.lm.mds.process_channel_dir(channel_dirname, channel.public_key, external_thread=True)
             self.session.lm.mds._db.disconnect()
 
-
         def _on_failure(failure):
             self._logger.error("Error when processing channel dir download: %s", failure)
 
-        finished_deferred = download.finished_deferred.addCallback(lambda dl: deferToThread(on_channel_download_finished, dl))
+        finished_deferred = download.finished_deferred.addCallback(
+            lambda dl: deferToThread(on_channel_download_finished, dl))
         finished_deferred.addErrback(_on_failure)
 
         return download, finished_deferred

--- a/Tribler/Core/Modules/restapi/downloads_endpoint.py
+++ b/Tribler/Core/Modules/restapi/downloads_endpoint.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 import logging
 from binascii import hexlify, unhexlify
+
 from libtorrent import bencode, create_torrent
 
 from pony.orm import db_session
@@ -16,7 +17,7 @@ from twisted.web.server import NOT_DONE_YET
 
 import Tribler.Core.Utilities.json_util as json
 from Tribler.Core.DownloadConfig import DownloadStartupConfig
-from Tribler.Core.Modules.MetadataStore.serialization import ChannelMetadataPayload, CHANNEL_TORRENT
+from Tribler.Core.Modules.MetadataStore.serialization import CHANNEL_TORRENT, ChannelMetadataPayload
 from Tribler.Core.Modules.MetadataStore.store import UNKNOWN_CHANNEL, UPDATED_OUR_VERSION
 from Tribler.Core.Modules.restapi.util import return_handled_exception
 from Tribler.Core.Utilities.torrent_utils import get_info_from_handle
@@ -348,16 +349,14 @@ class DownloadsEndpoint(DownloadBaseEndpoint):
                     return json.dumps({"error": "Metadata has invalid signature"})
 
                 with db_session:
-                    # TODO: move this to MetadataEndpoint
                     result = self.session.lm.mds.process_payload(payload)
                     if result:
-                        (node, status) = result[0]
+                        node, status = result[0]
                         if (status == UNKNOWN_CHANNEL or
                                 (status == UPDATED_OUR_VERSION and node.metadata_type == CHANNEL_TORRENT)):
                             node.subscribed = True
-                            download, _ = self.session.lm.gigachannel_manager.download_channel(node)
                             return json.dumps(
-                                {"started": True, "infohash": hexlify(str(download.get_def().get_infohash()))})
+                                {"started": True, "infohash": hexlify(node.infohash)})
                     return json.dumps({"error": "Already subscribed"})
             else:
                 download_uri = u"file:%s" % url2pathname(uri[5:]).decode('utf-8')

--- a/Tribler/Core/Modules/restapi/search_endpoint.py
+++ b/Tribler/Core/Modules/restapi/search_endpoint.py
@@ -111,7 +111,7 @@ class SearchEndpoint(BaseMetadataEndpoint):
                 pony_query, total = self.session.lm.mds.TorrentMetadata.get_entries(**sanitized)
                 search_results = [(dict(type={REGULAR_TORRENT: 'torrent', CHANNEL_TORRENT: 'channel'}[r.metadata_type],
                                         **(r.to_simple_dict()))) for r in pony_query]
-            self.session.lm.mds.TorrentMetadata._db.disconnect()
+            self.session.lm.mds._db.disconnect()
             return search_results, total
 
         def on_search_results(search_results_tuple):

--- a/Tribler/Core/Session.py
+++ b/Tribler/Core/Session.py
@@ -84,9 +84,11 @@ class Session(object):
         self.notifier = Notifier()
 
         self.upgrader_enabled = True
+        self.upgrader = None
         self.readable_status = ''  # Human-readable string to indicate the status during startup/shutdown of Tribler
 
         self.autoload_discovery = autoload_discovery
+
 
     def create_state_directory_structure(self):
         """Create directory structure of the state directory."""
@@ -402,9 +404,9 @@ class Session(object):
             self.lm.api_manager.start()
 
         if self.upgrader_enabled:
-            upgrader = TriblerUpgrader(self)
+            self.upgrader = TriblerUpgrader(self)
             self.readable_status = STATE_UPGRADING_READABLE
-            upgrader.run()
+            self.upgrader.run()
 
         startup_deferred = self.lm.register(self, self.session_lock)
 
@@ -445,6 +447,9 @@ class Session(object):
             if self.lm.mds:
                 self.notify_shutdown_state("Shutting down Metadata Store...")
                 self.lm.mds.shutdown()
+
+            if self.upgrader:
+                self.upgrader.shutdown()
 
             # We close the API manager as late as possible during shutdown.
             if self.lm.api_manager is not None:

--- a/Tribler/Core/TorrentChecker/session.py
+++ b/Tribler/Core/TorrentChecker/session.py
@@ -120,7 +120,7 @@ class TrackerSession(TaskManager):
 
     def add_infohash(self, infohash):
         """
-        Adds a infohash into this session.
+        Adds an infohash into this session.
         :param infohash: The infohash to be added.
         """
         assert not self._is_initiated, u"Must not add request to an initiated session."

--- a/Tribler/Core/Upgrade/upgrade.py
+++ b/Tribler/Core/Upgrade/upgrade.py
@@ -18,6 +18,8 @@ class TriblerUpgrader(object):
         self.notified = False
         self.is_done = False
         self.failed = True
+        self.finished_deferred = None
+        self.pony_upgrader = None
 
         self.current_status = u"Initializing"
 
@@ -43,13 +45,13 @@ class TriblerUpgrader(object):
         new_database_path = os.path.join(self.session.config.get_state_dir(), 'sqlite', 'metadata.db')
         channels_dir = os.path.join(self.session.config.get_chant_channels_dir())
 
-        d = DispersyToPonyMigration(old_database_path, self.update_status, logger=self._logger)
+        self.pony_upgrader  = DispersyToPonyMigration(old_database_path, self.update_status, logger=self._logger)
         if not should_upgrade(old_database_path, new_database_path, logger=self._logger):
             return
         # We have to create the Metadata Store object because the LaunchManyCore has not been started yet
         mds = MetadataStore(new_database_path, channels_dir, self.session.trustchain_keypair)
-        d.initialize(mds)
-        d.do_migration()
+        self.pony_upgrader.initialize(mds)
+        self.finished_deferred = self.pony_upgrader.do_migration()
         mds.shutdown()
 
     def upgrade_config_to_71(self):
@@ -74,3 +76,7 @@ class TriblerUpgrader(object):
         Broadcast a notification (event) that the upgrader is done.
         """
         self.session.notifier.notify(NTFY_UPGRADER, NTFY_FINISHED, None)
+
+    def shutdown(self):
+        if self.pony_upgrader:
+            self.pony_upgrader.shutting_down = True

--- a/Tribler/Core/Upgrade/upgrade.py
+++ b/Tribler/Core/Upgrade/upgrade.py
@@ -45,7 +45,7 @@ class TriblerUpgrader(object):
         new_database_path = os.path.join(self.session.config.get_state_dir(), 'sqlite', 'metadata.db')
         channels_dir = os.path.join(self.session.config.get_chant_channels_dir())
 
-        self.pony_upgrader  = DispersyToPonyMigration(old_database_path, self.update_status, logger=self._logger)
+        self.pony_upgrader = DispersyToPonyMigration(old_database_path, self.update_status, logger=self._logger)
         if not should_upgrade(old_database_path, new_database_path, logger=self._logger):
             return
         # We have to create the Metadata Store object because the LaunchManyCore has not been started yet

--- a/Tribler/Test/Core/Modules/MetadataStore/test_store.py
+++ b/Tribler/Test/Core/Modules/MetadataStore/test_store.py
@@ -168,28 +168,28 @@ class TestMetadataStore(TriblerCoreTest):
 
         _, node_payload, node_deleted_payload = get_payloads(self.mds.ChannelNode)
 
-        self.assertEqual((self.mds.ChannelNode[1], GOT_SAME_VERSION), self.mds.process_payload(node_payload))
-        self.assertEqual((None, DELETED_METADATA), self.mds.process_payload(node_deleted_payload))
+        self.assertFalse(self.mds.process_payload(node_payload))
+        self.assertEqual([(None, DELETED_METADATA)], self.mds.process_payload(node_deleted_payload))
         # Do nothing in case it is unknown/abstract payload type, like ChannelNode
-        self.assertEqual((None, NO_ACTION), self.mds.process_payload(node_payload))
+        self.assertFalse(self.mds.process_payload(node_payload))
 
         # Check if node metadata object is properly created on payload processing
         node, node_payload, node_deleted_payload = get_payloads(self.mds.TorrentMetadata)
         node_dict = node.to_dict()
         node.delete()
         result = self.mds.process_payload(node_payload)
-        self.assertEqual(UNKNOWN_TORRENT, result[1])
-        self.assertEqual(node_dict['metadata_type'], result[0].to_dict()['metadata_type'])
+        self.assertEqual(UNKNOWN_TORRENT, result[0][1])
+        self.assertEqual(node_dict['metadata_type'], result[0][0].to_dict()['metadata_type'])
 
         # Check the same for a channel
         node, node_payload, node_deleted_payload = get_payloads(self.mds.ChannelMetadata)
         node_dict = node.to_dict()
         node.delete()
         # Check there is no action if the signature on the delete object is unknown
-        self.assertEqual((None, NO_ACTION), self.mds.process_payload(node_deleted_payload))
+        self.assertFalse(self.mds.process_payload(node_deleted_payload))
         result = self.mds.process_payload(node_payload)
-        self.assertEqual(UNKNOWN_CHANNEL, result[1])
-        self.assertEqual(node_dict['metadata_type'], result[0].to_dict()['metadata_type'])
+        self.assertEqual(UNKNOWN_CHANNEL, result[0][1])
+        self.assertEqual(node_dict['metadata_type'], result[0][0].to_dict()['metadata_type'])
 
     @db_session
     def test_process_payload_reject_old(self):
@@ -201,7 +201,7 @@ class TestMetadataStore(TriblerCoreTest):
                                            infohash=str(random.getrandbits(160)))
         payload = torrent._payload_class(**torrent.to_dict())
         torrent.delete()
-        self.assertEqual((None, NO_ACTION), self.mds.process_payload(payload))
+        self.assertFalse(self.mds.process_payload(payload))
 
     @db_session
     def test_get_num_channels_nodes(self):

--- a/Tribler/Test/Core/Modules/MetadataStore/test_store.py
+++ b/Tribler/Test/Core/Modules/MetadataStore/test_store.py
@@ -212,7 +212,7 @@ class TestMetadataStore(TriblerCoreTest):
         self.mds.TorrentMetadata(**node2_dict)
 
         result = self.mds.process_payload(node_updated_payload)
-        self.assertIn((node, DELETED_METADATA), result)
+        self.assertIn((None, DELETED_METADATA), result)
         self.assertIn((self.mds.TorrentMetadata.get(), UPDATED_OUR_VERSION), result)
         self.assertEqual(database_blob(self.mds.TorrentMetadata.select()[:][0].signature),
                          database_blob(node_updated_payload.signature))

--- a/Tribler/Test/Core/Modules/RestApi/test_downloads_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_downloads_endpoint.py
@@ -578,8 +578,10 @@ class TestMetadataDownloadEndpoint(AbstractApiTest):
         Test adding a channel metadata download to the Tribler core
         """
 
+        @db_session
         def verify_download(_):
-            self.assertGreaterEqual(len(self.session.get_downloads()), 1)
+            self.assertEqual(self.session.lm.mds.ChannelMetadata.select().count(), 1)
+            self.assertTrue(self.session.lm.mds.ChannelMetadata.get().subscribed)
 
         post_data = {'uri': 'file:%s' % os.path.join(TESTS_DIR, 'Core/data/sample_channel/channel.mdblob')}
         expected_json = {'started': True, 'infohash': '8e1cfb5b832e124b681497578c3715b63df01b50'}

--- a/Tribler/Test/Core/Upgrade/test_db72_to_pony.py
+++ b/Tribler/Test/Core/Upgrade/test_db72_to_pony.py
@@ -168,7 +168,6 @@ class TestUpgradePreconditionChecker(TriblerCoreTest):
         db72_to_pony.old_db_version_ok = lambda _: True
         self.assertTrue(should_upgrade(OLD_DB_SAMPLE, pony_db))
 
-
         mock_logger = MockObject()
         mock_logger.error = lambda _,a: None
 

--- a/Tribler/Test/Core/Upgrade/test_db72_to_pony.py
+++ b/Tribler/Test/Core/Upgrade/test_db72_to_pony.py
@@ -5,14 +5,16 @@ import shutil
 import sqlite3
 
 from pony.orm import db_session
+
 from twisted.internet.defer import inlineCallbacks
 
 from Tribler.Core.Modules.MetadataStore.OrmBindings.channel_node import LEGACY_ENTRY
 from Tribler.Core.Modules.MetadataStore.store import MetadataStore
-from Tribler.Core.Upgrade.db72_to_pony import DispersyToPonyMigration, CONVERSION_FINISHED, \
-    CONVERSION_FROM_72, old_db_version_ok, cleanup_pony_experimental_db, new_db_version_ok, already_upgraded, \
-    should_upgrade
-from Tribler.Test.Core.base_test import TriblerCoreTest, MockObject
+from Tribler.Core.Upgrade.db72_to_pony import (
+    CONVERSION_FINISHED, CONVERSION_FROM_72, CONVERSION_FROM_72_CHANNELS, CONVERSION_FROM_72_DISCOVERED,
+    CONVERSION_FROM_72_PERSONAL, CONVERSION_STARTED, DispersyToPonyMigration, already_upgraded,
+    cleanup_pony_experimental_db, new_db_version_ok, old_db_version_ok, should_upgrade)
+from Tribler.Test.Core.base_test import MockObject, TriblerCoreTest
 from Tribler.pyipv8.ipv8.keyvault.crypto import default_eccrypto
 
 OLD_DB_SAMPLE = os.path.join(os.path.abspath(os.path.dirname(os.path.realpath(__file__))), '..', 'data',
@@ -47,28 +49,51 @@ class TestUpgradeDB72ToPony(TriblerCoreTest):
         self.assertEqual(self.m.get_personal_channel_torrents_count(), 2)
 
     def test_convert_personal_channel(self):
-        self.m.convert_personal_channel()
-        my_channel = self.mds.ChannelMetadata.get_my_channel()
-        self.assertEqual(len(my_channel.contents_list), 2)
-        self.assertEqual(my_channel.num_entries, 2)
-        for t in my_channel.contents_list:
-            self.assertTrue(t.has_valid_signature())
-        self.assertTrue(my_channel.has_valid_signature())
-        self.assertEqual(self.m.personal_channel_title[:200], my_channel.title)
+        def check_channel():
+            self.m.convert_personal_channel()
+            my_channel = self.mds.ChannelMetadata.get_my_channel()
+            self.assertEqual(len(my_channel.contents_list), 2)
+            self.assertEqual(my_channel.num_entries, 2)
+            for t in my_channel.contents_list:
+                self.assertTrue(t.has_valid_signature())
+            self.assertTrue(my_channel.has_valid_signature())
+            self.assertEqual(self.m.personal_channel_title[:200], my_channel.title)
+
+        check_channel()
+
+        # Now check the case where previous conversion of the personal channel had failed
+        with db_session:
+            self.mds.MiscData.get_for_update(name=CONVERSION_FROM_72_PERSONAL).value = CONVERSION_STARTED
+        check_channel()
 
     @db_session
     def test_convert_all_channels(self):
-        self.m.convert_discovered_torrents()
-        self.m.convert_discovered_channels()
-        chans = self.mds.ChannelMetadata.get_entries()
+        def check_conversion():
+            self.m.convert_discovered_torrents()
+            self.m.convert_discovered_channels()
+            chans = self.mds.ChannelMetadata.get_entries()
 
-        self.assertEqual(len(chans[0]), 2)
-        for c in chans[0]:
-            self.assertNotEqual(self.m.personal_channel_title[:200], c.title)
-            self.assertEqual(c.status, LEGACY_ENTRY)
-            self.assertTrue(c.contents_list)
-            for t in c.contents_list:
-                self.assertEqual(t.status, LEGACY_ENTRY)
+            self.assertEqual(len(chans[0]), 2)
+            for c in chans[0]:
+                self.assertNotEqual(self.m.personal_channel_title[:200], c.title[:200])
+                self.assertEqual(c.status, LEGACY_ENTRY)
+                self.assertTrue(c.contents_list)
+                for t in c.contents_list:
+                    self.assertEqual(t.status, LEGACY_ENTRY)
+        check_conversion()
+
+        # Now check the case where the previous conversion failed at channels conversion
+        with db_session:
+            self.mds.MiscData.get_for_update(name=CONVERSION_FROM_72_CHANNELS).value = CONVERSION_STARTED
+        check_conversion()
+
+        # Now check the case where the previous conversion stopped at torrents conversion
+        with db_session:
+            self.mds.MiscData.get_for_update(name=CONVERSION_FROM_72_CHANNELS).delete()
+            self.mds.MiscData.get_for_update(name=CONVERSION_FROM_72_DISCOVERED).value = CONVERSION_STARTED
+            for d in self.mds.TorrentMetadata.select()[:10][:10]:
+                d.delete()
+        check_conversion()
 
     @db_session
     def test_update_trackers(self):
@@ -175,5 +200,3 @@ class TestUpgradePreconditionChecker(TriblerCoreTest):
         with open(pony_db, 'w') as f:
             f.write("")
         self.assertFalse(should_upgrade(OLD_DB_SAMPLE, pony_db, logger=mock_logger))
-
-

--- a/Tribler/Test/Core/Upgrade/test_upgrader.py
+++ b/Tribler/Test/Core/Upgrade/test_upgrader.py
@@ -46,6 +46,8 @@ class TestUpgrader(AbstractUpgrader):
         self.upgrader.update_status("12345")
         return test_deferred
 
+    @trial_timeout(10)
+    @inlineCallbacks
     def test_upgrade_72_to_pony(self):
         OLD_DB_SAMPLE = os.path.abspath(os.path.join(os.path.abspath(
             os.path.dirname(os.path.realpath(__file__))), '..', 'data', 'upgrade_databases', 'tribler_v29.sdb'))
@@ -54,6 +56,7 @@ class TestUpgrader(AbstractUpgrader):
         channels_dir = os.path.join(self.session.config.get_chant_channels_dir())
         shutil.copyfile(OLD_DB_SAMPLE, old_database_path)
         self.upgrader.upgrade_72_to_pony()
+        yield self.upgrader.finished_deferred
         mds = MetadataStore(new_database_path, channels_dir, self.session.trustchain_keypair)
         with db_session:
             self.assertEqual(mds.TorrentMetadata.select().count(), 24)

--- a/TriblerGUI/tribler_window.py
+++ b/TriblerGUI/tribler_window.py
@@ -245,6 +245,11 @@ class TriblerWindow(QMainWindow):
         self.core_manager.events_manager.credit_mining_signal.connect(self.on_credit_mining_error)
         self.core_manager.events_manager.tribler_shutdown_signal.connect(self.on_tribler_shutdown_state_update)
 
+        self.core_manager.events_manager.upgrader_tick.connect(
+            lambda text: self.show_status_bar("Upgrading Tribler database: " + text))
+        self.core_manager.events_manager.upgrader_finished.connect(
+            lambda _: self.hide_status_bar())
+
         self.core_manager.events_manager.received_search_result.connect(
             self.search_results_page.received_search_result)
 


### PR DESCRIPTION
This PR moves the processing of GigaChannel data downloaded with libtorrent to a background thread spawned with `deferToThread`. Holding DB lock for a long time **severely** affects Twisted reactor performance. Thus, this PR implements a congestion-control algorithm to dynamically break the workload into smaller batches. The default target time for processing a single batch - **100ms** - was devised by experimentation. If the routine runs in the background thread, 50ms `sleep` intervals are inserted between batches, so that other threads got a chance to acquire the DB lock. Again, this proved to be necessary by hands-on experience.
Community payloads are still processed on the main thread.