### PR TITLE
Added BEP33 DHT health check

### DIFF
--- a/Tribler/Core/Modules/dht_health_manager.py
+++ b/Tribler/Core/Modules/dht_health_manager.py
@@ -1,0 +1,145 @@
+from __future__ import absolute_import, division
+
+import math
+from binascii import hexlify
+
+import libtorrent as lt
+
+from twisted.internet import reactor
+from twisted.internet.defer import Deferred
+
+from Tribler.pyipv8.ipv8.dht.routing import distance, id_to_binary_string
+from Tribler.pyipv8.ipv8.taskmanager import TaskManager
+
+
+class DHTHealthManager(TaskManager):
+    """
+    This class manages BEP33 health requests to the libtorrent DHT.
+    """
+
+    def __init__(self, lt_session):
+        """
+        Initialize the DHT health manager.
+        :param lt_session: The session used to perform health lookups.
+        """
+        TaskManager.__init__(self)
+        self.lookup_deferreds = {}  # Map from binary infohash to deferred
+        self.bf_seeders = {}        # Map from infohash to (final) seeders bloomfilter
+        self.bf_peers = {}          # Map from infohash to (final) peers bloomfilter
+        self.lt_session = lt_session
+
+    def get_health(self, infohash, timeout=15):
+        """
+        Lookup the health of a given infohash.
+        :param infohash: The 20-byte infohash to lookup.
+        :param timeout: The timeout of the lookup.
+        :return: A Deferred that fires with a tuple, indicating the number of seeders and peers respectively.
+        """
+        if infohash in self.lookup_deferreds:
+            return self.lookup_deferreds[infohash]
+
+        lookup_deferred = Deferred()
+        self.lookup_deferreds[infohash] = lookup_deferred
+        self.bf_seeders[infohash] = bytearray(256)
+        self.bf_peers[infohash] = bytearray(256)
+
+        # Perform a get_peers request. This should result in get_peers responses with the BEP33 bloom filters.
+        self.lt_session.dht_get_peers(lt.sha1_hash(infohash))
+
+        self.register_task("lookup_%s" % hexlify(infohash), reactor.callLater(timeout, self.finalize_lookup, infohash))
+
+        return lookup_deferred
+
+    def finalize_lookup(self, infohash):
+        """
+        Finalize the lookup of the provided infohash and invoke the appropriate deferred.
+        :param infohash: The infohash of the lookup we finialize.
+        """
+        if infohash not in self.lookup_deferreds:
+            return
+
+        # Determine the seeders/peers
+        bf_seeders = self.bf_seeders.pop(infohash)
+        bf_peers = self.bf_peers.pop(infohash)
+        seeders = DHTHealthManager.get_size_from_bloomfilter(bf_seeders)
+        peers = DHTHealthManager.get_size_from_bloomfilter(bf_peers)
+        self.lookup_deferreds[infohash].callback({
+            "DHT": [{
+                "infohash": hexlify(infohash),
+                "seeders": seeders,
+                "leechers": peers
+            }]
+        })
+
+        self.lookup_deferreds.pop(infohash, None)
+
+    @staticmethod
+    def combine_bloomfilters(bf1, bf2):
+        """
+        Combine two given bloom filters by ORing the bits.
+        :param bf1: The first bloom filter to combine.
+        :param bf2: The second bloom filter to combine.
+        :return: A bytearray with the combined bloomfilter.
+        """
+        final_bf_len = min(len(bf1), len(bf2))
+        final_bf = bytearray(final_bf_len)
+        for bf_index in range(final_bf_len):
+            final_bf[bf_index] = bf1[bf_index] | bf2[bf_index]
+        return final_bf
+
+    @staticmethod
+    def get_size_from_bloomfilter(bf):
+        """
+        Return the estimated number of items in the bloom filter.
+        :param bf: The bloom filter of which we estimate the size.
+        :return: A rounded integer, approximating the number of items in the filter.
+        """
+        def tobits(s):
+            result = []
+            for c in s:
+                bits = bin(ord(c))[2:]
+                bits = '00000000'[len(bits):] + bits
+                result.extend([int(b) for b in bits])
+            return result
+
+        bits_array = tobits(str(bf))
+        total_zeros = 0
+        for bit in bits_array:
+            if bit == 0:
+                total_zeros += 1
+
+        if total_zeros == 0:
+            return 6000  # The maximum capacity of the bloom filter used in BEP33
+
+        m = 256 * 8
+        c = min(m - 1, total_zeros)
+        return int(math.log(c / float(m)) / (2 * math.log(1 - 1 / float(m))))
+
+    def received_bloomfilters(self, node_id, bf_seeds=bytearray(256), bf_peers=bytearray(256)):
+        """
+        We have received bloom filters from the libtorrent DHT. Register the bloom filters and process them.
+        :param node_id: The ID of the node that sent the bloom filter.
+        :param bf_seeds: The bloom filter indicating the IP addresses of the seeders.
+        :param bf_peers: The bloom filter indicating the IP addresses of the peers (leechers).
+        """
+        min_distance = -1
+        closest_infohash = None
+
+        # We do not know to which infohash the received get_peers response belongs so we have to manually go through
+        # the infohashes and find the infohash that is the closest to the node id that sent us the message.
+        for infohash in self.lookup_deferreds:
+            infohash_bin = id_to_binary_string(infohash)
+            node_id_bin = id_to_binary_string(node_id)
+            ih_distance = distance(infohash_bin, node_id_bin)
+            if ih_distance < min_distance or min_distance == -1:
+                min_distance = ih_distance
+                closest_infohash = infohash
+
+        if not closest_infohash:
+            self._logger.info("Could not find lookup infohash for incoming BEP33 bloomfilters")
+            return
+
+        self.bf_seeders[closest_infohash] = DHTHealthManager.combine_bloomfilters(
+            self.bf_seeders[closest_infohash], bf_seeds)
+        self.bf_peers[closest_infohash] = DHTHealthManager.combine_bloomfilters(
+            self.bf_peers[closest_infohash], bf_peers)

--- a/Tribler/Core/Utilities/utilities.py
+++ b/Tribler/Core/Utilities/utilities.py
@@ -10,6 +10,7 @@ import logging
 import re
 from base64 import b32decode
 
+import libtorrent
 from libtorrent import bdecode, bencode
 
 import six
@@ -216,3 +217,11 @@ def is_simple_match_query(query):
         if connector and connector != " AND ":
             return False
     return True
+
+
+def has_bep33_support():
+    """
+    Return whether our libtorrent version has support for BEP33 (DHT health lookups).
+    Also see https://github.com/devos50/libtorrent/tree/bep33_support
+    """
+    return 'dht_pkt_alert' in dir(libtorrent)

--- a/Tribler/Test/Core/Modules/test_dht_health_manager.py
+++ b/Tribler/Test/Core/Modules/test_dht_health_manager.py
@@ -1,0 +1,99 @@
+from __future__ import absolute_import
+
+from binascii import hexlify, unhexlify
+
+from twisted.internet.defer import Deferred, inlineCallbacks
+
+from Tribler.Core.Modules.dht_health_manager import DHTHealthManager
+from Tribler.Test.Core.base_test import MockObject, TriblerCoreTest
+from Tribler.Test.tools import trial_timeout
+
+
+class TestDHTHealthManager(TriblerCoreTest):
+    """
+    This class contains various tests for the DHT health manager.
+    """
+
+    @inlineCallbacks
+    def setUp(self):
+        yield super(TestDHTHealthManager, self).setUp()
+
+        self.mock_lt_session = MockObject()
+        self.mock_lt_session.dht_get_peers = lambda _: None
+
+        self.dht_health_manager = DHTHealthManager(self.mock_lt_session)
+
+    @inlineCallbacks
+    def tearDown(self):
+        self.dht_health_manager.shutdown_task_manager()
+        yield super(TestDHTHealthManager, self).tearDown()
+
+    @trial_timeout(10)
+    def test_get_health(self):
+        """
+        Test fetching the health of a trackerless torrent.
+        """
+        def verify_health(response):
+            self.assertIsInstance(response, dict)
+            self.assertIn('DHT', response)
+            self.assertEqual(response['DHT'][0]['infohash'], hexlify('a' * 20))
+
+        return self.dht_health_manager.get_health('a' * 20, timeout=0.1).addCallback(verify_health)
+
+    @trial_timeout(10)
+    def test_existing_get_health(self):
+        lookup_deferred = self.dht_health_manager.get_health('a' * 20, timeout=0.1)
+        self.assertEqual(self.dht_health_manager.get_health('a' * 20, timeout=0.1), lookup_deferred)
+        return lookup_deferred
+
+    @trial_timeout(10)
+    def test_combine_bloom_filters(self):
+        """
+        Test combining two bloom filters
+        """
+        bf1 = bytearray('a' * 256)
+        bf2 = bytearray('a' * 256)
+        self.assertEqual(self.dht_health_manager.combine_bloomfilters(bf1, bf2), bf1)
+
+        bf1 = bytearray('\0' * 256)
+        bf2 = bytearray('b' * 256)
+        self.assertEqual(self.dht_health_manager.combine_bloomfilters(bf1, bf2), bf2)
+
+    @trial_timeout(10)
+    def test_get_size_from_bloom_filter(self):
+        """
+        Test whether we can successfully estimate the size from a bloom filter
+        """
+        # See http://www.bittorrent.org/beps/bep_0033.html
+        bf = bytearray(unhexlify("""F6C3F5EA A07FFD91 BDE89F77 7F26FB2B FF37BDB8 FB2BBAA2 FD3DDDE7 BACFFF75 EE7CCBAE
+                                    FE5EEDB1 FBFAFF67 F6ABFF5E 43DDBCA3 FD9B9FFD F4FFD3E9 DFF12D1B DF59DB53 DBE9FA5B
+                                    7FF3B8FD FCDE1AFB 8BEDD7BE 2F3EE71E BBBFE93B CDEEFE14 8246C2BC 5DBFF7E7 EFDCF24F
+                                    D8DC7ADF FD8FFFDF DDFFF7A4 BBEEDF5C B95CE81F C7FCFF1F F4FFFFDF E5F7FDCB B7FD79B3
+                                    FA1FC77B FE07FFF9 05B7B7FF C7FEFEFF E0B8370B B0CD3F5B 7F2BD93F EB4386CF DD6F7FD5
+                                    BFAF2E9E BFFFFEEC D67ADBF7 C67F17EF D5D75EBA 6FFEBA7F FF47A91E B1BFBB53 E8ABFB57
+                                    62ABE8FF 237279BF EFBFEEF5 FFC5FEBF DFE5ADFF ADFEE1FB 737FFFFB FD9F6AEF FEEE76B6
+                                    FD8F72EF""".replace(' ', '').replace('\n', '')))
+        self.assertEqual(self.dht_health_manager.get_size_from_bloomfilter(bf), 1224)
+
+        # Maximum capacity
+        bf = bytearray('\xff' * 256)
+        self.assertEqual(self.dht_health_manager.get_size_from_bloomfilter(bf), 6000)
+
+    @trial_timeout(10)
+    def test_receive_bloomfilters(self):
+        """
+        Test whether the right operations happen when receiving a bloom filter
+        """
+        infohash = 'a' * 20
+        self.dht_health_manager.received_bloomfilters(infohash)  # It should not do anything
+        self.assertFalse(self.dht_health_manager.bf_seeders)
+        self.assertFalse(self.dht_health_manager.bf_peers)
+
+        self.dht_health_manager.lookup_deferreds[infohash] = Deferred()
+        self.dht_health_manager.bf_seeders[infohash] = bytearray(256)
+        self.dht_health_manager.bf_peers[infohash] = bytearray(256)
+        self.dht_health_manager.received_bloomfilters('b' * 20,
+                                                      bf_seeds=bytearray('\xee' * 256),
+                                                      bf_peers=bytearray('\xff' * 256))
+        self.assertEqual(self.dht_health_manager.bf_seeders[infohash], bytearray('\xee' * 256))
+        self.assertEqual(self.dht_health_manager.bf_peers[infohash], bytearray('\xff' * 256))

--- a/Tribler/Test/Core/TorrentChecker/test_torrentchecker.py
+++ b/Tribler/Test/Core/TorrentChecker/test_torrentchecker.py
@@ -78,17 +78,6 @@ class TestTorrentChecker(TestAsServer):
         self.torrent_checker._reschedule_tracker_select()
         self.assertTrue(self.torrent_checker.is_pending_task_active("torrent_checker_tracker_selection"))
 
-    def test_add_gui_request_no_trackers(self):
-        """
-        Test whether adding a request to fetch health of a trackerless torrent fails
-        """
-        test_deferred = Deferred()
-        with db_session:
-            self.session.lm.mds.TorrentState(infohash='a' * 20)
-
-        self.torrent_checker.add_gui_request('a' * 20).addErrback(lambda _: test_deferred.callback(None))
-        return test_deferred
-
     def test_add_gui_request_blacklisted_trackers(self):
         """
         Test whether only cached results of a torrent are returned with only blacklisted trackers
@@ -122,14 +111,6 @@ class TestTorrentChecker(TestAsServer):
             self.assertEqual(result['db']['leechers'], 10)
 
         return self.torrent_checker.add_gui_request('a' * 20).addCallback(verify_response)
-
-    def test_add_gui_request_no_tor(self):
-        """
-        Test whether a Failure is raised when we try to fetch info about a torrent unknown to the database
-        """
-        test_deferred = Deferred()
-        self.torrent_checker.add_gui_request('a' * 20).addErrback(lambda _: test_deferred.callback(None))
-        return test_deferred
 
     @trial_timeout(10)
     def test_task_select_no_tracker(self):


### PR DESCRIPTION
Fixes #4321 

By default, BEP33 checks are disabled and it is checked whether ones libtorrent core has support for it. If not, the user cannot perform these checks.

Since BEP33 support is not enabled on the testing machines, there are a few uncovered lines.