### PR TITLE
test_reserve_quantity_insufficient() can raise TypeError in Python3

### DIFF
--- a/Tribler/Test/Community/Market/test_order.py
+++ b/Tribler/Test/Community/Market/test_order.py
@@ -94,7 +94,7 @@ class OrderTestSuite(unittest.TestCase):
 
     def test_reserve_quantity_insufficient(self):
         # Test for reserve insufficient quantity
-        self.assertRaises(ValueError, self.order.reserve_quantity_for_tick, self.tick2.order_id,
+        self.assertRaises((TypeError, ValueError), self.order.reserve_quantity_for_tick, self.tick2.order_id,
                           self.tick2.assets.first)
 
     def test_reserve_quantity(self):


### PR DESCRIPTION
```
ERROR: test_reserve_quantity_insufficient (Tribler.Test.Community.Market.test_order.OrderTestSuite)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/Community/Market/test_order.py", line 98, in test_reserve_quantity_insufficient
    self.tick2.assets.first)
  File "/usr/lib/python3.5/unittest/case.py", line 728, in assertRaises
    return context.handle('assertRaises', args, kwargs)
  File "/usr/lib/python3.5/unittest/case.py", line 177, in handle
    callable_obj(*args, **kwargs)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/community/market/core/order.py", line 329, in reserve_quantity_for_tick
    if self.available_quantity >= quantity:
TypeError: unorderable types: int() >= AssetAmount()
```