### PR TITLE
Add typing to pricelevel_list.py

### DIFF
--- a/Tribler/community/market/core/pricelevel_list.py
+++ b/Tribler/community/market/core/pricelevel_list.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict, List
+
 from Tribler.community.market.core.pricelevel import PriceLevel
 
 
@@ -8,10 +10,10 @@ class PriceLevelList(object):
 
     def __init__(self):
         super(PriceLevelList, self).__init__()
-        self._price_list = []
-        self._price_level_dictionary = {}
+        self._price_list = []  # type: List[float]
+        self._price_level_dictionary = {}  # type: Dict[float, PriceLevel]
 
-    def insert(self, price_level):
+    def insert(self, price_level):  # type: (PriceLevel) -> None
         """
         :type price_level: PriceLevel
         """
@@ -19,14 +21,14 @@ class PriceLevelList(object):
         self._price_list.sort()
         self._price_level_dictionary[price_level.price] = price_level
 
-    def remove(self, price):
+    def remove(self, price):  # type: (Price) -> None
         """
         :type price: Price
         """
         self._price_list.remove(price)
         del self._price_level_dictionary[price]
 
-    def succ_item(self, price):
+    def succ_item(self, price):  # type: (Price) -> PriceLevel
         """
         Returns the price level where price_level.price is successor to given price
 
@@ -39,7 +41,7 @@ class PriceLevelList(object):
         succ_price = self._price_list[index]
         return self._price_level_dictionary[succ_price]
 
-    def prev_item(self, price):
+    def prev_item(self, price):  # type: (Price) -> PriceLevel
         """
         Returns the price level where price_level.price is predecessor to given price
 
@@ -52,7 +54,7 @@ class PriceLevelList(object):
         prev_price = self._price_list[index]
         return self._price_level_dictionary[prev_price]
 
-    def min_key(self):
+    def min_key(self):  # type: () -> Price
         """
         Return the lowest price in the price level list
 
@@ -60,7 +62,7 @@ class PriceLevelList(object):
         """
         return self._price_list[0]
 
-    def max_key(self):
+    def max_key(self):  # type: () -> Price
         """
         Return the highest price in the price level list
 
@@ -68,7 +70,7 @@ class PriceLevelList(object):
         """
         return self._price_list[-1]
 
-    def items(self, reverse=False):
+    def items(self, reverse=False):  # type: (bool) -> List[(Price, PriceLevel)]
         """
         Returns a sorted list (on price) of price_levels
 
@@ -84,7 +86,7 @@ class PriceLevelList(object):
                 items.append(self._price_level_dictionary[price])
         return items
 
-    def get_ticks_list(self):
+    def get_ticks_list(self):  # type: () -> List[Any]
         """
         Returns a list describing all ticks.
         :return: list

--- a/Tribler/community/market/core/pricelevel_list.py
+++ b/Tribler/community/market/core/pricelevel_list.py
@@ -1,5 +1,8 @@
-from typing import Any, Dict, List
+from __future__ import absolute_import
 
+from typing import Any, Dict, List  # pylint: disable=unused-import
+
+from Tribler.community.market.core.price import Price
 from Tribler.community.market.core.pricelevel import PriceLevel
 
 

--- a/Tribler/community/market/core/pricelevel_list.py
+++ b/Tribler/community/market/core/pricelevel_list.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from typing import Any, Dict, List  # pylint: disable=unused-import
 
-from Tribler.community.market.core.price import Price
+from Tribler.community.market.core.price import Price  # pylint: disable=unused-import
 from Tribler.community.market.core.pricelevel import PriceLevel
 
 


### PR DESCRIPTION
@devos50 @qstokkink @ichorid Just to get the sense of the changes required to add __typing__ to a file that is causing us some type-related issues...

__Tests on Mac__ is failing because we would need to __pip install typing__ on Python 2 (it is built-in in Python 3) and then add a __mypy__ test run to our builds.  https://mypy.readthedocs.io/en/latest/cheat_sheet.html