### PR TITLE
dict.has_key() was removed in Python 3

### DIFF
--- a/Tribler/Core/Video/VideoServer.py
+++ b/Tribler/Core/Video/VideoServer.py
@@ -78,7 +78,7 @@ class VideoServer(ThreadingMixIn, HTTPServer):
                 time.sleep(1)
             self.vod_info[dl_hash]['stream'] = (VODFile(open(vod_filename, 'rb'), download), RLock())
 
-        if self.vod_info[dl_hash].has_key('stream'):
+        if 'stream' in self.vod_info[dl_hash]:
             return self.vod_info[dl_hash]['stream']
         return None, None
 

--- a/Tribler/Test/Integration/test_live_downloads.py
+++ b/Tribler/Test/Integration/test_live_downloads.py
@@ -43,7 +43,7 @@ num_hops = int(os.environ.get("TEST_NUM_HOPS", default_num_hops))
 state_dir = default_state_dir
 if os.environ.get("TEST_INTEGRATION") == "yes":
     # Get & set state directory
-    if os.environ.has_key('TSTATEDIR'):
+    if 'TSTATEDIR' in os.environ:
         state_dir = os.environ['TSTATEDIR']
     else:
         os.environ['TSTATEDIR'] = os.environ.get('TSTATEDIR', default_state_dir)
@@ -218,7 +218,7 @@ class TriblerDownloadTest(AbstractTriblerIntegrationTest):
         self.screenshot(window, name="home_page_torrents_loading")
 
         # Start downloading some torrents
-        if os.environ.has_key('TORRENTS_DIR'):
+        if 'TORRENTS_DIR' in os.environ:
             torrent_dir = os.environ.get('TORRENTS_DIR')
         else:
             torrent_dir = os.path.join(os.path.join(os.path.dirname(__file__), os.pardir), "data", "linux_torrents")


### PR DESCRIPTION
```
ERROR: Testing whether the right VOD stream is returned
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/defer.py", line 151, in maybeDeferred
    result = f(*args, **kw)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 201, in runWithWarningsSuppressed
    reraise(exc_info[1], exc_info[2])
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/python/compat.py", line 464, in reraise
    raise exception.with_traceback(traceback)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 197, in runWithWarningsSuppressed
    result = f(*a, **kw)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/test_as_server.py", line 62, in check
    result = fun(*argv, **kwargs)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/Core/Video/test_video_server.py", line 104, in test_get_vod_stream
    self.assertEqual(self.video_server.get_vod_stream("abcd"), (None, None))
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Core/Video/VideoServer.py", line 81, in get_vod_stream
    if self.vod_info[dl_hash].has_key('stream'):
AttributeError: 'dict' object has no attribute 'has_key'
-------------------- >> begin captured logging << --------------------
Tribler.Core.Utilities.network_utils: DEBUG: Got a working random port 27130
VideoServer: DEBUG: Listening at 27130
--------------------- >> end captured logging << ---------------------
```