### PR TITLE
Py3: Make a list of the keys

### DIFF
--- a/Tribler/Core/Utilities/maketorrent.py
+++ b/Tribler/Core/Utilities/maketorrent.py
@@ -327,7 +327,7 @@ def offset_to_piece(offset, piece_size, endpoint=True):
 
 
 def copy_metainfo_to_input(metainfo, input):
-    keys = tdefdictdefaults.keys()
+    keys = list(tdefdictdefaults)
     # Arno: For magnet link support
     keys.append("initial peers")
     for key in keys:


### PR DESCRIPTION
In Python 3 __dict.keys()__ is an iterator, not a __list__.
```
ERROR: test_is_private
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/defer.py", line 151, in maybeDeferred
    result = f(*args, **kw)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 201, in runWithWarningsSuppressed
    reraise(exc_info[1], exc_info[2])
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/python/compat.py", line 464, in reraise
    raise exception.with_traceback(traceback)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 197, in runWithWarningsSuppressed
    result = f(*a, **kw)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/test_as_server.py", line 62, in check
    result = fun(*argv, **kwargs)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/Core/test_torrent_def.py", line 252, in test_is_private
    t1 = TorrentDef.load(privatefn)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Core/TorrentDef.py", line 125, in load
    return TorrentDef._read(f)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Core/TorrentDef.py", line 143, in _read
    return TorrentDef._create(data)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Core/TorrentDef.py", line 157, in _create
    maketorrent.copy_metainfo_to_input(t.metainfo, t.input)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Core/Utilities/maketorrent.py", line 332, in copy_metainfo_to_input
    keys.append("initial peers")
AttributeError: 'dict_keys' object has no attribute 'append'

======================================================================
ERROR: test_load_from_dict
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/defer.py", line 151, in maybeDeferred
    result = f(*args, **kw)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 201, in runWithWarningsSuppressed
    reraise(exc_info[1], exc_info[2])
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/python/compat.py", line 464, in reraise
    raise exception.with_traceback(traceback)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 197, in runWithWarningsSuppressed
    result = f(*a, **kw)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/test_as_server.py", line 62, in check
    result = fun(*argv, **kwargs)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/Core/test_torrent_def.py", line 417, in test_load_from_dict
    self.assertTrue(TorrentDef.load_from_dict(bdecode(encoded_metainfo)))
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Core/TorrentDef.py", line 197, in load_from_dict
    return TorrentDef._create(metainfo)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Core/TorrentDef.py", line 157, in _create
    maketorrent.copy_metainfo_to_input(t.metainfo, t.input)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Core/Utilities/maketorrent.py", line 332, in copy_metainfo_to_input
    keys.append("initial peers")
AttributeError: 'dict_keys' object has no attribute 'append'
```