### PR TITLE
'Tribler/' + version_id + '/' + str(hexlify(mid))

### DIFF
--- a/Tribler/Core/Libtorrent/LibtorrentMgr.py
+++ b/Tribler/Core/Libtorrent/LibtorrentMgr.py
@@ -180,7 +180,7 @@ class LibtorrentMgr(TaskManager):
 
             mid = self.tribler_session.trustchain_keypair.key_to_hash()
             settings['peer_fingerprint'] = mid
-            settings['handshake_client_version'] = 'Tribler/' + version_id + '/' + hexlify(mid)
+            settings['handshake_client_version'] = 'Tribler/' + version_id + '/' + str(hexlify(mid))
         else:
             settings['enable_outgoing_utp'] = True
             settings['enable_incoming_utp'] = True


### PR DESCRIPTION
```
ERROR: test_combined
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/defer.py", line 1416, in _inlineCallbacks
    result = result.throwExceptionIntoGenerator(g)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/python/failure.py", line 491, in throwExceptionIntoGenerator
    return g.throw(self.type, self.value, self.tb)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/Core/Video/test_video_server.py", line 117, in setUp
    yield super(TestVideoServerSession, self).setUp()
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/defer.py", line 1418, in _inlineCallbacks
    result = g.send(result)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/test_as_server.py", line 278, in setUp
    self.tribler_started_deferred = self.session.start()
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Core/Session.py", line 409, in start
    startup_deferred = self.lm.register(self, self.session_lock)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Core/APIImplementation/LaunchManyCore.py", line 153, in register
    self.init()
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Core/APIImplementation/LaunchManyCore.py", line 309, in init
    self.ltmgr.initialize()
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Core/Libtorrent/LibtorrentMgr.py", line 97, in initialize
    self.get_session().start_upnp()
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Core/Libtorrent/LibtorrentMgr.py", line 247, in get_session
    self.ltsessions[hops] = self.create_session(hops)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Core/Libtorrent/LibtorrentMgr.py", line 183, in create_session
    settings['handshake_client_version'] = 'Tribler/' + version_id + '/' + hexlify(mid)
TypeError: Can't convert 'bytes' object to str implicitly
```