### PR TITLE
TypeError: unsupported operand type for +: 'dict_keys' and 'dict_keys'

### DIFF
--- a/Tribler/community/triblertunnel/community.py
+++ b/Tribler/community/triblertunnel/community.py
@@ -481,7 +481,7 @@ class TriblerTunnelCommunity(HiddenTunnelCommunity):
                                                self.settings.max_circuits)
                                 for hop_count, download_count in active_downloads_per_hop.items()}
 
-        for info_hash in set(new_states.keys() + self.download_states.keys()):
+        for info_hash in set(list(new_states) + list(self.download_states)):
             new_state = new_states.get(info_hash, None)
             old_state = self.download_states.get(info_hash, None)
             state_changed = new_state != old_state


### PR DESCRIPTION
```
======================================================================
ERROR: Test whether we remove peers from the PEX info when a download is stopped
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/defer.py", line 151, in maybeDeferred
    result = f(*args, **kw)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 201, in runWithWarningsSuppressed
    reraise(exc_info[1], exc_info[2])
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/python/compat.py", line 464, in reraise
    raise exception.with_traceback(traceback)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 197, in runWithWarningsSuppressed
    result = f(*a, **kw)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/Community/Tunnel/test_community.py", line 179, in test_monitor_downloads_ih_pex
    self.nodes[0].overlay.monitor_downloads([])
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/community/triblertunnel/community.py", line 484, in monitor_downloads
    for info_hash in set(new_states.keys() + self.download_states.keys()):
TypeError: unsupported operand type(s) for +: 'dict_keys' and 'dict_keys'
======================================================================
ERROR: Test whether rendezvous points are removed when a download is stopped
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/defer.py", line 151, in maybeDeferred
    result = f(*args, **kw)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 201, in runWithWarningsSuppressed
    reraise(exc_info[1], exc_info[2])
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/python/compat.py", line 464, in reraise
    raise exception.with_traceback(traceback)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 197, in runWithWarningsSuppressed
    result = f(*a, **kw)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/Community/Tunnel/test_community.py", line 193, in test_monitor_downloads_intro
    self.nodes[0].overlay.monitor_downloads([])
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/community/triblertunnel/community.py", line 484, in monitor_downloads
    for info_hash in set(new_states.keys() + self.download_states.keys()):
TypeError: unsupported operand type(s) for +: 'dict_keys' and 'dict_keys'
======================================================================
ERROR: Test whether circuits are removed when all downloads are stopped
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/defer.py", line 151, in maybeDeferred
    result = f(*args, **kw)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 201, in runWithWarningsSuppressed
    reraise(exc_info[1], exc_info[2])
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/python/compat.py", line 464, in reraise
    raise exception.with_traceback(traceback)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 197, in runWithWarningsSuppressed
    result = f(*a, **kw)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/Community/Tunnel/test_community.py", line 207, in test_monitor_downloads_stop_all
    self.nodes[0].overlay.monitor_downloads([])
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/community/triblertunnel/community.py", line 484, in monitor_downloads
    for info_hash in set(new_states.keys() + self.download_states.keys()):
TypeError: unsupported operand type(s) for +: 'dict_keys' and 'dict_keys'
======================================================================
ERROR: Test whether we stop building IPs when a download doesn't exist anymore
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/defer.py", line 151, in maybeDeferred
    result = f(*args, **kw)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 201, in runWithWarningsSuppressed
    reraise(exc_info[1], exc_info[2])
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/python/compat.py", line 464, in reraise
    raise exception.with_traceback(traceback)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 197, in runWithWarningsSuppressed
    result = f(*a, **kw)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/Community/Tunnel/test_community.py", line 140, in test_monitor_downloads_stop_ip
    self.nodes[0].overlay.monitor_downloads([])
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/community/triblertunnel/community.py", line 484, in monitor_downloads
    for info_hash in set(new_states.keys() + self.download_states.keys()):
TypeError: unsupported operand type(s) for +: 'dict_keys' and 'dict_keys'
```