### PR TITLE
Added random torrent health check to TorrentChecker

### DIFF
--- a/Tribler/Core/Session.py
+++ b/Tribler/Core/Session.py
@@ -541,7 +541,7 @@ class Session(object):
         :param scrape_now: flag to scrape immediately
         """
         if self.lm.torrent_checker:
-            return self.lm.torrent_checker.add_gui_request(infohash, timeout=timeout, scrape_now=scrape_now)
+            return self.lm.torrent_checker.check_torrent_health(infohash, timeout=timeout, scrape_now=scrape_now)
         return fail(Failure(RuntimeError("Torrent checker not available")))
 
     def notify_shutdown_state(self, state):


### PR DESCRIPTION
In this PR, I added a loop that checks the health of a random torrent every 2 minutes. This ensures that the health of trackless torrents is also determined eventually. Addresses #4256.

I Also refactored some attributes in the TorrentChecker class.