### PR TITLE
Class advice impossible in Python3.  Use @implementer class decorator

### DIFF
--- a/Tribler/Test/Core/Modules/RestApi/base_api_test.py
+++ b/Tribler/Test/Core/Modules/RestApi/base_api_test.py
@@ -9,7 +9,7 @@ from twisted.web.client import Agent, HTTPConnectionPool, readBody
 from twisted.web.http_headers import Headers
 from twisted.web.iweb import IBodyProducer
 
-from zope.interface import implements
+from zope.interface import implementer
 
 import Tribler.Core.Utilities.json_util as json
 from Tribler.Core.Modules.restapi import get_param
@@ -20,12 +20,11 @@ from Tribler.Test.test_as_server import TestAsServer
 from TriblerGUI.tribler_request_manager import tribler_urlencode
 
 
+@implementer(IBodyProducer)
 class POSTDataProducer(object):
     """
     This class is used for posting data by the requests made during the tests.
     """
-    implements(IBodyProducer)
-
     def __init__(self, data_dict, raw_data):
         self.body = {}
         if data_dict and not raw_data:


### PR DESCRIPTION
This raise 18 ERRORS like...
```
======================================================================
ERROR: Failure: TypeError (Class advice impossible in Python3.  Use the @implementer class decorator instead.)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/nose/failure.py", line 39, in runTest
    raise self.exc_val.with_traceback(self.tb)
  File "/usr/lib/python3/dist-packages/nose/loader.py", line 418, in loadTestsFromName
    addr.filename, addr.module)
  File "/usr/lib/python3/dist-packages/nose/importer.py", line 47, in importFromPath
    return self.importFromDir(dir_path, fqname)
  File "/usr/lib/python3/dist-packages/nose/importer.py", line 94, in importFromDir
    mod = load_module(part_fqname, fh, filename, desc)
  File "/usr/lib/python3.5/imp.py", line 234, in load_module
    return load_source(name, filename, file)
  File "/usr/lib/python3.5/imp.py", line 172, in load_source
    module = _load(spec)
  File "<frozen importlib._bootstrap>", line 693, in _load
  File "<frozen importlib._bootstrap>", line 673, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 673, in exec_module
  File "<frozen importlib._bootstrap>", line 222, in _call_with_frames_removed
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/Core/Modules/RestApi/test_shutdown_endpoint.py", line 3, in <module>
    from Tribler.Test.Core.Modules.RestApi.base_api_test import AbstractApiTest
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/Core/Modules/RestApi/base_api_test.py", line 23, in <module>
    class POSTDataProducer(object):
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Test/Core/Modules/RestApi/base_api_test.py", line 27, in POSTDataProducer
    implements(IBodyProducer)
  File "/home/jenkins/.local/lib/python3.5/site-packages/zope/interface/declarations.py", line 483, in implements
    raise TypeError(_ADVICE_ERROR % 'implementer')
TypeError: Class advice impossible in Python3.  Use the @implementer class decorator instead.
```