### PR TITLE
sys.maxint removed Py3 because int are of infinite precision

### DIFF
--- a/Tribler/community/triblertunnel/community.py
+++ b/Tribler/community/triblertunnel/community.py
@@ -141,7 +141,7 @@ class TriblerTunnelCommunity(HiddenTunnelCommunity):
 
         cache = self.request_cache.pop(u"balance-request", circuit_id)
 
-        lowest_balance = sys.maxint
+        lowest_balance = sys.maxsize
         lowest_index = -1
         for ind, tup in enumerate(self.competing_slots):
             if not tup[1]:


### PR DESCRIPTION
* https://docs.python.org/3.1/whatsnew/3.0.html#integers
* https://docs.python.org/3.1/library/sys.html#sys.maxsize