### PR TITLE
Py3: Avoid KeyError: 'name' by also looking at b'name'

### DIFF
--- a/Tribler/Core/TorrentDef.py
+++ b/Tribler/Core/TorrentDef.py
@@ -486,7 +486,7 @@ class TorrentDef(object):
             self.metainfo = metainfo
 
             # In Python 3, 'name' != b'name' so we should look for data in both
-            self.input['name'] = metainfo['info'].get('name', metainfo['info'].[b'name'])
+            self.input['name'] = metainfo['info'].get('name', metainfo['info'][b'name'])
             # May have been 0, meaning auto.
             self.input['piece length'] = metainfo['info']['piece length']
             self.metainfo_valid = True

--- a/Tribler/Core/TorrentDef.py
+++ b/Tribler/Core/TorrentDef.py
@@ -265,9 +265,7 @@ class TorrentDef(object):
         if not is_valid_url(url):
             raise ValueError("Invalid URL")
 
-        if url.endswith('/'):
-            # Some tracker code can't deal with / at end
-            url = url[:-1]
+        url = url.rstrip('/'):  # Some tracker code can't deal with / at end
         self.input['announce'] = url
         self.metainfo_valid = False
 
@@ -452,10 +450,7 @@ class TorrentDef(object):
     def get_initial_peers(self):
         """ Returns the list of initial peers.
         @return List of (IP,port) tuples. """
-        if 'initial peers' in self.input:
-            return self.input['initial peers']
-        else:
-            return []
+        return self.input.get('initial peers', [])
 
     def finalize(self, userabortflag=None, userprogresscallback=None):
         """ Create BT torrent file by reading the files added with
@@ -488,7 +483,7 @@ class TorrentDef(object):
             # In Python 3, 'name' != b'name' so we should look for data in both
             self.input['name'] = metainfo['info'].get('name', metainfo['info'][b'name'])
             # May have been 0, meaning auto.
-            self.input['piece length'] = metainfo['info']['piece length']
+            self.input['piece length'] = metainfo['info'].get('piece length', metainfo['info'][b'piece length'])
             self.metainfo_valid = True
 
         assert self.infohash is None or isinstance(

--- a/Tribler/Core/TorrentDef.py
+++ b/Tribler/Core/TorrentDef.py
@@ -265,7 +265,7 @@ class TorrentDef(object):
         if not is_valid_url(url):
             raise ValueError("Invalid URL")
 
-        url = url.rstrip('/'):  # Some tracker code can't deal with / at end
+        url = url.rstrip('/')  # Some tracker code can't deal with / at end
         self.input['announce'] = url
         self.metainfo_valid = False
 

--- a/Tribler/Core/TorrentDef.py
+++ b/Tribler/Core/TorrentDef.py
@@ -485,7 +485,8 @@ class TorrentDef(object):
             self.infohash = infohash
             self.metainfo = metainfo
 
-            self.input['name'] = metainfo['info']['name']
+            # In Python 3, 'name' != b'name' so we should look for data in both
+            self.input['name'] = metainfo['info'].get('name', metainfo['info'].[b'name'])
             # May have been 0, meaning auto.
             self.input['piece length'] = metainfo['info']['piece length']
             self.metainfo_valid = True


### PR DESCRIPTION
__d['name']__ --> __d.get('name', d[b'name'])__

```
ERROR: Add a single file with announce-list to a TorrentDef
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/defer.py", line 151, in maybeDeferred
    result = f(*args, **kw)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 201, in runWithWarningsSuppressed
    reraise(exc_info[1], exc_info[2])
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/python/compat.py", line 464, in reraise
    raise exception.with_traceback(traceback)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 197, in runWithWarningsSuppressed
    result = f(*a, **kw)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/test_as_server.py", line 62, in check
    result = fun(*argv, **kwargs)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/Core/test_torrent_def.py", line 192, in test_add_content_announce_list
    t.finalize()
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Core/TorrentDef.py", line 488, in finalize
    self.input['name'] = metainfo['info']['name']
KeyError: 'name'
-------------------- >> begin captured logging << --------------------
Tribler.Core.Utilities.maketorrent: DEBUG: makeinfo: inpath=/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/data/video.avi, outpath=None
--------------------- >> end captured logging << ---------------------
```