### PR TITLE
uri = uri.encode('utf-8')  # Try converting uri to bytes

### DIFF
--- a/Tribler/Core/Utilities/utilities.py
+++ b/Tribler/Core/Utilities/utilities.py
@@ -76,6 +76,10 @@ def http_get(uri):
         raise HttpError(response)
 
     try:
+        uri = uri.encode('utf-8')  # Try converting uri to bytes
+    except AttributeError:
+        pass
+    try:
         contextFactory = WebClientContextFactory()
         agent = Agent(reactor, contextFactory)
         headers = Headers({'User-Agent': ['Tribler ' + version_id]})


### PR DESCRIPTION
```
ERROR: Test if http_get is working properly if url redirects to a magnet link.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Core/Utilities/utilities.py", line 82, in http_get
    deferred = agent.request('GET', uri, headers, None)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/web/client.py", line 1649, in request
    parsedURI = URI.fromBytes(uri)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/web/client.py", line 638, in fromBytes
    scheme, netloc, path, params, query, fragment = http.urlparse(uri)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/web/http.py", line 181, in urlparse
    raise TypeError("url must be bytes, not unicode")
TypeError: url must be bytes, not unicode
-------------------- >> begin captured logging << --------------------
Tribler.Core.Utilities.network_utils: DEBUG: Got a working random port 44534
--------------------- >> end captured logging << ---------------------
```