### PR TITLE
Deal gracefully with failure to import meliae

### DIFF
--- a/TriblerGUI/debug_window.py
+++ b/TriblerGUI/debug_window.py
@@ -18,7 +18,11 @@ from matplotlib.backends.backend_qt5agg import FigureCanvas
 from matplotlib.dates import DateFormatter
 from matplotlib.figure import Figure
 
-from meliae import scanner
+try:
+    from meliae import scanner
+except ImportError:
+    scanner = None
+
 
 import psutil
 
@@ -658,7 +662,7 @@ class DebugWindow(QMainWindow):
                 self.request_mgr = TriblerRequestManager()
                 self.request_mgr.download_file("debug/memory/dump",
                                                lambda data: self.on_memory_dump_data_available(filename, data))
-            else:
+            elif scanner:
                 scanner.dump_all_objects(os.path.join(self.export_dir, filename))
 
     def on_memory_dump_data_available(self, filename, data):

--- a/TriblerGUI/debug_window.py
+++ b/TriblerGUI/debug_window.py
@@ -664,6 +664,10 @@ class DebugWindow(QMainWindow):
                                                lambda data: self.on_memory_dump_data_available(filename, data))
             elif scanner:
                 scanner.dump_all_objects(os.path.join(self.export_dir, filename))
+            else:
+                ConfirmationDialog.show_error(self.window(),
+                                              "Error when performing a memory dump",
+                                              "meliae memory dumper is not compatible with Python 3")
 
     def on_memory_dump_data_available(self, filename, data):
         if not data:


### PR DESCRIPTION
* https://pypi.org/project/meliae/
* https://launchpad.net/meliae
```
ERROR: Failure: ImportError (No module named 'meliae')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/nose/failure.py", line 39, in runTest
    raise self.exc_val.with_traceback(self.tb)
  File "/usr/lib/python3/dist-packages/nose/loader.py", line 418, in loadTestsFromName
    addr.filename, addr.module)
  File "/usr/lib/python3/dist-packages/nose/importer.py", line 47, in importFromPath
    return self.importFromDir(dir_path, fqname)
  File "/usr/lib/python3/dist-packages/nose/importer.py", line 94, in importFromDir
    mod = load_module(part_fqname, fh, filename, desc)
  File "/usr/lib/python3.5/imp.py", line 234, in load_module
    return load_source(name, filename, file)
  File "/usr/lib/python3.5/imp.py", line 172, in load_source
    module = _load(spec)
  File "<frozen importlib._bootstrap>", line 693, in _load
  File "<frozen importlib._bootstrap>", line 673, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 673, in exec_module
  File "<frozen importlib._bootstrap>", line 222, in _call_with_frames_removed
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/GUI/test_gui.py", line 24, in <module>
    from TriblerGUI.tribler_window import TriblerWindow
  File "/home/jenkins/workspace/test_tribler_python3/tribler/TriblerGUI/tribler_window.py", line 26, in <module>
    from TriblerGUI.debug_window import DebugWindow
  File "/home/jenkins/workspace/test_tribler_python3/tribler/TriblerGUI/debug_window.py", line 21, in <module>
    from meliae import scanner
ImportError: No module named 'meliae'

======================================================================
ERROR: Failure: ImportError (No module named 'meliae')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/nose/failure.py", line 39, in runTest
    raise self.exc_val.with_traceback(self.tb)
  File "/usr/lib/python3/dist-packages/nose/loader.py", line 418, in loadTestsFromName
    addr.filename, addr.module)
  File "/usr/lib/python3/dist-packages/nose/importer.py", line 47, in importFromPath
    return self.importFromDir(dir_path, fqname)
  File "/usr/lib/python3/dist-packages/nose/importer.py", line 94, in importFromDir
    mod = load_module(part_fqname, fh, filename, desc)
  File "/usr/lib/python3.5/imp.py", line 234, in load_module
    return load_source(name, filename, file)
  File "/usr/lib/python3.5/imp.py", line 172, in load_source
    module = _load(spec)
  File "<frozen importlib._bootstrap>", line 693, in _load
  File "<frozen importlib._bootstrap>", line 673, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 673, in exec_module
  File "<frozen importlib._bootstrap>", line 222, in _call_with_frames_removed
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/Integration/test_live_downloads.py", line 28, in <module>
    from TriblerGUI.tribler_window import TriblerWindow
  File "/home/jenkins/workspace/test_tribler_python3/tribler/TriblerGUI/tribler_window.py", line 26, in <module>
    from TriblerGUI.debug_window import DebugWindow
  File "/home/jenkins/workspace/test_tribler_python3/tribler/TriblerGUI/debug_window.py", line 21, in <module>
    from meliae import scanner
ImportError: No module named 'meliae'
```