### PR TITLE
Add title and category editing to the GUI

### DIFF
--- a/Tribler/Core/Category/category.conf
+++ b/Tribler/Core/Category/category.conf
@@ -1,6 +1,6 @@
 [Video]
 rank = 1
-displayname = Video Files
+displayname = Video
 suffix = asf, asp, avi, flc, fli, flic, mkv, mov, movie, mpeg, mpg, qicktime, ram, rm, rmvb, rpm, vob, wma, wmv
 minfilesize = 50
 maxfilesize = 10000000
@@ -12,7 +12,7 @@ matchpercentage = 0.5
 
 [VideoClips]
 rank = 2
-displayname = Video Clips
+displayname = VideoClips
 suffix = asf, asp, avi, flc, fli, flic, mkv, mov, movie, mpeg, mpg, qicktime, ram, rm, rmvb, rpm, vob, wma, wmv, mp4, flv
 minfilesize = 0
 maxfilesize = 50

--- a/Tribler/Core/Modules/MetadataStore/OrmBindings/channel_metadata.py
+++ b/Tribler/Core/Modules/MetadataStore/OrmBindings/channel_metadata.py
@@ -5,9 +5,11 @@ import random
 import sys
 from binascii import hexlify
 from datetime import datetime
+
 from libtorrent import add_files, bencode, create_torrent, file_storage, set_piece_hashes, torrent_info
 
 import lz4.frame
+
 from pony import orm
 from pony.orm import db_session, raw_sql, select
 
@@ -293,7 +295,6 @@ def define_binding(db):
                     raise DuplicateTorrentFileError()
             else:
                 torrent_metadata = db.TorrentMetadata.from_dict(new_entry_dict)
-                torrent_metadata.parents.add(self)
             return torrent_metadata
 
         @property

--- a/Tribler/Core/Modules/MetadataStore/OrmBindings/channel_node.py
+++ b/Tribler/Core/Modules/MetadataStore/OrmBindings/channel_node.py
@@ -19,7 +19,8 @@ COMMITTED = 2
 JUST_RECEIVED = 3
 UPDATE_AVAILABLE = 4
 PREVIEW_UPDATE_AVAILABLE = 5
-LEGACY_ENTRY = 6
+UPDATED = 6
+LEGACY_ENTRY = 1000
 
 PUBLIC_KEY_LEN = 64
 
@@ -197,5 +198,12 @@ def define_binding(db, logger=None, key=None, clock=None):
         @classmethod
         def from_dict(cls, dct):
             return cls(**dct)
+
+        def update_properties(self, update_dict):
+            #TODO: check if properties really changed
+            self.status = UPDATED
+            self.set(**update_dict)
+            self.timestamp = self._clock.tick()
+            self.sign(self._my_key)
 
     return ChannelNode

--- a/Tribler/Core/Modules/MetadataStore/store.py
+++ b/Tribler/Core/Modules/MetadataStore/store.py
@@ -34,14 +34,13 @@ DELETED_METADATA = 6
 # maintained by SQL triggers.
 sql_create_fts_table = """
     CREATE VIRTUAL TABLE IF NOT EXISTS FtsIndex USING FTS5
-        (title, tags, content='ChannelNode', prefix = '2 3 4 5',
+        (title, content='ChannelNode', prefix = '2 3 4 5',
          tokenize='porter unicode61 remove_diacritics 1');"""
 
 sql_add_fts_trigger_insert = """
     CREATE TRIGGER IF NOT EXISTS fts_ai AFTER INSERT ON ChannelNode
     BEGIN
-        INSERT INTO FtsIndex(rowid, title, tags) VALUES
-            (new.rowid, new.title, new.tags);
+        INSERT INTO FtsIndex(rowid, title) VALUES (new.rowid, new.title);
     END;"""
 
 sql_add_fts_trigger_delete = """
@@ -53,8 +52,7 @@ sql_add_fts_trigger_delete = """
 sql_add_fts_trigger_update = """
     CREATE TRIGGER IF NOT EXISTS fts_au AFTER UPDATE ON ChannelNode BEGIN
         DELETE FROM FtsIndex WHERE rowid = old.rowid;
-        INSERT INTO FtsIndex(rowid, title, tags) VALUES (new.rowid, new.title,
-      new.tags);
+        INSERT INTO FtsIndex(rowid, title) VALUES (new.rowid, new.title);
     END;"""
 
 sql_add_signature_index = "CREATE INDEX SignatureIndex ON ChannelNode(signature);"

--- a/Tribler/Test/Core/Modules/MetadataStore/test_store.py
+++ b/Tribler/Test/Core/Modules/MetadataStore/test_store.py
@@ -14,7 +14,7 @@ from Tribler.Core.Modules.MetadataStore.OrmBindings.channel_node import NEW
 from Tribler.Core.Modules.MetadataStore.serialization import (
     ChannelMetadataPayload, DeletedMetadataPayload, SignedPayload, UnknownBlobTypeException)
 from Tribler.Core.Modules.MetadataStore.store import (
-    DELETED_METADATA, MetadataStore, UNKNOWN_CHANNEL, UNKNOWN_TORRENT, UPDATED_OUR_VERSION, GOT_NEWER_VERSION)
+    DELETED_METADATA, GOT_NEWER_VERSION, MetadataStore, UNKNOWN_CHANNEL, UNKNOWN_TORRENT, UPDATED_OUR_VERSION)
 from Tribler.Test.Core.base_test import TriblerCoreTest
 from Tribler.pyipv8.ipv8.database import database_blob
 from Tribler.pyipv8.ipv8.keyvault.crypto import default_eccrypto
@@ -234,13 +234,13 @@ class TestMetadataStore(TriblerCoreTest):
     def test_process_payload_reject_older_entry_with_known_infohash_or_merge(self):
         # Check there is no action if the processed payload has a timestamp that is less than the
         # local_version of the corresponding local channel. (I.e. remote peer trying to push back a deleted entry)
-        torrent = self.mds.TorrentMetadata(title='blabla', timestamp=10, id_= 10,
+        torrent = self.mds.TorrentMetadata(title='blabla', timestamp=10, id_=10,
                                            infohash=database_blob(os.urandom(20)))
         payload = torrent._payload_class(**torrent.to_dict())
         torrent.delete()
 
         torrent2 = self.mds.TorrentMetadata(title='blabla', timestamp=11, id_=3,
-                                           infohash=payload.infohash)
+                                            infohash=payload.infohash)
         payload2 = torrent._payload_class(**torrent2.to_dict())
         torrent2.delete()
 
@@ -252,8 +252,8 @@ class TestMetadataStore(TriblerCoreTest):
         self.mds.process_payload(payload2)
         self.assertEqual(GOT_NEWER_VERSION, self.mds.process_payload(payload)[0][1])
 
-        # In this corner case the newle arrived payload contains a newer node
-        # that has the same infohash as the one that is alredy there.
+        # In this corner case the newly arrived payload contains a newer node
+        # that has the same infohash as the one that is already there.
         # The older one should be deleted, and the newer one should be installed instead.
         results = self.mds.process_payload(payload3)
         self.assertIn((None, DELETED_METADATA), results)

--- a/Tribler/Test/Core/Modules/MetadataStore/test_store.py
+++ b/Tribler/Test/Core/Modules/MetadataStore/test_store.py
@@ -14,7 +14,7 @@ from Tribler.Core.Modules.MetadataStore.OrmBindings.channel_node import NEW
 from Tribler.Core.Modules.MetadataStore.serialization import (
     ChannelMetadataPayload, DeletedMetadataPayload, SignedPayload, UnknownBlobTypeException)
 from Tribler.Core.Modules.MetadataStore.store import (
-    DELETED_METADATA, MetadataStore, UNKNOWN_CHANNEL, UNKNOWN_TORRENT, UPDATED_OUR_VERSION)
+    DELETED_METADATA, MetadataStore, UNKNOWN_CHANNEL, UNKNOWN_TORRENT, UPDATED_OUR_VERSION, GOT_NEWER_VERSION)
 from Tribler.Test.Core.base_test import TriblerCoreTest
 from Tribler.pyipv8.ipv8.database import database_blob
 from Tribler.pyipv8.ipv8.keyvault.crypto import default_eccrypto
@@ -185,7 +185,8 @@ class TestMetadataStore(TriblerCoreTest):
         node, node_payload, node_deleted_payload = get_payloads(self.mds.ChannelMetadata)
         node_dict = node.to_dict()
         node.delete()
-        # Check there is no action if the signature on the delete object is unknown
+
+        # Check that there is no action if the signature on the delete object is unknown
         self.assertFalse(self.mds.process_payload(node_deleted_payload))
         result = self.mds.process_payload(node_payload)
         self.assertEqual(UNKNOWN_CHANNEL, result[0][1])
@@ -208,7 +209,7 @@ class TestMetadataStore(TriblerCoreTest):
         node_updated_payload = node_updated._payload_class.from_signed_blob(node_updated.serialized())
         node_updated.delete()
 
-        node = self.mds.TorrentMetadata(**node_dict)
+        self.mds.TorrentMetadata(**node_dict)
         self.mds.TorrentMetadata(**node2_dict)
 
         result = self.mds.process_payload(node_updated_payload)
@@ -218,7 +219,7 @@ class TestMetadataStore(TriblerCoreTest):
                          database_blob(node_updated_payload.signature))
 
     @db_session
-    def test_process_payload_reject_old(self):
+    def test_process_payload_reject_older(self):
         # Check there is no action if the processed payload has a timestamp that is less than the
         # local_version of the corresponding local channel. (I.e. remote peer trying to push back a deleted entry)
         channel = self.mds.ChannelMetadata(title='bla', version=123, local_version=12,
@@ -228,6 +229,35 @@ class TestMetadataStore(TriblerCoreTest):
         payload = torrent._payload_class(**torrent.to_dict())
         torrent.delete()
         self.assertFalse(self.mds.process_payload(payload))
+
+    @db_session
+    def test_process_payload_reject_older_entry_with_known_infohash_or_merge(self):
+        # Check there is no action if the processed payload has a timestamp that is less than the
+        # local_version of the corresponding local channel. (I.e. remote peer trying to push back a deleted entry)
+        torrent = self.mds.TorrentMetadata(title='blabla', timestamp=10, id_= 10,
+                                           infohash=database_blob(os.urandom(20)))
+        payload = torrent._payload_class(**torrent.to_dict())
+        torrent.delete()
+
+        torrent2 = self.mds.TorrentMetadata(title='blabla', timestamp=11, id_=3,
+                                           infohash=payload.infohash)
+        payload2 = torrent._payload_class(**torrent2.to_dict())
+        torrent2.delete()
+
+        torrent3 = self.mds.TorrentMetadata(title='blabla', timestamp=12, id_=4,
+                                            infohash=payload.infohash)
+        payload3 = torrent._payload_class(**torrent3.to_dict())
+        torrent3.delete()
+
+        self.mds.process_payload(payload2)
+        self.assertEqual(GOT_NEWER_VERSION, self.mds.process_payload(payload)[0][1])
+
+        # In this corner case the newle arrived payload contains a newer node
+        # that has the same infohash as the one that is alredy there.
+        # The older one should be deleted, and the newer one should be installed instead.
+        results = self.mds.process_payload(payload3)
+        self.assertIn((None, DELETED_METADATA), results)
+        self.assertIn((self.mds.TorrentMetadata.get(), UNKNOWN_TORRENT), results)
 
     @db_session
     def test_get_num_channels_nodes(self):

--- a/Tribler/Test/Core/Modules/MetadataStore/test_torrent_metadata.py
+++ b/Tribler/Test/Core/Modules/MetadataStore/test_torrent_metadata.py
@@ -65,17 +65,17 @@ class TestTorrentMetadata(TriblerCoreTest):
         Test searching in a database with some torrent metadata inserted
         """
         torrent1 = self.mds.TorrentMetadata.from_dict(
-            dict(rnd_torrent(), title="foo bar 123", tags="video"))
+            dict(rnd_torrent(), title="foo bar 123"))
         torrent2 = self.mds.TorrentMetadata.from_dict(
-            dict(rnd_torrent(), title="eee 123", tags="video"))
+            dict(rnd_torrent(), title="eee 123"))
         self.mds.TorrentMetadata.from_dict(
-            dict(rnd_torrent(), title="xoxoxo bar", tags="video"))
+            dict(rnd_torrent(), title="xoxoxo bar"))
         self.mds.TorrentMetadata.from_dict(
-            dict(rnd_torrent(), title="xoxoxo bar", tags="audio"))
+            dict(rnd_torrent(), title="xoxoxo bar"))
         self.mds.TorrentMetadata.from_dict(
-            dict(rnd_torrent(), title=u"\"", tags="audio"))
+            dict(rnd_torrent(), title=u"\""))
         self.mds.TorrentMetadata.from_dict(
-            dict(rnd_torrent(), title=u"\'", tags="audio"))
+            dict(rnd_torrent(), title=u"\'"))
         orm.flush()
 
         # Search for torrents with the keyword 'foo', it should return one result
@@ -91,10 +91,6 @@ class TestTorrentMetadata(TriblerCoreTest):
         # Search for torrents with the keyword '123', it should return two results
         results = self.mds.TorrentMetadata.search_keyword("123")[:]
         self.assertEqual(len(results), 2)
-
-        # Search for torrents with the keyword 'video', it should return three results
-        results = self.mds.TorrentMetadata.search_keyword("video")[:]
-        self.assertEqual(len(results), 3)
 
     def test_search_empty_query(self):
         """

--- a/Tribler/Test/Core/Modules/MetadataStore/test_torrent_metadata.py
+++ b/Tribler/Test/Core/Modules/MetadataStore/test_torrent_metadata.py
@@ -213,3 +213,16 @@ class TestTorrentMetadata(TriblerCoreTest):
         self.assertTrue(md.metadata_conflicting(dict(tdict, title="bla")))
         tdict.pop('title')
         self.assertFalse(md.metadata_conflicting(tdict))
+
+    @db_session
+    def test_update_properties(self):
+        """
+        Test the updating of several properties of a TorrentMetadata object
+        """
+        metadata = self.mds.TorrentMetadata(title='torrent', infohash=str(random.getrandbits(160)))
+        self.assertRaises(NotImplementedError, metadata.update_properties, {"status": 3, "name": "bla"})
+        self.assertRaises(NotImplementedError, metadata.update_properties, {"name": "bla"})
+
+        # Test updating the status only
+        metadata.update_properties({"status": 456})
+        self.assertEqual(metadata.status, 456)

--- a/Tribler/Test/Core/Modules/RestApi/test_metadata_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_metadata_endpoint.py
@@ -58,7 +58,7 @@ class TestChannelsEndpoint(BaseTestMetadataEndpoint):
 
         def on_response(response):
             json_dict = json.loads(response)
-            self.assertEqual(len(json_dict['channels']), 10)
+            self.assertEqual(len(json_dict['results']), 10)
 
         self.should_check_equality = False
         return self.do_request('metadata/channels?sort_by=title', expected_code=200).addCallback(on_response)
@@ -67,7 +67,7 @@ class TestChannelsEndpoint(BaseTestMetadataEndpoint):
     def test_get_channels_sort_by_health(self):
         def on_response(response):
             json_dict = json.loads(response)
-            self.assertEqual(len(json_dict['channels']), 10)
+            self.assertEqual(len(json_dict['results']), 10)
 
         self.should_check_equality = False
         return self.do_request('metadata/channels?sort_by=health', expected_code=200).addCallback(on_response)
@@ -79,7 +79,7 @@ class TestChannelsEndpoint(BaseTestMetadataEndpoint):
 
         def on_response(response):
             json_dict = json.loads(response)
-            self.assertEqual(len(json_dict['channels']), 10)
+            self.assertEqual(len(json_dict['results']), 10)
 
         self.should_check_equality = False
         return self.do_request('metadata/channels?sort_by=fdsafsdf', expected_code=200).addCallback(on_response)
@@ -91,7 +91,7 @@ class TestChannelsEndpoint(BaseTestMetadataEndpoint):
 
         def on_response(response):
             json_dict = json.loads(response)
-            self.assertEqual(len(json_dict['channels']), 5)
+            self.assertEqual(len(json_dict['results']), 5)
 
         self.should_check_equality = False
         return self.do_request('metadata/channels?subscribed=1', expected_code=200).addCallback(on_response)
@@ -144,7 +144,7 @@ class TestSpecificChannelEndpoint(BaseTestMetadataEndpoint):
             for _ in range(0, 30):
                 with db_session:
                     c = self.session.lm.mds.ChannelMetadata.select()[:][0]
-                    if c.contents.count() == 2:
+                    if c.contents.count() == 0:
                         result = True
                         break
                     yield async_sleep(0.2)
@@ -163,7 +163,7 @@ class TestSpecificChannelTorrentsEndpoint(BaseTestMetadataEndpoint):
 
         def on_response(response):
             json_dict = json.loads(response)
-            self.assertEqual(len(json_dict['torrents']), 5)
+            self.assertEqual(len(json_dict['results']), 5)
 
         self.should_check_equality = False
         channel_pk = hexlify(self.session.lm.mds.ChannelNode._my_key.pub().key_to_bin()[10:])

--- a/Tribler/Test/Core/Modules/RestApi/test_mychannel_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_mychannel_endpoint.py
@@ -7,7 +7,9 @@ import shutil
 from binascii import hexlify
 
 from pony.orm import db_session
+
 from six.moves import xrange
+
 from twisted.internet.defer import inlineCallbacks
 
 from Tribler.Core.Modules.MetadataStore.OrmBindings.channel_node import NEW, TODELETE, UPDATED
@@ -171,8 +173,8 @@ class TestMyChannelTorrentsEndpoint(BaseTestMyChannelEndpoint):
         """
         def on_response(response):
             json_response = json.loads(response)
-            self.assertEqual(len(json_response['torrents']), 9)
-            self.assertIn('status', json_response['torrents'][0])
+            self.assertEqual(len(json_response['results']), 9)
+            self.assertIn('status', json_response['results'][0])
 
         self.create_my_channel()
         self.should_check_equality = False
@@ -222,7 +224,7 @@ class TestMyChannelTorrentsEndpoint(BaseTestMyChannelEndpoint):
     @trial_timeout(10)
     def test_update_my_torrents_POST(self):
         """
-        Test updating/creating a torrent in a personal channel with POST
+        Test updating/creating a torrent in a personal channel with a POST request
         """
         def on_response(_):
             with db_session:

--- a/Tribler/community/gigachannel/community.py
+++ b/Tribler/community/gigachannel/community.py
@@ -185,7 +185,7 @@ class GigaChannelCommunity(Community):
             search_results = [(dict(type={REGULAR_TORRENT: 'torrent', CHANNEL_TORRENT: 'channel'}[r.metadata_type],
                                     **(r.to_simple_dict()))) for (r, _) in metadata_result
                               if r and (r.metadata_type == CHANNEL_TORRENT or r.metadata_type == REGULAR_TORRENT)]
-        if self.notifier:
+        if self.notifier and search_results:
             self.notifier.notify(SIGNAL_GIGACHANNEL_COMMUNITY, SIGNAL_ON_SEARCH_RESULTS, None,
                                  {"results": search_results})
 

--- a/TriblerGUI/defs.py
+++ b/TriblerGUI/defs.py
@@ -101,7 +101,6 @@ COMMIT_STATUS_NEW = 0
 COMMIT_STATUS_TODELETE = 1
 COMMIT_STATUS_COMMITTED = 2
 
-
 HEALTH_CHECKING = u'Checking..'
 HEALTH_DEAD = u'No peers'
 HEALTH_ERROR = u'Error'
@@ -110,4 +109,21 @@ HEALTH_GOOD = u'Seeds found'
 HEALTH_UNCHECKED = u'Unknown'
 
 # Interval for refreshing the results in the debug pane
-DEBUG_PANE_REFRESH_TIMEOUT = 5000   # 5 seconds
+DEBUG_PANE_REFRESH_TIMEOUT = 5000  # 5 seconds
+
+# This list of content categories is used in drop-down menu when editing a personal channel
+# TODO: build this automatically and/or move it somewhere
+CATEGORY_LIST = [
+    u'Video',
+    u'Audio',
+    u'Documents',
+    u'CD/DVD/BD',
+    u'Games',
+    u'Pictures',
+    u'Books',
+    u'Comics',
+    u'Software',
+    u'Science',
+    u'XXX',
+    u'Other',
+]

--- a/TriblerGUI/qt_resources/mainwindow.ui
+++ b/TriblerGUI/qt_resources/mainwindow.ui
@@ -3310,7 +3310,7 @@ font-weight: bold;</string>
               </widget>
              </item>
              <item>
-              <widget class="QLabel" name="num_search_results_label">
+              <widget class="QLabel" name="num_results_label">
                <property name="styleSheet">
                 <string notr="true">font-size: 14px;
 color: #B5B5B5;</string>

--- a/TriblerGUI/qt_resources/mainwindow.ui
+++ b/TriblerGUI/qt_resources/mainwindow.ui
@@ -88,6 +88,9 @@ color: white;
 }
 QHeaderView {
 qproperty-defaultAlignment: AlignLeft;
+}
+QListView {
+color:#B5B5B5;
 }</string>
   </property>
   <widget class="QWidget" name="central_widget">

--- a/TriblerGUI/widgets/channelpage.py
+++ b/TriblerGUI/widgets/channelpage.py
@@ -25,7 +25,9 @@ class ChannelPage(QWidget):
         self.model = TorrentsContentModel(hide_xxx=get_gui_setting(self.gui_settings, "family_filter", True,
                                                                    is_bool=True) if self.gui_settings else True)
         self.window().core_manager.events_manager.torrent_info_updated.connect(self.model.update_torrent_info)
-        self.controller = TorrentsTableViewController(self.model, self.window().channel_page_container,
+        self.controller = TorrentsTableViewController(self.model,
+                                                      self.window().channel_page_container.content_table,
+                                                      self.window().channel_page_container.details_container,
                                                       None, self.window().channel_torrents_filter_input)
 
         # Remove the commit control from the delegate for performance
@@ -46,8 +48,9 @@ class ChannelPage(QWidget):
         self.window().channel_page_container.details_container.hide()
 
         self.model.channel_pk = channel_info['public_key']
+        self.window().channel_torrents_filter_input.setText("")
         self.load_torrents()
 
     def load_torrents(self):
         self.controller.model.reset()
-        self.controller.load_torrents(1, 50)  # Load the first 50 torrents
+        self.controller.perform_query(first=1, last=50)  # Load the first 50 torrents

--- a/TriblerGUI/widgets/discoveredpage.py
+++ b/TriblerGUI/widgets/discoveredpage.py
@@ -36,4 +36,4 @@ class DiscoveredPage(QWidget):
 
     def load_discovered_channels(self):
         self.controller.model.reset()
-        self.controller.load_channels(1, 50)  # Load the first 50 discovered channels
+        self.controller.perform_query(first=1, last=50)  # Load the first 50 discovered channels

--- a/TriblerGUI/widgets/editchannelpage.py
+++ b/TriblerGUI/widgets/editchannelpage.py
@@ -71,7 +71,9 @@ class EditChannelPage(QWidget):
         self.window().add_button.clicked.connect(self.on_torrents_add_clicked)
 
         self.model = MyTorrentsContentModel()
-        self.controller = MyTorrentsTableViewController(self.model, self.window().edit_channel_torrents_container,
+        self.controller = MyTorrentsTableViewController(self.model,
+                                                        self.window().edit_channel_torrents_container.content_table,
+                                                        self.window().edit_channel_torrents_container.details_container,
                                                         self.window().edit_channel_torrents_num_items_label,
                                                         self.window().edit_channel_torrents_filter)
         self.window().edit_channel_torrents_container.details_container.hide()
@@ -190,7 +192,7 @@ class EditChannelPage(QWidget):
 
     def load_my_torrents(self):
         self.controller.model.reset()
-        self.controller.load_torrents(1, 50)  # Load the first 50 torrents
+        self.controller.perform_query(first=1, last=50)  # Load the first 50 torrents
 
     def on_create_channel_intro_button_clicked(self):
         self.window().create_channel_form.show()
@@ -384,15 +386,17 @@ class EditChannelPage(QWidget):
         def commit_channel(overview):
             try:
                 if overview and overview['mychannel']['dirty']:
-                    TriblerRequestManager().perform_request("mychannel/commit", lambda _: None, method='POST',
-                                                            capture_errors=False)
+                    self.editchannel_request_mgr = TriblerRequestManager()
+                    self.editchannel_request_mgr.perform_request("mychannel/commit", lambda _: None, method='POST',
+                                                                 capture_errors=False)
             except KeyError:
                 return
 
         if self.channel_overview:
             self.clicked_edit_channel_commit_button()
         else:
-            TriblerRequestManager().perform_request("mychannel", commit_channel, capture_errors=False)
+            self.editchannel_request_mgr = TriblerRequestManager()
+            self.editchannel_request_mgr.perform_request("mychannel", commit_channel, capture_errors=False)
 
     # Commit button-related methods
     def clicked_edit_channel_commit_button(self):

--- a/TriblerGUI/widgets/lazytableview.py
+++ b/TriblerGUI/widgets/lazytableview.py
@@ -82,7 +82,7 @@ class SubscribeButtonMixin(TriblerContentTableView):
         item = index.model().data_items[index.row()]
         # skip LEGACY entries, regular torrents and personal channel
         if (u'subscribed' not in item or
-                item[u'status'] == 6 or
+                item[u'status'] == 1000 or
                 item[u'my_channel']):
             return
         status = int(item[u'subscribed'])

--- a/TriblerGUI/widgets/searchresultspage.py
+++ b/TriblerGUI/widgets/searchresultspage.py
@@ -27,7 +27,7 @@ class SearchResultsPage(QWidget):
                                                                         is_bool=True) if self.gui_settings else True)
         self.controller = SearchResultsTableViewController(self.model, self.window().search_results_list,
                                                            self.window().search_details_container,
-                                                           self.window().num_search_results_label)
+                                                           self.window().num_results_label)
         self.window().search_details_container.details_tab_widget.initialize_details_widget()
 
         self.set_columns_visibility([u'health'], True)
@@ -37,13 +37,14 @@ class SearchResultsPage(QWidget):
         self.query = query
         self.model.reset()
 
-        self.window().num_search_results_label.setText("")
+        self.window().num_results_label.setText("")
         self.window().search_details_container.hide()
 
         trimmed_query = query if len(query) < 50 else "%s..." % query[:50]
         self.window().search_results_header_label.setText("Search results for: %s" % trimmed_query)
 
-        self.controller.load_search_results(query, 1, 50)
+        self.controller.query_text = query
+        self.controller.perform_query(first=1, last=50)
 
     def set_columns_visibility(self, column_names, hide=False):
         for column_name in column_names:
@@ -52,7 +53,7 @@ class SearchResultsPage(QWidget):
 
     def clicked_tab_button(self, _):
         if self.window().search_results_tab.get_selected_index() == 0:
-            self.model.type_filter = None
+            self.model.type_filter = ''
             self.set_columns_visibility([u'health'], True)
             self.set_columns_visibility([u'torrents', u'updated'], False)
         elif self.window().search_results_tab.get_selected_index() == 1:

--- a/TriblerGUI/widgets/subscribedchannelspage.py
+++ b/TriblerGUI/widgets/subscribedchannelspage.py
@@ -26,4 +26,4 @@ class SubscribedChannelsPage(QWidget):
 
     def load_subscribed_channels(self):
         self.controller.model.reset()
-        self.controller.load_channels(1, 50)  # Load the first 50 subscribed channels
+        self.controller.perform_query(first=1, last=50)  # Load the first 50 subscribed channels

--- a/TriblerGUI/widgets/subscriptionswidget.py
+++ b/TriblerGUI/widgets/subscriptionswidget.py
@@ -65,7 +65,7 @@ class SubscriptionsWidget(QWidget):
             self.credit_mining_button.hide()
 
         # Disable channel control buttons for LEGACY_ENTRY channels
-        hide_controls = (self.channel_info["status"] == 6)
+        hide_controls = (self.channel_info["status"] == 1000)
         self.num_subs_label.setHidden(hide_controls)
         self.subscribe_button.setHidden(
             hide_controls or ("my_channel" in self.channel_info and self.channel_info["my_channel"]))

--- a/TriblerGUI/widgets/tablecontentdelegate.py
+++ b/TriblerGUI/widgets/tablecontentdelegate.py
@@ -11,6 +11,22 @@ from TriblerGUI.defs import ACTION_BUTTONS, COMMIT_STATUS_COMMITTED, COMMIT_STAT
 from TriblerGUI.utilities import get_health, get_image_path
 from TriblerGUI.widgets.tableiconbuttons import DeleteIconButton, DownloadIconButton, PlayIconButton
 
+#TODO: build this automatically and/or move it somewhere
+CATEGORY_LIST = [
+    u'Video',
+    u'Audio',
+    u'Documents',
+    u'CD/DVD/BD',
+    u'Games',
+    u'Pictures',
+    u'Books',
+    u'Comics',
+    u'Software',
+    u'Science',
+    u'XXX',
+    u'Other',
+]
+
 
 class TriblerButtonsDelegate(QStyledItemDelegate):
     redraw_required = pyqtSignal()
@@ -93,7 +109,7 @@ class TriblerButtonsDelegate(QStyledItemDelegate):
             return
         if index.column() == index.model().column_position['category']:
             cbox = QComboBox(parent)
-            cbox.addItems([str(i) for i in range(0,10)])
+            cbox.addItems(CATEGORY_LIST)
             return cbox
 
         return super(TriblerButtonsDelegate, self).createEditor(parent, option, index)

--- a/TriblerGUI/widgets/tablecontentdelegate.py
+++ b/TriblerGUI/widgets/tablecontentdelegate.py
@@ -4,7 +4,7 @@ from abc import abstractmethod
 
 from PyQt5.QtCore import QEvent, QModelIndex, QObject, QRect, QSize, Qt, pyqtSignal
 from PyQt5.QtGui import QBrush, QColor, QIcon, QPainter, QPen
-from PyQt5.QtWidgets import QStyle, QStyledItemDelegate
+from PyQt5.QtWidgets import QStyle, QStyledItemDelegate, QComboBox
 
 from TriblerGUI.defs import ACTION_BUTTONS, COMMIT_STATUS_COMMITTED, COMMIT_STATUS_NEW, COMMIT_STATUS_TODELETE, \
     HEALTH_CHECKING, HEALTH_DEAD, HEALTH_ERROR, HEALTH_GOOD, HEALTH_MOOT, HEALTH_UNCHECKED
@@ -91,8 +91,12 @@ class TriblerButtonsDelegate(QStyledItemDelegate):
         # Add null editor to action buttons column
         if index.column() == index.model().column_position[ACTION_BUTTONS]:
             return
+        if index.column() == index.model().column_position['category']:
+            cbox = QComboBox(parent)
+            cbox.addItems([str(i) for i in range(0,10)])
+            return cbox
 
-        super(TriblerButtonsDelegate, self).createEditor(parent, option, index)
+        return super(TriblerButtonsDelegate, self).createEditor(parent, option, index)
 
 
 class SearchResultsDelegate(TriblerButtonsDelegate):

--- a/TriblerGUI/widgets/tablecontentdelegate.py
+++ b/TriblerGUI/widgets/tablecontentdelegate.py
@@ -4,28 +4,12 @@ from abc import abstractmethod
 
 from PyQt5.QtCore import QEvent, QModelIndex, QObject, QRect, QSize, Qt, pyqtSignal
 from PyQt5.QtGui import QBrush, QColor, QIcon, QPainter, QPen
-from PyQt5.QtWidgets import QStyle, QStyledItemDelegate, QComboBox
+from PyQt5.QtWidgets import QComboBox, QStyle, QStyledItemDelegate
 
-from TriblerGUI.defs import ACTION_BUTTONS, COMMIT_STATUS_COMMITTED, COMMIT_STATUS_NEW, COMMIT_STATUS_TODELETE, \
-    HEALTH_CHECKING, HEALTH_DEAD, HEALTH_ERROR, HEALTH_GOOD, HEALTH_MOOT, HEALTH_UNCHECKED
+from TriblerGUI.defs import ACTION_BUTTONS, CATEGORY_LIST, COMMIT_STATUS_COMMITTED, COMMIT_STATUS_NEW, \
+    COMMIT_STATUS_TODELETE, HEALTH_CHECKING, HEALTH_DEAD, HEALTH_ERROR, HEALTH_GOOD, HEALTH_MOOT, HEALTH_UNCHECKED
 from TriblerGUI.utilities import get_health, get_image_path
 from TriblerGUI.widgets.tableiconbuttons import DeleteIconButton, DownloadIconButton, PlayIconButton
-
-#TODO: build this automatically and/or move it somewhere
-CATEGORY_LIST = [
-    u'Video',
-    u'Audio',
-    u'Documents',
-    u'CD/DVD/BD',
-    u'Games',
-    u'Pictures',
-    u'Books',
-    u'Comics',
-    u'Software',
-    u'Science',
-    u'XXX',
-    u'Other',
-]
 
 
 class TriblerButtonsDelegate(QStyledItemDelegate):

--- a/TriblerGUI/widgets/tablecontentdelegate.py
+++ b/TriblerGUI/widgets/tablecontentdelegate.py
@@ -121,7 +121,7 @@ class SearchResultsDelegate(TriblerButtonsDelegate):
             self.paint_empty_background(painter, option)
 
             if data_item['type'] == 'channel':
-                if index.model().data_items[index.row()][u'status'] == 6:  # LEGACY ENTRIES!
+                if index.model().data_items[index.row()][u'status'] == 1000:  # LEGACY ENTRIES!
                     return True
                 if index.model().data_items[index.row()][u'my_channel']:  # Skip personal channel
                     return True
@@ -185,7 +185,7 @@ class ChannelsButtonsDelegate(TriblerButtonsDelegate):
             # Draw empty cell as the background
             self.paint_empty_background(painter, option)
 
-            if index.model().data_items[index.row()][u'status'] == 6:  # LEGACY ENTRIES!
+            if index.model().data_items[index.row()][u'status'] == 1000:  # LEGACY ENTRIES!
                 return True
             if index.model().data_items[index.row()][u'my_channel']:
                 return True

--- a/TriblerGUI/widgets/tablecontentmodel.py
+++ b/TriblerGUI/widgets/tablecontentmodel.py
@@ -22,15 +22,6 @@ class RemoteTableModel(QAbstractTableModel):
         self.total_items = 0  # The total number of items without pagination
         self.infohashes = {}
 
-    @abstractmethod
-    def _get_remote_data(self, start, end, **kwargs):
-        # This must call self._on_new_items_received as a callback when data received
-        pass
-
-    @abstractmethod
-    def _set_remote_data(self):
-        pass
-
     def reset(self):
         self.beginResetModel()
         self.data_items = []
@@ -67,12 +58,6 @@ class TriblerContentModel(RemoteTableModel):
     def headerData(self, num, orientation, role=None):
         if orientation == Qt.Horizontal and role == Qt.DisplayRole:
             return self.column_headers[num]
-
-    def _get_remote_data(self, start, end, **kwargs):
-        pass
-
-    def _set_remote_data(self):
-        pass
 
     def rowCount(self, parent=QModelIndex()):
         return len(self.data_items)
@@ -206,8 +191,8 @@ class MyTorrentsContentModel(TorrentsContentModel):
     columns = [u'category', u'name', u'size', u'status', ACTION_BUTTONS]
     column_headers = [u'Category', u'Name', u'Size', u'', u'']
     column_flags = {
-        u'category': Qt.ItemIsEnabled | Qt.ItemIsSelectable,
-        u'name': Qt.ItemIsEnabled | Qt.ItemIsSelectable,
+        u'category': Qt.ItemIsEnabled | Qt.ItemIsSelectable | Qt.ItemIsEditable,
+        u'name': Qt.ItemIsEnabled | Qt.ItemIsSelectable | Qt.ItemIsEditable,
         u'size': Qt.ItemIsEnabled | Qt.ItemIsSelectable,
         u'status': Qt.ItemIsEnabled | Qt.ItemIsSelectable,
         ACTION_BUTTONS: Qt.ItemIsEnabled | Qt.ItemIsSelectable
@@ -217,3 +202,8 @@ class MyTorrentsContentModel(TorrentsContentModel):
         TorrentsContentModel.__init__(self, channel_pk=channel_pk, **kwargs)
         self.exclude_deleted = False
         self.edit_enabled = True
+
+    def setData(self, index, Any, role=None):
+        if role == Qt.EditRole:
+            self.data_items[index.row()][self.columns[index.column()]] = Any
+        return True

--- a/TriblerGUI/widgets/tablecontentmodel.py
+++ b/TriblerGUI/widgets/tablecontentmodel.py
@@ -1,10 +1,9 @@
 from __future__ import absolute_import
 
-from abc import abstractmethod
-
 from PyQt5.QtCore import QAbstractTableModel, QModelIndex, Qt, pyqtSignal
 
 from TriblerGUI.defs import ACTION_BUTTONS
+from TriblerGUI.tribler_request_manager import TriblerRequestManager
 from TriblerGUI.utilities import format_size, pretty_date
 
 
@@ -203,7 +202,18 @@ class MyTorrentsContentModel(TorrentsContentModel):
         self.exclude_deleted = False
         self.edit_enabled = True
 
-    def setData(self, index, Any, role=None):
+    def setData(self, index, new_value, role=None):
         if role == Qt.EditRole:
-            self.data_items[index.row()][self.columns[index.column()]] = Any
+            #self.data_items[index.row()][self.columns[index.column()]] = Any
+            infohash = self.data_items[index.row()][u'infohash']
+            attribute_name = self.columns[index.column()]
+            attribute_name = u'tags' if attribute_name == u'category' else attribute_name
+            attribute_name = u'title' if attribute_name == u'name' else attribute_name
+
+            TriblerRequestManager().perform_request(
+                "mychannel/torrents/%s" % infohash,
+                lambda _: None,
+                method='PATCH',
+                data={attribute_name: new_value})
+
         return True

--- a/TriblerGUI/widgets/tablecontentmodel.py
+++ b/TriblerGUI/widgets/tablecontentmodel.py
@@ -204,7 +204,6 @@ class MyTorrentsContentModel(TorrentsContentModel):
 
     def setData(self, index, new_value, role=None):
         if role == Qt.EditRole:
-            #self.data_items[index.row()][self.columns[index.column()]] = Any
             infohash = self.data_items[index.row()][u'infohash']
             attribute_name = self.columns[index.column()]
             attribute_name = u'tags' if attribute_name == u'category' else attribute_name
@@ -215,5 +214,8 @@ class MyTorrentsContentModel(TorrentsContentModel):
                 lambda _: None,
                 method='PATCH',
                 data={attribute_name: new_value})
+
+            #TODO: reload the item instead
+            self.data_items[index.row()][self.columns[index.column()]] = new_value
 
         return True

--- a/TriblerGUI/widgets/tablecontentmodel.py
+++ b/TriblerGUI/widgets/tablecontentmodel.py
@@ -67,7 +67,7 @@ class TriblerContentModel(RemoteTableModel):
         return self.column_flags[self.columns[index.column()]]
 
     def data(self, index, role):
-        if role == Qt.DisplayRole:
+        if role == Qt.DisplayRole or role == Qt.EditRole:
             column = self.columns[index.column()]
             data = self.data_items[index.row()][column] if column in self.data_items[index.row()] else u''
             return self.column_display_filters.get(column, str(data))(data) \

--- a/TriblerGUI/widgets/triblertablecontrollers.py
+++ b/TriblerGUI/widgets/triblertablecontrollers.py
@@ -309,6 +309,8 @@ class MyTorrentsTableViewController(TorrentsTableViewController):
             "mychannel/torrents",
             self.on_torrents,
             url_params={
+                "first": start,
+                "last": end,
                 "sort_by": sort_by,
                 "sort_asc": sort_asc,
                 "filter": to_fts_query(filter_text),

--- a/TriblerGUI/widgets/triblertablecontrollers.py
+++ b/TriblerGUI/widgets/triblertablecontrollers.py
@@ -35,13 +35,18 @@ class TriblerTableViewController(object):
         self.table_view = table_view
         self.table_view.setModel(self.model)
         self.table_view.verticalScrollBar().valueChanged.connect(self._on_list_scroll)
+        self.query_text = ''
+        self.num_results_label = None
         self.request_mgr = None
 
-    def _on_list_scroll(self, event):
-        pass
-
     def _on_view_sort(self, column, ascending):
-        pass
+        self.model.reset()
+        self.perform_query(first=1, last=50)
+
+    def _on_list_scroll(self, event):
+        if self.table_view.verticalScrollBar().value() == self.table_view.verticalScrollBar().maximum() and \
+                self.model.data_items:  # workaround for duplicate calls to _on_list_scroll on view creation
+            self.perform_query()
 
     def _get_sort_parameters(self):
         """
@@ -51,74 +56,46 @@ class TriblerTableViewController(object):
         sort_asc = self.table_view.horizontalHeader().sortIndicatorOrder()
         return sort_by, sort_asc
 
-
-class SearchResultsTableViewController(TriblerTableViewController):
-    """
-    Controller for the table view that handles search results.
-    """
-
-    def __init__(self, model, table_view, details_container, num_search_results_label=None):
-        TriblerTableViewController.__init__(self, model, table_view)
-        self.num_search_results_label = num_search_results_label
-        self.details_container = details_container
-        self.query = None
-        table_view.selectionModel().selectionChanged.connect(self._on_selection_changed)
-
-    def _on_selection_changed(self, _):
-        selected_indices = self.table_view.selectedIndexes()
-        if not selected_indices:
-            return
-
-        torrent_info = selected_indices[0].model().data_items[selected_indices[0].row()]
-        if torrent_info['type'] == 'channel':
-            self.details_container.hide()
-            self.table_view.clearSelection()
-            return
-
-        self.details_container.show()
-        self.details_container.details_tab_widget.update_with_torrent(selected_indices[0], torrent_info)
-
-    def _on_view_sort(self, column, ascending):
-        self.model.reset()
-        self.load_search_results(self.query, 1, 50)
-
-    def _on_list_scroll(self, event):
-        if self.table_view.verticalScrollBar().value() == self.table_view.verticalScrollBar().maximum() and \
-                self.model.data_items:  # workaround for duplicate calls to _on_list_scroll on view creation
-            self.load_search_results(self.query)
-
-    def load_search_results(self, query, start=None, end=None):
+    def perform_query(self, **kwargs):
         """
-        Fetch search results for a given query.
+        Fetch results for a given query.
         """
-        self.query = query
-
-        if not start or not end:
-            start, end = self.model.rowCount() + 1, self.model.rowCount() + self.model.item_load_batch
+        if 'first' not in kwargs or 'last' not in kwargs:
+            kwargs["first"], kwargs[
+                'last'] = self.model.rowCount() + 1, self.model.rowCount() + self.model.item_load_batch
 
         sort_by, sort_asc = self._get_sort_parameters()
-        url_params = {
-            "filter": to_fts_query(query),
-            "first": start if start else '',
-            "last": end if end else '',
-            "sort_by": sort_by if sort_by else '',
+        kwargs.update({
+            "filter": to_fts_query(self.query_text),
+            "sort_by": sort_by,
             "sort_asc": sort_asc,
-            "hide_xxx": self.model.hide_xxx,
-            "metadata_type": self.model.type_filter if self.model.type_filter else ''
-        }
+            "hide_xxx": self.model.hide_xxx})
+
+        rest_endpoint_url = kwargs.pop("rest_endpoint_url")
         self.request_mgr = TriblerRequestManager()
-        self.request_mgr.perform_request("search", self.on_search_results, url_params=url_params)
+        self.request_mgr.perform_request(rest_endpoint_url,
+                                         self.on_query_results,
+                                         url_params=kwargs)
 
-    def on_search_results(self, response):
+    def on_query_results(self, response):
         if not response:
-            return
-
+            return False
         self.model.total_items = response['total']
+        if self.num_results_label:
+            self.num_results_label.setText("%d results" % response['total'])
+        if response['first'] >= self.model.rowCount():
+            self.model.add_items(response['results'])
+        return True
 
-        if self.num_search_results_label:
-            self.num_search_results_label.setText("%d results" % response['total'])
 
-        self.model.add_items(response['results'])
+class FilterInputMixin(object):
+
+    def _on_filter_input_change(self, _):
+        self.query_text = self.filter_input.text().lower()
+        self.model.reset()
+        self.perform_query(start=1, end=50)
+
+class RemoteResultsMixin(object):
 
     def load_remote_results(self, response):
         if not response:
@@ -127,162 +104,101 @@ class SearchResultsTableViewController(TriblerTableViewController):
         self.model.add_remote_items(response['results'])
         self.model.total_items = len(self.model.data_items)
 
-        if self.num_search_results_label:
-            self.num_search_results_label.setText("%d results" % self.model.total_items)
+        if self.num_results_label:
+            self.num_results_label.setText("%d results" % self.model.total_items)
 
 
-class ChannelsTableViewController(TriblerTableViewController):
-    """
-    This class manages a list with channels.
-    """
-
-    def __init__(self, model, table_view, num_channels_label=None, filter_input=None):
-        TriblerTableViewController.__init__(self, model, table_view)
-        self.num_channels_label = num_channels_label
-        self.filter_input = filter_input
-
-        if self.filter_input:
-            self.filter_input.textChanged.connect(self._on_filter_input_change)
-
-    def _on_filter_input_change(self, _):
-        self.model.reset()
-        self.load_channels(1, 50)
-
-    def _on_view_sort(self, column, ascending):
-        self.model.reset()
-        self.load_channels(1, 50)
-
-    def _on_list_scroll(self, event):
-        if self.table_view.verticalScrollBar().value() == self.table_view.verticalScrollBar().maximum() and \
-                self.model.data_items:  # workaround for duplicate calls to _on_list_scroll on view creation
-            self.load_channels()
-
-    def load_channels(self, start=None, end=None):
-        """
-        Fetch various channels.
-        """
-        if not start and not end:
-            start, end = self.model.rowCount() + 1, self.model.rowCount() + self.model.item_load_batch
-
-        if self.filter_input and self.filter_input.text().lower():
-            filter_text = self.filter_input.text().lower()
-        else:
-            filter_text = ''
-
-        sort_by, sort_asc = self._get_sort_parameters()
-
-        self.request_mgr = TriblerRequestManager()
-        self.request_mgr.perform_request(
-            "metadata/channels",
-            self.on_channels,
-            url_params={
-                "first": start,
-                "last": end,
-                "sort_by": sort_by,
-                "sort_asc": sort_asc,
-                "filter": to_fts_query(filter_text),
-                "hide_xxx": self.model.hide_xxx,
-                "subscribed": self.model.subscribed})
-
-    def on_channels(self, response):
-        if not response:
-            return
-
-        self.model.total_items = response['total']
-
-        if self.num_channels_label:
-            self.num_channels_label.setText("%d items" % response['total'])
-
-        if response['first'] >= self.model.rowCount():
-            self.model.add_items(response['channels'])
-
-
-class TorrentsTableViewController(TriblerTableViewController):
-    """
-    This class manages a list with torrents.
-    """
-
-    def __init__(self, model, torrents_container, num_torrents_label=None, filter_input=None):
-        TriblerTableViewController.__init__(self, model, torrents_container.content_table)
-        self.torrents_container = torrents_container
-        self.num_torrents_label = num_torrents_label
-        self.filter_input = filter_input
-        torrents_container.content_table.selectionModel().selectionChanged.connect(self._on_selection_changed)
-
-        if self.filter_input:
-            self.filter_input.textChanged.connect(self._on_filter_input_change)
+class TableSelectionMixin(object):
 
     def _on_selection_changed(self, _):
         selected_indices = self.table_view.selectedIndexes()
         if not selected_indices:
             return
 
+        torrent_info = selected_indices[0].model().data_items[selected_indices[0].row()]
+        if 'type' in torrent_info and torrent_info['type'] == 'channel':
+            self.details_container.hide()
+            self.table_view.clearSelection()
+            return
+
         first_show = False
-        if self.torrents_container.details_container.isHidden():
+        if self.details_container.isHidden():
             first_show = True
 
-        self.torrents_container.details_container.show()
-        torrent_info = selected_indices[0].model().data_items[selected_indices[0].row()]
-        self.torrents_container.details_tab_widget.update_with_torrent(selected_indices[0], torrent_info)
+        self.details_container.show()
+        self.details_container.details_tab_widget.update_with_torrent(selected_indices[0], torrent_info)
         if first_show:
             window = self.table_view.window()
             # FIXME! Brain-dead way to show the rows covered by a newly-opened details_container
             # Note that none of then more civilized ways to fix it works:
             # various updateGeometry, viewport().update, adjustSize - nothing works!
-            window.resize(window.geometry().width()+1, window.geometry().height())
-            window.resize(window.geometry().width()-1, window.geometry().height())
+            window.resize(window.geometry().width() + 1, window.geometry().height())
+            window.resize(window.geometry().width() - 1, window.geometry().height())
 
-    def _on_filter_input_change(self, _):
-        self.model.reset()
-        self.load_torrents(1, 50)
 
-    def _on_view_sort(self, column, ascending):
-        self.model.reset()
-        self.load_torrents(1, 50)
+class SearchResultsTableViewController(RemoteResultsMixin, TableSelectionMixin, TriblerTableViewController):
+    """
+    Controller for the table view that handles search results.
+    """
 
-    def _on_list_scroll(self, event):
-        if self.table_view.verticalScrollBar().value() == self.table_view.verticalScrollBar().maximum() and \
-                self.model.data_items:  # workaround for duplicate calls to _on_list_scroll on view creation
-            self.load_torrents()
+    def __init__(self, model, table_view, details_container, num_results_label=None):
+        TriblerTableViewController.__init__(self, model, table_view)
+        self.num_results_label = num_results_label
+        self.details_container = details_container
+        table_view.selectionModel().selectionChanged.connect(self._on_selection_changed)
 
-    def load_torrents(self, start=None, end=None):
+    def perform_query(self, **kwargs):
         """
-        Fetch various torrents.
+        Fetch search results.
         """
-        if not start and not end:
-            start, end = self.model.rowCount() + 1, self.model.rowCount() + self.model.item_load_batch
+        if "rest_endpoint_url" not in kwargs:
+            kwargs.update({"metadata_type": self.model.type_filter})
+        kwargs.update({"rest_endpoint_url": "search"})
+        super(SearchResultsTableViewController, self).perform_query(**kwargs)
 
-        if self.filter_input and self.filter_input.text().lower():
-            filter_text = self.filter_input.text().lower()
-        else:
-            filter_text = ''
 
-        sort_by, sort_asc = self._get_sort_parameters()
+class ChannelsTableViewController(FilterInputMixin, TriblerTableViewController):
+    """
+    This class manages a list with channels.
+    """
 
-        self.request_mgr = TriblerRequestManager()
-        self.request_mgr.perform_request(
-            "metadata/channels/%s/torrents" % self.model.channel_pk,
-            self.on_torrents,
-            url_params={
-                "first": start,
-                "last": end,
-                "sort_by": sort_by,
-                "sort_asc": sort_asc,
-                "hide_xxx": self.model.hide_xxx,
-                "filter": to_fts_query(filter_text)})
+    def __init__(self, model, table_view, num_results_label=None, filter_input=None):
+        TriblerTableViewController.__init__(self, model, table_view)
+        self.num_results_label = num_results_label
+        self.filter_input = filter_input
 
-    def on_torrents(self, response):
-        if not response:
-            return None
+        if self.filter_input:
+            self.filter_input.textChanged.connect(self._on_filter_input_change)
 
-        self.model.total_items = response['total']
+    def perform_query(self, **kwargs):
+        self.query_text = (self.filter_input.text().lower()
+                           if (self.filter_input and self.filter_input.text().lower())
+                           else '')
+        if "rest_endpoint_url" not in kwargs:
+            kwargs.update({"rest_endpoint_url": "metadata/channels"})
+        kwargs.update({"subscribed": self.model.subscribed})
+        super(ChannelsTableViewController, self).perform_query(**kwargs)
 
-        if self.num_torrents_label:
-            self.num_torrents_label.setText("%d items" % response['total'])
 
-        if response['first'] >= self.model.rowCount():
-            self.model.add_items(response['torrents'])
-        return True
+class TorrentsTableViewController(TableSelectionMixin, FilterInputMixin, TriblerTableViewController):
+    """
+    This class manages a list with torrents.
+    """
+
+    def __init__(self, model, table_view, details_container, num_results_label=None, filter_input=None):
+        TriblerTableViewController.__init__(self, model, table_view)
+        self.num_results_label = num_results_label
+        self.filter_input = filter_input
+        self.details_container = details_container
+        table_view.selectionModel().selectionChanged.connect(self._on_selection_changed)
+        if self.filter_input:
+            self.filter_input.textChanged.connect(self._on_filter_input_change)
+
+    def perform_query(self, **kwargs):
+        if "rest_endpoint_url" not in kwargs:
+            kwargs.update({
+                "rest_endpoint_url": "metadata/channels/%s/torrents" % self.model.channel_pk})
+        super(TorrentsTableViewController, self).perform_query(**kwargs)
 
 
 class MyTorrentsTableViewController(TorrentsTableViewController):
@@ -290,33 +206,35 @@ class MyTorrentsTableViewController(TorrentsTableViewController):
     This class manages the list with the torrents in your own channel.
     """
 
-    def load_torrents(self, start=None, end=None):
-        """
-        Fetch various torrents.
-        """
-        if not start and not end:
-            start, end = self.model.rowCount() + 1, self.model.rowCount() + self.model.item_load_batch
+    def __init__(self, *args, **kwargs):
+        super(MyTorrentsTableViewController, self).__init__(*args, **kwargs)
+        self.model.row_edited.connect(self._on_row_edited)
 
-        if self.filter_input and self.filter_input.text().lower():
-            filter_text = self.filter_input.text().lower()
-        else:
-            filter_text = ''
-
-        sort_by, sort_asc = self._get_sort_parameters()
+    def _on_row_edited(self, index, new_value):
+        infohash = self.model.data_items[index.row()][u'infohash']
+        attribute_name = self.model.columns[index.column()]
+        attribute_name = u'tags' if attribute_name == u'category' else attribute_name
+        attribute_name = u'title' if attribute_name == u'name' else attribute_name
 
         self.request_mgr = TriblerRequestManager()
         self.request_mgr.perform_request(
-            "mychannel/torrents",
-            self.on_torrents,
-            url_params={
-                "first": start,
-                "last": end,
-                "sort_by": sort_by,
-                "sort_asc": sort_asc,
-                "filter": to_fts_query(filter_text),
-                "exclude_deleted": self.model.exclude_deleted})
+            "mychannel/torrents/%s" % infohash,
+            self._on_row_update_results,
+            method='PATCH',
+            data={attribute_name: new_value})
 
-    def on_torrents(self, response):
-        if super(MyTorrentsTableViewController, self).on_torrents(response):
+    def _on_row_update_results(self, response):
+        if response:
+            self.table_view.window().edit_channel_page.channel_dirty = response['dirty']
+            self.table_view.window().edit_channel_page.update_channel_commit_views()
+
+    def perform_query(self, **kwargs):
+        kwargs.update({
+            "rest_endpoint_url": "mychannel/torrents",
+            "exclude_deleted": self.model.exclude_deleted})
+        super(MyTorrentsTableViewController, self).perform_query(**kwargs)
+
+    def on_query_results(self, response):
+        if super(MyTorrentsTableViewController, self).on_query_results(response):
             self.table_view.window().edit_channel_page.channel_dirty = response['dirty']
             self.table_view.window().edit_channel_page.update_channel_commit_views()


### PR DESCRIPTION
This PR adds the ability to edit a GigaChannel entry through the GUI. The editing is done inline in the MyChannel table. The user can change the torrent's category by selecting one from a combo box. Torrent's title can also be edited by double-clicking on it.
Also, this PR changes Legacy entries status label from 6 to 1000, and removes FTS indexing from `tags` column, so the database format is not fully compatible with the previous versions.

This PR is really important for 7.3 release, as it provides a basis for crowdsourcing the torrents channels.

EDIT:
Also, this PR includes a refactoring of `triblertablecontrollers.py` and **breaking changes to DB schema** (removing unused tables and properties).