### PR TITLE
open(self.exitnode_cache, 'w' --> 'wb') for Python 3

### DIFF
--- a/Tribler/community/triblertunnel/community.py
+++ b/Tribler/community/triblertunnel/community.py
@@ -112,7 +112,7 @@ class TriblerTunnelCommunity(HiddenTunnelCommunity):
         for peer in self.exit_candidates.values():
             exit_nodes.add_verified_peer(peer)
         self.logger.debug('Writing exit nodes to cache: %s', self.exitnode_cache)
-        with open(self.exitnode_cache, 'w') as cache:
+        with open(self.exitnode_cache, 'wb') as cache:
             cache.write(exit_nodes.snapshot())
 
     def restore_exitnodes_from_disk(self):

--- a/Tribler/community/triblertunnel/community.py
+++ b/Tribler/community/triblertunnel/community.py
@@ -124,7 +124,7 @@ class TriblerTunnelCommunity(HiddenTunnelCommunity):
         if os.path.isfile(self.exitnode_cache):
             self.logger.debug('Loading exit nodes from cache: %s', self.exitnode_cache)
             exit_nodes = Network()
-            with open(self.exitnode_cache, 'r') as cache:
+            with open(self.exitnode_cache, 'rb') as cache:
                 exit_nodes.load_snapshot(cache.read())
             for exit_node in exit_nodes.get_walkable_addresses():
                 self.endpoint.send(exit_node, self.create_introduction_request(exit_node))


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/pyipv8/ipv8/test/base.py", line 61, in tearDown
    node.unload()
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/pyipv8/ipv8/test/mocking/ipv8.py", line 52, in unload
    self.overlay.unload()
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/defer.py", line 1613, in unwindGenerator
    return _cancellableInlineCallbacks(gen)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/defer.py", line 1529, in _cancellableInlineCallbacks
    _inlineCallbacks(None, g, status)
--- <exception caught here> ---
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/defer.py", line 1418, in _inlineCallbacks
    result = g.send(result)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/community/triblertunnel/community.py", line 556, in unload
    self.cache_exitnodes_to_disk()
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/community/triblertunnel/community.py", line 116, in cache_exitnodes_to_disk
    cache.write(exit_nodes.snapshot())
builtins.TypeError: write() argument must be str, not bytes
```