### PR TITLE
Using torrent_date instead of timestamp for channel metadata update time

### DIFF
--- a/Tribler/Core/Modules/MetadataStore/OrmBindings/channel_metadata.py
+++ b/Tribler/Core/Modules/MetadataStore/OrmBindings/channel_metadata.py
@@ -442,6 +442,8 @@ def define_binding(db):
             """
             Return a basic dictionary with information about the channel.
             """
+            epoch = datetime.utcfromtimestamp(0)
+
             return {
                 "id": self.rowid,
                 "public_key": hexlify(self.public_key),
@@ -450,7 +452,7 @@ def define_binding(db):
                 "subscribed": self.subscribed,
                 "votes": self.votes,
                 "status": self.status,
-                "updated": self.timestamp,
+                "updated": int((self.torrent_date - epoch).total_seconds()),
 
                 # TODO: optimize this?
                 "my_channel": database_blob(self._my_key.pub().key_to_bin()[10:]) == database_blob(self.public_key)

--- a/TriblerGUI/utilities.py
+++ b/TriblerGUI/utilities.py
@@ -93,7 +93,10 @@ def pretty_date(time=False):
     """
     now = datetime.now()
     if isinstance(time, integer_types):
-        diff = now - datetime.fromtimestamp(time)
+        try:
+            diff = now - datetime.fromtimestamp(time)
+        except ValueError:  # The time passed is out of range - return an empty string
+            return ''
     elif isinstance(time, datetime):
         diff = now - time
     elif not time:

--- a/TriblerGUI/widgets/tablecontentmodel.py
+++ b/TriblerGUI/widgets/tablecontentmodel.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division
+from __future__ import absolute_import
 
 from abc import abstractmethod
 
@@ -165,7 +165,7 @@ class ChannelsContentModel(TriblerContentModel):
         ACTION_BUTTONS: Qt.ItemIsEnabled
     }
     column_display_filters = {
-        u'updated': lambda date: pretty_date(date // 1000),
+        u'updated': pretty_date,
     }
 
     def __init__(self, subscribed=False, **kwargs):


### PR DESCRIPTION
Also not crashing the `pretty_date` method when an invalid time is passed to the method.

Fixes #4326 