### PR TITLE
Only bytes has .decode() in Python 3

### DIFF
--- a/Tribler/Core/Modules/restapi/util.py
+++ b/Tribler/Core/Modules/restapi/util.py
@@ -3,8 +3,7 @@ This file contains some utility methods that are used by the API.
 """
 from __future__ import absolute_import
 
-from six import binary_type, string_types
-from six.moves import xrange
+from six import binary_type
 
 from twisted.web import http
 

--- a/Tribler/Core/Modules/restapi/util.py
+++ b/Tribler/Core/Modules/restapi/util.py
@@ -3,7 +3,7 @@ This file contains some utility methods that are used by the API.
 """
 from __future__ import absolute_import
 
-from six import string_types
+from six import binary_type, string_types
 from six.moves import xrange
 
 from twisted.web import http
@@ -51,7 +51,7 @@ def fix_unicode_dict(d):
             new_dict[key] = fix_unicode_array(list(value))
         elif isinstance(value, list):
             new_dict[key] = fix_unicode_array(value)
-        elif isinstance(value, string_types):
+        elif isinstance(value, binary_type):
             new_dict[key] = value.decode('utf-8', 'ignore')
         else:
             new_dict[key] = value
@@ -65,12 +65,12 @@ def fix_unicode_array(arr):
     """
     new_arr = []
 
-    for ind in xrange(len(arr)):
-        if isinstance(arr[ind], string_types):
-            new_arr.append(arr[ind].decode('utf-8', 'ignore'))
-        elif isinstance(arr[ind], dict):
-            new_arr.append(fix_unicode_dict(arr[ind]))
+    for item in arr:
+        if isinstance(item, binary_type):
+            new_arr.append(item.decode('utf-8', 'ignore'))
+        elif isinstance(item, dict):
+            new_arr.append(fix_unicode_dict(item))
         else:
-            new_arr.append(arr[ind])
+            new_arr.append(item)
 
     return new_arr


### PR DESCRIPTION
```
ERROR: Testing the fix of a unicode array
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/defer.py", line 151, in maybeDeferred
    result = f(*args, **kw)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 201, in runWithWarningsSuppressed
    reraise(exc_info[1], exc_info[2])
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/python/compat.py", line 464, in reraise
    raise exception.with_traceback(traceback)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 197, in runWithWarningsSuppressed
    result = f(*a, **kw)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/test_as_server.py", line 62, in check
    result = fun(*argv, **kwargs)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/Core/Modules/RestApi/test_util.py", line 37, in test_fix_unicode_array
    self.assertListEqual(fix_unicode_array(arr1), ['a', 'b', 'c', 'd'])
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Core/Modules/restapi/util.py", line 70, in fix_unicode_array
    new_arr.append(arr[ind].decode('utf-8', 'ignore'))
AttributeError: 'str' object has no attribute 'decode'
```