### PR TITLE
Proper lists URL encoding and UTF-8 fixes

### DIFF
--- a/Tribler/Core/Config/tribler_config.py
+++ b/Tribler/Core/Config/tribler_config.py
@@ -43,9 +43,9 @@ class TriblerConfig(object):
         if config is None:
             file_name = os.path.join(self.get_default_state_dir(), FILENAME)
             if os.path.exists(file_name):
-                config = ConfigObj(file_name, configspec=CONFIG_SPEC_PATH, encoding='latin_1')
+                config = ConfigObj(file_name, configspec=CONFIG_SPEC_PATH, default_encoding='utf-8')
             else:
-                config = ConfigObj(configspec=CONFIG_SPEC_PATH, encoding='latin_1')
+                config = ConfigObj(configspec=CONFIG_SPEC_PATH, default_encoding='utf-8')
         self.config = config
         self.validate()
 
@@ -59,14 +59,14 @@ class TriblerConfig(object):
         """
         Load a TriblerConfig from disk.
         """
-        return TriblerConfig(ConfigObj(config_path, configspec=CONFIG_SPEC_PATH, encoding='latin_1'))
+        return TriblerConfig(ConfigObj(config_path, configspec=CONFIG_SPEC_PATH, default_encoding='utf-8'))
 
     def copy(self):
         """
         Return a TriblerConfig object that has the same values.
         """
         # References to the sections are copied here
-        new_configobj = ConfigObj(self.config.copy(), configspec=self.config.configspec, encoding='latin_1')
+        new_configobj = ConfigObj(self.config.copy(), configspec=self.config.configspec, default_encoding='utf-8')
         # Make a deep copy of every section
         for section in self.config:
             new_configobj[section] = self.config[section].copy()

--- a/Tribler/Core/Modules/restapi/create_torrent_endpoint.py
+++ b/Tribler/Core/Modules/restapi/create_torrent_endpoint.py
@@ -59,20 +59,21 @@ class CreateTorrentEndpoint(resource.Resource):
 
             :statuscode 500: if source files do not exist.
         """
-        parameters = http.parse_qs(request.content.read(), 1)
+        content = request.content.read()
+        parameters = http.parse_qs(content, 1)
         params = {}
 
-        if 'files[]' in parameters and len(parameters['files[]']) > 0:
-            file_path_list = [ensure_unicode(f, 'utf-8') for f in parameters['files[]']]
+        if 'files' in parameters and parameters['files']:
+            file_path_list = [ensure_unicode(f, 'utf-8') for f in parameters['files']]
         else:
             request.setResponseCode(http.BAD_REQUEST)
             return json.dumps({"error": "files parameter missing"})
 
-        if 'description' in parameters and len(parameters['description']) > 0:
+        if 'description' in parameters and parameters['description']:
             params['comment'] = parameters['description'][0]
 
-        if 'trackers[]' in parameters and len(parameters['trackers[]']) > 0:
-            tracker_url_list = parameters['trackers[]']
+        if 'trackers' in parameters and parameters['trackers']:
+            tracker_url_list = parameters['trackers']
             params['announce'] = tracker_url_list[0]
             params['announce-list'] = tracker_url_list
 

--- a/Tribler/Core/Modules/restapi/settings_endpoint.py
+++ b/Tribler/Core/Modules/restapi/settings_endpoint.py
@@ -70,7 +70,7 @@ class SettingsEndpoint(resource.Resource):
                     "modified": True
                 }
         """
-        settings_dict = json.loads(request.content.read(), encoding='latin_1')
+        settings_dict = json.loads(request.content.read(), encoding='utf-8')
         self.parse_settings_dict(settings_dict)
         self.session.config.write()
 

--- a/Tribler/Test/Core/Modules/RestApi/base_api_test.py
+++ b/Tribler/Test/Core/Modules/RestApi/base_api_test.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 import os
 
-from six.moves.urllib.parse import urlencode
 
 from twisted.internet import reactor
 from twisted.internet.defer import inlineCallbacks, succeed
@@ -18,6 +17,8 @@ from Tribler.Core.Utilities.network_utils import get_random_port
 from Tribler.Core.version import version_id
 from Tribler.Test.test_as_server import TestAsServer
 
+from TriblerGUI.tribler_request_manager import tribler_urlencode
+
 
 class POSTDataProducer(object):
     """
@@ -26,9 +27,11 @@ class POSTDataProducer(object):
     implements(IBodyProducer)
 
     def __init__(self, data_dict, raw_data):
-        self.body = data_dict
-        if not raw_data:
-            self.body = urlencode(data_dict)
+        self.body = {}
+        if data_dict and not raw_data:
+            self.body = tribler_urlencode(data_dict)
+        elif raw_data:
+            self.body = raw_data.encode('utf-8')
         self.length = len(self.body)
 
     def startProducing(self, consumer):

--- a/Tribler/Test/Core/Modules/RestApi/test_create_torrent_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_create_torrent_endpoint.py
@@ -44,9 +44,10 @@ class TestMyChannelCreateTorrentEndpoint(AbstractApiTest):
             self.assertEqual(dir(expected_tdef), dir(tdef))
 
         post_data = {
-            "files[]": os.path.join(self.files_path, "video.avi"),
+            "files": [os.path.join(self.files_path, "video.avi"),
+                      os.path.join(self.files_path, "video.avi.torrent")],
             "description": "Video of my cat",
-            "trackers[]": "http://localhost/announce"
+            "trackers": "http://localhost/announce"
         }
         self.should_check_equality = False
         return self.do_request('createtorrent?download=1', 200, None, 'POST', post_data).addCallback(verify_torrent)
@@ -63,13 +64,13 @@ class TestMyChannelCreateTorrentEndpoint(AbstractApiTest):
                 u"error": {
                     u"handled": True,
                     u"code": u"IOError",
-                    u"message": u"Path does not exist: %s" % post_data["files[]"]
+                    u"message": u"Path does not exist: %s" % post_data["files"]
                 }
             }
             self.assertDictContainsSubset(expected_response[u"error"], error_response[u"error"])
 
         post_data = {
-            "files[]": "non_existing_file.avi"
+            "files": "non_existing_file.avi"
         }
         self.should_check_equality = False
         return self.do_request('createtorrent', 500, None, 'POST', post_data).addCallback(verify_error_message)

--- a/Tribler/Test/Core/Modules/RestApi/test_downloads_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_downloads_endpoint.py
@@ -140,10 +140,10 @@ class TestDownloadsEndpoint(AbstractApiTest):
         ufile = os.path.join(TESTS_DATA_DIR, u'video\u266b.avi.torrent')
         udest = os.path.join(self.session_base_dir, u'video\u266b')
 
-        post_data = (u'uri=file:%s&destination=%s' % (ufile, udest)).encode('utf-8')
+        post_data = (u'uri=file:%s&destination=%s' % (ufile, udest))
         self.should_check_equality = False
-        return self.do_request('downloads', expected_code=200, request_type='PUT', post_data=post_data,
-                               raw_data=True).addCallback(verify_download)
+        return self.do_request('downloads', expected_code=200, request_type='PUT',
+                               raw_data=post_data).addCallback(verify_download)
 
     def create_mock_status(self):
         status = MockObject()

--- a/Tribler/Test/Core/Modules/RestApi/test_rest_manager.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_rest_manager.py
@@ -34,8 +34,8 @@ class RestRequestTest(AbstractApiTest):
         post_data = json.dumps({"settings": "bla", "ports": "bla"})
         SettingsEndpoint.parse_settings_dict = RaiseException
         self.should_check_equality = False
-        return self.do_request('settings', expected_code=500, raw_data=True, expected_json=None, request_type='POST',
-                               post_data=post_data.encode('latin_1')).addCallback(verify_error_message)
+        return self.do_request('settings', expected_code=500, raw_data=post_data, expected_json=None,
+                               request_type='POST').addCallback(verify_error_message)
 
     @trial_timeout(10)
     def test_tribler_shutting_down(self):

--- a/Tribler/Test/Core/Modules/RestApi/test_settings_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_settings_endpoint.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import
 
-from six import unichr
-
 from twisted.internet.defer import inlineCallbacks
 
 import Tribler.Core.Utilities.json_util as json
@@ -35,7 +33,7 @@ class TestSettingsEndpoint(AbstractApiTest):
         Test setting watch_folder to a unicode path.
         """
         self.should_check_equality = False
-        post_data_dict = {'watch_folder': {'directory': "".join([unichr(i) for i in range(256)])}}
+        post_data_dict = {'watch_folder': {'directory': u'\u2588'}}
         post_data = json.dumps(post_data_dict, ensure_ascii=False)
 
         def check_settings(settings):
@@ -47,7 +45,7 @@ class TestSettingsEndpoint(AbstractApiTest):
             return getter_deferred.addCallback(check_settings)
 
         return self.do_request('settings', expected_code=200, request_type='POST',
-                               post_data=post_data.encode('latin_1'), raw_data=True).addCallback(verify_response)
+                               raw_data=post_data).addCallback(verify_response)
 
     @trial_timeout(10)
     def test_get_settings(self):
@@ -68,7 +66,7 @@ class TestSettingsEndpoint(AbstractApiTest):
 
         self.should_check_equality = False
         post_data = json.dumps({'a': {'b': {'c': 'd'}}})
-        return self.do_request('settings', expected_code=500, request_type='POST', post_data=post_data, raw_data=True)\
+        return self.do_request('settings', expected_code=500, request_type='POST', raw_data=post_data)\
             .addCallback(verify_response)
 
     @trial_timeout(10)
@@ -83,11 +81,11 @@ class TestSettingsEndpoint(AbstractApiTest):
 
         self.should_check_equality = False
         post_data = json.dumps({'general': {'b': 'c'}})
-        yield self.do_request('settings', expected_code=500, request_type='POST', post_data=post_data, raw_data=True)\
+        yield self.do_request('settings', expected_code=500, request_type='POST', raw_data=post_data)\
             .addCallback(verify_response)
 
         post_data = json.dumps({'Tribler': {'b': 'c'}})
-        yield self.do_request('settings', expected_code=500, request_type='POST', post_data=post_data, raw_data=True)\
+        yield self.do_request('settings', expected_code=500, request_type='POST', raw_data=post_data)\
             .addCallback(verify_response)
 
     @trial_timeout(10)
@@ -107,7 +105,7 @@ class TestSettingsEndpoint(AbstractApiTest):
         self.should_check_equality = False
         post_data = json.dumps({'libtorrent': {'utp': False, 'max_download_rate': 50},
                                 'download_defaults': {'seeding_mode': 'time', 'seeding_time': 100}})
-        yield self.do_request('settings', expected_code=200, request_type='POST', post_data=post_data, raw_data=True) \
+        yield self.do_request('settings', expected_code=200, request_type='POST', raw_data=post_data) \
             .addCallback(verify_response1)
 
         def verify_response2(_):
@@ -115,7 +113,7 @@ class TestSettingsEndpoint(AbstractApiTest):
             self.assertEqual(download.get_seeding_ratio(), 3)
 
         post_data = json.dumps({'download_defaults': {'seeding_mode': 'ratio', 'seeding_ratio': 3}})
-        yield self.do_request('settings', expected_code=200, request_type='POST', post_data=post_data, raw_data=True) \
+        yield self.do_request('settings', expected_code=200, request_type='POST', raw_data=post_data) \
             .addCallback(verify_response2)
 
         download.get_credit_mining = lambda: True
@@ -124,5 +122,5 @@ class TestSettingsEndpoint(AbstractApiTest):
             self.assertNotEqual(download.get_seeding_mode(), 'never')
 
         post_data = json.dumps({'download_defaults': {'seeding_mode': 'never'}})
-        yield self.do_request('settings', expected_code=200, request_type='POST', post_data=post_data, raw_data=True) \
+        yield self.do_request('settings', expected_code=200, request_type='POST', raw_data=post_data) \
             .addCallback(verify_response3)

--- a/Tribler/Test/test_as_server.py
+++ b/Tribler/Test/test_as_server.py
@@ -285,7 +285,7 @@ class TestAsServer(AbstractServer):
         self.annotate(self._testMethodName, start=True)
 
     def setUpPreSession(self):
-        self.config = TriblerConfig(ConfigObj(configspec=CONFIG_SPEC_PATH, encoding='latin_1'))
+        self.config = TriblerConfig(ConfigObj(configspec=CONFIG_SPEC_PATH, default_encoding='utf-8'))
         self.config.set_default_destination_dir(self.dest_dir)
         self.config.set_state_dir(self.getStateDir())
         self.config.set_torrent_checking_enabled(False)

--- a/TriblerGUI/tribler_request_manager.py
+++ b/TriblerGUI/tribler_request_manager.py
@@ -19,27 +19,25 @@ from TriblerGUI.dialogs.confirmationdialog import ConfirmationDialog
 
 
 def tribler_urlencode(data):
-    # Convert all values that are an array to uri-encoded values
-    for key in data.keys():
-        value = data[key]
-        if isinstance(value, list):
-            if value:
-                data[key + "[]"] = "&".join(value)
-            else:
-                del data[key]
-
     # Convert all keys and values in the data to utf-8 unicode strings
     utf8_items = []
     for key, value in data.items():
-        utf8_key = quote_plus(text_type(key).encode('utf-8'))
-        # Convert bool values to ints
-        if isinstance(value, bool):
-            value = int(value)
-        utf8_value = quote_plus(text_type(value).encode('utf-8'))
-        utf8_items.append("%s=%s" % (utf8_key, utf8_value))
+        if isinstance(value, list):
+            utf8_items.extend([tribler_urlencode_single(key, list_item) for list_item in value if value])
+        else:
+            utf8_items.append(tribler_urlencode_single(key, value))
 
     data = "&".join(utf8_items)
     return data
+
+
+def tribler_urlencode_single(key, value):
+    utf8_key = quote_plus(text_type(key).encode('utf-8'))
+    # Convert bool values to ints
+    if isinstance(value, bool):
+        value = int(value)
+    utf8_value = quote_plus(text_type(value).encode('utf-8'))
+    return "%s=%s" % (utf8_key, utf8_value)
 
 
 class QueuePriorityEnum(object):


### PR DESCRIPTION
This PR implements proper, Twisted `http.parse_qs`-compatible encoding of URL arguments and makes our test suite use the same way of encoding URLs that we use in Tribler. Also, it changes Tribler config file encoding to `utf-8`. This change is necessary to conform with the "unicode sandwich" ideology and accommodate the changes in the endpoints data encoding.
Fixes #4365 