### PR TITLE
READY: Pass a str, not bytes into TraderId()

### DIFF
--- a/Tribler/community/market/community.py
+++ b/Tribler/community/market/community.py
@@ -276,13 +276,13 @@ class MarketCommunity(Community, BlockListener):
         self.is_matchmaker = False
 
     def create_introduction_request(self, socket_address, extra_bytes=''):
-        extra_payload = InfoPayload(TraderId(self.mid), Timestamp.now(), self.is_matchmaker)
+        extra_payload = InfoPayload(TraderId(str(self.mid)), Timestamp.now(), self.is_matchmaker)
         extra_bytes = self.serializer.pack_multiple(extra_payload.to_pack_list())[0]
         return super(MarketCommunity, self).create_introduction_request(socket_address, extra_bytes)
 
     def create_introduction_response(self, lan_socket_address, socket_address, identifier,
                                      introduction=None, extra_bytes=''):
-        extra_payload = InfoPayload(TraderId(self.mid), Timestamp.now(), self.is_matchmaker)
+        extra_payload = InfoPayload(TraderId(str(self.mid)), Timestamp.now(), self.is_matchmaker)
         extra_bytes = self.serializer.pack_multiple(extra_payload.to_pack_list())[0]
         return super(MarketCommunity, self).create_introduction_response(lan_socket_address, socket_address,
                                                                          identifier, introduction, extra_bytes)


### PR DESCRIPTION
```
ERROR: Test whether an order is unreserved when address resolution fails
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/Community/Market/test_community.py", line 279, in test_address_resolv_fail
    yield self.introduce_nodes()
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/defer.py", line 1418, in _inlineCallbacks
    result = g.send(result)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/pyipv8/ipv8/test/base.py", line 160, in introduce_nodes
    node.overlay.walk_to(other.endpoint.wan_address)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/pyipv8/ipv8/community.py", line 323, in walk_to
    packet = self.create_introduction_request(address)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/community/market/community.py", line 279, in create_introduction_request
    extra_payload = InfoPayload(TraderId(self.mid), Timestamp.now(), self.is_matchmaker)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/community/market/core/message.py", line 16, in __init__
    raise ValueError("Trader id must be a string")
ValueError: Trader id must be a string
```