### PR TITLE
hexlify() takes bytes, not str

### DIFF
--- a/Tribler/Test/Community/Market/test_tick.py
+++ b/Tribler/Test/Community/Market/test_tick.py
@@ -78,5 +78,5 @@ class TickTestSuite(unittest.TestCase):
             "timeout": 30,
             "timestamp": 0.0,
             "traded": 0,
-            "block_hash": hexlify('0' * 32)
+            "block_hash": hexlify(b'0' * 32)
         })


### PR DESCRIPTION
```
ERROR: Test the to dictionary method of a tick
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/Community/Market/test_tick.py", line 81, in test_to_dictionary
    "block_hash": hexlify('0' * 32)
TypeError: a bytes-like object is required, not 'str'
```