### PR TITLE
TraderId() takes bytes, not str

### DIFF
--- a/Tribler/Test/Community/Market/test_block.py
+++ b/Tribler/Test/Community/Market/test_block.py
@@ -23,14 +23,14 @@ class TestMarketBlock(AbstractServer):
     def setUp(self):
         yield super(TestMarketBlock, self).setUp()
 
-        self.ask = Ask(OrderId(TraderId('0' * 40), OrderNumber(1)),
+        self.ask = Ask(OrderId(TraderId(b'0' * 40), OrderNumber(1)),
                        AssetPair(AssetAmount(30, 'BTC'), AssetAmount(30, 'MB')), Timeout(30), Timestamp(0.0), True)
-        self.bid = Ask(OrderId(TraderId('1' * 40), OrderNumber(1)),
+        self.bid = Ask(OrderId(TraderId(b'1' * 40), OrderNumber(1)),
                        AssetPair(AssetAmount(30, 'BTC'), AssetAmount(30, 'MB')), Timeout(30), Timestamp(0.0), False)
-        self.transaction = Transaction(TransactionId(TraderId('0' * 40), TransactionNumber(1)),
+        self.transaction = Transaction(TransactionId(TraderId(b'0' * 40), TransactionNumber(1)),
                                        AssetPair(AssetAmount(30, 'BTC'), AssetAmount(30, 'MB')),
-                                       OrderId(TraderId('0' * 40), OrderNumber(1)),
-                                       OrderId(TraderId('1' * 40), OrderNumber(1)), Timestamp(0.0))
+                                       OrderId(TraderId(b'0' * 40), OrderNumber(1)),
+                                       OrderId(TraderId(b'1' * 40), OrderNumber(1)), Timestamp(0.0))
 
         ask_tx = self.ask.to_block_dict()
         bid_tx = self.bid.to_block_dict()

--- a/Tribler/Test/Community/Market/test_community.py
+++ b/Tribler/Test/Community/Market/test_community.py
@@ -441,7 +441,7 @@ class TestMarketCommunitySingle(TestMarketCommunityBase):
     @staticmethod
     def get_tick_block(return_ask, pair):
         tick_cls = Ask if return_ask else Bid
-        ask = tick_cls(OrderId(TraderId('0' * 40), OrderNumber(1)), pair, Timeout(3600), Timestamp.now(), return_ask)
+        ask = tick_cls(OrderId(TraderId(b'0' * 40), OrderNumber(1)), pair, Timeout(3600), Timestamp.now(), return_ask)
         ask_tx = ask.to_block_dict()
         ask_tx["address"], ask_tx["port"] = "127.0.0.1", 1337
         tick_block = MarketBlock()

--- a/Tribler/Test/Community/Market/test_database.py
+++ b/Tribler/Test/Community/Market/test_database.py
@@ -3,11 +3,12 @@ from __future__ import absolute_import
 import os
 
 import six
-from Tribler.community.market.core.assetamount import AssetAmount
-from Tribler.community.market.core.assetpair import AssetPair
+
 from twisted.internet.defer import inlineCallbacks
 
 from Tribler.Test.test_as_server import AbstractServer
+from Tribler.community.market.core.assetamount import AssetAmount
+from Tribler.community.market.core.assetpair import AssetPair
 from Tribler.community.market.core.message import TraderId
 from Tribler.community.market.core.order import Order, OrderId, OrderNumber
 from Tribler.community.market.core.payment import Payment
@@ -17,8 +18,7 @@ from Tribler.community.market.core.timeout import Timeout
 from Tribler.community.market.core.timestamp import Timestamp
 from Tribler.community.market.core.transaction import Transaction, TransactionId, TransactionNumber
 from Tribler.community.market.core.wallet_address import WalletAddress
-from Tribler.community.market.database import LATEST_DB_VERSION
-from Tribler.community.market.database import MarketDB
+from Tribler.community.market.database import LATEST_DB_VERSION, MarketDB
 
 
 class TestDatabase(AbstractServer):

--- a/Tribler/Test/Community/Market/test_database.py
+++ b/Tribler/Test/Community/Market/test_database.py
@@ -43,8 +43,8 @@ class TestDatabase(AbstractServer):
 
         self.transaction_id1 = TransactionId(TraderId(b"0"), TransactionNumber(4))
         self.transaction1 = Transaction(self.transaction_id1, AssetPair(AssetAmount(100, 'BTC'), AssetAmount(30, 'MB')),
-                                        OrderId(TraderId(b"0"), OrderNumber(1)), OrderId(TraderId(b"1"), OrderNumber(2)),
-                                        Timestamp(20.0))
+                                        OrderId(TraderId(b"0"), OrderNumber(1)), OrderId(TraderId(b"1"),
+                                        OrderNumber(2)), Timestamp(20.0))
 
         self.payment1 = Payment(TraderId(b"0"), self.transaction_id1, AssetAmount(5, 'BTC'),
                                 WalletAddress('abc'), WalletAddress('def'), PaymentId("abc"), Timestamp(20.0), False)

--- a/Tribler/Test/Community/Market/test_database.py
+++ b/Tribler/Test/Community/Market/test_database.py
@@ -43,8 +43,8 @@ class TestDatabase(AbstractServer):
 
         self.transaction_id1 = TransactionId(TraderId(b"0"), TransactionNumber(4))
         self.transaction1 = Transaction(self.transaction_id1, AssetPair(AssetAmount(100, 'BTC'), AssetAmount(30, 'MB')),
-                                        OrderId(TraderId(b"0"), OrderNumber(1)), OrderId(TraderId(b"1"),
-                                        OrderNumber(2)), Timestamp(20.0))
+                                        OrderId(TraderId(b"0"), OrderNumber(1)),
+                                        OrderId(TraderId(b"1"), OrderNumber(2)), Timestamp(20.0))
 
         self.payment1 = Payment(TraderId(b"0"), self.transaction_id1, AssetAmount(5, 'BTC'),
                                 WalletAddress('abc'), WalletAddress('def'), PaymentId("abc"), Timestamp(20.0), False)

--- a/Tribler/Test/Community/Market/test_database.py
+++ b/Tribler/Test/Community/Market/test_database.py
@@ -33,20 +33,20 @@ class TestDatabase(AbstractServer):
 
         self.database = MarketDB(self.getStateDir(), 'market')
 
-        self.order_id1 = OrderId(TraderId('3'), OrderNumber(4))
-        self.order_id2 = OrderId(TraderId('4'), OrderNumber(5))
+        self.order_id1 = OrderId(TraderId(b'3'), OrderNumber(4))
+        self.order_id2 = OrderId(TraderId(b'4'), OrderNumber(5))
         self.order1 = Order(self.order_id1, AssetPair(AssetAmount(5, 'BTC'), AssetAmount(6, 'EUR')),
                             Timeout(3600), Timestamp.now(), True)
         self.order2 = Order(self.order_id2, AssetPair(AssetAmount(5, 'BTC'), AssetAmount(6, 'EUR')),
                             Timeout(3600), Timestamp.now(), False)
-        self.order2.reserve_quantity_for_tick(OrderId(TraderId('3'), OrderNumber(4)), 3)
+        self.order2.reserve_quantity_for_tick(OrderId(TraderId(b'3'), OrderNumber(4)), 3)
 
-        self.transaction_id1 = TransactionId(TraderId("0"), TransactionNumber(4))
+        self.transaction_id1 = TransactionId(TraderId(b"0"), TransactionNumber(4))
         self.transaction1 = Transaction(self.transaction_id1, AssetPair(AssetAmount(100, 'BTC'), AssetAmount(30, 'MB')),
-                                        OrderId(TraderId("0"), OrderNumber(1)), OrderId(TraderId("1"), OrderNumber(2)),
+                                        OrderId(TraderId(b"0"), OrderNumber(1)), OrderId(TraderId(b"1"), OrderNumber(2)),
                                         Timestamp(20.0))
 
-        self.payment1 = Payment(TraderId("0"), self.transaction_id1, AssetAmount(5, 'BTC'),
+        self.payment1 = Payment(TraderId(b"0"), self.transaction_id1, AssetAmount(5, 'BTC'),
                                 WalletAddress('abc'), WalletAddress('def'), PaymentId("abc"), Timestamp(20.0), False)
 
         self.transaction1.add_payment(self.payment1)
@@ -64,7 +64,7 @@ class TestDatabase(AbstractServer):
         """
         Test the retrieval of a specific order
         """
-        order_id = OrderId(TraderId('3'), OrderNumber(4))
+        order_id = OrderId(TraderId(b'3'), OrderNumber(4))
         self.assertIsNone(self.database.get_order(order_id))
         self.database.add_order(self.order1)
         self.assertIsNotNone(self.database.get_order(order_id))
@@ -133,7 +133,7 @@ class TestDatabase(AbstractServer):
         """
         Test the retrieval of a specific transaction
         """
-        transaction_id = TransactionId(TraderId('0'), TransactionNumber(4))
+        transaction_id = TransactionId(TraderId(b'0'), TransactionNumber(4))
         self.assertIsNone(self.database.get_transaction(transaction_id))
         self.database.add_transaction(self.transaction1)
         self.assertIsNotNone(self.database.get_transaction(transaction_id))

--- a/Tribler/Test/Community/Market/test_matching_engine.py
+++ b/Tribler/Test/Community/Market/test_matching_engine.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 from twisted.internet.defer import inlineCallbacks
 
 from Tribler.Test.test_as_server import AbstractServer

--- a/Tribler/Test/Community/Market/test_matching_engine.py
+++ b/Tribler/Test/Community/Market/test_matching_engine.py
@@ -1,8 +1,8 @@
-from Tribler.community.market.core.assetamount import AssetAmount
-from Tribler.community.market.core.assetpair import AssetPair
 from twisted.internet.defer import inlineCallbacks
 
 from Tribler.Test.test_as_server import AbstractServer
+from Tribler.community.market.core.assetamount import AssetAmount
+from Tribler.community.market.core.assetpair import AssetPair
 from Tribler.community.market.core.matching_engine import MatchingEngine, PriceTimeStrategy
 from Tribler.community.market.core.message import TraderId
 from Tribler.community.market.core.order import Order, OrderId, OrderNumber

--- a/Tribler/Test/Community/Market/test_matching_engine.py
+++ b/Tribler/Test/Community/Market/test_matching_engine.py
@@ -19,33 +19,33 @@ class PriceTimeStrategyTestSuite(AbstractServer):
     def setUp(self):
         yield super(PriceTimeStrategyTestSuite, self).setUp()
         # Object creation
-        self.ask = Ask(OrderId(TraderId('0'), OrderNumber(1)),
+        self.ask = Ask(OrderId(TraderId(b'0'), OrderNumber(1)),
                        AssetPair(AssetAmount(3000, 'BTC'), AssetAmount(30, 'MB')), Timeout(100), Timestamp.now())
-        self.ask2 = Ask(OrderId(TraderId('1'), OrderNumber(2)),
+        self.ask2 = Ask(OrderId(TraderId(b'1'), OrderNumber(2)),
                         AssetPair(AssetAmount(3000, 'BTC'), AssetAmount(30, 'MB')), Timeout(100), Timestamp.now())
-        self.ask3 = Ask(OrderId(TraderId('0'), OrderNumber(3)),
+        self.ask3 = Ask(OrderId(TraderId(b'0'), OrderNumber(3)),
                         AssetPair(AssetAmount(40000, 'BTC'), AssetAmount(200, 'MB')), Timeout(100), Timestamp.now())
-        self.ask4 = Ask(OrderId(TraderId('1'), OrderNumber(4)),
+        self.ask4 = Ask(OrderId(TraderId(b'1'), OrderNumber(4)),
                         AssetPair(AssetAmount(3000, 'A'), AssetAmount(3000, 'MB')), Timeout(100), Timestamp.now())
-        self.ask5 = Ask(OrderId(TraderId('1'), OrderNumber(4)),
+        self.ask5 = Ask(OrderId(TraderId(b'1'), OrderNumber(4)),
                         AssetPair(AssetAmount(3000, 'BTC'), AssetAmount(30, 'C')), Timeout(100), Timestamp.now())
 
-        self.bid = Bid(OrderId(TraderId('0'), OrderNumber(5)),
+        self.bid = Bid(OrderId(TraderId(b'0'), OrderNumber(5)),
                        AssetPair(AssetAmount(3000, 'BTC'), AssetAmount(30, 'MB')), Timeout(100), Timestamp.now())
-        self.bid2 = Bid(OrderId(TraderId('0'), OrderNumber(6)),
+        self.bid2 = Bid(OrderId(TraderId(b'0'), OrderNumber(6)),
                         AssetPair(AssetAmount(6000, 'BTC'), AssetAmount(30, 'MB')), Timeout(100), Timestamp.now())
 
-        self.ask_order = Order(OrderId(TraderId('9'), OrderNumber(11)),
+        self.ask_order = Order(OrderId(TraderId(b'9'), OrderNumber(11)),
                                AssetPair(AssetAmount(3000, 'BTC'), AssetAmount(30, 'MB')),
                                Timeout(100), Timestamp.now(), True)
-        self.ask_order2 = Order(OrderId(TraderId('9'), OrderNumber(12)),
+        self.ask_order2 = Order(OrderId(TraderId(b'9'), OrderNumber(12)),
                                 AssetPair(AssetAmount(600, 'BTC'), AssetAmount(60, 'MB')),
                                 Timeout(100), Timestamp.now(), True)
 
-        self.bid_order = Order(OrderId(TraderId('9'), OrderNumber(13)),
+        self.bid_order = Order(OrderId(TraderId(b'9'), OrderNumber(13)),
                                AssetPair(AssetAmount(3000, 'BTC'), AssetAmount(30, 'MB')),
                                Timeout(100), Timestamp.now(), False)
-        self.bid_order2 = Order(OrderId(TraderId('9'), OrderNumber(14)),
+        self.bid_order2 = Order(OrderId(TraderId(b'9'), OrderNumber(14)),
                                 AssetPair(AssetAmount(6000, 'BTC'), AssetAmount(60, 'MB')),
                                 Timeout(100), Timestamp.now(), False)
         self.order_book = OrderBook()
@@ -192,14 +192,14 @@ class MatchingEngineTestSuite(AbstractServer):
     def setUp(self):
         yield super(MatchingEngineTestSuite, self).setUp()
         # Object creation
-        self.ask = Ask(OrderId(TraderId('2'), OrderNumber(1)),
+        self.ask = Ask(OrderId(TraderId(b'2'), OrderNumber(1)),
                        AssetPair(AssetAmount(3000, 'BTC'), AssetAmount(30, 'MB')), Timeout(30), Timestamp.now())
-        self.bid = Bid(OrderId(TraderId('4'), OrderNumber(2)),
+        self.bid = Bid(OrderId(TraderId(b'4'), OrderNumber(2)),
                        AssetPair(AssetAmount(3000, 'BTC'), AssetAmount(30, 'MB')), Timeout(30), Timestamp.now())
-        self.ask_order = Order(OrderId(TraderId('5'), OrderNumber(3)),
+        self.ask_order = Order(OrderId(TraderId(b'5'), OrderNumber(3)),
                                AssetPair(AssetAmount(3000, 'BTC'), AssetAmount(30, 'MB')),
                                Timeout(30), Timestamp.now(), True)
-        self.bid_order = Order(OrderId(TraderId('6'), OrderNumber(4)),
+        self.bid_order = Order(OrderId(TraderId(b'6'), OrderNumber(4)),
                                AssetPair(AssetAmount(3000, 'BTC'), AssetAmount(30, 'MB')),
                                Timeout(30), Timestamp.now(), False)
         self.order_book = OrderBook()
@@ -212,7 +212,7 @@ class MatchingEngineTestSuite(AbstractServer):
         """
         Create an ask with a specific price and quantity
         """
-        new_ask = Ask(OrderId(TraderId('2'), OrderNumber(self.ask_count)),
+        new_ask = Ask(OrderId(TraderId(b'2'), OrderNumber(self.ask_count)),
                       AssetPair(AssetAmount(amount1, 'BTC'), AssetAmount(amount2, 'MB')), Timeout(30), Timestamp.now())
         self.ask_count += 1
         return new_ask
@@ -221,7 +221,7 @@ class MatchingEngineTestSuite(AbstractServer):
         """
         Create a bid with a specific price and quantity
         """
-        new_bid = Bid(OrderId(TraderId('3'), OrderNumber(self.bid_count)),
+        new_bid = Bid(OrderId(TraderId(b'3'), OrderNumber(self.bid_count)),
                       AssetPair(AssetAmount(amount1, 'BTC'), AssetAmount(amount2, 'MB')), Timeout(30), Timestamp.now())
         self.bid_count += 1
         return new_bid

--- a/Tribler/Test/Community/Market/test_message.py
+++ b/Tribler/Test/Community/Market/test_message.py
@@ -8,9 +8,9 @@ class TraderIdTestSuite(unittest.TestCase):
 
     def setUp(self):
         # Object creation
-        self.trader_id = TraderId('0')
-        self.trader_id2 = TraderId('0')
-        self.trader_id3 = TraderId('1')
+        self.trader_id = TraderId(b'0')
+        self.trader_id2 = TraderId(b'0')
+        self.trader_id3 = TraderId(b'1')
 
     def test_init(self):
         # Test for init validation

--- a/Tribler/Test/Community/Market/test_order.py
+++ b/Tribler/Test/Community/Market/test_order.py
@@ -1,6 +1,7 @@
-import unittest
+from __future__ import absolute_import
 
 import time
+import unittest
 
 from Tribler.community.market.core.assetamount import AssetAmount
 from Tribler.community.market.core.assetpair import AssetPair
@@ -10,7 +11,7 @@ from Tribler.community.market.core.tick import Tick
 from Tribler.community.market.core.timeout import Timeout
 from Tribler.community.market.core.timestamp import Timestamp
 from Tribler.community.market.core.trade import Trade
-from Tribler.community.market.core.transaction import TransactionNumber, TransactionId, Transaction
+from Tribler.community.market.core.transaction import Transaction, TransactionId, TransactionNumber
 
 
 class OrderTestSuite(unittest.TestCase):

--- a/Tribler/Test/Community/Market/test_order.py
+++ b/Tribler/Test/Community/Market/test_order.py
@@ -18,28 +18,28 @@ class OrderTestSuite(unittest.TestCase):
 
     def setUp(self):
         # Object creation
-        self.transaction_id = TransactionId(TraderId("0"), TransactionNumber(1))
+        self.transaction_id = TransactionId(TraderId(b"0"), TransactionNumber(1))
         self.transaction = Transaction(self.transaction_id, AssetPair(AssetAmount(100, 'BTC'), AssetAmount(30, 'MC')),
-                                       OrderId(TraderId('0'), OrderNumber(2)),
-                                       OrderId(TraderId('1'), OrderNumber(1)), Timestamp(0.0))
-        self.proposed_trade = Trade.propose(TraderId('0'),
-                                            OrderId(TraderId('0'), OrderNumber(2)),
-                                            OrderId(TraderId('1'), OrderNumber(3)),
+                                       OrderId(TraderId(b'0'), OrderNumber(2)),
+                                       OrderId(TraderId(b'1'), OrderNumber(1)), Timestamp(0.0))
+        self.proposed_trade = Trade.propose(TraderId(b'0'),
+                                            OrderId(TraderId(b'0'), OrderNumber(2)),
+                                            OrderId(TraderId(b'1'), OrderNumber(3)),
                                             AssetPair(AssetAmount(100, 'BTC'), AssetAmount(30, 'MC')), Timestamp(0.0))
 
-        self.tick = Tick(OrderId(TraderId('0'), OrderNumber(1)),
+        self.tick = Tick(OrderId(TraderId(b'0'), OrderNumber(1)),
                          AssetPair(AssetAmount(5, 'BTC'), AssetAmount(5, 'MC')),
                          Timeout(0), Timestamp(float("inf")), True)
-        self.tick2 = Tick(OrderId(TraderId('0'), OrderNumber(2)),
+        self.tick2 = Tick(OrderId(b'0'), OrderNumber(2)),
                           AssetPair(AssetAmount(500, 'BTC'), AssetAmount(5, 'MC')),
                           Timeout(0), Timestamp(float("inf")), True)
 
         self.order_timestamp = Timestamp.now()
-        self.order = Order(OrderId(TraderId("0"), OrderNumber(3)),
+        self.order = Order(OrderId(TraderId(b"0"), OrderNumber(3)),
                            AssetPair(AssetAmount(50, 'BTC'), AssetAmount(5, 'MC')),
                            Timeout(5000), self.order_timestamp, False)
         self.order.set_verified()
-        self.order2 = Order(OrderId(TraderId("0"), OrderNumber(4)),
+        self.order2 = Order(OrderId(TraderId(b"0"), OrderNumber(4)),
                             AssetPair(AssetAmount(50, 'BTC'), AssetAmount(5, 'MC')),
                             Timeout(5), Timestamp(time.time() - 1000), True)
         self.order2.set_verified()
@@ -48,13 +48,13 @@ class OrderTestSuite(unittest.TestCase):
         """
         Test the add trade method of an order
         """
-        self.order.reserve_quantity_for_tick(OrderId(TraderId('5'), OrderNumber(1)), 10)
+        self.order.reserve_quantity_for_tick(OrderId(TraderId(b'5'), OrderNumber(1)), 10)
         self.assertEquals(self.order.traded_quantity, 0)
-        self.order.add_trade(OrderId(TraderId('5'), OrderNumber(1)), 10)
+        self.order.add_trade(OrderId(TraderId(b'5'), OrderNumber(1)), 10)
         self.assertEquals(self.order.traded_quantity, 10)
 
-        self.order.reserve_quantity_for_tick(OrderId(TraderId('6'), OrderNumber(1)), 40)
-        self.order.add_trade(OrderId(TraderId('6'), OrderNumber(1)), 40)
+        self.order.reserve_quantity_for_tick(OrderId(TraderId(b'6'), OrderNumber(1)), 40)
+        self.order.add_trade(OrderId(TraderId(b'6'), OrderNumber(1)), 40)
         self.assertTrue(self.order.is_complete())
         self.assertFalse(self.order.cancelled)
 
@@ -62,7 +62,7 @@ class OrderTestSuite(unittest.TestCase):
         """
         Test the acceptable price method
         """
-        order = Order(OrderId(TraderId("0"), OrderNumber(3)),
+        order = Order(OrderId(TraderId(b"0"), OrderNumber(3)),
                       AssetPair(AssetAmount(60, 'BTC'), AssetAmount(30, 'MB')),
                       Timeout(5000), self.order_timestamp, True)
 
@@ -172,9 +172,9 @@ class OrderIDTestSuite(unittest.TestCase):
 
     def setUp(self):
         # Object creation
-        self.order_id = OrderId(TraderId("0"), OrderNumber(1))
-        self.order_id2 = OrderId(TraderId("0"), OrderNumber(1))
-        self.order_id3 = OrderId(TraderId("0"), OrderNumber(2))
+        self.order_id = OrderId(TraderId(b"0"), OrderNumber(1))
+        self.order_id2 = OrderId(TraderId(b"0"), OrderNumber(1))
+        self.order_id3 = OrderId(TraderId(b"0"), OrderNumber(2))
 
     def test_equality(self):
         # Test for equality

--- a/Tribler/Test/Community/Market/test_order.py
+++ b/Tribler/Test/Community/Market/test_order.py
@@ -30,7 +30,7 @@ class OrderTestSuite(unittest.TestCase):
         self.tick = Tick(OrderId(TraderId(b'0'), OrderNumber(1)),
                          AssetPair(AssetAmount(5, 'BTC'), AssetAmount(5, 'MC')),
                          Timeout(0), Timestamp(float("inf")), True)
-        self.tick2 = Tick(OrderId(b'0'), OrderNumber(2)),
+        self.tick2 = Tick(OrderId(TraderId(b'0'), OrderNumber(2)),
                           AssetPair(AssetAmount(500, 'BTC'), AssetAmount(5, 'MC')),
                           Timeout(0), Timestamp(float("inf")), True)
 

--- a/Tribler/Test/Community/Market/test_order_repository.py
+++ b/Tribler/Test/Community/Market/test_order_repository.py
@@ -15,7 +15,7 @@ class MemoryOrderRepositoryTestSuite(unittest.TestCase):
     def setUp(self):
         # Object creation
         self.memory_order_repository = MemoryOrderRepository("0")
-        self.order_id = OrderId(TraderId("0"), OrderNumber(1))
+        self.order_id = OrderId(TraderId(b"0"), OrderNumber(1))
         self.order = Order(self.order_id, AssetPair(AssetAmount(100, 'BTC'), AssetAmount(30, 'MC')),
                            Timeout(0), Timestamp(10.0), False)
         self.order2 = Order(self.order_id, AssetPair(AssetAmount(1000, 'BTC'), AssetAmount(30, 'MC')),
@@ -53,7 +53,7 @@ class MemoryOrderRepositoryTestSuite(unittest.TestCase):
 
     def test_next_identity(self):
         # Test for next identity
-        self.assertEquals(OrderId(TraderId("0"), OrderNumber(1)),
+        self.assertEquals(OrderId(TraderId(b"0"), OrderNumber(1)),
                           self.memory_order_repository.next_identity())
 
     def test_update(self):

--- a/Tribler/Test/Community/Market/test_orderbook.py
+++ b/Tribler/Test/Community/Market/test_orderbook.py
@@ -25,21 +25,21 @@ class AbstractTestOrderBook(AbstractServer):
     def setUp(self):
         yield super(AbstractTestOrderBook, self).setUp()
         # Object creation
-        self.ask = Ask(OrderId(TraderId('0'), OrderNumber(1)),
+        self.ask = Ask(OrderId(TraderId(b'0'), OrderNumber(1)),
                        AssetPair(AssetAmount(100, 'BTC'), AssetAmount(30, 'MB')), Timeout(100), Timestamp.now())
-        self.invalid_ask = Ask(OrderId(TraderId('0'), OrderNumber(1)),
+        self.invalid_ask = Ask(OrderId(TraderId(b'0'), OrderNumber(1)),
                                AssetPair(AssetAmount(100, 'BTC'), AssetAmount(30, 'MB')), Timeout(0), Timestamp(0.0))
-        self.ask2 = Ask(OrderId(TraderId('1'), OrderNumber(1)),
+        self.ask2 = Ask(OrderId(TraderId(b'1'), OrderNumber(1)),
                         AssetPair(AssetAmount(400, 'BTC'), AssetAmount(30, 'MB')), Timeout(100), Timestamp.now())
-        self.bid = Bid(OrderId(TraderId('2'), OrderNumber(1)),
+        self.bid = Bid(OrderId(TraderId(b'2'), OrderNumber(1)),
                        AssetPair(AssetAmount(200, 'BTC'), AssetAmount(30, 'MB')), Timeout(100), Timestamp.now())
-        self.invalid_bid = Bid(OrderId(TraderId('0'), OrderNumber(1)),
+        self.invalid_bid = Bid(OrderId(TraderId(b'0'), OrderNumber(1)),
                                AssetPair(AssetAmount(100, 'BTC'), AssetAmount(30, 'MB')), Timeout(0), Timestamp(0.0))
-        self.bid2 = Bid(OrderId(TraderId('3'), OrderNumber(1)),
+        self.bid2 = Bid(OrderId(TraderId(b'3'), OrderNumber(1)),
                         AssetPair(AssetAmount(300, 'BTC'), AssetAmount(30, 'MB')), Timeout(100), Timestamp.now())
-        self.trade = Trade.propose(TraderId('0'),
-                                   OrderId(TraderId('0'), OrderNumber(1)),
-                                   OrderId(TraderId('0'), OrderNumber(1)),
+        self.trade = Trade.propose(TraderId(b'0'),
+                                   OrderId(TraderId(b'0'), OrderNumber(1)),
+                                   OrderId(TraderId(b'0'), OrderNumber(1)),
                                    AssetPair(AssetAmount(100, 'BTC'), AssetAmount(30, 'MB')),
                                    Timestamp(1462224447.117))
         self.order_book = OrderBook()

--- a/Tribler/Test/Community/Market/test_orderbook.py
+++ b/Tribler/Test/Community/Market/test_orderbook.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import os
 
 from twisted.internet.defer import inlineCallbacks

--- a/Tribler/Test/Community/Market/test_orderbook.py
+++ b/Tribler/Test/Community/Market/test_orderbook.py
@@ -1,15 +1,15 @@
 import os
 
-from Tribler.community.market.core.assetamount import AssetAmount
-from Tribler.community.market.core.assetpair import AssetPair
-from Tribler.community.market.core.price import Price
 from twisted.internet.defer import inlineCallbacks
 
 from Tribler.Test.test_as_server import AbstractServer
 from Tribler.Test.tools import trial_timeout
+from Tribler.community.market.core.assetamount import AssetAmount
+from Tribler.community.market.core.assetpair import AssetPair
 from Tribler.community.market.core.message import TraderId
 from Tribler.community.market.core.order import OrderId, OrderNumber
 from Tribler.community.market.core.orderbook import OrderBook
+from Tribler.community.market.core.price import Price
 from Tribler.community.market.core.tick import Ask, Bid
 from Tribler.community.market.core.timeout import Timeout
 from Tribler.community.market.core.timestamp import Timestamp

--- a/Tribler/Test/Community/Market/test_payment.py
+++ b/Tribler/Test/Community/Market/test_payment.py
@@ -1,11 +1,11 @@
 import unittest
 
 from Tribler.community.market.core.assetamount import AssetAmount
-from Tribler.community.market.core.transaction import TransactionNumber, TransactionId
 from Tribler.community.market.core.message import TraderId
-from Tribler.community.market.core.timestamp import Timestamp
 from Tribler.community.market.core.payment import Payment
 from Tribler.community.market.core.payment_id import PaymentId
+from Tribler.community.market.core.timestamp import Timestamp
+from Tribler.community.market.core.transaction import TransactionId, TransactionNumber
 from Tribler.community.market.core.wallet_address import WalletAddress
 
 

--- a/Tribler/Test/Community/Market/test_payment.py
+++ b/Tribler/Test/Community/Market/test_payment.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import unittest
 
 from Tribler.community.market.core.assetamount import AssetAmount

--- a/Tribler/Test/Community/Market/test_payment.py
+++ b/Tribler/Test/Community/Market/test_payment.py
@@ -14,8 +14,8 @@ class PaymentTestSuite(unittest.TestCase):
 
     def setUp(self):
         # Object creation
-        self.payment = Payment(TraderId("0"),
-                               TransactionId(TraderId('2'), TransactionNumber(2)),
+        self.payment = Payment(TraderId(b"0"),
+                               TransactionId(TraderId(b'2'), TransactionNumber(2)),
                                AssetAmount(3, 'BTC'),
                                WalletAddress('a'), WalletAddress('b'),
                                PaymentId('aaa'), Timestamp(4.0), True)
@@ -23,8 +23,8 @@ class PaymentTestSuite(unittest.TestCase):
     def test_from_network(self):
         # Test for from network
         data = Payment.from_network(
-            type('Data', (object,), {"trader_id": TraderId("0"),
-                                     "transaction_id": TransactionId(TraderId('2'), TransactionNumber(2)),
+            type('Data', (object,), {"trader_id": TraderId(b"0"),
+                                     "transaction_id": TransactionId(TraderId(b'2'), TransactionNumber(2)),
                                      "transferred_assets": AssetAmount(3, 'BTC'),
                                      "address_from": WalletAddress('a'),
                                      "address_to": WalletAddress('b'),
@@ -32,8 +32,8 @@ class PaymentTestSuite(unittest.TestCase):
                                      "timestamp": Timestamp(4.0),
                                      "success": True}))
 
-        self.assertEquals(TraderId("0"), data.trader_id)
-        self.assertEquals(TransactionId(TraderId('2'), TransactionNumber(2)), data.transaction_id)
+        self.assertEquals(TraderId(b"0"), data.trader_id)
+        self.assertEquals(TransactionId(TraderId(b'2'), TransactionNumber(2)), data.transaction_id)
         self.assertEquals(AssetAmount(3, 'BTC'), data.transferred_assets)
         self.assertEquals(Timestamp(4.0), data.timestamp)
         self.assertTrue(data.success)
@@ -42,9 +42,9 @@ class PaymentTestSuite(unittest.TestCase):
         # Test for to network
         data = self.payment.to_network()
 
-        self.assertEquals(data[0], TraderId("0"))
+        self.assertEquals(data[0], TraderId(b"0"))
         self.assertEquals(data[1], Timestamp(4.0))
-        self.assertEquals(data[2], TransactionId(TraderId("2"), TransactionNumber(2)))
+        self.assertEquals(data[2], TransactionId(TraderId(b"2"), TransactionNumber(2)))
         self.assertEquals(data[3], AssetAmount(3, 'BTC'))
         self.assertEquals(data[4], WalletAddress('a'))
         self.assertEquals(data[5], WalletAddress('b'))

--- a/Tribler/Test/Community/Market/test_portfolio.py
+++ b/Tribler/Test/Community/Market/test_portfolio.py
@@ -21,7 +21,7 @@ class PortfolioTestSuite(unittest.TestCase):
         ask_order = self.order_manager.create_ask_order(
             AssetPair(AssetAmount(100, 'BTC'), AssetAmount(10, 'MC')), Timeout(0))
         self.assertTrue(ask_order.is_ask())
-        self.assertEquals(OrderId(TraderId("0"), OrderNumber(1)), ask_order.order_id)
+        self.assertEquals(OrderId(TraderId(b"0"), OrderNumber(1)), ask_order.order_id)
         self.assertEquals(AssetPair(AssetAmount(100, 'BTC'), AssetAmount(10, 'MC')), ask_order.assets)
         self.assertEquals(100, ask_order.total_quantity)
         self.assertEquals(0, int(ask_order.timeout))
@@ -31,7 +31,7 @@ class PortfolioTestSuite(unittest.TestCase):
         bid_order = self.order_manager.create_bid_order(
             AssetPair(AssetAmount(100, 'BTC'), AssetAmount(10, 'MC')), Timeout(0))
         self.assertFalse(bid_order.is_ask())
-        self.assertEquals(OrderId(TraderId("0"), OrderNumber(1)), bid_order.order_id)
+        self.assertEquals(OrderId(TraderId(b"0"), OrderNumber(1)), bid_order.order_id)
         self.assertEquals(AssetPair(AssetAmount(100, 'BTC'), AssetAmount(10, 'MC')), bid_order.assets)
         self.assertEquals(100, bid_order.total_quantity)
         self.assertEquals(0, int(bid_order.timeout))

--- a/Tribler/Test/Community/Market/test_pricelevel.py
+++ b/Tribler/Test/Community/Market/test_pricelevel.py
@@ -17,9 +17,9 @@ class PriceLevelTestSuite(unittest.TestCase):
 
     def setUp(self):
         # Object creation
-        tick = Tick(OrderId(TraderId('0'), OrderNumber(1)), AssetPair(AssetAmount(60, 'BTC'), AssetAmount(30, 'MC')),
+        tick = Tick(OrderId(TraderId(b'0'), OrderNumber(1)), AssetPair(AssetAmount(60, 'BTC'), AssetAmount(30, 'MC')),
                     Timeout(100), Timestamp.now(), True)
-        tick2 = Tick(OrderId(TraderId('0'), OrderNumber(2)), AssetPair(AssetAmount(30, 'BTC'), AssetAmount(30, 'MC')),
+        tick2 = Tick(OrderId(TraderId(b'0'), OrderNumber(2)), AssetPair(AssetAmount(30, 'BTC'), AssetAmount(30, 'MC')),
                      Timeout(100), Timestamp.now(), True)
 
         self.price_level = PriceLevel(Price(10, 'MC', 'BTC'))

--- a/Tribler/Test/Community/Market/test_side.py
+++ b/Tribler/Test/Community/Market/test_side.py
@@ -17,10 +17,10 @@ class SideTestSuite(unittest.TestCase):
     def setUp(self):
         # Object creation
 
-        self.tick = Tick(OrderId(TraderId('0'), OrderNumber(1)),
+        self.tick = Tick(OrderId(TraderId(b'0'), OrderNumber(1)),
                          AssetPair(AssetAmount(60, 'BTC'), AssetAmount(30, 'MB')),
                          Timeout(100), Timestamp.now(), True)
-        self.tick2 = Tick(OrderId(TraderId('1'), OrderNumber(2)),
+        self.tick2 = Tick(OrderId(TraderId(b'1'), OrderNumber(2)),
                           AssetPair(AssetAmount(120, 'BTC'), AssetAmount(30, 'MB')),
                           Timeout(100), Timestamp.now(), True)
         self.side = Side()
@@ -48,22 +48,22 @@ class SideTestSuite(unittest.TestCase):
     def test_insert_tick(self):
         # Test insert tick
         self.assertEquals(0, len(self.side))
-        self.assertFalse(self.side.tick_exists(OrderId(TraderId('0'), OrderNumber(1))))
+        self.assertFalse(self.side.tick_exists(OrderId(TraderId(b'0'), OrderNumber(1))))
 
         self.side.insert_tick(self.tick)
         self.side.insert_tick(self.tick2)
 
         self.assertEquals(2, len(self.side))
-        self.assertTrue(self.side.tick_exists(OrderId(TraderId('0'), OrderNumber(1))))
+        self.assertTrue(self.side.tick_exists(OrderId(TraderId(b'0'), OrderNumber(1))))
 
     def test_remove_tick(self):
         # Test remove tick
         self.side.insert_tick(self.tick)
         self.side.insert_tick(self.tick2)
 
-        self.side.remove_tick(OrderId(TraderId('0'), OrderNumber(1)))
+        self.side.remove_tick(OrderId(TraderId(b'0'), OrderNumber(1)))
         self.assertEquals(1, len(self.side))
-        self.side.remove_tick(OrderId(TraderId('1'), OrderNumber(2)))
+        self.side.remove_tick(OrderId(TraderId(b'1'), OrderNumber(2)))
         self.assertEquals(0, len(self.side))
 
     def test_get_price_level_list_wallets(self):

--- a/Tribler/Test/Community/Market/test_tick.py
+++ b/Tribler/Test/Community/Market/test_tick.py
@@ -20,14 +20,14 @@ class TickTestSuite(unittest.TestCase):
     def setUp(self):
         # Object creation
         self.timestamp_now = Timestamp.now()
-        self.tick = Tick(OrderId(TraderId('0'), OrderNumber(1)),
+        self.tick = Tick(OrderId(TraderId(b'0'), OrderNumber(1)),
                          AssetPair(AssetAmount(30, 'BTC'), AssetAmount(30, 'MB')), Timeout(30), Timestamp(0.0), True)
-        self.tick2 = Tick(OrderId(TraderId('0'), OrderNumber(2)),
+        self.tick2 = Tick(OrderId(TraderId(b'0'), OrderNumber(2)),
                           AssetPair(AssetAmount(30, 'BTC'), AssetAmount(30, 'MB')), Timeout(0), Timestamp(0.0), False)
-        self.order_ask = Order(OrderId(TraderId('0'), OrderNumber(2)),
+        self.order_ask = Order(OrderId(TraderId(b'0'), OrderNumber(2)),
                                AssetPair(AssetAmount(30, 'BTC'), AssetAmount(30, 'MB')),
                                Timeout(0), Timestamp(0.0), True)
-        self.order_bid = Order(OrderId(TraderId('0'), OrderNumber(2)),
+        self.order_bid = Order(OrderId(TraderId(b'0'), OrderNumber(2)),
                                AssetPair(AssetAmount(30, 'BTC'), AssetAmount(30, 'MB')),
                                Timeout(0), Timestamp(0.0), False)
 
@@ -38,7 +38,7 @@ class TickTestSuite(unittest.TestCase):
 
     def test_to_network(self):
         # Test for to network
-        self.assertEquals((TraderId('0'), self.tick.timestamp, OrderNumber(1),
+        self.assertEquals((TraderId(b'0'), self.tick.timestamp, OrderNumber(1),
                            AssetPair(AssetAmount(30, 'BTC'), AssetAmount(30, 'MB')), self.tick.timeout, 0),
                           self.tick.to_network())
 

--- a/Tribler/Test/Community/Market/test_tickentry.py
+++ b/Tribler/Test/Community/Market/test_tickentry.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 from twisted.internet.defer import inlineCallbacks
 
 from Tribler.Test.test_as_server import AbstractServer

--- a/Tribler/Test/Community/Market/test_tickentry.py
+++ b/Tribler/Test/Community/Market/test_tickentry.py
@@ -1,11 +1,11 @@
-from Tribler.community.market.core.assetamount import AssetAmount
-from Tribler.community.market.core.assetpair import AssetPair
-from Tribler.community.market.core.price import Price
 from twisted.internet.defer import inlineCallbacks
 
 from Tribler.Test.test_as_server import AbstractServer
+from Tribler.community.market.core.assetamount import AssetAmount
+from Tribler.community.market.core.assetpair import AssetPair
 from Tribler.community.market.core.message import TraderId
 from Tribler.community.market.core.order import OrderId, OrderNumber
+from Tribler.community.market.core.price import Price
 from Tribler.community.market.core.pricelevel import PriceLevel
 from Tribler.community.market.core.tick import Tick
 from Tribler.community.market.core.tickentry import TickEntry

--- a/Tribler/Test/Community/Market/test_tickentry.py
+++ b/Tribler/Test/Community/Market/test_tickentry.py
@@ -21,9 +21,9 @@ class TickEntryTestSuite(AbstractServer):
         yield super(TickEntryTestSuite, self).setUp()
 
         # Object creation
-        tick = Tick(OrderId(TraderId('0'), OrderNumber(1)), AssetPair(AssetAmount(60, 'BTC'), AssetAmount(30, 'MB')),
+        tick = Tick(OrderId(TraderId(b'0'), OrderNumber(1)), AssetPair(AssetAmount(60, 'BTC'), AssetAmount(30, 'MB')),
                     Timeout(0), Timestamp(0.0), True)
-        tick2 = Tick(OrderId(TraderId('0'), OrderNumber(2)),
+        tick2 = Tick(OrderId(TraderId(b'0'), OrderNumber(2)),
                      AssetPair(AssetAmount(63400, 'BTC'), AssetAmount(30, 'MB')), Timeout(100), Timestamp.now(), True)
 
         self.price_level = PriceLevel(Price(100, 'MB', 'BTC'))
@@ -66,9 +66,9 @@ class TickEntryTestSuite(AbstractServer):
         """
         Test blocking of a match
         """
-        self.tick_entry.block_for_matching(OrderId(TraderId("abc"), OrderNumber(3)))
+        self.tick_entry.block_for_matching(OrderId(TraderId(b"abc"), OrderNumber(3)))
         self.assertEqual(len(self.tick_entry._blocked_for_matching), 1)
 
         # Try to add it again - should be ignored
-        self.tick_entry.block_for_matching(OrderId(TraderId("abc"), OrderNumber(3)))
+        self.tick_entry.block_for_matching(OrderId(TraderId(b"abc"), OrderNumber(3)))
         self.assertEqual(len(self.tick_entry._blocked_for_matching), 1)

--- a/Tribler/Test/Community/Market/test_trade.py
+++ b/Tribler/Test/Community/Market/test_trade.py
@@ -6,7 +6,7 @@ from Tribler.community.market.core.assetpair import AssetPair
 from Tribler.community.market.core.message import TraderId
 from Tribler.community.market.core.order import OrderId, OrderNumber
 from Tribler.community.market.core.timestamp import Timestamp
-from Tribler.community.market.core.trade import Trade, ProposedTrade, DeclinedTrade, CounterTrade
+from Tribler.community.market.core.trade import CounterTrade, DeclinedTrade, ProposedTrade, Trade
 
 
 class TradeTestSuite(unittest.TestCase):

--- a/Tribler/Test/Community/Market/test_trade.py
+++ b/Tribler/Test/Community/Market/test_trade.py
@@ -14,9 +14,9 @@ class TradeTestSuite(unittest.TestCase):
 
     def setUp(self):
         # Object creation
-        self.trade = Trade(TraderId('0'),
-                           OrderId(TraderId('0'), OrderNumber(3)),
-                           OrderId(TraderId('0'), OrderNumber(4)), 1234, Timestamp(1462224447.117))
+        self.trade = Trade(TraderId(b'0'),
+                           OrderId(TraderId(b'0'), OrderNumber(3)),
+                           OrderId(TraderId(b'0'), OrderNumber(4)), 1234, Timestamp(1462224447.117))
 
     def test_to_network(self):
         # Test for to network
@@ -28,31 +28,31 @@ class ProposedTradeTestSuite(unittest.TestCase):
 
     def setUp(self):
         # Object creation
-        self.proposed_trade = Trade.propose(TraderId('0'),
-                                            OrderId(TraderId('0'), OrderNumber(1)),
-                                            OrderId(TraderId('1'), OrderNumber(2)),
+        self.proposed_trade = Trade.propose(TraderId(b'0'),
+                                            OrderId(TraderId(b'0'), OrderNumber(1)),
+                                            OrderId(TraderId(b'1'), OrderNumber(2)),
                                             AssetPair(AssetAmount(60, 'BTC'), AssetAmount(30, 'MB')),
                                             Timestamp(1462224447.117))
 
     def test_to_network(self):
         # Test for to network
-        self.assertEquals((TraderId('0'), Timestamp(1462224447.117),
-                           OrderNumber(1), OrderId(TraderId('1'), OrderNumber(2)), self.proposed_trade.proposal_id,
+        self.assertEquals((TraderId(b'0'), Timestamp(1462224447.117),
+                           OrderNumber(1), OrderId(TraderId(b'1'), OrderNumber(2)), self.proposed_trade.proposal_id,
                            AssetPair(AssetAmount(60, 'BTC'), AssetAmount(30, 'MB'))), self.proposed_trade.to_network())
 
     def test_from_network(self):
         # Test for from network
         data = ProposedTrade.from_network(type('Data', (object,),
-                                               {"trader_id": TraderId('0'),
+                                               {"trader_id": TraderId(b'0'),
                                                 "order_number": OrderNumber(1),
                                                 "recipient_order_id": OrderId(TraderId('1'), OrderNumber(2)),
                                                 "proposal_id": 1234,
                                                 "timestamp": Timestamp(1462224447.117),
                                                 "assets": AssetPair(AssetAmount(60, 'BTC'), AssetAmount(30, 'MB'))}))
 
-        self.assertEquals(TraderId('0'), data.trader_id)
-        self.assertEquals(OrderId(TraderId('0'), OrderNumber(1)), data.order_id)
-        self.assertEquals(OrderId(TraderId('1'), OrderNumber(2)),
+        self.assertEquals(TraderId(b'0'), data.trader_id)
+        self.assertEquals(OrderId(TraderId(b'0'), OrderNumber(1)), data.order_id)
+        self.assertEquals(OrderId(TraderId(b'1'), OrderNumber(2)),
                           data.recipient_order_id)
         self.assertEquals(1234, data.proposal_id)
         self.assertEquals(AssetPair(AssetAmount(60, 'BTC'), AssetAmount(30, 'MB')), data.assets)
@@ -64,12 +64,12 @@ class DeclinedTradeTestSuite(unittest.TestCase):
 
     def setUp(self):
         # Object creation
-        self.proposed_trade = Trade.propose(TraderId('0'),
-                                            OrderId(TraderId('0'), OrderNumber(1)),
-                                            OrderId(TraderId('1'), OrderNumber(2)),
+        self.proposed_trade = Trade.propose(TraderId(b'0'),
+                                            OrderId(TraderId(b'0'), OrderNumber(1)),
+                                            OrderId(TraderId(b'1'), OrderNumber(2)),
                                             AssetPair(AssetAmount(60, 'BTC'), AssetAmount(30, 'MB')),
                                             Timestamp(1462224447.117))
-        self.declined_trade = Trade.decline(TraderId('0'),
+        self.declined_trade = Trade.decline(TraderId(b'0'),
                                             Timestamp(1462224447.117), self.proposed_trade,
                                             DeclinedTradeReason.ORDER_COMPLETED)
 
@@ -77,24 +77,24 @@ class DeclinedTradeTestSuite(unittest.TestCase):
         # Test for to network
         data = self.declined_trade.to_network()
 
-        self.assertEquals(data[0], TraderId("0"))
+        self.assertEquals(data[0], TraderId(b"0"))
         self.assertEquals(data[1], Timestamp(1462224447.117))
         self.assertEquals(data[2], OrderNumber(2))
-        self.assertEquals(data[3], OrderId(TraderId("0"), OrderNumber(1)))
+        self.assertEquals(data[3], OrderId(TraderId(b"0"), OrderNumber(1)))
         self.assertEquals(data[4], self.proposed_trade.proposal_id)
 
     def test_from_network(self):
         # Test for from network
         data = DeclinedTrade.from_network(type('Data', (object,),
-                                               {"trader_id": TraderId('0'),
+                                               {"trader_id": TraderId(b'0'),
                                                 "order_number": OrderNumber(1),
-                                                "recipient_order_id": OrderId(TraderId('1'), OrderNumber(2)),
+                                                "recipient_order_id": OrderId(TraderId(b'1'), OrderNumber(2)),
                                                 "proposal_id": 1235,
                                                 "timestamp": Timestamp(1462224447.117),
                                                 "decline_reason": 0}))
 
-        self.assertEquals(TraderId('0'), data.trader_id)
-        self.assertEquals(OrderId(TraderId('1'), OrderNumber(2)),
+        self.assertEquals(TraderId(b'0'), data.trader_id)
+        self.assertEquals(OrderId(TraderId(b'1'), OrderNumber(2)),
                           data.recipient_order_id)
         self.assertEquals(1235, data.proposal_id)
         self.assertEquals(Timestamp(1462224447.117), data.timestamp)
@@ -111,34 +111,34 @@ class CounterTradeTestSuite(unittest.TestCase):
 
     def setUp(self):
         # Object creation
-        self.proposed_trade = Trade.propose(TraderId('0'),
-                                            OrderId(TraderId('0'), OrderNumber(1)),
-                                            OrderId(TraderId('1'), OrderNumber(2)),
+        self.proposed_trade = Trade.propose(TraderId(b'0'),
+                                            OrderId(TraderId(b'0'), OrderNumber(1)),
+                                            OrderId(TraderId(b'1'), OrderNumber(2)),
                                             AssetPair(AssetAmount(60, 'BTC'), AssetAmount(30, 'MB')),
                                             Timestamp(1462224447.117))
-        self.counter_trade = Trade.counter(TraderId('0'), AssetPair(AssetAmount(60, 'BTC'), AssetAmount(30, 'MB')),
+        self.counter_trade = Trade.counter(TraderId(b'0'), AssetPair(AssetAmount(60, 'BTC'), AssetAmount(30, 'MB')),
                                            Timestamp(1462224447.117), self.proposed_trade)
 
     def test_to_network(self):
         # Test for to network
         self.assertEquals(
-            ((TraderId('0'), Timestamp(1462224447.117), OrderNumber(2),
-              OrderId(TraderId('0'), OrderNumber(1)), self.proposed_trade.proposal_id,
+            ((TraderId(b'0'), Timestamp(1462224447.117), OrderNumber(2),
+              OrderId(TraderId(b'0'), OrderNumber(1)), self.proposed_trade.proposal_id,
               AssetPair(AssetAmount(60, 'BTC'), AssetAmount(30, 'MB')))), self.counter_trade.to_network())
 
     def test_from_network(self):
         # Test for from network
         data = CounterTrade.from_network(type('Data', (object,),
-                                              {"trader_id": TraderId('0'),
+                                              {"trader_id": TraderId(b'0'),
                                                "timestamp": Timestamp(1462224447.117),
                                                "order_number": OrderNumber(1),
-                                               "recipient_order_id": OrderId(TraderId('1'), OrderNumber(2)),
+                                               "recipient_order_id": OrderId(TraderId(b'1'), OrderNumber(2)),
                                                "proposal_id": 1236,
                                                "assets": AssetPair(AssetAmount(60, 'BTC'), AssetAmount(30, 'MB')), }))
 
-        self.assertEquals(TraderId('0'), data.trader_id)
-        self.assertEquals(OrderId(TraderId('0'), OrderNumber(1)), data.order_id)
-        self.assertEquals(OrderId(TraderId('1'), OrderNumber(2)),
+        self.assertEquals(TraderId(b'0'), data.trader_id)
+        self.assertEquals(OrderId(TraderId(b'0'), OrderNumber(1)), data.order_id)
+        self.assertEquals(OrderId(TraderId(b'1'), OrderNumber(2)),
                           data.recipient_order_id)
         self.assertEquals(1236, data.proposal_id)
         self.assertEquals(AssetPair(AssetAmount(60, 'BTC'), AssetAmount(30, 'MB')), data.assets)

--- a/Tribler/Test/Community/Market/test_trade.py
+++ b/Tribler/Test/Community/Market/test_trade.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import unittest
 
 from Tribler.community.market.core import DeclinedTradeReason

--- a/Tribler/Test/Community/Market/test_transaction.py
+++ b/Tribler/Test/Community/Market/test_transaction.py
@@ -1,17 +1,18 @@
 from __future__ import absolute_import
 
-import six
 import unittest
+
+import six
 
 from Tribler.community.market.core.assetamount import AssetAmount
 from Tribler.community.market.core.assetpair import AssetPair
+from Tribler.community.market.core.message import TraderId
+from Tribler.community.market.core.order import OrderId, OrderNumber
 from Tribler.community.market.core.payment import Payment
 from Tribler.community.market.core.payment_id import PaymentId
-from Tribler.community.market.core.transaction import TransactionNumber, TransactionId, Transaction, StartTransaction
 from Tribler.community.market.core.timestamp import Timestamp
-from Tribler.community.market.core.order import OrderId, OrderNumber
-from Tribler.community.market.core.message import TraderId
 from Tribler.community.market.core.trade import Trade
+from Tribler.community.market.core.transaction import StartTransaction, Transaction, TransactionId, TransactionNumber
 from Tribler.community.market.core.wallet_address import WalletAddress
 
 

--- a/Tribler/Test/Community/Market/test_transaction.py
+++ b/Tribler/Test/Community/Market/test_transaction.py
@@ -51,13 +51,13 @@ class TransactionIdTestSuite(unittest.TestCase):
 
     def setUp(self):
         # Object creation
-        self.transaction_id = TransactionId(TraderId('0'), TransactionNumber(1))
-        self.transaction_id2 = TransactionId(TraderId('0'), TransactionNumber(1))
-        self.transaction_id3 = TransactionId(TraderId('0'), TransactionNumber(2))
+        self.transaction_id = TransactionId(TraderId(b'0'), TransactionNumber(1))
+        self.transaction_id2 = TransactionId(TraderId(b'0'), TransactionNumber(1))
+        self.transaction_id3 = TransactionId(TraderId(b'0'), TransactionNumber(2))
 
     def test_properties(self):
         # Test for properties
-        self.assertEqual(TraderId('0'), self.transaction_id.trader_id)
+        self.assertEqual(TraderId(b'0'), self.transaction_id.trader_id)
         self.assertEqual(TransactionNumber(1), self.transaction_id.transaction_number)
 
     def test_conversion(self):
@@ -81,15 +81,15 @@ class TransactionTestSuite(unittest.TestCase):
 
     def setUp(self):
         # Object creation
-        self.transaction_id = TransactionId(TraderId("0"), TransactionNumber(1))
+        self.transaction_id = TransactionId(TraderId(b"0"), TransactionNumber(1))
         self.transaction = Transaction(self.transaction_id, AssetPair(AssetAmount(100, 'BTC'), AssetAmount(100, 'MB')),
-                                       OrderId(TraderId('3'), OrderNumber(2)),
-                                       OrderId(TraderId('2'), OrderNumber(1)), Timestamp(0.0))
-        self.proposed_trade = Trade.propose(TraderId('0'),
-                                            OrderId(TraderId('0'), OrderNumber(2)),
-                                            OrderId(TraderId('1'), OrderNumber(3)),
+                                       OrderId(TraderId(b'3'), OrderNumber(2)),
+                                       OrderId(TraderId(b'2'), OrderNumber(1)), Timestamp(0.0))
+        self.proposed_trade = Trade.propose(TraderId(b'0'),
+                                            OrderId(TraderId(b'0'), OrderNumber(2)),
+                                            OrderId(TraderId(b'1'), OrderNumber(3)),
                                             AssetPair(AssetAmount(100, 'BTC'), AssetAmount(100, 'MB')), Timestamp(0.0))
-        self.payment = Payment(TraderId("0"), TransactionId(TraderId('2'), TransactionNumber(2)),
+        self.payment = Payment(TraderId(b"0"), TransactionId(TraderId(b'2'), TransactionNumber(2)),
                                AssetAmount(3, 'MB'), WalletAddress('a'), WalletAddress('b'),
                                PaymentId('aaa'), Timestamp(4.0), True)
 
@@ -177,28 +177,28 @@ class StartTransactionTestSuite(unittest.TestCase):
 
     def setUp(self):
         # Object creation
-        self.start_transaction = StartTransaction(TraderId('0'),
-                                                  TransactionId(TraderId("0"), TransactionNumber(1)),
-                                                  OrderId(TraderId('0'), OrderNumber(1)),
-                                                  OrderId(TraderId('1'), OrderNumber(1)), 1234,
+        self.start_transaction = StartTransaction(TraderId(b'0'),
+                                                  TransactionId(TraderId(b"0"), TransactionNumber(1)),
+                                                  OrderId(TraderId(b'0'), OrderNumber(1)),
+                                                  OrderId(TraderId(b'1'), OrderNumber(1)), 1234,
                                                   AssetPair(AssetAmount(30, 'BTC'), AssetAmount(40, 'MC')),
                                                   Timestamp(0.0))
 
     def test_from_network(self):
         # Test for from network
         data = StartTransaction.from_network(
-            type('Data', (object,), {"trader_id": TraderId('0'),
-                                     "transaction_id": TransactionId(TraderId('0'), TransactionNumber(1)),
-                                     "order_id": OrderId(TraderId('0'), OrderNumber(1)),
-                                     "recipient_order_id": OrderId(TraderId('1'), OrderNumber(2)),
+            type('Data', (object,), {"trader_id": TraderId(b'0'),
+                                     "transaction_id": TransactionId(TraderId(b'0'), TransactionNumber(1)),
+                                     "order_id": OrderId(TraderId(b'0'), OrderNumber(1)),
+                                     "recipient_order_id": OrderId(TraderId(b'1'), OrderNumber(2)),
                                      "proposal_id": 1235,
                                      "assets": AssetPair(AssetAmount(30, 'BTC'), AssetAmount(40, 'MC')),
                                      "timestamp": Timestamp(0.0)}))
 
-        self.assertEquals(TraderId("0"), data.trader_id)
-        self.assertEquals(TransactionId(TraderId("0"), TransactionNumber(1)), data.transaction_id)
-        self.assertEquals(OrderId(TraderId('0'), OrderNumber(1)), data.order_id)
-        self.assertEquals(OrderId(TraderId('1'), OrderNumber(2)), data.recipient_order_id)
+        self.assertEquals(TraderId(b"0"), data.trader_id)
+        self.assertEquals(TransactionId(TraderId(b"0"), TransactionNumber(1)), data.transaction_id)
+        self.assertEquals(OrderId(TraderId(b'0'), OrderNumber(1)), data.order_id)
+        self.assertEquals(OrderId(TraderId(b'1'), OrderNumber(2)), data.recipient_order_id)
         self.assertEquals(1235, data.proposal_id)
         self.assertEquals(Timestamp(0.0), data.timestamp)
 

--- a/Tribler/Test/Community/Market/test_transaction_manager.py
+++ b/Tribler/Test/Community/Market/test_transaction_manager.py
@@ -24,19 +24,19 @@ class TransactionManagerTestSuite(unittest.TestCase):
         self.memory_transaction_repository = MemoryTransactionRepository("0")
         self.transaction_manager = TransactionManager(self.memory_transaction_repository)
 
-        self.transaction_id = TransactionId(TraderId("0"), TransactionNumber(1))
+        self.transaction_id = TransactionId(TraderId(b"0"), TransactionNumber(1))
         self.transaction = Transaction(self.transaction_id, AssetPair(AssetAmount(100, 'BTC'), AssetAmount(30, 'MB')),
-                                       OrderId(TraderId('3'), OrderNumber(2)),
-                                       OrderId(TraderId('2'), OrderNumber(1)), Timestamp(0.0))
-        self.proposed_trade = Trade.propose(TraderId('0'),
-                                            OrderId(TraderId('0'), OrderNumber(1)),
-                                            OrderId(TraderId('1'), OrderNumber(2)),
+                                       OrderId(TraderId(b'3'), OrderNumber(2)),
+                                       OrderId(TraderId(b'2'), OrderNumber(1)), Timestamp(0.0))
+        self.proposed_trade = Trade.propose(TraderId(b'0'),
+                                            OrderId(TraderId(b'0'), OrderNumber(1)),
+                                            OrderId(TraderId(b'1'), OrderNumber(2)),
                                             AssetPair(AssetAmount(30, 'BTC'), AssetAmount(30, 'MB')),
                                             Timestamp(1462224447.117))
-        self.start_transaction = StartTransaction(TraderId('0'),
-                                                  TransactionId(TraderId("0"), TransactionNumber(1)),
-                                                  OrderId(TraderId('0'), OrderNumber(1)),
-                                                  OrderId(TraderId('1'), OrderNumber(2)), 1235,
+        self.start_transaction = StartTransaction(TraderId(b'0'),
+                                                  TransactionId(TraderId(b"0"), TransactionNumber(1)),
+                                                  OrderId(TraderId(b'0'), OrderNumber(1)),
+                                                  OrderId(TraderId(b'1'), OrderNumber(2)), 1235,
                                                   AssetPair(AssetAmount(20, 'BTC'), AssetAmount(20, 'MB')),
                                                   Timestamp(0.0))
 
@@ -70,7 +70,7 @@ class TransactionManagerTestSuite(unittest.TestCase):
         self.transaction.outgoing_address = WalletAddress('def')
         self.transaction.partner_incoming_address = WalletAddress('ghi')
         self.transaction.partner_outgoing_address = WalletAddress('jkl')
-        payment_msg = self.transaction_manager.create_payment_message(TraderId("0"),
+        payment_msg = self.transaction_manager.create_payment_message(TraderId(b"0"),
                                                                       PaymentId('abc'), self.transaction,
                                                                       AssetAmount(1, 'BTC'),
                                                                       True)

--- a/Tribler/Test/Community/Market/test_transaction_repository.py
+++ b/Tribler/Test/Community/Market/test_transaction_repository.py
@@ -17,10 +17,10 @@ class MemoryTransactionRepositoryTestSuite(unittest.TestCase):
     def setUp(self):
         # Object creation
         self.memory_transaction_repository = MemoryTransactionRepository("0")
-        self.transaction_id = TransactionId(TraderId("0"), TransactionNumber(1))
+        self.transaction_id = TransactionId(TraderId(b"0"), TransactionNumber(1))
         self.transaction = Transaction(self.transaction_id, AssetPair(AssetAmount(10, 'BTC'), AssetAmount(10, 'MB')),
-                                       OrderId(TraderId("0"), OrderNumber(1)),
-                                       OrderId(TraderId("2"), OrderNumber(2)), Timestamp(0.0))
+                                       OrderId(TraderId(b"0"), OrderNumber(1)),
+                                       OrderId(TraderId(b"2"), OrderNumber(2)), Timestamp(0.0))
 
     def test_find_by_id(self):
         # Test for find by id
@@ -43,9 +43,9 @@ class MemoryTransactionRepositoryTestSuite(unittest.TestCase):
 
     def test_next_identity(self):
         # Test for next identity
-        self.assertEquals(TransactionId(TraderId("0"), TransactionNumber(1)),
+        self.assertEquals(TransactionId(TraderId(b"0"), TransactionNumber(1)),
                           self.memory_transaction_repository.next_identity())
-        self.assertEquals(TransactionId(TraderId("0"), TransactionNumber(2)),
+        self.assertEquals(TransactionId(TraderId(b"0"), TransactionNumber(2)),
                           self.memory_transaction_repository.next_identity())
 
     def test_update(self):

--- a/Tribler/Test/Core/Modules/RestApi/test_market_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_market_endpoint.py
@@ -57,15 +57,15 @@ class TestMarketEndpoint(AbstractApiTest):
         """
         Add a transaction and a payment to the market
         """
-        proposed_trade = Trade.propose(TraderId('0'),
-                                       OrderId(TraderId('0'), OrderNumber(1)),
-                                       OrderId(TraderId('1'), OrderNumber(2)),
+        proposed_trade = Trade.propose(TraderId(b'0'),
+                                       OrderId(TraderId(b'0'), OrderNumber(1)),
+                                       OrderId(TraderId(b'1'), OrderNumber(2)),
                                        AssetPair(AssetAmount(30, 'BTC'), AssetAmount(60, 'MB')),
                                        Timestamp(1462224447.117))
         transaction = self.session.lm.market_community.transaction_manager.create_from_proposed_trade(
             proposed_trade, 'abcd')
 
-        payment = Payment(TraderId("0"), transaction.transaction_id,
+        payment = Payment(TraderId(b"0"), transaction.transaction_id,
                           AssetAmount(20, 'BTC'), WalletAddress('a'), WalletAddress('b'),
                           PaymentId('aaa'), Timestamp(4.0), True)
         transaction.add_payment(payment)

--- a/Tribler/community/market/community.py
+++ b/Tribler/community/market/community.py
@@ -189,7 +189,7 @@ class MarketCommunity(Community, BlockListener):
             self.enable_matchmaker()
 
         for trader in self.market_database.get_traders():
-            self.update_ip(TraderId(trader[0]), (str(trader[1]), trader[2]))
+            self.update_ip(TraderId(bytes(trader[0])), (str(trader[1]), trader[2]))
 
         # Register messages
         self.decode_map.update({

--- a/Tribler/community/market/community.py
+++ b/Tribler/community/market/community.py
@@ -189,7 +189,7 @@ class MarketCommunity(Community, BlockListener):
             self.enable_matchmaker()
 
         for trader in self.market_database.get_traders():
-            self.update_ip(TraderId(str(trader[0])), (str(trader[1]), trader[2]))
+            self.update_ip(TraderId(trader[0]), (str(trader[1]), trader[2]))
 
         # Register messages
         self.decode_map.update({

--- a/Tribler/community/market/core/message.py
+++ b/Tribler/community/market/core/message.py
@@ -1,3 +1,7 @@
+from __future__ import absolute_import
+
+from six import binary_type
+
 from Tribler.community.market.core.timestamp import Timestamp
 
 
@@ -5,16 +9,17 @@ class TraderId(object):
     """Immutable class for representing the id of a trader."""
 
     def __init__(self, trader_id):
-        # type: (bytes) -> None
         """
         :param trader_id: String representing the trader id
-        :type trader_id: str
+        :type trader_id: binary_type
         :raises ValueError: Thrown when one of the arguments are invalid
         """
         super(TraderId, self).__init__()
 
-        if not isinstance(trader_id, bytes):
-            raise ValueError("Trader id must be bytes")
+        trader_id = trader_id if isinstance(trader_id, bytes) else binary_type(trader_id)
+
+        if not isinstance(trader_id, binary_type):
+            raise ValueError("Trader id must be a binary type")
 
         try:
             int(trader_id, 16)
@@ -26,13 +31,16 @@ class TraderId(object):
     def __str__(self):
         return "%s" % self._trader_id
 
+    def to_string(self):
+        return self._trader_id
+
     def __eq__(self, other):
         if not isinstance(other, TraderId):
             return NotImplemented
         elif self is other:
             return True
         else:
-            return self._trader_id == other._trader_id
+            return self._trader_id == other.to_string()
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/Tribler/community/market/core/message.py
+++ b/Tribler/community/market/core/message.py
@@ -5,6 +5,7 @@ class TraderId(object):
     """Immutable class for representing the id of a trader."""
 
     def __init__(self, trader_id):
+        # type: (bytes) -> None
         """
         :param trader_id: String representing the trader id
         :type trader_id: str
@@ -12,8 +13,8 @@ class TraderId(object):
         """
         super(TraderId, self).__init__()
 
-        if not isinstance(trader_id, str):
-            raise ValueError("Trader id must be a string")
+        if not isinstance(trader_id, bytes):
+            raise ValueError("Trader id must be bytes")
 
         try:
             int(trader_id, 16)
@@ -31,8 +32,7 @@ class TraderId(object):
         elif self is other:
             return True
         else:
-            return self._trader_id == \
-                   other._trader_id
+            return self._trader_id == other._trader_id
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/Tribler/community/market/core/order.py
+++ b/Tribler/community/market/core/order.py
@@ -144,7 +144,7 @@ class Order(object):
         (trader_id, order_number, asset1_amount, asset1_type, asset2_amount, asset2_type, traded_quantity,
          timeout, order_timestamp, completed_timestamp, is_ask, cancelled, verified) = data
 
-        order_id = OrderId(TraderId(trader_id), OrderNumber(order_number))
+        order_id = OrderId(TraderId(bytes(trader_id)), OrderNumber(order_number))
         order = cls(order_id, AssetPair(AssetAmount(asset1_amount, str(asset1_type)),
                                         AssetAmount(asset2_amount, str(asset2_type))),
                     Timeout(timeout), Timestamp(order_timestamp), bool(is_ask))

--- a/Tribler/community/market/core/order.py
+++ b/Tribler/community/market/core/order.py
@@ -144,7 +144,7 @@ class Order(object):
         (trader_id, order_number, asset1_amount, asset1_type, asset2_amount, asset2_type, traded_quantity,
          timeout, order_timestamp, completed_timestamp, is_ask, cancelled, verified) = data
 
-        order_id = OrderId(TraderId(str(trader_id)), OrderNumber(order_number))
+        order_id = OrderId(TraderId(trader_id), OrderNumber(order_number))
         order = cls(order_id, AssetPair(AssetAmount(asset1_amount, str(asset1_type)),
                                         AssetAmount(asset2_amount, str(asset2_type))),
                     Timeout(timeout), Timestamp(order_timestamp), bool(is_ask))

--- a/Tribler/community/market/core/payment.py
+++ b/Tribler/community/market/core/payment.py
@@ -31,8 +31,8 @@ class Payment(Message):
         (trader_id, transaction_trader_id, transaction_number, payment_id, transferred_amount, transferred_id,
          address_from, address_to, timestamp, success) = data
 
-        transaction_id = TransactionId(TraderId(transaction_trader_id), TransactionNumber(transaction_number))
-        return cls(TraderId(trader_id), transaction_id, AssetAmount(transferred_amount, str(transferred_id)),
+        transaction_id = TransactionId(TraderId(bytes(transaction_trader_id)), TransactionNumber(transaction_number))
+        return cls(TraderId(bytes(trader_id)), transaction_id, AssetAmount(transferred_amount, str(transferred_id)),
                    WalletAddress(str(address_from)), WalletAddress(str(address_to)), PaymentId(str(payment_id)),
                    Timestamp(float(timestamp)), bool(success))
 

--- a/Tribler/community/market/core/payment.py
+++ b/Tribler/community/market/core/payment.py
@@ -31,8 +31,8 @@ class Payment(Message):
         (trader_id, transaction_trader_id, transaction_number, payment_id, transferred_amount, transferred_id,
          address_from, address_to, timestamp, success) = data
 
-        transaction_id = TransactionId(TraderId(str(transaction_trader_id)), TransactionNumber(transaction_number))
-        return cls(TraderId(str(trader_id)), transaction_id, AssetAmount(transferred_amount, str(transferred_id)),
+        transaction_id = TransactionId(TraderId(transaction_trader_id), TransactionNumber(transaction_number))
+        return cls(TraderId(trader_id), transaction_id, AssetAmount(transferred_amount, str(transferred_id)),
                    WalletAddress(str(address_from)), WalletAddress(str(address_to)), PaymentId(str(payment_id)),
                    Timestamp(float(timestamp)), bool(success))
 

--- a/Tribler/community/market/core/tick.py
+++ b/Tribler/community/market/core/tick.py
@@ -56,7 +56,7 @@ class Tick(object):
         is_ask, traded, block_hash = data
 
         tick_cls = Ask if is_ask else Bid
-        order_id = OrderId(TraderId(str(trader_id)), OrderNumber(order_number))
+        order_id = OrderId(TraderId(trader_id), OrderNumber(order_number))
         return tick_cls(order_id, AssetPair(AssetAmount(asset1_amount, str(asset1_type)),
                                             AssetAmount(asset2_amount, str(asset2_type))),
                         Timeout(timeout), Timestamp(timestamp), traded=traded, block_hash=str(block_hash))

--- a/Tribler/community/market/core/tick.py
+++ b/Tribler/community/market/core/tick.py
@@ -62,8 +62,8 @@ class Tick(object):
                         Timeout(timeout), Timestamp(timestamp), traded=traded, block_hash=str(block_hash))
 
     def to_database(self):
-        return (text_type(self.order_id.trader_id), int(self.order_id.order_number), self.assets.first.amount,
-                text_type(self.assets.first.asset_id), self.assets.second.amount,
+        return (database_blob(self.order_id.trader_id.to_string()), int(self.order_id.order_number),
+                self.assets.first.amount, text_type(self.assets.first.asset_id), self.assets.second.amount,
                 text_type(self.assets.second.asset_id), int(self.timeout), float(self.timestamp), self.is_ask(),
                 self.traded, database_blob(self.block_hash))
 

--- a/Tribler/community/market/core/transaction.py
+++ b/Tribler/community/market/core/transaction.py
@@ -150,12 +150,12 @@ class Transaction(object):
          transaction_timestamp, sent_wallet_info, received_wallet_info, incoming_address, outgoing_address,
          partner_incoming_address, partner_outgoing_address, match_id) = data
 
-        transaction_id = TransactionId(TraderId(trader_id), TransactionNumber(transaction_number))
+        transaction_id = TransactionId(TraderId(bytes(trader_id)), TransactionNumber(transaction_number))
         transaction = cls(transaction_id,
                           AssetPair(AssetAmount(asset1_amount, str(asset1_type)),
                                     AssetAmount(asset2_amount, str(asset2_type))),
-                          OrderId(TraderId(order_trader_id), OrderNumber(order_number)),
-                          OrderId(TraderId(partner_trader_id), OrderNumber(partner_order_number)),
+                          OrderId(TraderId(bytes(order_trader_id)), OrderNumber(order_number)),
+                          OrderId(TraderId(bytes(partner_trader_id)), OrderNumber(partner_order_number)),
                           Timestamp(float(transaction_timestamp)))
 
         transaction._transferred_assets = AssetPair(AssetAmount(asset1_transferred, str(asset1_type)),
@@ -197,12 +197,12 @@ class Transaction(object):
         partner_outgoing_address = None
         match_id = ''
 
-        transaction_id = TransactionId(TraderId(trader_id), TransactionNumber(transaction_number))
+        transaction_id = TransactionId(TraderId(bytes(trader_id)), TransactionNumber(transaction_number))
         transaction = cls(transaction_id,
                           AssetPair(AssetAmount(asset1_amount, str(asset1_type)),
                                     AssetAmount(asset2_amount, str(asset2_type))),
-                          OrderId(TraderId(order_trader_id), OrderNumber(order_number)),
-                          OrderId(TraderId(partner_trader_id), OrderNumber(partner_order_number)),
+                          OrderId(TraderId(bytes(order_trader_id)), OrderNumber(order_number)),
+                          OrderId(TraderId(bytes(partner_trader_id)), OrderNumber(partner_order_number)),
                           Timestamp(float(transaction_timestamp)))
 
         transaction._transferred_assets = AssetPair(AssetAmount(asset1_transferred, str(asset1_type)),

--- a/Tribler/community/market/core/transaction.py
+++ b/Tribler/community/market/core/transaction.py
@@ -150,12 +150,12 @@ class Transaction(object):
          transaction_timestamp, sent_wallet_info, received_wallet_info, incoming_address, outgoing_address,
          partner_incoming_address, partner_outgoing_address, match_id) = data
 
-        transaction_id = TransactionId(TraderId(str(trader_id)), TransactionNumber(transaction_number))
+        transaction_id = TransactionId(TraderId(trader_id), TransactionNumber(transaction_number))
         transaction = cls(transaction_id,
                           AssetPair(AssetAmount(asset1_amount, str(asset1_type)),
                                     AssetAmount(asset2_amount, str(asset2_type))),
-                          OrderId(TraderId(str(order_trader_id)), OrderNumber(order_number)),
-                          OrderId(TraderId(str(partner_trader_id)), OrderNumber(partner_order_number)),
+                          OrderId(TraderId(order_trader_id), OrderNumber(order_number)),
+                          OrderId(TraderId(partner_trader_id), OrderNumber(partner_order_number)),
                           Timestamp(float(transaction_timestamp)))
 
         transaction._transferred_assets = AssetPair(AssetAmount(asset1_transferred, str(asset1_type)),
@@ -197,12 +197,12 @@ class Transaction(object):
         partner_outgoing_address = None
         match_id = ''
 
-        transaction_id = TransactionId(TraderId(str(trader_id)), TransactionNumber(transaction_number))
+        transaction_id = TransactionId(TraderId(trader_id), TransactionNumber(transaction_number))
         transaction = cls(transaction_id,
                           AssetPair(AssetAmount(asset1_amount, str(asset1_type)),
                                     AssetAmount(asset2_amount, str(asset2_type))),
-                          OrderId(TraderId(str(order_trader_id)), OrderNumber(order_number)),
-                          OrderId(TraderId(str(partner_trader_id)), OrderNumber(partner_order_number)),
+                          OrderId(TraderId(order_trader_id), OrderNumber(order_number)),
+                          OrderId(TraderId(partner_trader_id), OrderNumber(partner_order_number)),
                           Timestamp(float(transaction_timestamp)))
 
         transaction._transferred_assets = AssetPair(AssetAmount(asset1_transferred, str(asset1_type)),

--- a/Tribler/community/market/database.py
+++ b/Tribler/community/market/database.py
@@ -137,7 +137,7 @@ class MarketDB(TrustChainDB):
         """
         db_result = self.execute(u"SELECT * FROM orders")
         return [Order.from_database(db_item, self.get_reserved_ticks(
-            OrderId(TraderId(str(db_item[0])), OrderNumber(db_item[1])))) for db_item in db_result]
+            OrderId(TraderId(db_item[0]), OrderNumber(db_item[1])))) for db_item in db_result]
 
     def get_order(self, order_id):
         """
@@ -206,7 +206,7 @@ class MarketDB(TrustChainDB):
         """
         db_results = self.execute(u"SELECT * FROM orders_reserved_ticks WHERE trader_id = ? AND order_number = ?",
                                   (text_type(order_id.trader_id), text_type(order_id.order_number)))
-        return [(OrderId(TraderId(str(data[2])), OrderNumber(data[3])), data[4]) for data in db_results]
+        return [(OrderId(TraderId(data[2]), OrderNumber(data[3])), data[4]) for data in db_results]
 
     def get_all_transactions(self):
         """
@@ -214,7 +214,7 @@ class MarketDB(TrustChainDB):
         """
         db_result = self.execute(u"SELECT * FROM transactions")
         return [Transaction.from_database(db_item,
-                                          self.get_payments(TransactionId(TraderId(str(db_item[0])),
+                                          self.get_payments(TransactionId(TraderId(db_item[0]),
                                                                           TransactionNumber(db_item[1]))))
                 for db_item in db_result]
 

--- a/Tribler/community/market/database.py
+++ b/Tribler/community/market/database.py
@@ -137,7 +137,7 @@ class MarketDB(TrustChainDB):
         """
         db_result = self.execute(u"SELECT * FROM orders")
         return [Order.from_database(db_item, self.get_reserved_ticks(
-            OrderId(TraderId(db_item[0]), OrderNumber(db_item[1])))) for db_item in db_result]
+            OrderId(TraderId(bytes(db_item[0])), OrderNumber(db_item[1])))) for db_item in db_result]
 
     def get_order(self, order_id):
         """
@@ -206,7 +206,7 @@ class MarketDB(TrustChainDB):
         """
         db_results = self.execute(u"SELECT * FROM orders_reserved_ticks WHERE trader_id = ? AND order_number = ?",
                                   (text_type(order_id.trader_id), text_type(order_id.order_number)))
-        return [(OrderId(TraderId(data[2]), OrderNumber(data[3])), data[4]) for data in db_results]
+        return [(OrderId(TraderId(bytes(data[2])), OrderNumber(data[3])), data[4]) for data in db_results]
 
     def get_all_transactions(self):
         """
@@ -214,7 +214,7 @@ class MarketDB(TrustChainDB):
         """
         db_result = self.execute(u"SELECT * FROM transactions")
         return [Transaction.from_database(db_item,
-                                          self.get_payments(TransactionId(TraderId(db_item[0]),
+                                          self.get_payments(TransactionId(TraderId(bytes(db_item[0])),
                                                                           TransactionNumber(db_item[1]))))
                 for db_item in db_result]
 


### PR DESCRIPTION
Opposite approach to #4351
```python
class TraderId(object):
    def __init__(self, trader_id):
        # type: (bytes) -> None
```
https://mypy.readthedocs.io/en/latest/cheat_sheet.html#classes

```
ERROR: Test whether an order is unreserved when address resolution fails
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/Community/Market/test_community.py", line 279, in test_address_resolv_fail
    yield self.introduce_nodes()
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/defer.py", line 1418, in _inlineCallbacks
    result = g.send(result)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/pyipv8/ipv8/test/base.py", line 160, in introduce_nodes
    node.overlay.walk_to(other.endpoint.wan_address)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/pyipv8/ipv8/community.py", line 323, in walk_to
    packet = self.create_introduction_request(address)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/community/market/community.py", line 279, in create_introduction_request
    extra_payload = InfoPayload(TraderId(self.mid), Timestamp.now(), self.is_matchmaker)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/community/market/core/message.py", line 16, in __init__
    raise ValueError("Trader id must be a string")
ValueError: Trader id must be a string
```