### PR TITLE
infohash should be bytes

### DIFF
--- a/Tribler/Test/Community/popularity/test_payload.py
+++ b/Tribler/Test/Community/popularity/test_payload.py
@@ -35,7 +35,7 @@ class TestSerializer(TestCase):
 
     def test_torrent_health_payload(self):
         """ Test serialization/deserialization of Torrent health payload """
-        infohash = 'a' * 20
+        infohash = b'a' * 20
         num_seeders = 10
         num_leechers = 5
         timestamp = 123123123


### PR DESCRIPTION
Tribler.pyipv8.ipv8.messaging.serialization.PackError: Could not pack item 0: ('20s', 'aaaaaaaaaaaaaaaaaaaa')
error: argument for 's' must be a bytes object

```
ERROR: Test serialization/deserialization of Torrent health payload
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/pyipv8/ipv8/messaging/serialization.py", line 264, in pack_multiple
    packed, packed_size = self.pack(*packable)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/pyipv8/ipv8/messaging/serialization.py", line 248, in pack
    return self._packers[format].pack(*data)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/pyipv8/ipv8/messaging/serialization.py", line 171, in pack
    return super(DefaultStruct, self).pack(*data), self.size
struct.error: argument for 's' must be a bytes object

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/Community/popularity/test_payload.py", line 44, in test_torrent_health_payload
    serialized = self.serializer.pack_multiple(health_payload.to_pack_list())[0]
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/pyipv8/ipv8/messaging/serialization.py", line 270, in pack_multiple
    sys.exc_info()[2])
  File "/home/jenkins/.local/lib/python3.5/site-packages/six.py", line 692, in reraise
    raise value.with_traceback(tb)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/pyipv8/ipv8/messaging/serialization.py", line 264, in pack_multiple
    packed, packed_size = self.pack(*packable)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/pyipv8/ipv8/messaging/serialization.py", line 248, in pack
    return self._packers[format].pack(*data)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/pyipv8/ipv8/messaging/serialization.py", line 171, in pack
    return super(DefaultStruct, self).pack(*data), self.size
Tribler.pyipv8.ipv8.messaging.serialization.PackError: Could not pack item 0: ('20s', 'aaaaaaaaaaaaaaaaaaaa')
error: argument for 's' must be a bytes object
```