### PR TITLE
Fix escape_as_utf8() for Python 3 str

### DIFF
--- a/Tribler/Core/TorrentDef.py
+++ b/Tribler/Core/TorrentDef.py
@@ -34,7 +34,7 @@ def escape_as_utf8(string, encoding='utf8'):
         # can convert to utf8 without any issues.
         return string.decode(encoding).encode('utf8').decode('utf8')
     except AttributeError:  # Python 3 'str' object has no attribute 'decode'
-        return string.encode('utf8').decode('utf8')
+        return escape_as_utf8(string.encode(encoding), encoding)
     except (LookupError, TypeError, ValueError):
         try:
             # The delivered encoding is incorrect, cast it to

--- a/Tribler/Core/TorrentDef.py
+++ b/Tribler/Core/TorrentDef.py
@@ -33,6 +33,8 @@ def escape_as_utf8(string, encoding='utf8'):
         # Try seeing if the delivered encoding is correct and we
         # can convert to utf8 without any issues.
         return string.decode(encoding).encode('utf8').decode('utf8')
+    except AttributeError:  # Python 3 'str' object has no attribute 'decode'
+        return string.encode('utf8').decode('utf8')
     except (LookupError, TypeError, ValueError):
         try:
             # The delivered encoding is incorrect, cast it to


### PR DESCRIPTION
__escape_as_utf8()__ probably should be moved into __Tribler.Core.Utilities.unicode__

```
ERROR: Test whether we can succesfully get the UTF-8 name
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/defer.py", line 151, in maybeDeferred
    result = f(*args, **kw)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 201, in runWithWarningsSuppressed
    reraise(exc_info[1], exc_info[2])
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/python/compat.py", line 464, in reraise
    raise exception.with_traceback(traceback)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 197, in runWithWarningsSuppressed
    result = f(*a, **kw)
  File "/home/jenkins/workspace/test_tribler_python3@2/tribler/Tribler/Test/test_as_server.py", line 62, in check
    result = fun(*argv, **kwargs)
  File "/home/jenkins/workspace/test_tribler_python3@2/tribler/Tribler/Test/Core/test_torrent_def.py", line 98, in test_get_name_utf8_unknown
    self.assertEqual(t.get_name_utf8(), u'\xf7')
  File "/home/jenkins/workspace/test_tribler_python3@2/tribler/Tribler/Core/TorrentDef.py", line 247, in get_name_utf8
    return escape_as_utf8(self.get_name(), self.get_encoding())
  File "/home/jenkins/workspace/test_tribler_python3@2/tribler/Tribler/Core/TorrentDef.py", line 35, in escape_as_utf8
    return string.decode(encoding).encode('utf8').decode('utf8')
AttributeError: 'str' object has no attribute 'decode'
```