### PR TITLE
unittest.TestCase().assertItemsEqual() --> assertCountEqual()

### DIFF
--- a/Tribler/Test/Core/CreditMining/test_credit_mining_policies.py
+++ b/Tribler/Test/Core/CreditMining/test_credit_mining_policies.py
@@ -27,12 +27,16 @@ class TestCreditMiningPolicies(TriblerCoreTest):
     def setUp(self):
         yield super(TestCreditMiningPolicies, self).setUp()
         self.torrents = [CreditMiningTorrent(i, 'test torrent %d' % i) for i in range(10)]
+        try:
+            self.assertCountEqual  # Python 3
+        except AttributeError:     # Python 2
+            self.assertCountEqual = self.assertItemsEqual
 
     def test_random_policy(self):
         policy = RandomPolicy()
 
         sorted_torrents = policy.sort(self.torrents)
-        self.assertItemsEqual(self.torrents, sorted_torrents, 'Arrays contains different torrents')
+        self.assertCountEqual(self.torrents, sorted_torrents, 'Arrays contains different torrents')
 
     def test_seederratio_policy(self):
         for i, torrent in enumerate(self.torrents):
@@ -44,7 +48,7 @@ class TestCreditMiningPolicies(TriblerCoreTest):
         sorted_torrents = policy.sort(self.torrents)
         expected_torrents = list(reversed(self.torrents))
 
-        self.assertItemsEqual(sorted_torrents, expected_torrents, 'Arrays contains different torrents')
+        self.assertCountEqual(sorted_torrents, expected_torrents, 'Arrays contains different torrents')
         self.assertListEqual(sorted_torrents, expected_torrents, 'Array is not sorted properly')
 
     def test_upload_based_policy_sort(self):
@@ -73,7 +77,7 @@ class TestCreditMiningPolicies(TriblerCoreTest):
         sorted_torrents1 = upload_policy.sort(torrent_collection1)
         expected_torrents1 = list(reversed(torrent_collection1))
 
-        self.assertItemsEqual(sorted_torrents1, expected_torrents1, 'Arrays contains different torrents')
+        self.assertCountEqual(sorted_torrents1, expected_torrents1, 'Arrays contains different torrents')
         self.assertListEqual(sorted_torrents1, expected_torrents1, 'Array is not sorted properly')
 
         # Test Investment policy
@@ -82,7 +86,7 @@ class TestCreditMiningPolicies(TriblerCoreTest):
         sorted_torrents2 = investment_policy.sort(torrent_collection2)
         expected_torrents2 = list(reversed(torrent_collection2))
 
-        self.assertItemsEqual(sorted_torrents2, expected_torrents2, 'Arrays contains different torrents')
+        self.assertCountEqual(sorted_torrents2, expected_torrents2, 'Arrays contains different torrents')
         self.assertListEqual(sorted_torrents2, expected_torrents2, 'Array is not sorted properly')
 
     def test_schedule_start(self):

--- a/Tribler/Test/Core/CreditMining/test_credit_mining_policies.py
+++ b/Tribler/Test/Core/CreditMining/test_credit_mining_policies.py
@@ -27,16 +27,12 @@ class TestCreditMiningPolicies(TriblerCoreTest):
     def setUp(self):
         yield super(TestCreditMiningPolicies, self).setUp()
         self.torrents = [CreditMiningTorrent(i, 'test torrent %d' % i) for i in range(10)]
-        try:
-            self.assertCountEqual  # Python 3
-        except AttributeError:     # Python 2
-            self.assertCountEqual = self.assertItemsEqual
 
     def test_random_policy(self):
         policy = RandomPolicy()
 
         sorted_torrents = policy.sort(self.torrents)
-        self.assertCountEqual(self.torrents, sorted_torrents, 'Arrays contains different torrents')
+        self.assertSetEqual(self.torrents, sorted_torrents, 'Arrays contains different torrents')
 
     def test_seederratio_policy(self):
         for i, torrent in enumerate(self.torrents):
@@ -48,7 +44,7 @@ class TestCreditMiningPolicies(TriblerCoreTest):
         sorted_torrents = policy.sort(self.torrents)
         expected_torrents = list(reversed(self.torrents))
 
-        self.assertCountEqual(sorted_torrents, expected_torrents, 'Arrays contains different torrents')
+        self.assertSetEqual(sorted_torrents, expected_torrents, 'Arrays contains different torrents')
         self.assertListEqual(sorted_torrents, expected_torrents, 'Array is not sorted properly')
 
     def test_upload_based_policy_sort(self):
@@ -77,7 +73,7 @@ class TestCreditMiningPolicies(TriblerCoreTest):
         sorted_torrents1 = upload_policy.sort(torrent_collection1)
         expected_torrents1 = list(reversed(torrent_collection1))
 
-        self.assertCountEqual(sorted_torrents1, expected_torrents1, 'Arrays contains different torrents')
+        self.assertSetEqual(sorted_torrents1, expected_torrents1, 'Arrays contains different torrents')
         self.assertListEqual(sorted_torrents1, expected_torrents1, 'Array is not sorted properly')
 
         # Test Investment policy
@@ -86,7 +82,7 @@ class TestCreditMiningPolicies(TriblerCoreTest):
         sorted_torrents2 = investment_policy.sort(torrent_collection2)
         expected_torrents2 = list(reversed(torrent_collection2))
 
-        self.assertCountEqual(sorted_torrents2, expected_torrents2, 'Arrays contains different torrents')
+        self.assertSetEqual(sorted_torrents2, expected_torrents2, 'Arrays contains different torrents')
         self.assertListEqual(sorted_torrents2, expected_torrents2, 'Array is not sorted properly')
 
     def test_schedule_start(self):

--- a/Tribler/Test/Core/CreditMining/test_credit_mining_policies.py
+++ b/Tribler/Test/Core/CreditMining/test_credit_mining_policies.py
@@ -27,12 +27,16 @@ class TestCreditMiningPolicies(TriblerCoreTest):
     def setUp(self):
         yield super(TestCreditMiningPolicies, self).setUp()
         self.torrents = [CreditMiningTorrent(i, 'test torrent %d' % i) for i in range(10)]
+        try:
+            self.assertCountEqual  # Python 3
+        except AttributeError:     # Python 2
+            self.assertCountEqual = self.assertItemsEqual
 
     def test_random_policy(self):
         policy = RandomPolicy()
 
         sorted_torrents = policy.sort(self.torrents)
-        self.assertSetEqual(self.torrents, sorted_torrents, 'Arrays contains different torrents')
+        self.assertCountEqual(self.torrents, sorted_torrents, 'Arrays contains different torrents')
 
     def test_seederratio_policy(self):
         for i, torrent in enumerate(self.torrents):
@@ -44,7 +48,7 @@ class TestCreditMiningPolicies(TriblerCoreTest):
         sorted_torrents = policy.sort(self.torrents)
         expected_torrents = list(reversed(self.torrents))
 
-        self.assertSetEqual(sorted_torrents, expected_torrents, 'Arrays contains different torrents')
+        self.assertCountEqual(sorted_torrents, expected_torrents, 'Arrays contains different torrents')
         self.assertListEqual(sorted_torrents, expected_torrents, 'Array is not sorted properly')
 
     def test_upload_based_policy_sort(self):
@@ -73,7 +77,7 @@ class TestCreditMiningPolicies(TriblerCoreTest):
         sorted_torrents1 = upload_policy.sort(torrent_collection1)
         expected_torrents1 = list(reversed(torrent_collection1))
 
-        self.assertSetEqual(sorted_torrents1, expected_torrents1, 'Arrays contains different torrents')
+        self.assertCountEqual(sorted_torrents1, expected_torrents1, 'Arrays contains different torrents')
         self.assertListEqual(sorted_torrents1, expected_torrents1, 'Array is not sorted properly')
 
         # Test Investment policy
@@ -82,7 +86,7 @@ class TestCreditMiningPolicies(TriblerCoreTest):
         sorted_torrents2 = investment_policy.sort(torrent_collection2)
         expected_torrents2 = list(reversed(torrent_collection2))
 
-        self.assertSetEqual(sorted_torrents2, expected_torrents2, 'Arrays contains different torrents')
+        self.assertCountEqual(sorted_torrents2, expected_torrents2, 'Arrays contains different torrents')
         self.assertListEqual(sorted_torrents2, expected_torrents2, 'Array is not sorted properly')
 
     def test_schedule_start(self):


### PR DESCRIPTION
* https://docs.python.org/2/library/unittest.html#unittest.TestCase.assertItemsEqual -->
* https://docs.python.org/3/library/unittest.html#unittest.TestCase.assertCountEqual
```
======================================================================
ERROR: test_random_policy
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/defer.py", line 1418, in _inlineCallbacks
    result = g.send(result)
StopIteration

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/defer.py", line 1418, in _inlineCallbacks
    result = g.send(result)
StopIteration

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/defer.py", line 151, in maybeDeferred
    result = f(*args, **kw)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 201, in runWithWarningsSuppressed
    reraise(exc_info[1], exc_info[2])
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/python/compat.py", line 464, in reraise
    raise exception.with_traceback(traceback)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 197, in runWithWarningsSuppressed
    result = f(*a, **kw)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/test_as_server.py", line 62, in check
    result = fun(*argv, **kwargs)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/Core/CreditMining/test_credit_mining_policies.py", line 35, in test_random_policy
    self.assertItemsEqual(self.torrents, sorted_torrents, 'Arrays contains different torrents')
AttributeError: 'TestCreditMiningPolicies' object has no attribute 'assertItemsEqual'

======================================================================
ERROR: test_seederratio_policy
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/defer.py", line 1418, in _inlineCallbacks
    result = g.send(result)
StopIteration

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/defer.py", line 1418, in _inlineCallbacks
    result = g.send(result)
StopIteration

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/defer.py", line 151, in maybeDeferred
    result = f(*args, **kw)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 201, in runWithWarningsSuppressed
    reraise(exc_info[1], exc_info[2])
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/python/compat.py", line 464, in reraise
    raise exception.with_traceback(traceback)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 197, in runWithWarningsSuppressed
    result = f(*a, **kw)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/test_as_server.py", line 62, in check
    result = fun(*argv, **kwargs)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/Core/CreditMining/test_credit_mining_policies.py", line 47, in test_seederratio_policy
    self.assertItemsEqual(sorted_torrents, expected_torrents, 'Arrays contains different torrents')
AttributeError: 'TestCreditMiningPolicies' object has no attribute 'assertItemsEqual'

======================================================================
ERROR: Tests both UploadPolicy and InvestmentPolicy since they both sorts torrents based on upload.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/defer.py", line 1418, in _inlineCallbacks
    result = g.send(result)
StopIteration

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/defer.py", line 1418, in _inlineCallbacks
    result = g.send(result)
StopIteration

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/defer.py", line 151, in maybeDeferred
    result = f(*args, **kw)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 201, in runWithWarningsSuppressed
    reraise(exc_info[1], exc_info[2])
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/python/compat.py", line 464, in reraise
    raise exception.with_traceback(traceback)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/internet/utils.py", line 197, in runWithWarningsSuppressed
    result = f(*a, **kw)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/test_as_server.py", line 62, in check
    result = fun(*argv, **kwargs)
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/Core/CreditMining/test_credit_mining_policies.py", line 76, in test_upload_based_policy_sort
    self.assertItemsEqual(sorted_torrents1, expected_torrents1, 'Arrays contains different torrents')
AttributeError: 'TestCreditMiningPolicies' object has no attribute 'assertItemsEqual'
```