### PR TITLE
write bytes in test_default_download_startup_config_load()

### DIFF
--- a/Tribler/Test/Core/test_downloadconfig.py
+++ b/Tribler/Test/Core/test_downloadconfig.py
@@ -8,7 +8,7 @@ import six
 from six.moves.configparser import MissingSectionHeaderError
 
 from Tribler.Core.DownloadConfig import (DefaultDownloadStartupConfig, DownloadConfigInterface,
-                                         DownloadStartupConfig, get_default_dest_dir )
+                                         DownloadStartupConfig, get_default_dest_dir)
 from Tribler.Core.simpledefs import DLMODE_VOD
 from Tribler.Test.Core.base_test import TriblerCoreTest
 

--- a/Tribler/Test/Core/test_downloadconfig.py
+++ b/Tribler/Test/Core/test_downloadconfig.py
@@ -90,7 +90,7 @@ class TestConfigParser(TriblerCoreTest):
 
     def test_default_download_startup_config_load(self):
         with open(os.path.join(self.session_base_dir, "dlconfig.conf"), 'wb') as conf_file:
-            conf_file.write("[Tribler]\nabc=def")
+            conf_file.write(b"[Tribler]\nabc=def")
 
         ddsc = DefaultDownloadStartupConfig.load(os.path.join(self.session_base_dir, "dlconfig.conf"))
         self.assertEqual(ddsc.dlconfig.get('Tribler', 'abc'), 'def')

--- a/Tribler/Test/Core/test_downloadconfig.py
+++ b/Tribler/Test/Core/test_downloadconfig.py
@@ -1,12 +1,14 @@
 from __future__ import absolute_import
 
 import os
+
 from nose.tools import raises
+
 import six
 from six.moves.configparser import MissingSectionHeaderError
 
-from Tribler.Core.DownloadConfig import (DownloadConfigInterface, DownloadStartupConfig, get_default_dest_dir,
-                                         DefaultDownloadStartupConfig)
+from Tribler.Core.DownloadConfig import (DefaultDownloadStartupConfig, DownloadConfigInterface,
+                                         DownloadStartupConfig, get_default_dest_dir )
 from Tribler.Core.simpledefs import DLMODE_VOD
 from Tribler.Test.Core.base_test import TriblerCoreTest
 


### PR DESCRIPTION
```
ERROR: test_default_download_startup_config_load
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/defer.py", line 1418, in _inlineCallbacks
    result = g.send(result)
StopIteration

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/defer.py", line 151, in maybeDeferred
    result = f(*args, **kw)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 201, in runWithWarningsSuppressed
    reraise(exc_info[1], exc_info[2])
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/python/compat.py", line 464, in reraise
    raise exception.with_traceback(traceback)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 197, in runWithWarningsSuppressed
    result = f(*a, **kw)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/test_as_server.py", line 62, in check
    result = fun(*argv, **kwargs)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/Core/test_downloadconfig.py", line 93, in test_default_download_startup_config_load
    conf_file.write("[Tribler]\nabc=def")
TypeError: a bytes-like object is required, not 'str'
```