### PR TITLE
Make sure qwindows.dll is in the right location

### DIFF
--- a/tribler.spec
+++ b/tribler.spec
@@ -99,3 +99,7 @@ shutil.rmtree(os.path.join(DISTPATH, 'tribler', 'tribler_source', 'Tribler', 'Te
 # Replace the Info.plist file on MacOS
 if sys.platform == 'darwin':
     shutil.copy('Tribler/Main/Build/Mac/Info.plist', 'dist/Tribler.app/Contents/Info.plist')
+
+# On Windows 10, we have to make sure that qwindows.dll is in the right path
+if sys.platform == 'win32':
+    shutil.copytree(os.path.join('dist', 'tribler', 'PyQt5', 'Qt', 'plugins', 'platforms'), os.path.join('dist', 'tribler', 'platforms'))


### PR DESCRIPTION
Also see https://stackoverflow.com/questions/47468705/pyinstaller-could-not-find-or-load-the-qt-platform-plugin-windows