### PR TITLE
TraderId(1.0) will raise a TypeError in Python 3

### DIFF
--- a/Tribler/Test/Community/Market/test_message.py
+++ b/Tribler/Test/Community/Market/test_message.py
@@ -14,7 +14,7 @@ class TraderIdTestSuite(unittest.TestCase):
 
     def test_init(self):
         # Test for init validation
-        with self.assertRaises(ValueError):
+        with self.assertRaises((TypeError, ValueError)):
             TraderId(1.0)
         with self.assertRaises(ValueError):
             TraderId('non hexadecimal')


### PR DESCRIPTION
```
ERROR: test_init (Tribler.Test.Community.Market.test_message.TraderIdTestSuite)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/Community/Market/test_message.py", line 18, in test_init
    TraderId(1.0)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/community/market/core/message.py", line 19, in __init__
    trader_id = trader_id if isinstance(trader_id, bytes) else binary_type(trader_id)
TypeError: 'float' object is not iterable
```