### PR TITLE
Added additional check for torrent_info existence

### DIFF
--- a/Tribler/Core/Libtorrent/LibtorrentDownloadImpl.py
+++ b/Tribler/Core/Libtorrent/LibtorrentDownloadImpl.py
@@ -455,7 +455,7 @@ class LibtorrentDownloadImpl(DownloadConfigInterface, TaskManager):
             self._logger.info("LibtorrentDownloadImpl: could not get info from download handle")
 
         for fileindex, bytes_begin, bytes_end in byteranges:
-            if fileindex >= 0:
+            if fileindex >= 0 and torrent_info:
                 # Ensure the we remain within the file's boundaries
                 file_entry = torrent_info.file_at(fileindex)
                 bytes_begin = min(


### PR DESCRIPTION
It could be that torrent_info is set to None while looping over the bytes. This additional check should prevent Tribler from crashing when this happens.

Fixes #4360