### PR TITLE
Bytes in Community/Market

### DIFF
--- a/Tribler/Test/Community/Market/test_order.py
+++ b/Tribler/Test/Community/Market/test_order.py
@@ -195,7 +195,7 @@ class OrderIDTestSuite(unittest.TestCase):
 
     def test_str(self):
         # Test for string representation
-        self.assertEquals('0.1', str(self.order_id))
+        self.assertEquals(str(b'0.1'), str(self.order_id))
 
 
 class OrderNumberTestSuite(unittest.TestCase):

--- a/Tribler/Test/Community/Market/test_transaction.py
+++ b/Tribler/Test/Community/Market/test_transaction.py
@@ -63,7 +63,7 @@ class TransactionIdTestSuite(unittest.TestCase):
 
     def test_conversion(self):
         # Test for conversions
-        self.assertEqual('0.1', str(self.transaction_id))
+        self.assertEqual(str(b'0.1'), str(self.transaction_id))
 
     def test_equality(self):
         # Test for equality


### PR DESCRIPTION
```
======================================================================
FAIL: test_str (Tribler.Test.Community.Market.test_order.OrderIDTestSuite)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/Community/Market/test_order.py", line 198, in test_str
    self.assertEquals('0.1', str(self.order_id))
AssertionError: '0.1' != "b'0'.1"
- 0.1
+ b'0'.1


======================================================================
FAIL: test_conversion (Tribler.Test.Community.Market.test_transaction.TransactionIdTestSuite)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/Community/Market/test_transaction.py", line 66, in test_conversion
    self.assertEqual('0.1', str(self.transaction_id))
AssertionError: '0.1' != "b'0'.1"
- 0.1
+ b'0'.1
```