### PR TITLE
Made Tribler compatible with libtorrent 1.2.0

### DIFF
--- a/Tribler/Core/Libtorrent/LibtorrentDownloadImpl.py
+++ b/Tribler/Core/Libtorrent/LibtorrentDownloadImpl.py
@@ -254,15 +254,15 @@ class LibtorrentDownloadImpl(DownloadConfigInterface, TaskManager):
             atp = {}
             atp["save_path"] = os.path.normpath(os.path.join(get_default_dest_dir(), self.get_dest_dir()))
             atp["storage_mode"] = lt.storage_mode_t.storage_mode_sparse
-            atp["paused"] = True
-            atp["auto_managed"] = False
-            atp["duplicate_is_error"] = False
             atp["hops"] = self.get_hops()
+            atp["flags"] = lt.add_torrent_params_flags_t.flag_paused | \
+                           lt.add_torrent_params_flags_t.flag_duplicate_is_error | \
+                           lt.add_torrent_params_flags_t.flag_update_subscribe
 
             if share_mode:
-                atp["flags"] = lt.add_torrent_params_flags_t.flag_share_mode
+                atp["flags"] = atp["flags"] | lt.add_torrent_params_flags_t.flag_share_mode
             if upload_mode:
-                atp["flags"] = lt.add_torrent_params_flags_t.flag_upload_mode
+                atp["flags"] = atp["flags"] | lt.add_torrent_params_flags_t.flag_upload_mode
 
             self.set_checkpoint_disabled(checkpoint_disabled)
 

--- a/Tribler/Core/Libtorrent/LibtorrentDownloadImpl.py
+++ b/Tribler/Core/Libtorrent/LibtorrentDownloadImpl.py
@@ -597,7 +597,7 @@ class LibtorrentDownloadImpl(DownloadConfigInterface, TaskManager):
                     "LibtorrentDownloadImpl: setting send_buffer_watermark to %s",
                     2 * settings['send_buffer_watermark'])
                 settings['send_buffer_watermark'] *= 2
-                self.ltmgr.get_session().set_settings(settings)
+                self.ltmgr.set_session_settings(self.ltmgr.get_session(), settings)
         # When the write cache is too small, double the buffer size to a maximum
         # of 64MiB. Again, this is the same mechanism as Deluge uses.
         elif alert.message().endswith("max outstanding disk writes reached"):
@@ -607,7 +607,7 @@ class LibtorrentDownloadImpl(DownloadConfigInterface, TaskManager):
                     "LibtorrentDownloadImpl: setting max_queued_disk_bytes to %s",
                     2 * settings['max_queued_disk_bytes'])
                 settings['max_queued_disk_bytes'] *= 2
-                self.ltmgr.get_session().set_settings(settings)
+                self.ltmgr.set_session_settings(self.ltmgr.get_session(), settings)
 
     def on_torrent_checked_alert(self, alert):
         if self.pause_after_next_hashcheck:

--- a/Tribler/Core/Libtorrent/LibtorrentMgr.py
+++ b/Tribler/Core/Libtorrent/LibtorrentMgr.py
@@ -277,19 +277,6 @@ class LibtorrentMgr(TaskManager):
 
             ltsession.set_proxy(proxy_settings)
 
-    def set_utp(self, enable, hops=None):
-        def do_set_utp(ltsession):
-            settings = ltsession.get_settings()
-            settings['enable_outgoing_utp'] = enable
-            settings['enable_incoming_utp'] = enable
-            self.set_session_settings(ltsession, settings)
-
-        if hops is None:
-            for ltsession in self.ltsessions.values():
-                do_set_utp(ltsession)
-        else:
-            do_set_utp(self.get_session(hops))
-
     def set_max_connections(self, conns, hops=None):
         self._map_call_on_ltsessions(hops, 'set_max_connections', conns)
 

--- a/Tribler/Core/Libtorrent/LibtorrentMgr.py
+++ b/Tribler/Core/Libtorrent/LibtorrentMgr.py
@@ -45,7 +45,6 @@ DEFAULT_DHT_ROUTERS = [
     ("router.utorrent.com", 6881)
 ]
 DEFAULT_LT_EXTENSIONS = [
-    lt.create_metadata_plugin,
     lt.create_ut_metadata_plugin,
     lt.create_ut_pex_plugin,
     lt.create_smart_ban_plugin

--- a/Tribler/Core/Socks5/connection.py
+++ b/Tribler/Core/Socks5/connection.py
@@ -38,6 +38,12 @@ class Socks5Connection(Protocol):
 
         self.destinations = {}
 
+    def get_udp_socket(self):
+        """
+        Return the UDP socket. This socket is only available if a SOCKS5 ASSOCIATE request is sent.
+        """
+        return self._udp_socket
+
     def dataReceived(self, data):
         self.buffer = self.buffer + data
         while len(self.buffer) > 0:

--- a/Tribler/Test/API/test_download.py
+++ b/Tribler/Test/API/test_download.py
@@ -4,7 +4,6 @@ import logging
 import os
 import shutil
 from binascii import hexlify
-from unittest import skip
 
 from twisted.internet.defer import Deferred
 
@@ -46,14 +45,6 @@ class TestDownload(TestAsServer):
         self.setUpFileServer(file_server_port, files_path)
 
         d = self.session.start_download_from_uri('http://localhost:%s/ubuntu.torrent' % file_server_port)
-        d.addCallback(self.on_download)
-        return self.test_deferred
-
-    @skip("Fetching a torrent from the external network is unreliable")
-    @trial_timeout(60)
-    def test_download_torrent_from_magnet(self):
-        magnet_link = 'magnet:?xt=urn:btih:%s' % hexlify(UBUNTU_1504_INFOHASH)
-        d = self.session.start_download_from_uri(magnet_link)
         d.addCallback(self.on_download)
         return self.test_deferred
 

--- a/Tribler/Test/Community/Tunnel/test_community.py
+++ b/Tribler/Test/Community/Tunnel/test_community.py
@@ -147,6 +147,9 @@ class TestTriblerTunnelCommunity(TestBase):
         tribler_session = MockObject()
         tribler_session.notifier = MockObject()
         tribler_session.notifier.notify = lambda *_: None
+        tribler_session.lm = MockObject()
+        tribler_session.lm.ltmgr = MockObject()
+        tribler_session.lm.ltmgr.get_libtorrent_version = lambda: "1.1.0.0"
         self.nodes[0].overlay.tribler_session = tribler_session
 
         mock_state = MockObject()

--- a/Tribler/community/triblertunnel/community.py
+++ b/Tribler/community/triblertunnel/community.py
@@ -4,6 +4,7 @@ import os
 import sys
 import time
 from binascii import hexlify, unhexlify
+from distutils.version import LooseVersion
 
 from six.moves import xrange
 
@@ -538,7 +539,19 @@ class TriblerTunnelCommunity(HiddenTunnelCommunity):
     def create_introduction_point(self, info_hash, amount=1):
         download = self.get_download(info_hash)
         if download:
-            download.add_peer(('1.1.1.1', 1024))
+            # We now have to associate the SOCKS5 UDP connection with the libtorrent listen port ourselves.
+            # The reason for this is that libtorrent does not include the source IP/port in an SOCKS5 ASSOCIATE message.
+            # In libtorrent < 1.2.0, we could do so by simply adding an (invalid) peer to the download to enforce
+            # an outgoing message through the SOCKS5 port.
+            # This does not seem to work anymore in libtorrent 1.2.0 (and probably higher) so we manually associate
+            # the connection and the libtorrent listen port.
+            if LooseVersion(self.tribler_session.lm.ltmgr.get_libtorrent_version()) < LooseVersion("1.2.0"):
+                download.add_peer(('1.1.1.1', 1024))
+            else:
+                hops = download.get_hops()
+                lt_listen_port = self.tribler_session.lm.ltmgr.get_session(hops).listen_port()
+                for session in self.socks_servers[hops - 1].sessions:
+                    session.get_udp_socket().remote_udp_address = ("127.0.0.1", lt_listen_port)
         super(TriblerTunnelCommunity, self).create_introduction_point(info_hash, amount)
 
     def on_linked_e2e(self, source_address, data, circuit_id):


### PR DESCRIPTION
Two months ago, libtorrent 1.2.0 has been released with many fixes and improvements. This PR should make Tribler compatible with 1.2.0.

While having overlap with #3437, this PR ensures that Tribler still works with libtorrent versions between 1.0.0 and 1.1.0 (in contrast to #3437).

**Important:** this PR drops support for libtorrent 0.16.19 and older. Since 0.16.19 has been released almost four years ago, I think we can safely drop support for these old versions of libtorrent.