### PR TITLE
Fix str representation of OrderId and TransactionId

### DIFF
--- a/Tribler/community/market/core/order.py
+++ b/Tribler/community/market/core/order.py
@@ -88,7 +88,7 @@ class OrderId(object):
         """
         format: <trader_id>.<order_number>
         """
-        return "%s.%s" % (self._trader_id.to_bytes.decode('utf-8'), self._order_number)
+        return "%s.%s" % (self._trader_id.to_bytes().decode('utf-8'), self._order_number)
 
     def __eq__(self, other):
         if not isinstance(other, OrderId):

--- a/Tribler/community/market/core/order.py
+++ b/Tribler/community/market/core/order.py
@@ -10,6 +10,7 @@ from Tribler.community.market.core.message import TraderId
 from Tribler.community.market.core.timeout import Timeout
 from Tribler.community.market.core.timestamp import Timestamp
 from Tribler.pyipv8.ipv8.database import database_blob
+from Tribler.pyipv8.ipv8.util import cast_to_unicode
 
 
 class TickWasNotReserved(Exception):
@@ -88,7 +89,7 @@ class OrderId(object):
         """
         format: <trader_id>.<order_number>
         """
-        return "%s.%s" % (self._trader_id.to_bytes().decode('utf-8'), self._order_number)
+        return "%s.%d" % (cast_to_unicode(self._trader_id.to_bytes()), self._order_number)
 
     def __eq__(self, other):
         if not isinstance(other, OrderId):

--- a/Tribler/community/market/core/order.py
+++ b/Tribler/community/market/core/order.py
@@ -88,7 +88,7 @@ class OrderId(object):
         """
         format: <trader_id>.<order_number>
         """
-        return "%s.%s" % (self._trader_id.decode('utf-8'), self._order_number)
+        return "%s.%s" % (self._trader_id.to_bytes.decode('utf-8'), self._order_number)
 
     def __eq__(self, other):
         if not isinstance(other, OrderId):

--- a/Tribler/community/market/core/order.py
+++ b/Tribler/community/market/core/order.py
@@ -88,7 +88,7 @@ class OrderId(object):
         """
         format: <trader_id>.<order_number>
         """
-        return "%s.%s" % (self._trader_id, self._order_number)
+        return "%s.%s" % (self._trader_id.decode.('utf-8'), self._order_number)
 
     def __eq__(self, other):
         if not isinstance(other, OrderId):

--- a/Tribler/community/market/core/order.py
+++ b/Tribler/community/market/core/order.py
@@ -88,7 +88,7 @@ class OrderId(object):
         """
         format: <trader_id>.<order_number>
         """
-        return "%s.%s" % (self._trader_id.decode.('utf-8'), self._order_number)
+        return "%s.%s" % (self._trader_id.decode('utf-8'), self._order_number)
 
     def __eq__(self, other):
         if not isinstance(other, OrderId):

--- a/Tribler/community/market/core/transaction.py
+++ b/Tribler/community/market/core/transaction.py
@@ -84,7 +84,7 @@ class TransactionId(object):
         """
         format: <trader_id>.<transaction_number>
         """
-        return "%s.%s" % (self.trader_id.to_bytes.decode('utf-8'), self.transaction_number)
+        return "%s.%s" % (self.trader_id.to_bytes().decode('utf-8'), self.transaction_number)
 
     def __eq__(self, other):
         if not isinstance(other, TransactionId):

--- a/Tribler/community/market/core/transaction.py
+++ b/Tribler/community/market/core/transaction.py
@@ -84,7 +84,7 @@ class TransactionId(object):
         """
         format: <trader_id>.<transaction_number>
         """
-        return "%s.%s" % (self.trader_id.decode.('utf-8'), self.transaction_number)
+        return "%s.%s" % (self.trader_id.decode('utf-8'), self.transaction_number)
 
     def __eq__(self, other):
         if not isinstance(other, TransactionId):

--- a/Tribler/community/market/core/transaction.py
+++ b/Tribler/community/market/core/transaction.py
@@ -85,7 +85,7 @@ class TransactionId(object):
         """
         format: <trader_id>.<transaction_number>
         """
-        return "%s.%d" % (cast_to_unicode(self._trader_id.to_bytes()), self.transaction_number)
+        return "%s.%d" % (cast_to_unicode(self._trader_id.to_bytes()), self._transaction_number)
 
     def __eq__(self, other):
         if not isinstance(other, TransactionId):

--- a/Tribler/community/market/core/transaction.py
+++ b/Tribler/community/market/core/transaction.py
@@ -84,7 +84,7 @@ class TransactionId(object):
         """
         format: <trader_id>.<transaction_number>
         """
-        return "%s.%s" % (self.trader_id, self.transaction_number)
+        return "%s.%s" % (self.trader_id.decode.('utf-8'), self.transaction_number)
 
     def __eq__(self, other):
         if not isinstance(other, TransactionId):

--- a/Tribler/community/market/core/transaction.py
+++ b/Tribler/community/market/core/transaction.py
@@ -12,6 +12,7 @@ from Tribler.community.market.core.timestamp import Timestamp
 from Tribler.community.market.core.trade import ProposedTrade
 from Tribler.community.market.core.wallet_address import WalletAddress
 from Tribler.pyipv8.ipv8.database import database_blob
+from Tribler.pyipv8.ipv8.util import cast_to_unicode
 
 
 class TransactionNumber(object):
@@ -84,7 +85,7 @@ class TransactionId(object):
         """
         format: <trader_id>.<transaction_number>
         """
-        return "%s.%s" % (self.trader_id.to_bytes().decode('utf-8'), self.transaction_number)
+        return "%s.%d" % (cast_to_unicode(self._trader_id.to_bytes()), self.transaction_number)
 
     def __eq__(self, other):
         if not isinstance(other, TransactionId):

--- a/Tribler/community/market/core/transaction.py
+++ b/Tribler/community/market/core/transaction.py
@@ -84,7 +84,7 @@ class TransactionId(object):
         """
         format: <trader_id>.<transaction_number>
         """
-        return "%s.%s" % (self.trader_id.decode('utf-8'), self.transaction_number)
+        return "%s.%s" % (self.trader_id.to_bytes.decode('utf-8'), self.transaction_number)
 
     def __eq__(self, other):
         if not isinstance(other, TransactionId):


### PR DESCRIPTION
Fixes #4403
```
======================================================================
FAIL: test_str (Tribler.Test.Community.Market.test_order.OrderIDTestSuite)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/workspace/test_tribler_python3@2/tribler/Tribler/Test/Community/Market/test_order.py", line 198, in test_str
    self.assertEquals('0.1', str(self.order_id))
AssertionError: '0.1' != "b'0'.1"
- 0.1
+ b'0'.1


======================================================================
FAIL: test_conversion (Tribler.Test.Community.Market.test_transaction.TransactionIdTestSuite)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/workspace/test_tribler_python3@2/tribler/Tribler/Test/Community/Market/test_transaction.py", line 66, in test_conversion
    self.assertEqual('0.1', str(self.transaction_id))
AssertionError: '0.1' != "b'0'.1"
- 0.1
+ b'0'.1
```