### PR TITLE
Join bytes, not strings

### DIFF
--- a/Tribler/Core/Socks5/conversion.py
+++ b/Tribler/Core/Socks5/conversion.py
@@ -212,7 +212,7 @@ def encode_reply(version, rep, rsv, address_type, bind_address, bind_port):
     return data
 
 
-def decode_udp_packet(data):
+def decode_udp_packet(data):  # type: (bytes) -> UdpRequest
     """
     Decodes a SOCKS5 UDP packet
     @param str data: the raw packet data
@@ -253,7 +253,7 @@ def encode_udp_packet(rsv, frag, address_type, address, port, payload):
         payload
     ]
 
-    return ''.join(strings)
+    return b''.join(strings)
 
 
 class IPV6AddrError(NotImplementedError):


### PR DESCRIPTION
```
======================================================================
ERROR: Test whether no data is sent to the SOCKS5 server when we receive data from the tunnels
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/defer.py", line 151, in maybeDeferred
    result = f(*args, **kw)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 201, in runWithWarningsSuppressed
    reraise(exc_info[1], exc_info[2])
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/python/compat.py", line 464, in reraise
    raise exception.with_traceback(traceback)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 197, in runWithWarningsSuppressed
    result = f(*a, **kw)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/test_as_server.py", line 62, in check
    result = fun(*argv, **kwargs)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/Community/Tunnel/test_dispatcher.py", line 55, in test_on_tunnel_in
    self.assertTrue(self.dispatcher.on_incoming_from_tunnel(self.mock_tunnel_community, mock_circuit, origin, 'a'))
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/community/triblertunnel/dispatcher.py", line 55, in on_incoming_from_tunnel
    0, 0, conversion.ADDRESS_TYPE_IPV4, origin[0], origin[1], data)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Core/Socks5/conversion.py", line 256, in encode_udp_packet
    return ''.join(strings)
TypeError: sequence item 0: expected str instance, bytes found
-------------------- >> begin captured logging << --------------------
TunnelDispatcher: ERROR: No socks server found for 300 hops
--------------------- >> end captured logging << ---------------------
```