### PR TITLE
Refactor pathlist2filename()

### DIFF
--- a/Tribler/Core/Utilities/maketorrent.py
+++ b/Tribler/Core/Utilities/maketorrent.py
@@ -9,22 +9,12 @@ import codecs
 import logging
 import os
 
-import chardet
-
 from six.moves import xrange
+
+from Tribler.Core.Utilities.unicode import ensure_unicode_detect_encoding
 
 
 logger = logging.getLogger(__name__)
-
-
-def ensure_unicode_detect_encoding(s):
-    try:
-        return s.decode('utf-8')  # Try bytes --> Unicode
-    except AttributeError:
-        return s  # Already is Unicode
-    except UnicodeDecodeError:
-        charenc = chardet.detect(s)['encoding']
-        return s.decode(charenc) if charenc else s  # Hope for the best
 
 
 def pathlist2filename(pathlist):

--- a/Tribler/Core/Utilities/maketorrent.py
+++ b/Tribler/Core/Utilities/maketorrent.py
@@ -25,7 +25,7 @@ def ensure_unicode_detect_encoding(s):
     except UnicodeDecodeError:
         charenc = chardet.detect(s)['encoding']
         return s.decode(charenc) if charenc else s  # Hope for the best
-    
+
 
 def pathlist2filename(pathlist):
     """ Convert a multi-file torrent file 'path' entry to a filename. """

--- a/Tribler/Core/Utilities/maketorrent.py
+++ b/Tribler/Core/Utilities/maketorrent.py
@@ -11,6 +11,7 @@ import os
 
 import chardet
 
+from six import ensure_text
 from six.moves import xrange
 
 
@@ -19,16 +20,17 @@ logger = logging.getLogger(__name__)
 
 def pathlist2filename(pathlist):
     """ Convert a multi-file torrent file 'path' entry to a filename. """
-    fullpath = os.path.join(*pathlist)
-    try:
-        return codecs.decode(fullpath, 'utf-8')
-    except TypeError:
-        return fullpath  # Python 3: a bytes-like object is required, not 'str'
-    except UnicodeDecodeError:
-        charenc = chardet.detect(fullpath)['encoding']
-        if not charenc:
-            return fullpath  # Hope for the best
-        return fullpath.decode(charenc)
+    return os.path.join(ensure_text(elem) for elem in pathlist)
+    # fullpath = os.path.join(*pathlist)
+    # try:
+    #    return codecs.decode(fullpath, 'utf-8')
+    # except TypeError:
+    #    return fullpath  # Python 3: a bytes-like object is required, not 'str'
+    # except UnicodeDecodeError:
+    #    charenc = chardet.detect(fullpath)['encoding']
+    #    if not charenc:
+    #        return fullpath  # Hope for the best
+    #    return fullpath.decode(charenc)
 
 
 def get_length_from_metainfo(metainfo, selectedfiles):

--- a/Tribler/Core/Utilities/maketorrent.py
+++ b/Tribler/Core/Utilities/maketorrent.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 def pathlist2filename(pathlist):
     """ Convert a multi-file torrent file 'path' entry to a filename. """
-    return os.path.join([ensure_unicode(elem, 'utf-8') for elem in pathlist])
+    return os.path.join(*(ensure_unicode(elem, 'utf-8') for elem in pathlist))
     # fullpath = os.path.join(*pathlist)
     # try:
     #    return codecs.decode(fullpath, 'utf-8')

--- a/Tribler/Core/Utilities/maketorrent.py
+++ b/Tribler/Core/Utilities/maketorrent.py
@@ -13,25 +13,23 @@ import chardet
 
 from six.moves import xrange
 
-from Tribler.Core.Utilities.unicode import ensure_unicode
-
 
 logger = logging.getLogger(__name__)
 
 
+def ensure_unicode_detect_encoding(s):
+    try:
+        return s.decode('utf-8')  # Try bytes --> Unicode
+    except AttributeError:
+        return s  # Already is Unicode
+    except UnicodeDecodeError:
+        charenc = chardet.detect(s)['encoding']
+        return s.decode(charenc) if charenc else s  # Hope for the best
+    
+
 def pathlist2filename(pathlist):
     """ Convert a multi-file torrent file 'path' entry to a filename. """
-    return os.path.join(*(ensure_unicode(elem, 'utf-8') for elem in pathlist))
-    # fullpath = os.path.join(*pathlist)
-    # try:
-    #    return codecs.decode(fullpath, 'utf-8')
-    # except TypeError:
-    #    return fullpath  # Python 3: a bytes-like object is required, not 'str'
-    # except UnicodeDecodeError:
-    #    charenc = chardet.detect(fullpath)['encoding']
-    #    if not charenc:
-    #        return fullpath  # Hope for the best
-    #    return fullpath.decode(charenc)
+    return os.path.join(*(ensure_unicode_detect_encoding(x) for x in pathlist))
 
 
 def get_length_from_metainfo(metainfo, selectedfiles):

--- a/Tribler/Core/Utilities/maketorrent.py
+++ b/Tribler/Core/Utilities/maketorrent.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 def pathlist2filename(pathlist):
     """ Convert a multi-file torrent file 'path' entry to a filename. """
-    return os.path.join(ensure_unicode(elem, 'utf-8') for elem in pathlist)
+    return os.path.join([ensure_unicode(elem, 'utf-8') for elem in pathlist])
     # fullpath = os.path.join(*pathlist)
     # try:
     #    return codecs.decode(fullpath, 'utf-8')

--- a/Tribler/Core/Utilities/maketorrent.py
+++ b/Tribler/Core/Utilities/maketorrent.py
@@ -11,8 +11,9 @@ import os
 
 import chardet
 
-from six import ensure_text
 from six.moves import xrange
+
+from Tribler.Core.Utilities.unicode import ensure_unicode
 
 
 logger = logging.getLogger(__name__)
@@ -20,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 def pathlist2filename(pathlist):
     """ Convert a multi-file torrent file 'path' entry to a filename. """
-    return os.path.join(ensure_text(elem) for elem in pathlist)
+    return os.path.join(ensure_unicode(elem, 'utf-8') for elem in pathlist)
     # fullpath = os.path.join(*pathlist)
     # try:
     #    return codecs.decode(fullpath, 'utf-8')

--- a/Tribler/Core/Utilities/unicode.py
+++ b/Tribler/Core/Utilities/unicode.py
@@ -7,6 +7,8 @@ from __future__ import absolute_import
 
 import sys
 
+import chardet
+
 from six import binary_type, text_type
 
 
@@ -19,3 +21,13 @@ def ensure_unicode(s, encoding, errors='strict'):
         return s
     else:
         raise TypeError("not expecting type '%s'" % type(s))
+
+
+def ensure_unicode_detect_encoding(s):
+    try:
+        return s.decode('utf-8')  # Try converting bytes --> Unicode utf-8
+    except AttributeError:
+        return s  # Already is Unicode
+    except UnicodeDecodeError:
+        charenc = chardet.detect(s)['encoding']
+        return s.decode(charenc) if charenc else s  # Hope for the best

--- a/Tribler/Core/Utilities/unicode.py
+++ b/Tribler/Core/Utilities/unicode.py
@@ -24,10 +24,15 @@ def ensure_unicode(s, encoding, errors='strict'):
 
 
 def ensure_unicode_detect_encoding(s):
-    try:
-        return s.decode('utf-8')  # Try converting bytes --> Unicode utf-8
-    except AttributeError:
-        return s  # Already is Unicode
-    except UnicodeDecodeError:
-        charenc = chardet.detect(s)['encoding']
-        return s.decode(charenc) if charenc else s  # Hope for the best
+    """Similar to ensure_unicode() but use chardet to detect the encoding
+    """
+    if isinstance(s, binary_type):
+        try:
+            return s.decode('utf-8')  # Try converting bytes --> Unicode utf-8
+        except UnicodeDecodeError:
+            charenc = chardet.detect(s)['encoding']
+            return s.decode(charenc) if charenc else s  # Hope for the best
+    elif isinstance(s, text_type):
+        return s
+    else:
+        raise TypeError("not expecting type '%s'" % type(s))


### PR DESCRIPTION
As discussed in #4318  __Can't mix strings and bytes in path components__
```
ERROR: test_pathlist2filename_not_utf8
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/defer.py", line 151, in maybeDeferred
    result = f(*args, **kw)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 201, in runWithWarningsSuppressed
    reraise(exc_info[1], exc_info[2])
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/python/compat.py", line 464, in reraise
    raise exception.with_traceback(traceback)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 197, in runWithWarningsSuppressed
    result = f(*a, **kw)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/test_as_server.py", line 62, in check
    result = fun(*argv, **kwargs)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/Core/Utilities/test_maketorrent.py", line 17, in test_pathlist2filename_not_utf8
    path = pathlist2filename(path_list)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Core/Utilities/maketorrent.py", line 22, in pathlist2filename
    fullpath = os.path.join(*pathlist)
  File "/usr/lib/python3.5/posixpath.py", line 89, in join
    genericpath._check_arg_types('join', a, *p)
  File "/usr/lib/python3.5/genericpath.py", line 145, in _check_arg_types
    raise TypeError("Can't mix strings and bytes in path components") from None
TypeError: Can't mix strings and bytes in path components
```