### PR TITLE
Made the MarketCommunity Python 3 compatible

### DIFF
--- a/Tribler/Core/Modules/restapi/market/asks_bids_endpoint.py
+++ b/Tribler/Core/Modules/restapi/market/asks_bids_endpoint.py
@@ -129,7 +129,7 @@ class AsksEndpoint(BaseAsksBidsEndpoint):
             if not request.finished:
                 request.write(json.dumps({
                     'assets': ask.assets.to_dictionary(),
-                    'timestamp': float(ask.timestamp),
+                    'timestamp': int(ask.timestamp),
                     'trader_id': ask.order_id.trader_id.as_hex(),
                     'order_number': int(ask.order_id.order_number),
                     'timeout': int(ask.timeout)
@@ -236,7 +236,7 @@ class BidsEndpoint(BaseAsksBidsEndpoint):
             if not request.finished:
                 request.write(json.dumps({
                     'assets': bid.assets.to_dictionary(),
-                    'timestamp': float(bid.timestamp),
+                    'timestamp': int(bid.timestamp),
                     'trader_id': bid.order_id.trader_id.as_hex(),
                     'order_number': int(bid.order_id.order_number),
                     'timeout': int(bid.timeout)

--- a/Tribler/Core/Modules/restapi/market/asks_bids_endpoint.py
+++ b/Tribler/Core/Modules/restapi/market/asks_bids_endpoint.py
@@ -130,7 +130,7 @@ class AsksEndpoint(BaseAsksBidsEndpoint):
                 request.write(json.dumps({
                     'assets': ask.assets.to_dictionary(),
                     'timestamp': float(ask.timestamp),
-                    'trader_id': str(ask.order_id.trader_id),
+                    'trader_id': ask.order_id.trader_id.as_hex(),
                     'order_number': int(ask.order_id.order_number),
                     'timeout': int(ask.timeout)
                 }))
@@ -237,7 +237,7 @@ class BidsEndpoint(BaseAsksBidsEndpoint):
                 request.write(json.dumps({
                     'assets': bid.assets.to_dictionary(),
                     'timestamp': float(bid.timestamp),
-                    'trader_id': str(bid.order_id.trader_id),
+                    'trader_id': bid.order_id.trader_id.as_hex(),
                     'order_number': int(bid.order_id.order_number),
                     'timeout': int(bid.timeout)
                 }))

--- a/Tribler/Core/Modules/restapi/market/transactions_endpoint.py
+++ b/Tribler/Core/Modules/restapi/market/transactions_endpoint.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+from binascii import unhexlify
+
 from twisted.web import http
 
 import Tribler.Core.Utilities.json_util as json
@@ -139,7 +141,7 @@ class TransactionPaymentsEndpoint(BaseMarketEndpoint):
                     ]
                 }
         """
-        transaction_id = TransactionId(TraderId(self.transaction_trader_id),
+        transaction_id = TransactionId(TraderId(unhexlify(self.transaction_trader_id)),
                                        TransactionNumber(int(self.transaction_number)))
         transaction = self.get_market_community().transaction_manager.find_by_id(transaction_id)
 

--- a/Tribler/Core/Modules/wallet/tc_wallet.py
+++ b/Tribler/Core/Modules/wallet/tc_wallet.py
@@ -141,7 +141,7 @@ class TrustchainWallet(Wallet, BlockListener):
         return monitor_deferred
 
     def get_address(self):
-        return b64encode(self.trustchain.my_peer.public_key.key_to_bin())
+        return b64encode(self.trustchain.my_peer.public_key.key_to_bin()).decode('utf-8')
 
     def get_transactions(self):
         return succeed(self.transaction_history)

--- a/Tribler/Core/Modules/wallet/tc_wallet.py
+++ b/Tribler/Core/Modules/wallet/tc_wallet.py
@@ -3,11 +3,11 @@ from __future__ import absolute_import, division
 from base64 import b64encode
 from binascii import hexlify, unhexlify
 
-from twisted.internet.defer import succeed, fail, Deferred
+from twisted.internet.defer import Deferred, fail, succeed
 from twisted.internet.task import LoopingCall
 
 from Tribler.Core.Modules.wallet.bandwidth_block import TriblerBandwidthBlock
-from Tribler.Core.Modules.wallet.wallet import Wallet, InsufficientFunds
+from Tribler.Core.Modules.wallet.wallet import InsufficientFunds, Wallet
 from Tribler.pyipv8.ipv8.attestation.trustchain.listener import BlockListener
 from Tribler.pyipv8.ipv8.keyvault.crypto import ECCrypto
 from Tribler.pyipv8.ipv8.peer import Peer

--- a/Tribler/Core/Modules/wallet/tc_wallet.py
+++ b/Tribler/Core/Modules/wallet/tc_wallet.py
@@ -97,7 +97,7 @@ class TrustchainWallet(Wallet, BlockListener):
         addCallback(deferred, lambda _: None)
         latest_block = self.trustchain.persistence.get_latest(self.trustchain.my_peer.public_key.key_to_bin(),
                                                               block_type=b'tribler_bandwidth')
-        txid = "%s.%s.%d.%d" % (hexlify(latest_block.public_key),
+        txid = "%s.%s.%d.%d" % (hexlify(latest_block.public_key).decode('utf-8'),
                                 latest_block.sequence_number, 0, int(quantity * MEGA_DIV))
 
         self.transaction_history.append({
@@ -118,7 +118,7 @@ class TrustchainWallet(Wallet, BlockListener):
         """
         Monitor an incoming transaction with a specific id.
         """
-        pub_key, sequence_number = payment_id.split(b'.')[:2]
+        pub_key, sequence_number = payment_id.split('.')[:2]
         pub_key = unhexlify(pub_key)
         sequence_number = int(sequence_number)
 

--- a/Tribler/Test/Community/Market/Reputation/test_reputation_base.py
+++ b/Tribler/Test/Community/Market/Reputation/test_reputation_base.py
@@ -35,6 +35,6 @@ class TestReputationBase(AbstractServer):
     def compute_reputations(self):
         blocks = self.market_db.get_all_blocks()
         rep_manager = TemporalPagerankReputationManager(blocks)
-        rep = rep_manager.compute(own_public_key='a')
+        rep = rep_manager.compute(own_public_key=b'a')
         self.assertIsInstance(rep, dict)
         return rep

--- a/Tribler/Test/Community/Market/test_assetpair.py
+++ b/Tribler/Test/Community/Market/test_assetpair.py
@@ -26,8 +26,8 @@ class TestAssetPair(unittest.TestCase):
         """
         Test the equality method of an AssetPair
         """
-        self.assertTrue(self.assetpair1 != self.assetpair3)
         self.assertFalse(self.assetpair1 == self.assetpair2)
+        self.assertTrue(self.assetpair1 == self.assetpair3)
 
     def test_to_dictionary(self):
         """

--- a/Tribler/Test/Community/Market/test_block.py
+++ b/Tribler/Test/Community/Market/test_block.py
@@ -24,13 +24,13 @@ class TestMarketBlock(AbstractServer):
         yield super(TestMarketBlock, self).setUp()
 
         self.ask = Ask(OrderId(TraderId(b'0' * 20), OrderNumber(1)),
-                       AssetPair(AssetAmount(30, 'BTC'), AssetAmount(30, 'MB')), Timeout(30), Timestamp(0.0), True)
+                       AssetPair(AssetAmount(30, 'BTC'), AssetAmount(30, 'MB')), Timeout(30), Timestamp(0), True)
         self.bid = Ask(OrderId(TraderId(b'1' * 20), OrderNumber(1)),
-                       AssetPair(AssetAmount(30, 'BTC'), AssetAmount(30, 'MB')), Timeout(30), Timestamp(0.0), False)
+                       AssetPair(AssetAmount(30, 'BTC'), AssetAmount(30, 'MB')), Timeout(30), Timestamp(0), False)
         self.transaction = Transaction(TransactionId(TraderId(b'0' * 20), TransactionNumber(1)),
                                        AssetPair(AssetAmount(30, 'BTC'), AssetAmount(30, 'MB')),
                                        OrderId(TraderId(b'0' * 20), OrderNumber(1)),
-                                       OrderId(TraderId(b'1' * 20), OrderNumber(1)), Timestamp(0.0))
+                                       OrderId(TraderId(b'1' * 20), OrderNumber(1)), Timestamp(0))
 
         ask_tx = self.ask.to_block_dict()
         bid_tx = self.bid.to_block_dict()
@@ -61,7 +61,7 @@ class TestMarketBlock(AbstractServer):
             'payment_id': 'a',
             'address_from': 'a',
             'address_to': 'b',
-            'timestamp': 1234.3,
+            'timestamp': 1234,
             'success': True
         }
         self.payment_block = MarketBlock()

--- a/Tribler/Test/Community/Market/test_block.py
+++ b/Tribler/Test/Community/Market/test_block.py
@@ -23,14 +23,14 @@ class TestMarketBlock(AbstractServer):
     def setUp(self):
         yield super(TestMarketBlock, self).setUp()
 
-        self.ask = Ask(OrderId(TraderId(b'0' * 40), OrderNumber(1)),
+        self.ask = Ask(OrderId(TraderId(b'0' * 20), OrderNumber(1)),
                        AssetPair(AssetAmount(30, 'BTC'), AssetAmount(30, 'MB')), Timeout(30), Timestamp(0.0), True)
-        self.bid = Ask(OrderId(TraderId(b'1' * 40), OrderNumber(1)),
+        self.bid = Ask(OrderId(TraderId(b'1' * 20), OrderNumber(1)),
                        AssetPair(AssetAmount(30, 'BTC'), AssetAmount(30, 'MB')), Timeout(30), Timestamp(0.0), False)
-        self.transaction = Transaction(TransactionId(TraderId(b'0' * 40), TransactionNumber(1)),
+        self.transaction = Transaction(TransactionId(TraderId(b'0' * 20), TransactionNumber(1)),
                                        AssetPair(AssetAmount(30, 'BTC'), AssetAmount(30, 'MB')),
-                                       OrderId(TraderId(b'0' * 40), OrderNumber(1)),
-                                       OrderId(TraderId(b'1' * 40), OrderNumber(1)), Timestamp(0.0))
+                                       OrderId(TraderId(b'0' * 20), OrderNumber(1)),
+                                       OrderId(TraderId(b'1' * 20), OrderNumber(1)), Timestamp(0.0))
 
         ask_tx = self.ask.to_block_dict()
         bid_tx = self.bid.to_block_dict()
@@ -41,7 +41,7 @@ class TestMarketBlock(AbstractServer):
 
         self.cancel_block = MarketBlock()
         self.cancel_block.type = 'cancel_order'
-        self.cancel_block.transaction = {'trader_id': 'a' * 40, 'order_number': 1}
+        self.cancel_block.transaction = {'trader_id': 'a' * 20, 'order_number': 1}
 
         self.tx_block = MarketBlock()
         self.tx_block.type = 'tx_init'
@@ -93,7 +93,7 @@ class TestMarketBlock(AbstractServer):
         self.assertFalse(self.tick_block.is_valid_tick_block())
 
         self.tick_block.transaction['tick']['timeout'] = 300
-        self.tick_block.transaction['tick']['trader_id'] = 'g' * 40
+        self.tick_block.transaction['tick']['trader_id'] = 'g' * 21
         self.assertFalse(self.tick_block.is_valid_tick_block())
 
         # Make the asset pair invalid

--- a/Tribler/Test/Community/Market/test_block.py
+++ b/Tribler/Test/Community/Market/test_block.py
@@ -36,15 +36,15 @@ class TestMarketBlock(AbstractServer):
         bid_tx = self.bid.to_block_dict()
 
         self.tick_block = MarketBlock()
-        self.tick_block.type = 'ask'
+        self.tick_block.type = b'ask'
         self.tick_block.transaction = {'tick': ask_tx}
 
         self.cancel_block = MarketBlock()
-        self.cancel_block.type = 'cancel_order'
+        self.cancel_block.type = b'cancel_order'
         self.cancel_block.transaction = {'trader_id': 'a' * 20, 'order_number': 1}
 
         self.tx_block = MarketBlock()
-        self.tx_block.type = 'tx_init'
+        self.tx_block.type = b'tx_init'
         self.tx_block.transaction = {
             'ask': ask_tx,
             'bid': bid_tx,
@@ -65,7 +65,7 @@ class TestMarketBlock(AbstractServer):
             'success': True
         }
         self.payment_block = MarketBlock()
-        self.payment_block.type = 'tx_payment'
+        self.payment_block.type = b'tx_payment'
         self.payment_block.transaction = {'payment': payment}
 
     def test_tick_block(self):
@@ -78,10 +78,10 @@ class TestMarketBlock(AbstractServer):
         self.assertFalse(self.tick_block.is_valid_tick_block())
         self.tick_block.transaction['tick']['timeout'] = 3600
 
-        self.tick_block.type = 'test'
+        self.tick_block.type = b'test'
         self.assertFalse(self.tick_block.is_valid_tick_block())
 
-        self.tick_block.type = 'ask'
+        self.tick_block.type = b'ask'
         self.tick_block.transaction['test'] = self.tick_block.transaction.pop('tick')
         self.assertFalse(self.tick_block.is_valid_tick_block())
 
@@ -127,10 +127,10 @@ class TestMarketBlock(AbstractServer):
         """
         self.assertTrue(self.cancel_block.is_valid_cancel_block())
 
-        self.cancel_block.type = 'cancel'
+        self.cancel_block.type = b'cancel'
         self.assertFalse(self.cancel_block.is_valid_cancel_block())
 
-        self.cancel_block.type = 'cancel_order'
+        self.cancel_block.type = b'cancel_order'
         self.cancel_block.transaction.pop('trader_id')
         self.assertFalse(self.cancel_block.is_valid_cancel_block())
 
@@ -143,10 +143,10 @@ class TestMarketBlock(AbstractServer):
         """
         self.assertTrue(self.tx_block.is_valid_tx_init_done_block())
 
-        self.tx_block.type = 'test'
+        self.tx_block.type = b'test'
         self.assertFalse(self.tx_block.is_valid_tx_init_done_block())
 
-        self.tx_block.type = 'tx_init'
+        self.tx_block.type = b'tx_init'
         self.tx_block.transaction['test'] = self.tx_block.transaction.pop('ask')
         self.assertFalse(self.tx_block.is_valid_tx_init_done_block())
 
@@ -188,10 +188,10 @@ class TestMarketBlock(AbstractServer):
         """
         self.assertTrue(self.payment_block.is_valid_tx_payment_block())
 
-        self.payment_block.type = 'test'
+        self.payment_block.type = b'test'
         self.assertFalse(self.payment_block.is_valid_tx_payment_block())
 
-        self.payment_block.type = 'tx_payment'
+        self.payment_block.type = b'tx_payment'
         self.payment_block.transaction['test'] = self.payment_block.transaction.pop('payment')
         self.assertFalse(self.payment_block.is_valid_tx_payment_block())
 

--- a/Tribler/Test/Community/Market/test_community.py
+++ b/Tribler/Test/Community/Market/test_community.py
@@ -460,7 +460,7 @@ class TestMarketCommunitySingle(TestMarketCommunityBase):
         tx = Transaction(TransactionId(TraderId(b'0' * 20), TransactionNumber(1)),
                          AssetPair(AssetAmount(traded_amount, 'BTC'), AssetAmount(traded_amount, 'MB')),
                          OrderId(TraderId(b'0' * 20), OrderNumber(1)),
-                         OrderId(TraderId(b'1' * 20), OrderNumber(1)), Timestamp(0.0))
+                         OrderId(TraderId(b'1' * 20), OrderNumber(1)), Timestamp(0))
         tx.transferred_assets.first += AssetAmount(traded_amount, 'BTC')
         tx.transferred_assets.second += AssetAmount(traded_amount, 'MB')
         tx_done_block = MarketBlock()

--- a/Tribler/Test/Community/Market/test_community.py
+++ b/Tribler/Test/Community/Market/test_community.py
@@ -445,7 +445,7 @@ class TestMarketCommunitySingle(TestMarketCommunityBase):
         ask_tx = ask.to_block_dict()
         ask_tx["address"], ask_tx["port"] = "127.0.0.1", 1337
         tick_block = MarketBlock()
-        tick_block.type = 'ask' if return_ask else 'bid'
+        tick_block.type = b'ask' if return_ask else b'bid'
         tick_block.transaction = {'tick': ask_tx, 'version': MarketCommunity.PROTOCOL_VERSION}
         return tick_block
 
@@ -464,7 +464,7 @@ class TestMarketCommunitySingle(TestMarketCommunityBase):
         tx.transferred_assets.first += AssetAmount(traded_amount, 'BTC')
         tx.transferred_assets.second += AssetAmount(traded_amount, 'MB')
         tx_done_block = MarketBlock()
-        tx_done_block.type = 'tx_done'
+        tx_done_block.type = b'tx_done'
         tx_done_block.transaction = {
             'ask': ask.to_status_dictionary(),
             'bid': bid.to_status_dictionary(),

--- a/Tribler/Test/Community/Market/test_community.py
+++ b/Tribler/Test/Community/Market/test_community.py
@@ -475,15 +475,6 @@ class TestMarketCommunitySingle(TestMarketCommunityBase):
         tx_done_block.transaction['bid']['address'], tx_done_block.transaction['bid']['port'] = "1.1.1.1", 1234
         return tx_done_block
 
-    def test_initialize_traders(self):
-        """
-        Test whether we can successfully load information of traders from the database when starting the market
-        """
-        self.assertFalse(self.nodes[0].overlay.mid_register)
-        self.nodes[0].overlay.market_database.add_trader_identity(TraderId(b'1' * 20), "127.0.0.1", 1234)
-        self.nodes[0].overlay.initialize_traders()
-        self.assertTrue(self.nodes[0].overlay.mid_register)
-
     def test_insert_ask_bid(self):
         """
         Test whether an ask is successfully inserted when a tick block is received

--- a/Tribler/Test/Community/Market/test_community.py
+++ b/Tribler/Test/Community/Market/test_community.py
@@ -441,7 +441,7 @@ class TestMarketCommunitySingle(TestMarketCommunityBase):
     @staticmethod
     def get_tick_block(return_ask, pair):
         tick_cls = Ask if return_ask else Bid
-        ask = tick_cls(OrderId(TraderId(b'0' * 40), OrderNumber(1)), pair, Timeout(3600), Timestamp.now(), return_ask)
+        ask = tick_cls(OrderId(TraderId(b'0' * 20), OrderNumber(1)), pair, Timeout(3600), Timestamp.now(), return_ask)
         ask_tx = ask.to_block_dict()
         ask_tx["address"], ask_tx["port"] = "127.0.0.1", 1337
         tick_block = MarketBlock()
@@ -453,14 +453,14 @@ class TestMarketCommunitySingle(TestMarketCommunityBase):
     def get_tx_done_block(ask_amount, bid_amount, traded_amount, ask_total_traded, bid_total_traded):
         ask_pair = AssetPair(AssetAmount(ask_amount, 'BTC'), AssetAmount(ask_amount, 'MB'))
         bid_pair = AssetPair(AssetAmount(bid_amount, 'BTC'), AssetAmount(bid_amount, 'MB'))
-        ask = Order(OrderId(TraderId(b'0' * 40), OrderNumber(1)), ask_pair, Timeout(3600), Timestamp.now(), True)
+        ask = Order(OrderId(TraderId(b'0' * 20), OrderNumber(1)), ask_pair, Timeout(3600), Timestamp.now(), True)
         ask._traded_quantity = ask_total_traded
-        bid = Order(OrderId(TraderId(b'1' * 40), OrderNumber(1)), bid_pair, Timeout(3600), Timestamp.now(), False)
+        bid = Order(OrderId(TraderId(b'1' * 20), OrderNumber(1)), bid_pair, Timeout(3600), Timestamp.now(), False)
         bid._traded_quantity = bid_total_traded
-        tx = Transaction(TransactionId(TraderId(b'0' * 40), TransactionNumber(1)),
+        tx = Transaction(TransactionId(TraderId(b'0' * 20), TransactionNumber(1)),
                          AssetPair(AssetAmount(traded_amount, 'BTC'), AssetAmount(traded_amount, 'MB')),
-                         OrderId(TraderId(b'0' * 40), OrderNumber(1)),
-                         OrderId(TraderId(b'1' * 40), OrderNumber(1)), Timestamp(0.0))
+                         OrderId(TraderId(b'0' * 20), OrderNumber(1)),
+                         OrderId(TraderId(b'1' * 20), OrderNumber(1)), Timestamp(0.0))
         tx.transferred_assets.first += AssetAmount(traded_amount, 'BTC')
         tx.transferred_assets.second += AssetAmount(traded_amount, 'MB')
         tx_done_block = MarketBlock()
@@ -480,7 +480,7 @@ class TestMarketCommunitySingle(TestMarketCommunityBase):
         Test whether we can successfully load information of traders from the database when starting the market
         """
         self.assertFalse(self.nodes[0].overlay.mid_register)
-        self.nodes[0].overlay.market_database.add_trader_identity(TraderId(b'1'), "127.0.0.1", 1234)
+        self.nodes[0].overlay.market_database.add_trader_identity(TraderId(b'1' * 20), "127.0.0.1", 1234)
         self.nodes[0].overlay.initialize_traders()
         self.assertTrue(self.nodes[0].overlay.mid_register)
 

--- a/Tribler/Test/Community/Market/test_database.py
+++ b/Tribler/Test/Community/Market/test_database.py
@@ -177,15 +177,6 @@ class TestDatabase(AbstractServer):
         self.database.delete_all_ticks()
         self.assertEqual(len(self.database.get_ticks()), 0)
 
-    def test_add_get_trader_identity(self):
-        """
-        Test the addition and retrieval of a trader identity in the database
-        """
-        self.database.add_trader_identity(TraderId(b'a' * 20), "123", 1234)
-        self.database.add_trader_identity(TraderId(b'b' * 20), "124", 1235)
-        traders = self.database.get_traders()
-        self.assertEqual(len(traders), 2)
-
     def test_check_database(self):
         """
         Test the check of the database

--- a/Tribler/Test/Community/Market/test_database.py
+++ b/Tribler/Test/Community/Market/test_database.py
@@ -33,20 +33,20 @@ class TestDatabase(AbstractServer):
 
         self.database = MarketDB(self.getStateDir(), 'market')
 
-        self.order_id1 = OrderId(TraderId(b'3'), OrderNumber(4))
-        self.order_id2 = OrderId(TraderId(b'4'), OrderNumber(5))
+        self.order_id1 = OrderId(TraderId(b'3' * 20), OrderNumber(4))
+        self.order_id2 = OrderId(TraderId(b'4' * 20), OrderNumber(5))
         self.order1 = Order(self.order_id1, AssetPair(AssetAmount(5, 'BTC'), AssetAmount(6, 'EUR')),
                             Timeout(3600), Timestamp.now(), True)
         self.order2 = Order(self.order_id2, AssetPair(AssetAmount(5, 'BTC'), AssetAmount(6, 'EUR')),
                             Timeout(3600), Timestamp.now(), False)
-        self.order2.reserve_quantity_for_tick(OrderId(TraderId(b'3'), OrderNumber(4)), 3)
+        self.order2.reserve_quantity_for_tick(OrderId(TraderId(b'3' * 20), OrderNumber(4)), 3)
 
-        self.transaction_id1 = TransactionId(TraderId(b"0"), TransactionNumber(4))
+        self.transaction_id1 = TransactionId(TraderId(b'0' * 20), TransactionNumber(4))
         self.transaction1 = Transaction(self.transaction_id1, AssetPair(AssetAmount(100, 'BTC'), AssetAmount(30, 'MB')),
-                                        OrderId(TraderId(b"0"), OrderNumber(1)),
-                                        OrderId(TraderId(b"1"), OrderNumber(2)), Timestamp(20.0))
+                                        OrderId(TraderId(b'0' * 20), OrderNumber(1)),
+                                        OrderId(TraderId(b'1' * 20), OrderNumber(2)), Timestamp(20.0))
 
-        self.payment1 = Payment(TraderId(b"0"), self.transaction_id1, AssetAmount(5, 'BTC'),
+        self.payment1 = Payment(TraderId(b'0' * 20), self.transaction_id1, AssetAmount(5, 'BTC'),
                                 WalletAddress('abc'), WalletAddress('def'), PaymentId("abc"), Timestamp(20.0), False)
 
         self.transaction1.add_payment(self.payment1)
@@ -64,7 +64,7 @@ class TestDatabase(AbstractServer):
         """
         Test the retrieval of a specific order
         """
-        order_id = OrderId(TraderId(b'3'), OrderNumber(4))
+        order_id = OrderId(TraderId(b'3' * 20), OrderNumber(4))
         self.assertIsNone(self.database.get_order(order_id))
         self.database.add_order(self.order1)
         self.assertIsNotNone(self.database.get_order(order_id))
@@ -133,7 +133,7 @@ class TestDatabase(AbstractServer):
         """
         Test the retrieval of a specific transaction
         """
-        transaction_id = TransactionId(TraderId(b'0'), TransactionNumber(4))
+        transaction_id = TransactionId(TraderId(b'0' * 20), TransactionNumber(4))
         self.assertIsNone(self.database.get_transaction(transaction_id))
         self.database.add_transaction(self.transaction1)
         self.assertIsNotNone(self.database.get_transaction(transaction_id))
@@ -181,8 +181,8 @@ class TestDatabase(AbstractServer):
         """
         Test the addition and retrieval of a trader identity in the database
         """
-        self.database.add_trader_identity(TraderId(b"a"), "123", 1234)
-        self.database.add_trader_identity(TraderId(b"b"), "124", 1235)
+        self.database.add_trader_identity(TraderId(b'a' * 20), "123", 1234)
+        self.database.add_trader_identity(TraderId(b'b' * 20), "124", 1235)
         traders = self.database.get_traders()
         self.assertEqual(len(traders), 2)
 
@@ -203,4 +203,4 @@ class TestDatabase(AbstractServer):
         self.database.execute(u"DROP TABLE ticks;")
         self.database.execute(u"CREATE TABLE orders(x INTEGER PRIMARY KEY ASC);")
         self.database.execute(u"CREATE TABLE ticks(x INTEGER PRIMARY KEY ASC);")
-        self.assertEqual(self.database.check_database(u"1"), 3)
+        self.assertEqual(self.database.check_database(u"1"), 4)

--- a/Tribler/Test/Community/Market/test_database.py
+++ b/Tribler/Test/Community/Market/test_database.py
@@ -44,10 +44,10 @@ class TestDatabase(AbstractServer):
         self.transaction_id1 = TransactionId(TraderId(b'0' * 20), TransactionNumber(4))
         self.transaction1 = Transaction(self.transaction_id1, AssetPair(AssetAmount(100, 'BTC'), AssetAmount(30, 'MB')),
                                         OrderId(TraderId(b'0' * 20), OrderNumber(1)),
-                                        OrderId(TraderId(b'1' * 20), OrderNumber(2)), Timestamp(20.0))
+                                        OrderId(TraderId(b'1' * 20), OrderNumber(2)), Timestamp(20000))
 
         self.payment1 = Payment(TraderId(b'0' * 20), self.transaction_id1, AssetAmount(5, 'BTC'),
-                                WalletAddress('abc'), WalletAddress('def'), PaymentId("abc"), Timestamp(20.0), False)
+                                WalletAddress('abc'), WalletAddress('def'), PaymentId("abc"), Timestamp(20000), False)
 
         self.transaction1.add_payment(self.payment1)
 
@@ -116,18 +116,18 @@ class TestDatabase(AbstractServer):
         # Test try to update with older timestamp
         before_trans1 = Transaction(self.transaction1.transaction_id, self.transaction1.assets,
                                     self.transaction1.order_id, self.transaction1.partner_order_id,
-                                    Timestamp(float(self.transaction1.timestamp) - 1.0))
+                                    Timestamp(int(self.transaction1.timestamp) - 1000))
         self.database.insert_or_update_transaction(before_trans1)
         transaction = self.database.get_transaction(self.transaction1.transaction_id)
-        self.assertEqual(float(transaction.timestamp), float(self.transaction1.timestamp))
+        self.assertEqual(int(transaction.timestamp), int(self.transaction1.timestamp))
 
         # Test update with newer timestamp
         after_trans1 = Transaction(self.transaction1.transaction_id, self.transaction1.assets,
                                    self.transaction1.order_id, self.transaction1.partner_order_id,
-                                   Timestamp(float(self.transaction1.timestamp) + 1.0))
+                                   Timestamp(int(self.transaction1.timestamp) + 1000))
         self.database.insert_or_update_transaction(after_trans1)
         transaction = self.database.get_transaction(self.transaction1.transaction_id)
-        self.assertEqual(float(transaction.timestamp), float(after_trans1.timestamp))
+        self.assertEqual(int(transaction.timestamp), int(after_trans1.timestamp))
 
     def test_get_specific_transaction(self):
         """

--- a/Tribler/Test/Community/Market/test_matching_engine.py
+++ b/Tribler/Test/Community/Market/test_matching_engine.py
@@ -21,33 +21,33 @@ class PriceTimeStrategyTestSuite(AbstractServer):
     def setUp(self):
         yield super(PriceTimeStrategyTestSuite, self).setUp()
         # Object creation
-        self.ask = Ask(OrderId(TraderId(b'0'), OrderNumber(1)),
+        self.ask = Ask(OrderId(TraderId(b'0' * 20), OrderNumber(1)),
                        AssetPair(AssetAmount(3000, 'BTC'), AssetAmount(30, 'MB')), Timeout(100), Timestamp.now())
-        self.ask2 = Ask(OrderId(TraderId(b'1'), OrderNumber(2)),
+        self.ask2 = Ask(OrderId(TraderId(b'1' * 20), OrderNumber(2)),
                         AssetPair(AssetAmount(3000, 'BTC'), AssetAmount(30, 'MB')), Timeout(100), Timestamp.now())
-        self.ask3 = Ask(OrderId(TraderId(b'0'), OrderNumber(3)),
+        self.ask3 = Ask(OrderId(TraderId(b'0' * 20), OrderNumber(3)),
                         AssetPair(AssetAmount(40000, 'BTC'), AssetAmount(200, 'MB')), Timeout(100), Timestamp.now())
-        self.ask4 = Ask(OrderId(TraderId(b'1'), OrderNumber(4)),
+        self.ask4 = Ask(OrderId(TraderId(b'1' * 20), OrderNumber(4)),
                         AssetPair(AssetAmount(3000, 'A'), AssetAmount(3000, 'MB')), Timeout(100), Timestamp.now())
-        self.ask5 = Ask(OrderId(TraderId(b'1'), OrderNumber(4)),
+        self.ask5 = Ask(OrderId(TraderId(b'1' * 20), OrderNumber(4)),
                         AssetPair(AssetAmount(3000, 'BTC'), AssetAmount(30, 'C')), Timeout(100), Timestamp.now())
 
-        self.bid = Bid(OrderId(TraderId(b'0'), OrderNumber(5)),
+        self.bid = Bid(OrderId(TraderId(b'0' * 20), OrderNumber(5)),
                        AssetPair(AssetAmount(3000, 'BTC'), AssetAmount(30, 'MB')), Timeout(100), Timestamp.now())
-        self.bid2 = Bid(OrderId(TraderId(b'0'), OrderNumber(6)),
+        self.bid2 = Bid(OrderId(TraderId(b'0' * 20), OrderNumber(6)),
                         AssetPair(AssetAmount(6000, 'BTC'), AssetAmount(30, 'MB')), Timeout(100), Timestamp.now())
 
-        self.ask_order = Order(OrderId(TraderId(b'9'), OrderNumber(11)),
+        self.ask_order = Order(OrderId(TraderId(b'9' * 20), OrderNumber(11)),
                                AssetPair(AssetAmount(3000, 'BTC'), AssetAmount(30, 'MB')),
                                Timeout(100), Timestamp.now(), True)
-        self.ask_order2 = Order(OrderId(TraderId(b'9'), OrderNumber(12)),
+        self.ask_order2 = Order(OrderId(TraderId(b'9' * 20), OrderNumber(12)),
                                 AssetPair(AssetAmount(600, 'BTC'), AssetAmount(60, 'MB')),
                                 Timeout(100), Timestamp.now(), True)
 
-        self.bid_order = Order(OrderId(TraderId(b'9'), OrderNumber(13)),
+        self.bid_order = Order(OrderId(TraderId(b'9' * 20), OrderNumber(13)),
                                AssetPair(AssetAmount(3000, 'BTC'), AssetAmount(30, 'MB')),
                                Timeout(100), Timestamp.now(), False)
-        self.bid_order2 = Order(OrderId(TraderId(b'9'), OrderNumber(14)),
+        self.bid_order2 = Order(OrderId(TraderId(b'9' * 20), OrderNumber(14)),
                                 AssetPair(AssetAmount(6000, 'BTC'), AssetAmount(60, 'MB')),
                                 Timeout(100), Timestamp.now(), False)
         self.order_book = OrderBook()
@@ -194,14 +194,14 @@ class MatchingEngineTestSuite(AbstractServer):
     def setUp(self):
         yield super(MatchingEngineTestSuite, self).setUp()
         # Object creation
-        self.ask = Ask(OrderId(TraderId(b'2'), OrderNumber(1)),
+        self.ask = Ask(OrderId(TraderId(b'2' * 20), OrderNumber(1)),
                        AssetPair(AssetAmount(3000, 'BTC'), AssetAmount(30, 'MB')), Timeout(30), Timestamp.now())
-        self.bid = Bid(OrderId(TraderId(b'4'), OrderNumber(2)),
+        self.bid = Bid(OrderId(TraderId(b'4' * 20), OrderNumber(2)),
                        AssetPair(AssetAmount(3000, 'BTC'), AssetAmount(30, 'MB')), Timeout(30), Timestamp.now())
-        self.ask_order = Order(OrderId(TraderId(b'5'), OrderNumber(3)),
+        self.ask_order = Order(OrderId(TraderId(b'5' * 20), OrderNumber(3)),
                                AssetPair(AssetAmount(3000, 'BTC'), AssetAmount(30, 'MB')),
                                Timeout(30), Timestamp.now(), True)
-        self.bid_order = Order(OrderId(TraderId(b'6'), OrderNumber(4)),
+        self.bid_order = Order(OrderId(TraderId(b'6' * 20), OrderNumber(4)),
                                AssetPair(AssetAmount(3000, 'BTC'), AssetAmount(30, 'MB')),
                                Timeout(30), Timestamp.now(), False)
         self.order_book = OrderBook()
@@ -214,7 +214,7 @@ class MatchingEngineTestSuite(AbstractServer):
         """
         Create an ask with a specific price and quantity
         """
-        new_ask = Ask(OrderId(TraderId(b'2'), OrderNumber(self.ask_count)),
+        new_ask = Ask(OrderId(TraderId(b'2' * 20), OrderNumber(self.ask_count)),
                       AssetPair(AssetAmount(amount1, 'BTC'), AssetAmount(amount2, 'MB')), Timeout(30), Timestamp.now())
         self.ask_count += 1
         return new_ask
@@ -223,7 +223,7 @@ class MatchingEngineTestSuite(AbstractServer):
         """
         Create a bid with a specific price and quantity
         """
-        new_bid = Bid(OrderId(TraderId(b'3'), OrderNumber(self.bid_count)),
+        new_bid = Bid(OrderId(TraderId(b'3' * 20), OrderNumber(self.bid_count)),
                       AssetPair(AssetAmount(amount1, 'BTC'), AssetAmount(amount2, 'MB')), Timeout(30), Timestamp.now())
         self.bid_count += 1
         return new_bid

--- a/Tribler/Test/Community/Market/test_message.py
+++ b/Tribler/Test/Community/Market/test_message.py
@@ -21,7 +21,7 @@ class TraderIdTestSuite(unittest.TestCase):
 
     def test_conversion(self):
         # Test for conversions
-        self.assertEqual(b'0', self.trader_id.to_bytes())
+        self.assertEqual(b'0', bytes(self.trader_id))
 
     def test_equality(self):
         # Test for equality

--- a/Tribler/Test/Community/Market/test_message.py
+++ b/Tribler/Test/Community/Market/test_message.py
@@ -8,20 +8,18 @@ class TraderIdTestSuite(unittest.TestCase):
 
     def setUp(self):
         # Object creation
-        self.trader_id = TraderId(b'0')
-        self.trader_id2 = TraderId(b'0')
-        self.trader_id3 = TraderId(b'1')
+        self.trader_id = TraderId(b'0' * 20)
+        self.trader_id2 = TraderId(b'0' * 20)
+        self.trader_id3 = TraderId(b'1' * 20)
 
     def test_init(self):
         # Test for init validation
         with self.assertRaises((TypeError, ValueError)):
             TraderId(1.0)
-        with self.assertRaises(ValueError):
-            TraderId('non hexadecimal')
 
     def test_conversion(self):
         # Test for conversions
-        self.assertEqual(b'0', bytes(self.trader_id))
+        self.assertEqual(b'0' * 20, bytes(self.trader_id))
 
     def test_equality(self):
         # Test for equality

--- a/Tribler/Test/Community/Market/test_order.py
+++ b/Tribler/Test/Community/Market/test_order.py
@@ -19,28 +19,28 @@ class OrderTestSuite(unittest.TestCase):
 
     def setUp(self):
         # Object creation
-        self.transaction_id = TransactionId(TraderId(b"0"), TransactionNumber(1))
+        self.transaction_id = TransactionId(TraderId(b'0' * 20), TransactionNumber(1))
         self.transaction = Transaction(self.transaction_id, AssetPair(AssetAmount(100, 'BTC'), AssetAmount(30, 'MC')),
-                                       OrderId(TraderId(b'0'), OrderNumber(2)),
-                                       OrderId(TraderId(b'1'), OrderNumber(1)), Timestamp(0.0))
-        self.proposed_trade = Trade.propose(TraderId(b'0'),
-                                            OrderId(TraderId(b'0'), OrderNumber(2)),
-                                            OrderId(TraderId(b'1'), OrderNumber(3)),
+                                       OrderId(TraderId(b'0' * 20), OrderNumber(2)),
+                                       OrderId(TraderId(b'1' * 20), OrderNumber(1)), Timestamp(0.0))
+        self.proposed_trade = Trade.propose(TraderId(b'0' * 20),
+                                            OrderId(TraderId(b'0' * 20), OrderNumber(2)),
+                                            OrderId(TraderId(b'1' * 20), OrderNumber(3)),
                                             AssetPair(AssetAmount(100, 'BTC'), AssetAmount(30, 'MC')), Timestamp(0.0))
 
-        self.tick = Tick(OrderId(TraderId(b'0'), OrderNumber(1)),
+        self.tick = Tick(OrderId(TraderId(b'0' * 20), OrderNumber(1)),
                          AssetPair(AssetAmount(5, 'BTC'), AssetAmount(5, 'MC')),
                          Timeout(0), Timestamp(float("inf")), True)
-        self.tick2 = Tick(OrderId(TraderId(b'0'), OrderNumber(2)),
+        self.tick2 = Tick(OrderId(TraderId(b'0' * 20), OrderNumber(2)),
                           AssetPair(AssetAmount(500, 'BTC'), AssetAmount(5, 'MC')),
                           Timeout(0), Timestamp(float("inf")), True)
 
         self.order_timestamp = Timestamp.now()
-        self.order = Order(OrderId(TraderId(b"0"), OrderNumber(3)),
+        self.order = Order(OrderId(TraderId(b'0' * 20), OrderNumber(3)),
                            AssetPair(AssetAmount(50, 'BTC'), AssetAmount(5, 'MC')),
                            Timeout(5000), self.order_timestamp, False)
         self.order.set_verified()
-        self.order2 = Order(OrderId(TraderId(b"0"), OrderNumber(4)),
+        self.order2 = Order(OrderId(TraderId(b'0' * 20), OrderNumber(4)),
                             AssetPair(AssetAmount(50, 'BTC'), AssetAmount(5, 'MC')),
                             Timeout(5), Timestamp(time.time() - 1000), True)
         self.order2.set_verified()
@@ -49,13 +49,13 @@ class OrderTestSuite(unittest.TestCase):
         """
         Test the add trade method of an order
         """
-        self.order.reserve_quantity_for_tick(OrderId(TraderId(b'5'), OrderNumber(1)), 10)
+        self.order.reserve_quantity_for_tick(OrderId(TraderId(b'5' * 20), OrderNumber(1)), 10)
         self.assertEquals(self.order.traded_quantity, 0)
-        self.order.add_trade(OrderId(TraderId(b'5'), OrderNumber(1)), 10)
+        self.order.add_trade(OrderId(TraderId(b'5' * 20), OrderNumber(1)), 10)
         self.assertEquals(self.order.traded_quantity, 10)
 
-        self.order.reserve_quantity_for_tick(OrderId(TraderId(b'6'), OrderNumber(1)), 40)
-        self.order.add_trade(OrderId(TraderId(b'6'), OrderNumber(1)), 40)
+        self.order.reserve_quantity_for_tick(OrderId(TraderId(b'6' * 20), OrderNumber(1)), 40)
+        self.order.add_trade(OrderId(TraderId(b'6' * 20), OrderNumber(1)), 40)
         self.assertTrue(self.order.is_complete())
         self.assertFalse(self.order.cancelled)
 
@@ -63,7 +63,7 @@ class OrderTestSuite(unittest.TestCase):
         """
         Test the acceptable price method
         """
-        order = Order(OrderId(TraderId(b"0"), OrderNumber(3)),
+        order = Order(OrderId(TraderId(b'0' * 20), OrderNumber(3)),
                       AssetPair(AssetAmount(60, 'BTC'), AssetAmount(30, 'MB')),
                       Timeout(5000), self.order_timestamp, True)
 
@@ -145,7 +145,7 @@ class OrderTestSuite(unittest.TestCase):
         Test the conversion of an order to a dictionary
         """
         self.assertEqual(self.order.to_dictionary(), {
-            "trader_id": b"0",
+            "trader_id": "30" * 20,
             "cancelled": False,
             "completed_timestamp": None,
             "is_ask": False,
@@ -173,9 +173,9 @@ class OrderIDTestSuite(unittest.TestCase):
 
     def setUp(self):
         # Object creation
-        self.order_id = OrderId(TraderId(b"0"), OrderNumber(1))
-        self.order_id2 = OrderId(TraderId(b"0"), OrderNumber(1))
-        self.order_id3 = OrderId(TraderId(b"0"), OrderNumber(2))
+        self.order_id = OrderId(TraderId(b'0' * 20), OrderNumber(1))
+        self.order_id2 = OrderId(TraderId(b'0' * 20), OrderNumber(1))
+        self.order_id3 = OrderId(TraderId(b'0' * 20), OrderNumber(2))
 
     def test_equality(self):
         # Test for equality
@@ -195,7 +195,7 @@ class OrderIDTestSuite(unittest.TestCase):
 
     def test_str(self):
         # Test for string representation
-        self.assertEquals('0.1', str(self.order_id))
+        self.assertEquals('%s.1' % ('30' * 20), str(self.order_id))
 
 
 class OrderNumberTestSuite(unittest.TestCase):

--- a/Tribler/Test/Community/Market/test_order.py
+++ b/Tribler/Test/Community/Market/test_order.py
@@ -12,6 +12,7 @@ from Tribler.community.market.core.timeout import Timeout
 from Tribler.community.market.core.timestamp import Timestamp
 from Tribler.community.market.core.trade import Trade
 from Tribler.community.market.core.transaction import Transaction, TransactionId, TransactionNumber
+from Tribler.pyipv8.ipv8.util import old_round
 
 
 class OrderTestSuite(unittest.TestCase):
@@ -22,18 +23,18 @@ class OrderTestSuite(unittest.TestCase):
         self.transaction_id = TransactionId(TraderId(b'0' * 20), TransactionNumber(1))
         self.transaction = Transaction(self.transaction_id, AssetPair(AssetAmount(100, 'BTC'), AssetAmount(30, 'MC')),
                                        OrderId(TraderId(b'0' * 20), OrderNumber(2)),
-                                       OrderId(TraderId(b'1' * 20), OrderNumber(1)), Timestamp(0.0))
+                                       OrderId(TraderId(b'1' * 20), OrderNumber(1)), Timestamp(0))
         self.proposed_trade = Trade.propose(TraderId(b'0' * 20),
                                             OrderId(TraderId(b'0' * 20), OrderNumber(2)),
                                             OrderId(TraderId(b'1' * 20), OrderNumber(3)),
-                                            AssetPair(AssetAmount(100, 'BTC'), AssetAmount(30, 'MC')), Timestamp(0.0))
+                                            AssetPair(AssetAmount(100, 'BTC'), AssetAmount(30, 'MC')), Timestamp(0))
 
         self.tick = Tick(OrderId(TraderId(b'0' * 20), OrderNumber(1)),
                          AssetPair(AssetAmount(5, 'BTC'), AssetAmount(5, 'MC')),
-                         Timeout(0), Timestamp(float("inf")), True)
+                         Timeout(0), Timestamp(00), True)
         self.tick2 = Tick(OrderId(TraderId(b'0' * 20), OrderNumber(2)),
                           AssetPair(AssetAmount(500, 'BTC'), AssetAmount(5, 'MC')),
-                          Timeout(0), Timestamp(float("inf")), True)
+                          Timeout(0), Timestamp(0), True)
 
         self.order_timestamp = Timestamp.now()
         self.order = Order(OrderId(TraderId(b'0' * 20), OrderNumber(3)),
@@ -42,7 +43,7 @@ class OrderTestSuite(unittest.TestCase):
         self.order.set_verified()
         self.order2 = Order(OrderId(TraderId(b'0' * 20), OrderNumber(4)),
                             AssetPair(AssetAmount(50, 'BTC'), AssetAmount(5, 'MC')),
-                            Timeout(5), Timestamp(time.time() - 1000), True)
+                            Timeout(5), Timestamp(int(old_round(time.time() * 1000)) - 1000 * 1000), True)
         self.order2.set_verified()
 
     def test_add_trade(self):
@@ -164,7 +165,7 @@ class OrderTestSuite(unittest.TestCase):
             "traded": 0,
             "status": "open",
             "timeout": 5000,
-            "timestamp": float(self.order_timestamp)
+            "timestamp": int(self.order_timestamp)
         })
 
 

--- a/Tribler/Test/Community/Market/test_order_repository.py
+++ b/Tribler/Test/Community/Market/test_order_repository.py
@@ -17,9 +17,9 @@ class MemoryOrderRepositoryTestSuite(unittest.TestCase):
         self.memory_order_repository = MemoryOrderRepository(b'0' * 20)
         self.order_id = OrderId(TraderId(b'0' * 20), OrderNumber(1))
         self.order = Order(self.order_id, AssetPair(AssetAmount(100, 'BTC'), AssetAmount(30, 'MC')),
-                           Timeout(0), Timestamp(10.0), False)
+                           Timeout(0), Timestamp(10), False)
         self.order2 = Order(self.order_id, AssetPair(AssetAmount(1000, 'BTC'), AssetAmount(30, 'MC')),
-                            Timeout(0), Timestamp(10.0), False)
+                            Timeout(0), Timestamp(10), False)
 
     def test_add(self):
         # Test for add

--- a/Tribler/Test/Community/Market/test_order_repository.py
+++ b/Tribler/Test/Community/Market/test_order_repository.py
@@ -14,17 +14,12 @@ class MemoryOrderRepositoryTestSuite(unittest.TestCase):
 
     def setUp(self):
         # Object creation
-        self.memory_order_repository = MemoryOrderRepository("0")
-        self.order_id = OrderId(TraderId(b"0"), OrderNumber(1))
+        self.memory_order_repository = MemoryOrderRepository(b'0' * 20)
+        self.order_id = OrderId(TraderId(b'0' * 20), OrderNumber(1))
         self.order = Order(self.order_id, AssetPair(AssetAmount(100, 'BTC'), AssetAmount(30, 'MC')),
                            Timeout(0), Timestamp(10.0), False)
         self.order2 = Order(self.order_id, AssetPair(AssetAmount(1000, 'BTC'), AssetAmount(30, 'MC')),
                             Timeout(0), Timestamp(10.0), False)
-
-    def test_init(self):
-        # Test for init validation
-        with self.assertRaises(ValueError):
-            self.memory_order_repository = MemoryOrderRepository("-")
 
     def test_add(self):
         # Test for add
@@ -53,7 +48,7 @@ class MemoryOrderRepositoryTestSuite(unittest.TestCase):
 
     def test_next_identity(self):
         # Test for next identity
-        self.assertEquals(OrderId(TraderId(b"0"), OrderNumber(1)),
+        self.assertEquals(OrderId(TraderId(b'0' * 20), OrderNumber(1)),
                           self.memory_order_repository.next_identity())
 
     def test_update(self):

--- a/Tribler/Test/Community/Market/test_orderbook.py
+++ b/Tribler/Test/Community/Market/test_orderbook.py
@@ -179,7 +179,7 @@ class TestOrderBook(AbstractTestOrderBook):
         self.order_book.insert_bid(self.bid)
 
         ask_dict = {
-            "trader_id": self.ask.order_id.trader_id.to_bytes(),
+            "trader_id": bytes(self.ask.order_id.trader_id),
             "order_number": int(self.ask.order_id.order_number),
             "assets": self.ask.assets.to_dictionary(),
             "traded": 100,
@@ -187,7 +187,7 @@ class TestOrderBook(AbstractTestOrderBook):
             "timestamp": float(Timestamp.now())
         }
         bid_dict = {
-            "trader_id": self.bid.order_id.trader_id.to_bytes(),
+            "trader_id": bytes(self.bid.order_id.trader_id),
             "order_number": int(self.bid.order_id.order_number),
             "assets": self.bid.assets.to_dictionary(),
             "traded": 100,

--- a/Tribler/Test/Community/Market/test_orderbook.py
+++ b/Tribler/Test/Community/Market/test_orderbook.py
@@ -30,20 +30,20 @@ class AbstractTestOrderBook(AbstractServer):
         self.ask = Ask(OrderId(TraderId(b'0' * 20), OrderNumber(1)),
                        AssetPair(AssetAmount(100, 'BTC'), AssetAmount(30, 'MB')), Timeout(100), Timestamp.now())
         self.invalid_ask = Ask(OrderId(TraderId(b'0' * 20), OrderNumber(1)),
-                               AssetPair(AssetAmount(100, 'BTC'), AssetAmount(30, 'MB')), Timeout(0), Timestamp(0.0))
+                               AssetPair(AssetAmount(100, 'BTC'), AssetAmount(30, 'MB')), Timeout(0), Timestamp(0))
         self.ask2 = Ask(OrderId(TraderId(b'1' * 20), OrderNumber(1)),
                         AssetPair(AssetAmount(400, 'BTC'), AssetAmount(30, 'MB')), Timeout(100), Timestamp.now())
         self.bid = Bid(OrderId(TraderId(b'2' * 20), OrderNumber(1)),
                        AssetPair(AssetAmount(200, 'BTC'), AssetAmount(30, 'MB')), Timeout(100), Timestamp.now())
         self.invalid_bid = Bid(OrderId(TraderId(b'0' * 20), OrderNumber(1)),
-                               AssetPair(AssetAmount(100, 'BTC'), AssetAmount(30, 'MB')), Timeout(0), Timestamp(0.0))
+                               AssetPair(AssetAmount(100, 'BTC'), AssetAmount(30, 'MB')), Timeout(0), Timestamp(0))
         self.bid2 = Bid(OrderId(TraderId(b'3' * 20), OrderNumber(1)),
                         AssetPair(AssetAmount(300, 'BTC'), AssetAmount(30, 'MB')), Timeout(100), Timestamp.now())
         self.trade = Trade.propose(TraderId(b'0' * 20),
                                    OrderId(TraderId(b'0' * 20), OrderNumber(1)),
                                    OrderId(TraderId(b'0' * 20), OrderNumber(1)),
                                    AssetPair(AssetAmount(100, 'BTC'), AssetAmount(30, 'MB')),
-                                   Timestamp(1462224447.117))
+                                   Timestamp(1462224447117))
         self.order_book = OrderBook()
 
     def tearDown(self):
@@ -183,7 +183,7 @@ class TestOrderBook(AbstractTestOrderBook):
             "assets": self.ask.assets.to_dictionary(),
             "traded": 100,
             "timeout": 3600,
-            "timestamp": float(Timestamp.now())
+            "timestamp": int(Timestamp.now())
         }
         bid_dict = {
             "trader_id": self.bid.order_id.trader_id.as_hex(),
@@ -191,7 +191,7 @@ class TestOrderBook(AbstractTestOrderBook):
             "assets": self.bid.assets.to_dictionary(),
             "traded": 100,
             "timeout": 3600,
-            "timestamp": float(Timestamp.now())
+            "timestamp": int(Timestamp.now())
         }
 
         self.order_book.get_tick(self.ask.order_id).reserve_for_matching(100)

--- a/Tribler/Test/Community/Market/test_orderbook.py
+++ b/Tribler/Test/Community/Market/test_orderbook.py
@@ -123,7 +123,6 @@ class TestOrderBook(AbstractTestOrderBook):
         # Test for properties
         self.order_book.insert_ask(self.ask2)
         self.order_book.insert_bid(self.bid2)
-        self.assertEquals(Price(0.0875, 'MB', 'BTC'), self.order_book.get_mid_price('MB', 'BTC'))
         self.assertEquals(Price(-0.025, 'MB', 'BTC'), self.order_book.get_bid_ask_spread('MB', 'BTC'))
 
     def test_ask_price_level(self):

--- a/Tribler/Test/Community/Market/test_orderbook.py
+++ b/Tribler/Test/Community/Market/test_orderbook.py
@@ -27,21 +27,21 @@ class AbstractTestOrderBook(AbstractServer):
     def setUp(self):
         yield super(AbstractTestOrderBook, self).setUp()
         # Object creation
-        self.ask = Ask(OrderId(TraderId(b'0'), OrderNumber(1)),
+        self.ask = Ask(OrderId(TraderId(b'0' * 20), OrderNumber(1)),
                        AssetPair(AssetAmount(100, 'BTC'), AssetAmount(30, 'MB')), Timeout(100), Timestamp.now())
-        self.invalid_ask = Ask(OrderId(TraderId(b'0'), OrderNumber(1)),
+        self.invalid_ask = Ask(OrderId(TraderId(b'0' * 20), OrderNumber(1)),
                                AssetPair(AssetAmount(100, 'BTC'), AssetAmount(30, 'MB')), Timeout(0), Timestamp(0.0))
-        self.ask2 = Ask(OrderId(TraderId(b'1'), OrderNumber(1)),
+        self.ask2 = Ask(OrderId(TraderId(b'1' * 20), OrderNumber(1)),
                         AssetPair(AssetAmount(400, 'BTC'), AssetAmount(30, 'MB')), Timeout(100), Timestamp.now())
-        self.bid = Bid(OrderId(TraderId(b'2'), OrderNumber(1)),
+        self.bid = Bid(OrderId(TraderId(b'2' * 20), OrderNumber(1)),
                        AssetPair(AssetAmount(200, 'BTC'), AssetAmount(30, 'MB')), Timeout(100), Timestamp.now())
-        self.invalid_bid = Bid(OrderId(TraderId(b'0'), OrderNumber(1)),
+        self.invalid_bid = Bid(OrderId(TraderId(b'0' * 20), OrderNumber(1)),
                                AssetPair(AssetAmount(100, 'BTC'), AssetAmount(30, 'MB')), Timeout(0), Timestamp(0.0))
-        self.bid2 = Bid(OrderId(TraderId(b'3'), OrderNumber(1)),
+        self.bid2 = Bid(OrderId(TraderId(b'3' * 20), OrderNumber(1)),
                         AssetPair(AssetAmount(300, 'BTC'), AssetAmount(30, 'MB')), Timeout(100), Timestamp.now())
-        self.trade = Trade.propose(TraderId(b'0'),
-                                   OrderId(TraderId(b'0'), OrderNumber(1)),
-                                   OrderId(TraderId(b'0'), OrderNumber(1)),
+        self.trade = Trade.propose(TraderId(b'0' * 20),
+                                   OrderId(TraderId(b'0' * 20), OrderNumber(1)),
+                                   OrderId(TraderId(b'0' * 20), OrderNumber(1)),
                                    AssetPair(AssetAmount(100, 'BTC'), AssetAmount(30, 'MB')),
                                    Timestamp(1462224447.117))
         self.order_book = OrderBook()
@@ -179,7 +179,7 @@ class TestOrderBook(AbstractTestOrderBook):
         self.order_book.insert_bid(self.bid)
 
         ask_dict = {
-            "trader_id": bytes(self.ask.order_id.trader_id),
+            "trader_id": self.ask.order_id.trader_id.as_hex(),
             "order_number": int(self.ask.order_id.order_number),
             "assets": self.ask.assets.to_dictionary(),
             "traded": 100,
@@ -187,7 +187,7 @@ class TestOrderBook(AbstractTestOrderBook):
             "timestamp": float(Timestamp.now())
         }
         bid_dict = {
-            "trader_id": bytes(self.bid.order_id.trader_id),
+            "trader_id": self.bid.order_id.trader_id.as_hex(),
             "order_number": int(self.bid.order_id.order_number),
             "assets": self.bid.assets.to_dictionary(),
             "traded": 100,

--- a/Tribler/Test/Community/Market/test_payment.py
+++ b/Tribler/Test/Community/Market/test_payment.py
@@ -20,7 +20,7 @@ class PaymentTestSuite(unittest.TestCase):
                                TransactionId(TraderId(b'2' * 20), TransactionNumber(2)),
                                AssetAmount(3, 'BTC'),
                                WalletAddress('a'), WalletAddress('b'),
-                               PaymentId('aaa'), Timestamp(4.0), True)
+                               PaymentId('aaa'), Timestamp(4000), True)
 
     def test_from_network(self):
         # Test for from network
@@ -31,13 +31,13 @@ class PaymentTestSuite(unittest.TestCase):
                                      "address_from": WalletAddress('a'),
                                      "address_to": WalletAddress('b'),
                                      "payment_id": PaymentId('aaa'),
-                                     "timestamp": Timestamp(4.0),
+                                     "timestamp": Timestamp(4000),
                                      "success": True}))
 
         self.assertEquals(TraderId(b'0' * 20), data.trader_id)
         self.assertEquals(TransactionId(TraderId(b'2' * 20), TransactionNumber(2)), data.transaction_id)
         self.assertEquals(AssetAmount(3, 'BTC'), data.transferred_assets)
-        self.assertEquals(Timestamp(4.0), data.timestamp)
+        self.assertEquals(Timestamp(4000), data.timestamp)
         self.assertTrue(data.success)
 
     def test_to_network(self):
@@ -45,7 +45,7 @@ class PaymentTestSuite(unittest.TestCase):
         data = self.payment.to_network()
 
         self.assertEquals(data[0], TraderId(b'0' * 20))
-        self.assertEquals(data[1], Timestamp(4.0))
+        self.assertEquals(data[1], Timestamp(4000))
         self.assertEquals(data[2], TransactionId(TraderId(b'2' * 20), TransactionNumber(2)))
         self.assertEquals(data[3], AssetAmount(3, 'BTC'))
         self.assertEquals(data[4], WalletAddress('a'))
@@ -67,6 +67,6 @@ class PaymentTestSuite(unittest.TestCase):
             "payment_id": 'aaa',
             "address_from": 'a',
             "address_to": 'b',
-            "timestamp": 4.0,
+            "timestamp": 4000,
             "success": True
         })

--- a/Tribler/Test/Community/Market/test_payment.py
+++ b/Tribler/Test/Community/Market/test_payment.py
@@ -16,8 +16,8 @@ class PaymentTestSuite(unittest.TestCase):
 
     def setUp(self):
         # Object creation
-        self.payment = Payment(TraderId(b"0"),
-                               TransactionId(TraderId(b'2'), TransactionNumber(2)),
+        self.payment = Payment(TraderId(b'0' * 20),
+                               TransactionId(TraderId(b'2' * 20), TransactionNumber(2)),
                                AssetAmount(3, 'BTC'),
                                WalletAddress('a'), WalletAddress('b'),
                                PaymentId('aaa'), Timestamp(4.0), True)
@@ -25,8 +25,8 @@ class PaymentTestSuite(unittest.TestCase):
     def test_from_network(self):
         # Test for from network
         data = Payment.from_network(
-            type('Data', (object,), {"trader_id": TraderId(b"0"),
-                                     "transaction_id": TransactionId(TraderId(b'2'), TransactionNumber(2)),
+            type('Data', (object,), {"trader_id": TraderId(b'0' * 20),
+                                     "transaction_id": TransactionId(TraderId(b'2' * 20), TransactionNumber(2)),
                                      "transferred_assets": AssetAmount(3, 'BTC'),
                                      "address_from": WalletAddress('a'),
                                      "address_to": WalletAddress('b'),
@@ -34,8 +34,8 @@ class PaymentTestSuite(unittest.TestCase):
                                      "timestamp": Timestamp(4.0),
                                      "success": True}))
 
-        self.assertEquals(TraderId(b"0"), data.trader_id)
-        self.assertEquals(TransactionId(TraderId(b'2'), TransactionNumber(2)), data.transaction_id)
+        self.assertEquals(TraderId(b'0' * 20), data.trader_id)
+        self.assertEquals(TransactionId(TraderId(b'2' * 20), TransactionNumber(2)), data.transaction_id)
         self.assertEquals(AssetAmount(3, 'BTC'), data.transferred_assets)
         self.assertEquals(Timestamp(4.0), data.timestamp)
         self.assertTrue(data.success)
@@ -44,9 +44,9 @@ class PaymentTestSuite(unittest.TestCase):
         # Test for to network
         data = self.payment.to_network()
 
-        self.assertEquals(data[0], TraderId(b"0"))
+        self.assertEquals(data[0], TraderId(b'0' * 20))
         self.assertEquals(data[1], Timestamp(4.0))
-        self.assertEquals(data[2], TransactionId(TraderId(b"2"), TransactionNumber(2)))
+        self.assertEquals(data[2], TransactionId(TraderId(b'2' * 20), TransactionNumber(2)))
         self.assertEquals(data[3], AssetAmount(3, 'BTC'))
         self.assertEquals(data[4], WalletAddress('a'))
         self.assertEquals(data[5], WalletAddress('b'))
@@ -58,7 +58,7 @@ class PaymentTestSuite(unittest.TestCase):
         Test the dictionary representation of a payment
         """
         self.assertDictEqual(self.payment.to_dictionary(), {
-            "trader_id": b'2',
+            "trader_id": "32" * 20,
             "transaction_number": 2,
             "transferred": {
                 "amount": 3,

--- a/Tribler/Test/Community/Market/test_portfolio.py
+++ b/Tribler/Test/Community/Market/test_portfolio.py
@@ -14,14 +14,14 @@ class PortfolioTestSuite(unittest.TestCase):
 
     def setUp(self):
         # Object creation
-        self.order_manager = OrderManager(MemoryOrderRepository("0"))
+        self.order_manager = OrderManager(MemoryOrderRepository(b'0' * 20))
 
     def test_create_ask_order(self):
         # Test for create ask order
         ask_order = self.order_manager.create_ask_order(
             AssetPair(AssetAmount(100, 'BTC'), AssetAmount(10, 'MC')), Timeout(0))
         self.assertTrue(ask_order.is_ask())
-        self.assertEquals(OrderId(TraderId(b"0"), OrderNumber(1)), ask_order.order_id)
+        self.assertEquals(OrderId(TraderId(b'0' * 20), OrderNumber(1)), ask_order.order_id)
         self.assertEquals(AssetPair(AssetAmount(100, 'BTC'), AssetAmount(10, 'MC')), ask_order.assets)
         self.assertEquals(100, ask_order.total_quantity)
         self.assertEquals(0, int(ask_order.timeout))
@@ -31,7 +31,7 @@ class PortfolioTestSuite(unittest.TestCase):
         bid_order = self.order_manager.create_bid_order(
             AssetPair(AssetAmount(100, 'BTC'), AssetAmount(10, 'MC')), Timeout(0))
         self.assertFalse(bid_order.is_ask())
-        self.assertEquals(OrderId(TraderId(b"0"), OrderNumber(1)), bid_order.order_id)
+        self.assertEquals(OrderId(TraderId(b'0' * 20), OrderNumber(1)), bid_order.order_id)
         self.assertEquals(AssetPair(AssetAmount(100, 'BTC'), AssetAmount(10, 'MC')), bid_order.assets)
         self.assertEquals(100, bid_order.total_quantity)
         self.assertEquals(0, int(bid_order.timeout))

--- a/Tribler/Test/Community/Market/test_pricelevel.py
+++ b/Tribler/Test/Community/Market/test_pricelevel.py
@@ -17,9 +17,11 @@ class PriceLevelTestSuite(unittest.TestCase):
 
     def setUp(self):
         # Object creation
-        tick = Tick(OrderId(TraderId(b'0'), OrderNumber(1)), AssetPair(AssetAmount(60, 'BTC'), AssetAmount(30, 'MC')),
+        tick = Tick(OrderId(TraderId(b'0' * 20), OrderNumber(1)), AssetPair(AssetAmount(60, 'BTC'),
+                                                                            AssetAmount(30, 'MC')),
                     Timeout(100), Timestamp.now(), True)
-        tick2 = Tick(OrderId(TraderId(b'0'), OrderNumber(2)), AssetPair(AssetAmount(30, 'BTC'), AssetAmount(30, 'MC')),
+        tick2 = Tick(OrderId(TraderId(b'0' * 20), OrderNumber(2)), AssetPair(AssetAmount(30, 'BTC'),
+                                                                             AssetAmount(30, 'MC')),
                      Timeout(100), Timestamp.now(), True)
 
         self.price_level = PriceLevel(Price(10, 'MC', 'BTC'))

--- a/Tribler/Test/Community/Market/test_side.py
+++ b/Tribler/Test/Community/Market/test_side.py
@@ -17,10 +17,10 @@ class SideTestSuite(unittest.TestCase):
     def setUp(self):
         # Object creation
 
-        self.tick = Tick(OrderId(TraderId(b'0'), OrderNumber(1)),
+        self.tick = Tick(OrderId(TraderId(b'0' * 20), OrderNumber(1)),
                          AssetPair(AssetAmount(60, 'BTC'), AssetAmount(30, 'MB')),
                          Timeout(100), Timestamp.now(), True)
-        self.tick2 = Tick(OrderId(TraderId(b'1'), OrderNumber(2)),
+        self.tick2 = Tick(OrderId(TraderId(b'1' * 20), OrderNumber(2)),
                           AssetPair(AssetAmount(120, 'BTC'), AssetAmount(30, 'MB')),
                           Timeout(100), Timestamp.now(), True)
         self.side = Side()
@@ -48,22 +48,22 @@ class SideTestSuite(unittest.TestCase):
     def test_insert_tick(self):
         # Test insert tick
         self.assertEquals(0, len(self.side))
-        self.assertFalse(self.side.tick_exists(OrderId(TraderId(b'0'), OrderNumber(1))))
+        self.assertFalse(self.side.tick_exists(OrderId(TraderId(b'0' * 20), OrderNumber(1))))
 
         self.side.insert_tick(self.tick)
         self.side.insert_tick(self.tick2)
 
         self.assertEquals(2, len(self.side))
-        self.assertTrue(self.side.tick_exists(OrderId(TraderId(b'0'), OrderNumber(1))))
+        self.assertTrue(self.side.tick_exists(OrderId(TraderId(b'0' * 20), OrderNumber(1))))
 
     def test_remove_tick(self):
         # Test remove tick
         self.side.insert_tick(self.tick)
         self.side.insert_tick(self.tick2)
 
-        self.side.remove_tick(OrderId(TraderId(b'0'), OrderNumber(1)))
+        self.side.remove_tick(OrderId(TraderId(b'0' * 20), OrderNumber(1)))
         self.assertEquals(1, len(self.side))
-        self.side.remove_tick(OrderId(TraderId(b'1'), OrderNumber(2)))
+        self.side.remove_tick(OrderId(TraderId(b'1' * 20), OrderNumber(2)))
         self.assertEquals(0, len(self.side))
 
     def test_get_price_level_list_wallets(self):

--- a/Tribler/Test/Community/Market/test_tick.py
+++ b/Tribler/Test/Community/Market/test_tick.py
@@ -20,14 +20,14 @@ class TickTestSuite(unittest.TestCase):
     def setUp(self):
         # Object creation
         self.timestamp_now = Timestamp.now()
-        self.tick = Tick(OrderId(TraderId(b'0'), OrderNumber(1)),
+        self.tick = Tick(OrderId(TraderId(b'0' * 20), OrderNumber(1)),
                          AssetPair(AssetAmount(30, 'BTC'), AssetAmount(30, 'MB')), Timeout(30), Timestamp(0.0), True)
-        self.tick2 = Tick(OrderId(TraderId(b'0'), OrderNumber(2)),
+        self.tick2 = Tick(OrderId(TraderId(b'0' * 20), OrderNumber(2)),
                           AssetPair(AssetAmount(30, 'BTC'), AssetAmount(30, 'MB')), Timeout(0), Timestamp(0.0), False)
-        self.order_ask = Order(OrderId(TraderId(b'0'), OrderNumber(2)),
+        self.order_ask = Order(OrderId(TraderId(b'0' * 20), OrderNumber(2)),
                                AssetPair(AssetAmount(30, 'BTC'), AssetAmount(30, 'MB')),
                                Timeout(0), Timestamp(0.0), True)
-        self.order_bid = Order(OrderId(TraderId(b'0'), OrderNumber(2)),
+        self.order_bid = Order(OrderId(TraderId(b'0' * 20), OrderNumber(2)),
                                AssetPair(AssetAmount(30, 'BTC'), AssetAmount(30, 'MB')),
                                Timeout(0), Timestamp(0.0), False)
 
@@ -38,7 +38,7 @@ class TickTestSuite(unittest.TestCase):
 
     def test_to_network(self):
         # Test for to network
-        self.assertEquals((TraderId(b'0'), self.tick.timestamp, OrderNumber(1),
+        self.assertEquals((TraderId(b'0' * 20), self.tick.timestamp, OrderNumber(1),
                            AssetPair(AssetAmount(30, 'BTC'), AssetAmount(30, 'MB')), self.tick.timeout, 0),
                           self.tick.to_network())
 
@@ -72,7 +72,7 @@ class TickTestSuite(unittest.TestCase):
         Test the to dictionary method of a tick
         """
         self.assertDictEqual(self.tick.to_dictionary(), {
-            "trader_id": b'0',
+            "trader_id": '30' * 20,
             "order_number": 1,
             "assets": self.tick.assets.to_dictionary(),
             "timeout": 30,

--- a/Tribler/Test/Community/Market/test_tick.py
+++ b/Tribler/Test/Community/Market/test_tick.py
@@ -21,15 +21,15 @@ class TickTestSuite(unittest.TestCase):
         # Object creation
         self.timestamp_now = Timestamp.now()
         self.tick = Tick(OrderId(TraderId(b'0' * 20), OrderNumber(1)),
-                         AssetPair(AssetAmount(30, 'BTC'), AssetAmount(30, 'MB')), Timeout(30), Timestamp(0.0), True)
+                         AssetPair(AssetAmount(30, 'BTC'), AssetAmount(30, 'MB')), Timeout(30), Timestamp(0), True)
         self.tick2 = Tick(OrderId(TraderId(b'0' * 20), OrderNumber(2)),
-                          AssetPair(AssetAmount(30, 'BTC'), AssetAmount(30, 'MB')), Timeout(0), Timestamp(0.0), False)
+                          AssetPair(AssetAmount(30, 'BTC'), AssetAmount(30, 'MB')), Timeout(0), Timestamp(0), False)
         self.order_ask = Order(OrderId(TraderId(b'0' * 20), OrderNumber(2)),
                                AssetPair(AssetAmount(30, 'BTC'), AssetAmount(30, 'MB')),
-                               Timeout(0), Timestamp(0.0), True)
+                               Timeout(0), Timestamp(0), True)
         self.order_bid = Order(OrderId(TraderId(b'0' * 20), OrderNumber(2)),
                                AssetPair(AssetAmount(30, 'BTC'), AssetAmount(30, 'MB')),
-                               Timeout(0), Timestamp(0.0), False)
+                               Timeout(0), Timestamp(0), False)
 
     def test_is_ask(self):
         # Test 'is ask' function

--- a/Tribler/Test/Community/Market/test_tickentry.py
+++ b/Tribler/Test/Community/Market/test_tickentry.py
@@ -25,7 +25,7 @@ class TickEntryTestSuite(AbstractServer):
         # Object creation
         tick = Tick(OrderId(TraderId(b'0' * 20), OrderNumber(1)), AssetPair(AssetAmount(60, 'BTC'),
                                                                             AssetAmount(30, 'MB')),
-                    Timeout(0), Timestamp(0.0), True)
+                    Timeout(0), Timestamp(0), True)
         tick2 = Tick(OrderId(TraderId(b'0' * 20), OrderNumber(2)),
                      AssetPair(AssetAmount(63400, 'BTC'), AssetAmount(30, 'MB')), Timeout(100), Timestamp.now(), True)
 

--- a/Tribler/Test/Community/Market/test_tickentry.py
+++ b/Tribler/Test/Community/Market/test_tickentry.py
@@ -23,9 +23,10 @@ class TickEntryTestSuite(AbstractServer):
         yield super(TickEntryTestSuite, self).setUp()
 
         # Object creation
-        tick = Tick(OrderId(TraderId(b'0'), OrderNumber(1)), AssetPair(AssetAmount(60, 'BTC'), AssetAmount(30, 'MB')),
+        tick = Tick(OrderId(TraderId(b'0' * 20), OrderNumber(1)), AssetPair(AssetAmount(60, 'BTC'),
+                                                                            AssetAmount(30, 'MB')),
                     Timeout(0), Timestamp(0.0), True)
-        tick2 = Tick(OrderId(TraderId(b'0'), OrderNumber(2)),
+        tick2 = Tick(OrderId(TraderId(b'0' * 20), OrderNumber(2)),
                      AssetPair(AssetAmount(63400, 'BTC'), AssetAmount(30, 'MB')), Timeout(100), Timestamp.now(), True)
 
         self.price_level = PriceLevel(Price(100, 'MB', 'BTC'))
@@ -68,9 +69,9 @@ class TickEntryTestSuite(AbstractServer):
         """
         Test blocking of a match
         """
-        self.tick_entry.block_for_matching(OrderId(TraderId(b"abc"), OrderNumber(3)))
+        self.tick_entry.block_for_matching(OrderId(TraderId(b'a' * 20), OrderNumber(3)))
         self.assertEqual(len(self.tick_entry._blocked_for_matching), 1)
 
         # Try to add it again - should be ignored
-        self.tick_entry.block_for_matching(OrderId(TraderId(b"abc"), OrderNumber(3)))
+        self.tick_entry.block_for_matching(OrderId(TraderId(b'a' * 20), OrderNumber(3)))
         self.assertEqual(len(self.tick_entry._blocked_for_matching), 1)

--- a/Tribler/Test/Community/Market/test_timeout.py
+++ b/Tribler/Test/Community/Market/test_timeout.py
@@ -1,9 +1,11 @@
-import unittest
+from __future__ import absolute_import
 
 import time
+import unittest
 
 from Tribler.community.market.core.timeout import Timeout
 from Tribler.community.market.core.timestamp import Timestamp
+from Tribler.pyipv8.ipv8.util import old_round
 
 
 class TimeoutTestSuite(unittest.TestCase):
@@ -23,8 +25,8 @@ class TimeoutTestSuite(unittest.TestCase):
 
     def test_timed_out(self):
         # Test for timed out
-        self.assertTrue(self.timeout1.is_timed_out(Timestamp(time.time() - 3700)))
-        self.assertFalse(self.timeout2.is_timed_out(Timestamp(time.time())))
+        self.assertTrue(self.timeout1.is_timed_out(Timestamp(int(old_round(time.time() * 1000)) - 3700 * 1000)))
+        self.assertFalse(self.timeout2.is_timed_out(Timestamp(int(old_round(time.time() * 1000)))))
 
     def test_hash(self):
         # Test for hashes

--- a/Tribler/Test/Community/Market/test_timestamp.py
+++ b/Tribler/Test/Community/Market/test_timestamp.py
@@ -1,7 +1,10 @@
+from __future__ import absolute_import
+
 import time
 import unittest
 
 from Tribler.community.market.core.timestamp import Timestamp
+from Tribler.pyipv8.ipv8.util import old_round
 
 
 class TimestampTestSuite(unittest.TestCase):
@@ -9,9 +12,9 @@ class TimestampTestSuite(unittest.TestCase):
 
     def setUp(self):
         # Object creation
-        self.timestamp = Timestamp(1462224447.117)
-        self.timestamp2 = Timestamp(1462224447.117)
-        self.timestamp3 = Timestamp(1305743832.438)
+        self.timestamp = Timestamp(1462224447000)
+        self.timestamp2 = Timestamp(1462224447000)
+        self.timestamp3 = Timestamp(1305743832000)
 
     def test_init(self):
         # Test for init validation
@@ -22,11 +25,11 @@ class TimestampTestSuite(unittest.TestCase):
 
     def test_now(self):
         # Test for Timestamp.now
-        self.assertAlmostEqual(time.time(), float(Timestamp.now()), delta=.1)
+        self.assertAlmostEqual(int(old_round(time.time() * 1000)), int(Timestamp.now()), delta=1000)
 
     def test_conversion(self):
         # Test for conversions
-        self.assertEqual(1462224447.117, float(self.timestamp))
+        self.assertEqual(1462224447000, int(self.timestamp))
 
         # We cannot check the exact timestamp since this is specific to the configured time zone
         self.assertTrue(str(self.timestamp))
@@ -35,14 +38,14 @@ class TimestampTestSuite(unittest.TestCase):
         # Test for comparison
         self.assertTrue(self.timestamp3 < self.timestamp)
         self.assertTrue(self.timestamp > self.timestamp3)
-        self.assertTrue(self.timestamp3 < 1405743832.438)
-        self.assertTrue(self.timestamp <= 1462224447.117)
-        self.assertTrue(self.timestamp > 1362224447.117)
-        self.assertTrue(self.timestamp3 >= 1305743832.438)
-        self.assertEqual(NotImplemented, self.timestamp.__lt__(10))
-        self.assertEqual(NotImplemented, self.timestamp.__le__(10))
-        self.assertEqual(NotImplemented, self.timestamp.__gt__(10))
-        self.assertEqual(NotImplemented, self.timestamp.__ge__(10))
+        self.assertTrue(self.timestamp3 < 1405743832000)
+        self.assertTrue(self.timestamp <= 1462224447000)
+        self.assertTrue(self.timestamp > 1362224447000)
+        self.assertTrue(self.timestamp3 >= 1305743832000)
+        self.assertEqual(NotImplemented, self.timestamp.__lt__("10"))
+        self.assertEqual(NotImplemented, self.timestamp.__le__("10"))
+        self.assertEqual(NotImplemented, self.timestamp.__gt__("10"))
+        self.assertEqual(NotImplemented, self.timestamp.__ge__("10"))
 
     def test_equality(self):
         # Test for equality

--- a/Tribler/Test/Community/Market/test_trade.py
+++ b/Tribler/Test/Community/Market/test_trade.py
@@ -16,9 +16,9 @@ class TradeTestSuite(unittest.TestCase):
 
     def setUp(self):
         # Object creation
-        self.trade = Trade(TraderId(b'0'),
-                           OrderId(TraderId(b'0'), OrderNumber(3)),
-                           OrderId(TraderId(b'0'), OrderNumber(4)), 1234, Timestamp(1462224447.117))
+        self.trade = Trade(TraderId(b'0' * 20),
+                           OrderId(TraderId(b'0' * 20), OrderNumber(3)),
+                           OrderId(TraderId(b'0' * 20), OrderNumber(4)), 1234, Timestamp(1462224447.117))
 
     def test_to_network(self):
         # Test for to network
@@ -30,31 +30,32 @@ class ProposedTradeTestSuite(unittest.TestCase):
 
     def setUp(self):
         # Object creation
-        self.proposed_trade = Trade.propose(TraderId(b'0'),
-                                            OrderId(TraderId(b'0'), OrderNumber(1)),
-                                            OrderId(TraderId(b'1'), OrderNumber(2)),
+        self.proposed_trade = Trade.propose(TraderId(b'0' * 20),
+                                            OrderId(TraderId(b'0' * 20), OrderNumber(1)),
+                                            OrderId(TraderId(b'1' * 20), OrderNumber(2)),
                                             AssetPair(AssetAmount(60, 'BTC'), AssetAmount(30, 'MB')),
                                             Timestamp(1462224447.117))
 
     def test_to_network(self):
         # Test for to network
-        self.assertEquals((TraderId(b'0'), Timestamp(1462224447.117),
-                           OrderNumber(1), OrderId(TraderId(b'1'), OrderNumber(2)), self.proposed_trade.proposal_id,
+        self.assertEquals((TraderId(b'0' * 20), Timestamp(1462224447.117),
+                           OrderNumber(1), OrderId(TraderId(b'1' * 20), OrderNumber(2)),
+                           self.proposed_trade.proposal_id,
                            AssetPair(AssetAmount(60, 'BTC'), AssetAmount(30, 'MB'))), self.proposed_trade.to_network())
 
     def test_from_network(self):
         # Test for from network
         data = ProposedTrade.from_network(type('Data', (object,),
-                                               {"trader_id": TraderId(b'0'),
+                                               {"trader_id": TraderId(b'0' * 20),
                                                 "order_number": OrderNumber(1),
-                                                "recipient_order_id": OrderId(TraderId('1'), OrderNumber(2)),
+                                                "recipient_order_id": OrderId(TraderId(b'1' * 20), OrderNumber(2)),
                                                 "proposal_id": 1234,
                                                 "timestamp": Timestamp(1462224447.117),
                                                 "assets": AssetPair(AssetAmount(60, 'BTC'), AssetAmount(30, 'MB'))}))
 
-        self.assertEquals(TraderId(b'0'), data.trader_id)
-        self.assertEquals(OrderId(TraderId(b'0'), OrderNumber(1)), data.order_id)
-        self.assertEquals(OrderId(TraderId(b'1'), OrderNumber(2)),
+        self.assertEquals(TraderId(b'0' * 20), data.trader_id)
+        self.assertEquals(OrderId(TraderId(b'0' * 20), OrderNumber(1)), data.order_id)
+        self.assertEquals(OrderId(TraderId(b'1' * 20), OrderNumber(2)),
                           data.recipient_order_id)
         self.assertEquals(1234, data.proposal_id)
         self.assertEquals(AssetPair(AssetAmount(60, 'BTC'), AssetAmount(30, 'MB')), data.assets)
@@ -66,12 +67,12 @@ class DeclinedTradeTestSuite(unittest.TestCase):
 
     def setUp(self):
         # Object creation
-        self.proposed_trade = Trade.propose(TraderId(b'0'),
-                                            OrderId(TraderId(b'0'), OrderNumber(1)),
-                                            OrderId(TraderId(b'1'), OrderNumber(2)),
+        self.proposed_trade = Trade.propose(TraderId(b'0' * 20),
+                                            OrderId(TraderId(b'0' * 20), OrderNumber(1)),
+                                            OrderId(TraderId(b'1' * 20), OrderNumber(2)),
                                             AssetPair(AssetAmount(60, 'BTC'), AssetAmount(30, 'MB')),
                                             Timestamp(1462224447.117))
-        self.declined_trade = Trade.decline(TraderId(b'0'),
+        self.declined_trade = Trade.decline(TraderId(b'0' * 20),
                                             Timestamp(1462224447.117), self.proposed_trade,
                                             DeclinedTradeReason.ORDER_COMPLETED)
 
@@ -79,24 +80,24 @@ class DeclinedTradeTestSuite(unittest.TestCase):
         # Test for to network
         data = self.declined_trade.to_network()
 
-        self.assertEquals(data[0], TraderId(b"0"))
+        self.assertEquals(data[0], TraderId(b'0' * 20))
         self.assertEquals(data[1], Timestamp(1462224447.117))
         self.assertEquals(data[2], OrderNumber(2))
-        self.assertEquals(data[3], OrderId(TraderId(b"0"), OrderNumber(1)))
+        self.assertEquals(data[3], OrderId(TraderId(b'0' * 20), OrderNumber(1)))
         self.assertEquals(data[4], self.proposed_trade.proposal_id)
 
     def test_from_network(self):
         # Test for from network
         data = DeclinedTrade.from_network(type('Data', (object,),
-                                               {"trader_id": TraderId(b'0'),
+                                               {"trader_id": TraderId(b'0' * 20),
                                                 "order_number": OrderNumber(1),
-                                                "recipient_order_id": OrderId(TraderId(b'1'), OrderNumber(2)),
+                                                "recipient_order_id": OrderId(TraderId(b'1' * 20), OrderNumber(2)),
                                                 "proposal_id": 1235,
                                                 "timestamp": Timestamp(1462224447.117),
                                                 "decline_reason": 0}))
 
-        self.assertEquals(TraderId(b'0'), data.trader_id)
-        self.assertEquals(OrderId(TraderId(b'1'), OrderNumber(2)),
+        self.assertEquals(TraderId(b'0' * 20), data.trader_id)
+        self.assertEquals(OrderId(TraderId(b'1' * 20), OrderNumber(2)),
                           data.recipient_order_id)
         self.assertEquals(1235, data.proposal_id)
         self.assertEquals(Timestamp(1462224447.117), data.timestamp)
@@ -113,34 +114,35 @@ class CounterTradeTestSuite(unittest.TestCase):
 
     def setUp(self):
         # Object creation
-        self.proposed_trade = Trade.propose(TraderId(b'0'),
-                                            OrderId(TraderId(b'0'), OrderNumber(1)),
-                                            OrderId(TraderId(b'1'), OrderNumber(2)),
+        self.proposed_trade = Trade.propose(TraderId(b'0' * 20),
+                                            OrderId(TraderId(b'0' * 20), OrderNumber(1)),
+                                            OrderId(TraderId(b'1' * 20), OrderNumber(2)),
                                             AssetPair(AssetAmount(60, 'BTC'), AssetAmount(30, 'MB')),
                                             Timestamp(1462224447.117))
-        self.counter_trade = Trade.counter(TraderId(b'0'), AssetPair(AssetAmount(60, 'BTC'), AssetAmount(30, 'MB')),
+        self.counter_trade = Trade.counter(TraderId(b'0' * 20), AssetPair(AssetAmount(60, 'BTC'),
+                                                                          AssetAmount(30, 'MB')),
                                            Timestamp(1462224447.117), self.proposed_trade)
 
     def test_to_network(self):
         # Test for to network
         self.assertEquals(
-            ((TraderId(b'0'), Timestamp(1462224447.117), OrderNumber(2),
-              OrderId(TraderId(b'0'), OrderNumber(1)), self.proposed_trade.proposal_id,
+            ((TraderId(b'0' * 20), Timestamp(1462224447.117), OrderNumber(2),
+              OrderId(TraderId(b'0' * 20), OrderNumber(1)), self.proposed_trade.proposal_id,
               AssetPair(AssetAmount(60, 'BTC'), AssetAmount(30, 'MB')))), self.counter_trade.to_network())
 
     def test_from_network(self):
         # Test for from network
         data = CounterTrade.from_network(type('Data', (object,),
-                                              {"trader_id": TraderId(b'0'),
+                                              {"trader_id": TraderId(b'0' * 20),
                                                "timestamp": Timestamp(1462224447.117),
                                                "order_number": OrderNumber(1),
-                                               "recipient_order_id": OrderId(TraderId(b'1'), OrderNumber(2)),
+                                               "recipient_order_id": OrderId(TraderId(b'1' * 20), OrderNumber(2)),
                                                "proposal_id": 1236,
                                                "assets": AssetPair(AssetAmount(60, 'BTC'), AssetAmount(30, 'MB')), }))
 
-        self.assertEquals(TraderId(b'0'), data.trader_id)
-        self.assertEquals(OrderId(TraderId(b'0'), OrderNumber(1)), data.order_id)
-        self.assertEquals(OrderId(TraderId(b'1'), OrderNumber(2)),
+        self.assertEquals(TraderId(b'0' * 20), data.trader_id)
+        self.assertEquals(OrderId(TraderId(b'0' * 20), OrderNumber(1)), data.order_id)
+        self.assertEquals(OrderId(TraderId(b'1' * 20), OrderNumber(2)),
                           data.recipient_order_id)
         self.assertEquals(1236, data.proposal_id)
         self.assertEquals(AssetPair(AssetAmount(60, 'BTC'), AssetAmount(30, 'MB')), data.assets)

--- a/Tribler/Test/Community/Market/test_trade.py
+++ b/Tribler/Test/Community/Market/test_trade.py
@@ -18,7 +18,7 @@ class TradeTestSuite(unittest.TestCase):
         # Object creation
         self.trade = Trade(TraderId(b'0' * 20),
                            OrderId(TraderId(b'0' * 20), OrderNumber(3)),
-                           OrderId(TraderId(b'0' * 20), OrderNumber(4)), 1234, Timestamp(1462224447.117))
+                           OrderId(TraderId(b'0' * 20), OrderNumber(4)), 1234, Timestamp(1462224447117))
 
     def test_to_network(self):
         # Test for to network
@@ -34,11 +34,11 @@ class ProposedTradeTestSuite(unittest.TestCase):
                                             OrderId(TraderId(b'0' * 20), OrderNumber(1)),
                                             OrderId(TraderId(b'1' * 20), OrderNumber(2)),
                                             AssetPair(AssetAmount(60, 'BTC'), AssetAmount(30, 'MB')),
-                                            Timestamp(1462224447.117))
+                                            Timestamp(1462224447117))
 
     def test_to_network(self):
         # Test for to network
-        self.assertEquals((TraderId(b'0' * 20), Timestamp(1462224447.117),
+        self.assertEquals((TraderId(b'0' * 20), Timestamp(1462224447117),
                            OrderNumber(1), OrderId(TraderId(b'1' * 20), OrderNumber(2)),
                            self.proposed_trade.proposal_id,
                            AssetPair(AssetAmount(60, 'BTC'), AssetAmount(30, 'MB'))), self.proposed_trade.to_network())
@@ -50,7 +50,7 @@ class ProposedTradeTestSuite(unittest.TestCase):
                                                 "order_number": OrderNumber(1),
                                                 "recipient_order_id": OrderId(TraderId(b'1' * 20), OrderNumber(2)),
                                                 "proposal_id": 1234,
-                                                "timestamp": Timestamp(1462224447.117),
+                                                "timestamp": Timestamp(1462224447117),
                                                 "assets": AssetPair(AssetAmount(60, 'BTC'), AssetAmount(30, 'MB'))}))
 
         self.assertEquals(TraderId(b'0' * 20), data.trader_id)
@@ -59,7 +59,7 @@ class ProposedTradeTestSuite(unittest.TestCase):
                           data.recipient_order_id)
         self.assertEquals(1234, data.proposal_id)
         self.assertEquals(AssetPair(AssetAmount(60, 'BTC'), AssetAmount(30, 'MB')), data.assets)
-        self.assertEquals(Timestamp(1462224447.117), data.timestamp)
+        self.assertEquals(Timestamp(1462224447117), data.timestamp)
 
 
 class DeclinedTradeTestSuite(unittest.TestCase):
@@ -71,9 +71,9 @@ class DeclinedTradeTestSuite(unittest.TestCase):
                                             OrderId(TraderId(b'0' * 20), OrderNumber(1)),
                                             OrderId(TraderId(b'1' * 20), OrderNumber(2)),
                                             AssetPair(AssetAmount(60, 'BTC'), AssetAmount(30, 'MB')),
-                                            Timestamp(1462224447.117))
+                                            Timestamp(1462224447117))
         self.declined_trade = Trade.decline(TraderId(b'0' * 20),
-                                            Timestamp(1462224447.117), self.proposed_trade,
+                                            Timestamp(1462224447117), self.proposed_trade,
                                             DeclinedTradeReason.ORDER_COMPLETED)
 
     def test_to_network(self):
@@ -81,7 +81,7 @@ class DeclinedTradeTestSuite(unittest.TestCase):
         data = self.declined_trade.to_network()
 
         self.assertEquals(data[0], TraderId(b'0' * 20))
-        self.assertEquals(data[1], Timestamp(1462224447.117))
+        self.assertEquals(data[1], Timestamp(1462224447117))
         self.assertEquals(data[2], OrderNumber(2))
         self.assertEquals(data[3], OrderId(TraderId(b'0' * 20), OrderNumber(1)))
         self.assertEquals(data[4], self.proposed_trade.proposal_id)
@@ -93,14 +93,14 @@ class DeclinedTradeTestSuite(unittest.TestCase):
                                                 "order_number": OrderNumber(1),
                                                 "recipient_order_id": OrderId(TraderId(b'1' * 20), OrderNumber(2)),
                                                 "proposal_id": 1235,
-                                                "timestamp": Timestamp(1462224447.117),
+                                                "timestamp": Timestamp(1462224447117),
                                                 "decline_reason": 0}))
 
         self.assertEquals(TraderId(b'0' * 20), data.trader_id)
         self.assertEquals(OrderId(TraderId(b'1' * 20), OrderNumber(2)),
                           data.recipient_order_id)
         self.assertEquals(1235, data.proposal_id)
-        self.assertEquals(Timestamp(1462224447.117), data.timestamp)
+        self.assertEquals(Timestamp(1462224447117), data.timestamp)
 
     def test_decline_reason(self):
         """
@@ -118,15 +118,15 @@ class CounterTradeTestSuite(unittest.TestCase):
                                             OrderId(TraderId(b'0' * 20), OrderNumber(1)),
                                             OrderId(TraderId(b'1' * 20), OrderNumber(2)),
                                             AssetPair(AssetAmount(60, 'BTC'), AssetAmount(30, 'MB')),
-                                            Timestamp(1462224447.117))
+                                            Timestamp(1462224447117))
         self.counter_trade = Trade.counter(TraderId(b'0' * 20), AssetPair(AssetAmount(60, 'BTC'),
                                                                           AssetAmount(30, 'MB')),
-                                           Timestamp(1462224447.117), self.proposed_trade)
+                                           Timestamp(1462224447117), self.proposed_trade)
 
     def test_to_network(self):
         # Test for to network
         self.assertEquals(
-            ((TraderId(b'0' * 20), Timestamp(1462224447.117), OrderNumber(2),
+            ((TraderId(b'0' * 20), Timestamp(1462224447117), OrderNumber(2),
               OrderId(TraderId(b'0' * 20), OrderNumber(1)), self.proposed_trade.proposal_id,
               AssetPair(AssetAmount(60, 'BTC'), AssetAmount(30, 'MB')))), self.counter_trade.to_network())
 
@@ -134,7 +134,7 @@ class CounterTradeTestSuite(unittest.TestCase):
         # Test for from network
         data = CounterTrade.from_network(type('Data', (object,),
                                               {"trader_id": TraderId(b'0' * 20),
-                                               "timestamp": Timestamp(1462224447.117),
+                                               "timestamp": Timestamp(1462224447117),
                                                "order_number": OrderNumber(1),
                                                "recipient_order_id": OrderId(TraderId(b'1' * 20), OrderNumber(2)),
                                                "proposal_id": 1236,
@@ -146,4 +146,4 @@ class CounterTradeTestSuite(unittest.TestCase):
                           data.recipient_order_id)
         self.assertEquals(1236, data.proposal_id)
         self.assertEquals(AssetPair(AssetAmount(60, 'BTC'), AssetAmount(30, 'MB')), data.assets)
-        self.assertEquals(Timestamp(1462224447.117), data.timestamp)
+        self.assertEquals(Timestamp(1462224447117), data.timestamp)

--- a/Tribler/Test/Community/Market/test_transaction.py
+++ b/Tribler/Test/Community/Market/test_transaction.py
@@ -85,14 +85,14 @@ class TransactionTestSuite(unittest.TestCase):
         self.transaction_id = TransactionId(TraderId(b'0' * 20), TransactionNumber(1))
         self.transaction = Transaction(self.transaction_id, AssetPair(AssetAmount(100, 'BTC'), AssetAmount(100, 'MB')),
                                        OrderId(TraderId(b'3' * 20), OrderNumber(2)),
-                                       OrderId(TraderId(b'2' * 20), OrderNumber(1)), Timestamp(0.0))
+                                       OrderId(TraderId(b'2' * 20), OrderNumber(1)), Timestamp(0))
         self.proposed_trade = Trade.propose(TraderId(b'0' * 20),
                                             OrderId(TraderId(b'0' * 20), OrderNumber(2)),
                                             OrderId(TraderId(b'1' * 20), OrderNumber(3)),
-                                            AssetPair(AssetAmount(100, 'BTC'), AssetAmount(100, 'MB')), Timestamp(0.0))
+                                            AssetPair(AssetAmount(100, 'BTC'), AssetAmount(100, 'MB')), Timestamp(0))
         self.payment = Payment(TraderId(b'0' * 20), TransactionId(TraderId(b'2' * 20), TransactionNumber(2)),
                                AssetAmount(3, 'MB'), WalletAddress('a'), WalletAddress('b'),
-                               PaymentId('aaa'), Timestamp(4.0), True)
+                               PaymentId('aaa'), Timestamp(4), True)
 
     def test_from_proposed_trade(self):
         """
@@ -158,7 +158,7 @@ class TransactionTestSuite(unittest.TestCase):
                     'type': 'MB'
                 }
             },
-            'timestamp': 0.0,
+            'timestamp': 0,
             'status': 'pending'
         })
 
@@ -183,7 +183,7 @@ class StartTransactionTestSuite(unittest.TestCase):
                                                   OrderId(TraderId(b'0' * 20), OrderNumber(1)),
                                                   OrderId(TraderId(b'1' * 20), OrderNumber(1)), 1234,
                                                   AssetPair(AssetAmount(30, 'BTC'), AssetAmount(40, 'MC')),
-                                                  Timestamp(0.0))
+                                                  Timestamp(0))
 
     def test_from_network(self):
         # Test for from network
@@ -194,14 +194,14 @@ class StartTransactionTestSuite(unittest.TestCase):
                                      "recipient_order_id": OrderId(TraderId(b'1' * 20), OrderNumber(2)),
                                      "proposal_id": 1235,
                                      "assets": AssetPair(AssetAmount(30, 'BTC'), AssetAmount(40, 'MC')),
-                                     "timestamp": Timestamp(0.0)}))
+                                     "timestamp": Timestamp(0)}))
 
         self.assertEquals(TraderId(b'0' * 20), data.trader_id)
         self.assertEquals(TransactionId(TraderId(b'0' * 20), TransactionNumber(1)), data.transaction_id)
         self.assertEquals(OrderId(TraderId(b'0' * 20), OrderNumber(1)), data.order_id)
         self.assertEquals(OrderId(TraderId(b'1' * 20), OrderNumber(2)), data.recipient_order_id)
         self.assertEquals(1235, data.proposal_id)
-        self.assertEquals(Timestamp(0.0), data.timestamp)
+        self.assertEquals(Timestamp(0), data.timestamp)
 
     def test_to_network(self):
         """
@@ -220,7 +220,7 @@ class StartTransactionTestSuite(unittest.TestCase):
                 'status': 'pending',
                 'partner_trader_id': '1111111111111111111111111111111111111111',
                 'trader_id': '0000000000000000000000000000000000000000',
-                'timestamp': 0.0,
+                'timestamp': 0,
                 'transferred': {
                     'second': {
                         'amount': 0,
@@ -253,7 +253,7 @@ class StartTransactionTestSuite(unittest.TestCase):
         self.assertEqual(block['tx']['transaction_number'], int(transaction.transaction_id.transaction_number))
         self.assertEqual(block['tx']['partner_trader_id'], transaction.partner_order_id.trader_id.as_hex())
         self.assertEqual(block['tx']['partner_order_number'], int(transaction.partner_order_id.order_number))
-        self.assertEqual(block['tx']['timestamp'], float(transaction.timestamp))
+        self.assertEqual(block['tx']['timestamp'], int(transaction.timestamp))
         self.assertEqual(block['tx']['assets']['first']['amount'], transaction.assets.first.amount)
         self.assertEqual(block['tx']['assets']['first']['type'], transaction.assets.first.asset_id)
         self.assertEqual(block['tx']['assets']['second']['amount'], transaction.assets.second.amount)

--- a/Tribler/Test/Community/Market/test_transaction.py
+++ b/Tribler/Test/Community/Market/test_transaction.py
@@ -52,18 +52,18 @@ class TransactionIdTestSuite(unittest.TestCase):
 
     def setUp(self):
         # Object creation
-        self.transaction_id = TransactionId(TraderId(b'0'), TransactionNumber(1))
-        self.transaction_id2 = TransactionId(TraderId(b'0'), TransactionNumber(1))
-        self.transaction_id3 = TransactionId(TraderId(b'0'), TransactionNumber(2))
+        self.transaction_id = TransactionId(TraderId(b'0' * 20), TransactionNumber(1))
+        self.transaction_id2 = TransactionId(TraderId(b'0' * 20), TransactionNumber(1))
+        self.transaction_id3 = TransactionId(TraderId(b'0' * 20), TransactionNumber(2))
 
     def test_properties(self):
         # Test for properties
-        self.assertEqual(TraderId(b'0'), self.transaction_id.trader_id)
+        self.assertEqual(TraderId(b'0' * 20), self.transaction_id.trader_id)
         self.assertEqual(TransactionNumber(1), self.transaction_id.transaction_number)
 
     def test_conversion(self):
         # Test for conversions
-        self.assertEqual('0.1', str(self.transaction_id))
+        self.assertEqual('%s.1' % ("30" * 20), str(self.transaction_id))
 
     def test_equality(self):
         # Test for equality
@@ -82,15 +82,15 @@ class TransactionTestSuite(unittest.TestCase):
 
     def setUp(self):
         # Object creation
-        self.transaction_id = TransactionId(TraderId(b"0"), TransactionNumber(1))
+        self.transaction_id = TransactionId(TraderId(b'0' * 20), TransactionNumber(1))
         self.transaction = Transaction(self.transaction_id, AssetPair(AssetAmount(100, 'BTC'), AssetAmount(100, 'MB')),
-                                       OrderId(TraderId(b'3'), OrderNumber(2)),
-                                       OrderId(TraderId(b'2'), OrderNumber(1)), Timestamp(0.0))
-        self.proposed_trade = Trade.propose(TraderId(b'0'),
-                                            OrderId(TraderId(b'0'), OrderNumber(2)),
-                                            OrderId(TraderId(b'1'), OrderNumber(3)),
+                                       OrderId(TraderId(b'3' * 20), OrderNumber(2)),
+                                       OrderId(TraderId(b'2' * 20), OrderNumber(1)), Timestamp(0.0))
+        self.proposed_trade = Trade.propose(TraderId(b'0' * 20),
+                                            OrderId(TraderId(b'0' * 20), OrderNumber(2)),
+                                            OrderId(TraderId(b'1' * 20), OrderNumber(3)),
                                             AssetPair(AssetAmount(100, 'BTC'), AssetAmount(100, 'MB')), Timestamp(0.0))
-        self.payment = Payment(TraderId(b"0"), TransactionId(TraderId(b'2'), TransactionNumber(2)),
+        self.payment = Payment(TraderId(b'0' * 20), TransactionId(TraderId(b'2' * 20), TransactionNumber(2)),
                                AssetAmount(3, 'MB'), WalletAddress('a'), WalletAddress('b'),
                                PaymentId('aaa'), Timestamp(4.0), True)
 
@@ -132,10 +132,10 @@ class TransactionTestSuite(unittest.TestCase):
         Test the to dictionary method of a transaction
         """
         self.assertDictEqual(self.transaction.to_dictionary(), {
-            'trader_id': b'0',
+            'trader_id': "30" * 20,
             'transaction_number': 1,
             'order_number': 2,
-            'partner_trader_id': b'2',
+            'partner_trader_id': "32" * 20,
             'partner_order_number': 1,
             'payment_complete': False,
             'assets': {
@@ -178,28 +178,28 @@ class StartTransactionTestSuite(unittest.TestCase):
 
     def setUp(self):
         # Object creation
-        self.start_transaction = StartTransaction(TraderId(b'0'),
-                                                  TransactionId(TraderId(b"0"), TransactionNumber(1)),
-                                                  OrderId(TraderId(b'0'), OrderNumber(1)),
-                                                  OrderId(TraderId(b'1'), OrderNumber(1)), 1234,
+        self.start_transaction = StartTransaction(TraderId(b'0' * 20),
+                                                  TransactionId(TraderId(b'0' * 20), TransactionNumber(1)),
+                                                  OrderId(TraderId(b'0' * 20), OrderNumber(1)),
+                                                  OrderId(TraderId(b'1' * 20), OrderNumber(1)), 1234,
                                                   AssetPair(AssetAmount(30, 'BTC'), AssetAmount(40, 'MC')),
                                                   Timestamp(0.0))
 
     def test_from_network(self):
         # Test for from network
         data = StartTransaction.from_network(
-            type('Data', (object,), {"trader_id": TraderId(b'0'),
-                                     "transaction_id": TransactionId(TraderId(b'0'), TransactionNumber(1)),
-                                     "order_id": OrderId(TraderId(b'0'), OrderNumber(1)),
-                                     "recipient_order_id": OrderId(TraderId(b'1'), OrderNumber(2)),
+            type('Data', (object,), {"trader_id": TraderId(b'0' * 20),
+                                     "transaction_id": TransactionId(TraderId(b'0' * 20), TransactionNumber(1)),
+                                     "order_id": OrderId(TraderId(b'0' * 20), OrderNumber(1)),
+                                     "recipient_order_id": OrderId(TraderId(b'1' * 20), OrderNumber(2)),
                                      "proposal_id": 1235,
                                      "assets": AssetPair(AssetAmount(30, 'BTC'), AssetAmount(40, 'MC')),
                                      "timestamp": Timestamp(0.0)}))
 
-        self.assertEquals(TraderId(b"0"), data.trader_id)
-        self.assertEquals(TransactionId(TraderId(b"0"), TransactionNumber(1)), data.transaction_id)
-        self.assertEquals(OrderId(TraderId(b'0'), OrderNumber(1)), data.order_id)
-        self.assertEquals(OrderId(TraderId(b'1'), OrderNumber(2)), data.recipient_order_id)
+        self.assertEquals(TraderId(b'0' * 20), data.trader_id)
+        self.assertEquals(TransactionId(TraderId(b'0' * 20), TransactionNumber(1)), data.transaction_id)
+        self.assertEquals(OrderId(TraderId(b'0' * 20), OrderNumber(1)), data.order_id)
+        self.assertEquals(OrderId(TraderId(b'1' * 20), OrderNumber(2)), data.recipient_order_id)
         self.assertEquals(1235, data.proposal_id)
         self.assertEquals(Timestamp(0.0), data.timestamp)
 
@@ -249,11 +249,9 @@ class StartTransactionTestSuite(unittest.TestCase):
 
         transaction = Transaction.from_block(block)
 
-        self.assertEqual(block['tx']['trader_id'], six.text_type(transaction.transaction_id.trader_id))
+        self.assertEqual(block['tx']['trader_id'], transaction.transaction_id.trader_id.as_hex())
         self.assertEqual(block['tx']['transaction_number'], int(transaction.transaction_id.transaction_number))
-        self.assertEqual(block['tx']['trader_id'], six.text_type(transaction.order_id.trader_id))
-        self.assertEqual(block['tx']['transaction_number'], int(transaction.order_id.order_number))
-        self.assertEqual(block['tx']['partner_trader_id'], six.text_type(transaction.partner_order_id.trader_id))
+        self.assertEqual(block['tx']['partner_trader_id'], transaction.partner_order_id.trader_id.as_hex())
         self.assertEqual(block['tx']['partner_order_number'], int(transaction.partner_order_id.order_number))
         self.assertEqual(block['tx']['timestamp'], float(transaction.timestamp))
         self.assertEqual(block['tx']['assets']['first']['amount'], transaction.assets.first.amount)

--- a/Tribler/Test/Community/Market/test_transaction_manager.py
+++ b/Tribler/Test/Community/Market/test_transaction_manager.py
@@ -27,18 +27,18 @@ class TransactionManagerTestSuite(unittest.TestCase):
         self.transaction_id = TransactionId(TraderId(b'0' * 20), TransactionNumber(1))
         self.transaction = Transaction(self.transaction_id, AssetPair(AssetAmount(100, 'BTC'), AssetAmount(30, 'MB')),
                                        OrderId(TraderId(b'3' * 20), OrderNumber(2)),
-                                       OrderId(TraderId(b'2' * 20), OrderNumber(1)), Timestamp(0.0))
+                                       OrderId(TraderId(b'2' * 20), OrderNumber(1)), Timestamp(0))
         self.proposed_trade = Trade.propose(TraderId(b'0' * 20),
                                             OrderId(TraderId(b'0' * 20), OrderNumber(1)),
                                             OrderId(TraderId(b'1' * 20), OrderNumber(2)),
                                             AssetPair(AssetAmount(30, 'BTC'), AssetAmount(30, 'MB')),
-                                            Timestamp(1462224447.117))
+                                            Timestamp(1462224447117))
         self.start_transaction = StartTransaction(TraderId(b'0' * 20),
                                                   TransactionId(TraderId(b'0' * 20), TransactionNumber(1)),
                                                   OrderId(TraderId(b'0' * 20), OrderNumber(1)),
                                                   OrderId(TraderId(b'1' * 20), OrderNumber(2)), 1235,
                                                   AssetPair(AssetAmount(20, 'BTC'), AssetAmount(20, 'MB')),
-                                                  Timestamp(0.0))
+                                                  Timestamp(0))
 
     def test_create_from_proposed_trade(self):
         # Test for create from a proposed trade

--- a/Tribler/Test/Community/Market/test_transaction_manager.py
+++ b/Tribler/Test/Community/Market/test_transaction_manager.py
@@ -21,22 +21,22 @@ class TransactionManagerTestSuite(unittest.TestCase):
 
     def setUp(self):
         # Object creation
-        self.memory_transaction_repository = MemoryTransactionRepository("0")
+        self.memory_transaction_repository = MemoryTransactionRepository(b'0' * 20)
         self.transaction_manager = TransactionManager(self.memory_transaction_repository)
 
-        self.transaction_id = TransactionId(TraderId(b"0"), TransactionNumber(1))
+        self.transaction_id = TransactionId(TraderId(b'0' * 20), TransactionNumber(1))
         self.transaction = Transaction(self.transaction_id, AssetPair(AssetAmount(100, 'BTC'), AssetAmount(30, 'MB')),
-                                       OrderId(TraderId(b'3'), OrderNumber(2)),
-                                       OrderId(TraderId(b'2'), OrderNumber(1)), Timestamp(0.0))
-        self.proposed_trade = Trade.propose(TraderId(b'0'),
-                                            OrderId(TraderId(b'0'), OrderNumber(1)),
-                                            OrderId(TraderId(b'1'), OrderNumber(2)),
+                                       OrderId(TraderId(b'3' * 20), OrderNumber(2)),
+                                       OrderId(TraderId(b'2' * 20), OrderNumber(1)), Timestamp(0.0))
+        self.proposed_trade = Trade.propose(TraderId(b'0' * 20),
+                                            OrderId(TraderId(b'0' * 20), OrderNumber(1)),
+                                            OrderId(TraderId(b'1' * 20), OrderNumber(2)),
                                             AssetPair(AssetAmount(30, 'BTC'), AssetAmount(30, 'MB')),
                                             Timestamp(1462224447.117))
-        self.start_transaction = StartTransaction(TraderId(b'0'),
-                                                  TransactionId(TraderId(b"0"), TransactionNumber(1)),
-                                                  OrderId(TraderId(b'0'), OrderNumber(1)),
-                                                  OrderId(TraderId(b'1'), OrderNumber(2)), 1235,
+        self.start_transaction = StartTransaction(TraderId(b'0' * 20),
+                                                  TransactionId(TraderId(b'0' * 20), TransactionNumber(1)),
+                                                  OrderId(TraderId(b'0' * 20), OrderNumber(1)),
+                                                  OrderId(TraderId(b'1' * 20), OrderNumber(2)), 1235,
                                                   AssetPair(AssetAmount(20, 'BTC'), AssetAmount(20, 'MB')),
                                                   Timestamp(0.0))
 
@@ -70,7 +70,7 @@ class TransactionManagerTestSuite(unittest.TestCase):
         self.transaction.outgoing_address = WalletAddress('def')
         self.transaction.partner_incoming_address = WalletAddress('ghi')
         self.transaction.partner_outgoing_address = WalletAddress('jkl')
-        payment_msg = self.transaction_manager.create_payment_message(TraderId(b"0"),
+        payment_msg = self.transaction_manager.create_payment_message(TraderId(b'0' * 20),
                                                                       PaymentId('abc'), self.transaction,
                                                                       AssetAmount(1, 'BTC'),
                                                                       True)

--- a/Tribler/Test/Community/Market/test_transaction_repository.py
+++ b/Tribler/Test/Community/Market/test_transaction_repository.py
@@ -16,11 +16,11 @@ class MemoryTransactionRepositoryTestSuite(unittest.TestCase):
 
     def setUp(self):
         # Object creation
-        self.memory_transaction_repository = MemoryTransactionRepository("0")
-        self.transaction_id = TransactionId(TraderId(b"0"), TransactionNumber(1))
+        self.memory_transaction_repository = MemoryTransactionRepository(b'0' * 20)
+        self.transaction_id = TransactionId(TraderId(b'0' * 20), TransactionNumber(1))
         self.transaction = Transaction(self.transaction_id, AssetPair(AssetAmount(10, 'BTC'), AssetAmount(10, 'MB')),
-                                       OrderId(TraderId(b"0"), OrderNumber(1)),
-                                       OrderId(TraderId(b"2"), OrderNumber(2)), Timestamp(0.0))
+                                       OrderId(TraderId(b'0' * 20), OrderNumber(1)),
+                                       OrderId(TraderId(b'2' * 20), OrderNumber(2)), Timestamp(0.0))
 
     def test_find_by_id(self):
         # Test for find by id
@@ -43,9 +43,9 @@ class MemoryTransactionRepositoryTestSuite(unittest.TestCase):
 
     def test_next_identity(self):
         # Test for next identity
-        self.assertEquals(TransactionId(TraderId(b"0"), TransactionNumber(1)),
+        self.assertEquals(TransactionId(TraderId(b'0' * 20), TransactionNumber(1)),
                           self.memory_transaction_repository.next_identity())
-        self.assertEquals(TransactionId(TraderId(b"0"), TransactionNumber(2)),
+        self.assertEquals(TransactionId(TraderId(b'0' * 20), TransactionNumber(2)),
                           self.memory_transaction_repository.next_identity())
 
     def test_update(self):

--- a/Tribler/Test/Community/Market/test_transaction_repository.py
+++ b/Tribler/Test/Community/Market/test_transaction_repository.py
@@ -20,7 +20,7 @@ class MemoryTransactionRepositoryTestSuite(unittest.TestCase):
         self.transaction_id = TransactionId(TraderId(b'0' * 20), TransactionNumber(1))
         self.transaction = Transaction(self.transaction_id, AssetPair(AssetAmount(10, 'BTC'), AssetAmount(10, 'MB')),
                                        OrderId(TraderId(b'0' * 20), OrderNumber(1)),
-                                       OrderId(TraderId(b'2' * 20), OrderNumber(2)), Timestamp(0.0))
+                                       OrderId(TraderId(b'2' * 20), OrderNumber(2)), Timestamp(0))
 
     def test_find_by_id(self):
         # Test for find by id

--- a/Tribler/Test/Core/Modules/RestApi/base_api_test.py
+++ b/Tribler/Test/Core/Modules/RestApi/base_api_test.py
@@ -71,11 +71,12 @@ class AbstractBaseApiTest(TestAsServer):
 
     def do_request(self, endpoint, req_type, post_data, raw_data):
         try:
-            req_type = req_type.encode('utf-8')
+            req_type = req_type.encode('ascii')
+            endpoint = endpoint.encode('ascii')
         except AttributeError:
             pass
         agent = Agent(reactor, pool=self.connection_pool)
-        return agent.request(req_type, 'http://localhost:%s/%s' % (self.session.config.get_http_api_port(), endpoint),
+        return agent.request(req_type, b'http://localhost:%d/%s' % (self.session.config.get_http_api_port(), endpoint),
                              Headers({'User-Agent': ['Tribler ' + version_id],
                                       "Content-Type": ["text/plain; charset=utf-8"]}),
                              POSTDataProducer(post_data, raw_data))

--- a/Tribler/Test/Core/Modules/RestApi/test_market_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_market_endpoint.py
@@ -57,15 +57,15 @@ class TestMarketEndpoint(AbstractApiTest):
         """
         Add a transaction and a payment to the market
         """
-        proposed_trade = Trade.propose(TraderId(b'0'),
-                                       OrderId(TraderId(b'0'), OrderNumber(1)),
-                                       OrderId(TraderId(b'1'), OrderNumber(2)),
+        proposed_trade = Trade.propose(TraderId(b'0' * 20),
+                                       OrderId(TraderId(b'0' * 20), OrderNumber(1)),
+                                       OrderId(TraderId(b'1' * 20), OrderNumber(2)),
                                        AssetPair(AssetAmount(30, 'BTC'), AssetAmount(60, 'MB')),
                                        Timestamp(1462224447.117))
         transaction = self.session.lm.market_community.transaction_manager.create_from_proposed_trade(
             proposed_trade, 'abcd')
 
-        payment = Payment(TraderId(b"0"), transaction.transaction_id,
+        payment = Payment(TraderId(b'0' * 20), transaction.transaction_id,
                           AssetAmount(20, 'BTC'), WalletAddress('a'), WalletAddress('b'),
                           PaymentId('aaa'), Timestamp(4.0), True)
         transaction.add_payment(payment)
@@ -205,7 +205,7 @@ class TestMarketEndpoint(AbstractApiTest):
         Test whether the API returns a 404 when a payment cannot be found
         """
         self.should_check_equality = False
-        return self.do_request('market/transactions/abc/3/payments', expected_code=404)
+        return self.do_request('market/transactions/%s/3/payments' % ('30' * 20), expected_code=404)
 
     @trial_timeout(10)
     def test_get_orders(self):
@@ -236,7 +236,8 @@ class TestMarketEndpoint(AbstractApiTest):
         transaction = self.add_transaction_and_payment()
         self.should_check_equality = False
         return self.do_request('market/transactions/%s/%s/payments' %
-                               (transaction.transaction_id.trader_id, transaction.transaction_id.transaction_number),
+                               (transaction.transaction_id.trader_id.as_hex(),
+                                transaction.transaction_id.transaction_number),
                                expected_code=200).addCallback(on_response)
 
     @trial_timeout(10)

--- a/Tribler/Test/Core/Modules/RestApi/test_market_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_market_endpoint.py
@@ -61,13 +61,13 @@ class TestMarketEndpoint(AbstractApiTest):
                                        OrderId(TraderId(b'0' * 20), OrderNumber(1)),
                                        OrderId(TraderId(b'1' * 20), OrderNumber(2)),
                                        AssetPair(AssetAmount(30, 'BTC'), AssetAmount(60, 'MB')),
-                                       Timestamp(1462224447.117))
+                                       Timestamp(1462224447117))
         transaction = self.session.lm.market_community.transaction_manager.create_from_proposed_trade(
             proposed_trade, 'abcd')
 
         payment = Payment(TraderId(b'0' * 20), transaction.transaction_id,
                           AssetAmount(20, 'BTC'), WalletAddress('a'), WalletAddress('b'),
-                          PaymentId('aaa'), Timestamp(4.0), True)
+                          PaymentId('aaa'), Timestamp(4000), True)
         transaction.add_payment(payment)
         self.session.lm.market_community.transaction_manager.transaction_repository.update(transaction)
 

--- a/Tribler/Test/Core/Modules/Wallet/test_trustchain_wallet.py
+++ b/Tribler/Test/Core/Modules/Wallet/test_trustchain_wallet.py
@@ -6,10 +6,10 @@ from twisted.internet.defer import Deferred, inlineCallbacks
 
 from Tribler.Core.Modules.wallet.tc_wallet import TrustchainWallet
 from Tribler.Core.Modules.wallet.wallet import InsufficientFunds
+from Tribler.Test.tools import trial_timeout
 from Tribler.pyipv8.ipv8.attestation.trustchain.community import TrustChainCommunity
 from Tribler.pyipv8.ipv8.test.base import TestBase
 from Tribler.pyipv8.ipv8.test.mocking.ipv8 import MockIPv8
-from Tribler.Test.tools import trial_timeout
 
 
 class TestTrustchainWallet(TestBase):

--- a/Tribler/Test/Core/Modules/Wallet/test_trustchain_wallet.py
+++ b/Tribler/Test/Core/Modules/Wallet/test_trustchain_wallet.py
@@ -89,7 +89,7 @@ class TestTrustchainWallet(TestBase):
         """
         his_pubkey = self.nodes[0].overlay.my_peer.public_key.key_to_bin()
 
-        tx_deferred = self.tc_wallet.monitor_transaction(b'%s.1' % hexlify(his_pubkey))
+        tx_deferred = self.tc_wallet.monitor_transaction('%s.1' % hexlify(his_pubkey).decode('utf-8'))
 
         # Now create the transaction
         transaction = {
@@ -118,7 +118,7 @@ class TestTrustchainWallet(TestBase):
         his_pubkey = self.nodes[0].overlay.my_peer.public_key.key_to_bin()
         yield self.nodes[1].overlay.sign_block(self.nodes[1].network.verified_peers[0], public_key=his_pubkey,
                                                block_type=b'tribler_bandwidth', transaction=transaction)
-        yield self.tc_wallet.monitor_transaction(b'%s.1' % hexlify(his_pubkey))
+        yield self.tc_wallet.monitor_transaction('%s.1' % hexlify(his_pubkey).decode('utf-8'))
 
     def test_address(self):
         """

--- a/Tribler/community/market/block.py
+++ b/Tribler/community/market/block.py
@@ -70,7 +70,7 @@ class MarketBlock(TrustChainBlock):
         if not MarketBlock.has_fields(required_fields, tick):
             return False
 
-        required_types = [('trader_id', string_types), ('order_number', int), ('assets', dict), ('timestamp', float),
+        required_types = [('trader_id', string_types), ('order_number', int), ('assets', dict), ('timestamp', int),
                           ('timeout', int)]
 
         if not MarketBlock.is_valid_trader_id(tick['trader_id']):
@@ -98,7 +98,7 @@ class MarketBlock(TrustChainBlock):
 
         required_types = [('trader_id', string_types), ('order_number', int), ('partner_trader_id', string_types),
                           ('partner_order_number', int), ('transaction_number', int), ('assets', dict),
-                          ('transferred', dict), ('timestamp', float), ('payment_complete', bool), ('status', str)]
+                          ('transferred', dict), ('timestamp', int), ('payment_complete', bool), ('status', str)]
 
         if not MarketBlock.is_valid_trader_id(tx['trader_id']) or not \
                 MarketBlock.is_valid_trader_id(tx['partner_trader_id']):
@@ -125,7 +125,7 @@ class MarketBlock(TrustChainBlock):
             return False
 
         required_types = [('trader_id', string_types), ('transaction_number', int), ('transferred', dict),
-                          ('payment_id', str), ('address_from', str), ('address_to', str), ('timestamp', float),
+                          ('payment_id', str), ('address_from', str), ('address_to', str), ('timestamp', int),
                           ('success', bool)]
         if not MarketBlock.is_valid_trader_id(payment['trader_id']):
             return False

--- a/Tribler/community/market/block.py
+++ b/Tribler/community/market/block.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from six import integer_types
+from six import integer_types, string_types
 
 from Tribler.community.market import MAX_ORDER_TIMEOUT
 from Tribler.pyipv8.ipv8.attestation.trustchain.block import TrustChainBlock
@@ -68,7 +68,7 @@ class MarketBlock(TrustChainBlock):
         if not MarketBlock.has_fields(required_fields, tick):
             return False
 
-        required_types = [('trader_id', str), ('order_number', int), ('assets', dict), ('timestamp', float),
+        required_types = [('trader_id', string_types), ('order_number', int), ('assets', dict), ('timestamp', float),
                           ('timeout', int)]
 
         if not MarketBlock.is_valid_trader_id(tick['trader_id']):
@@ -94,7 +94,7 @@ class MarketBlock(TrustChainBlock):
         if len(tx) != len(required_fields):
             return False
 
-        required_types = [('trader_id', str), ('order_number', int), ('partner_trader_id', str),
+        required_types = [('trader_id', string_types), ('order_number', int), ('partner_trader_id', string_types),
                           ('partner_order_number', int), ('transaction_number', int), ('assets', dict),
                           ('transferred', dict), ('timestamp', float), ('payment_complete', bool), ('status', str)]
 
@@ -122,8 +122,9 @@ class MarketBlock(TrustChainBlock):
         if len(payment) != len(required_fields):
             return False
 
-        required_types = [('trader_id', str), ('transaction_number', int), ('transferred', dict), ('payment_id', str),
-                          ('address_from', str), ('address_to', str), ('timestamp', float), ('success', bool)]
+        required_types = [('trader_id', string_types), ('transaction_number', int), ('transferred', dict),
+                          ('payment_id', str), ('address_from', str), ('address_to', str), ('timestamp', float),
+                          ('success', bool)]
         if not MarketBlock.is_valid_trader_id(payment['trader_id']):
             return False
         if not MarketBlock.has_required_types(required_types, payment):
@@ -154,7 +155,7 @@ class MarketBlock(TrustChainBlock):
         if not MarketBlock.has_fields(['trader_id', 'order_number'], self.transaction):
             return False
 
-        required_types = [('trader_id', str), ('order_number', int)]
+        required_types = [('trader_id', string_types), ('order_number', int)]
         if not MarketBlock.has_required_types(required_types, self.transaction):
             return False
 

--- a/Tribler/community/market/block.py
+++ b/Tribler/community/market/block.py
@@ -35,9 +35,11 @@ class MarketBlock(TrustChainBlock):
         if 'amount' not in assets_dict['second'] or 'type' not in assets_dict['second']:
             return False
 
-        if not MarketBlock.has_required_types([('amount', integer_types), ('type', str)], assets_dict['first']):
+        if not MarketBlock.has_required_types([('amount', integer_types), ('type', string_types)],
+                                              assets_dict['first']):
             return False
-        if not MarketBlock.has_required_types([('amount', integer_types), ('type', str)], assets_dict['second']):
+        if not MarketBlock.has_required_types([('amount', integer_types), ('type', string_types)],
+                                              assets_dict['second']):
             return False
 
         if assets_dict['first']['amount'].bit_length() > 63 or assets_dict['second']['amount'].bit_length() > 63:
@@ -136,7 +138,7 @@ class MarketBlock(TrustChainBlock):
         """
         Verify whether an incoming block with the tick type is valid.
         """
-        if self.type != "ask" and self.type != "bid":
+        if self.type != b"ask" and self.type != b"bid":
             return False
         if not MarketBlock.has_fields(['tick'], self.transaction):
             return False
@@ -149,7 +151,7 @@ class MarketBlock(TrustChainBlock):
         """
         Verify whether an incoming block with cancel type is valid.
         """
-        if self.type != "cancel_order":
+        if self.type != b"cancel_order":
             return False
 
         if not MarketBlock.has_fields(['trader_id', 'order_number'], self.transaction):
@@ -165,7 +167,7 @@ class MarketBlock(TrustChainBlock):
         """
         Verify whether an incoming block with tx_init/tx_done type is valid.
         """
-        if self.type != "tx_init" and self.type != "tx_done":
+        if self.type != b"tx_init" and self.type != b"tx_done":
             return False
 
         if not MarketBlock.has_fields(['ask', 'bid', 'tx'], self.transaction):
@@ -184,7 +186,7 @@ class MarketBlock(TrustChainBlock):
         """
         Verify whether an incoming block with tx_payment type is valid.
         """
-        if self.type != "tx_payment":
+        if self.type != b"tx_payment":
             return False
 
         if not MarketBlock.has_fields(['payment'], self.transaction):

--- a/Tribler/community/market/community.py
+++ b/Tribler/community/market/community.py
@@ -1461,7 +1461,7 @@ class MarketCommunity(Community, BlockListener):
 
         def monitor_for_transaction():
             wallet = self.wallets[asset_id]
-            transaction_deferred = wallet.monitor_transaction(str(payment.payment_id))
+            transaction_deferred = wallet.monitor_transaction(payment.payment_id.payment_id)
             transaction_deferred.addCallback(lambda _: self.received_payment(peer, payment, transaction))
 
         reactor.callFromThread(monitor_for_transaction)

--- a/Tribler/community/market/community.py
+++ b/Tribler/community/market/community.py
@@ -185,8 +185,6 @@ class MarketCommunity(Community, BlockListener):
         if self.is_matchmaker:
             self.enable_matchmaker()
 
-        self.initialize_traders()
-
         # Register messages
         self.decode_map.update({
             chr(MSG_MATCH): self.received_match,
@@ -207,13 +205,6 @@ class MarketCommunity(Community, BlockListener):
         })
 
         self.logger.info("Market community initialized with mid %s", hexlify(self.mid))
-
-    def initialize_traders(self):
-        """
-        Load the information of traders from the database.
-        """
-        for trader_info in self.market_database.get_traders():
-            self.update_ip(*trader_info)
 
     def get_address_for_trader(self, trader_id):
         """
@@ -332,10 +323,6 @@ class MarketCommunity(Community, BlockListener):
     @inlineCallbacks
     def unload(self):
         self.request_cache.clear()
-
-        # Store all traders to the database
-        for trader_id, sock_addr in self.mid_register.items():
-            self.market_database.add_trader_identity(trader_id, sock_addr[0], sock_addr[1])
 
         # Save the ticks to the database
         if self.is_matchmaker:

--- a/Tribler/community/market/community.py
+++ b/Tribler/community/market/community.py
@@ -1331,7 +1331,7 @@ class MarketCommunity(Community, BlockListener):
             "assets": payload.assets.to_dictionary(),
             "traded": payload.traded,
             "timeout": int(payload.timeout),
-            "timestamp": float(payload.timestamp),
+            "timestamp": int(payload.timestamp),
         }
 
         reactor.callFromThread(request.request_deferred.callback, order_dict)

--- a/Tribler/community/market/community.py
+++ b/Tribler/community/market/community.py
@@ -323,7 +323,7 @@ class MarketCommunity(Community, BlockListener):
         self.endpoint.send(peer.address, packet)
 
     def get_orders_bloomfilter(self):
-        order_ids = [str(order_id) for order_id in self.order_book.get_order_ids()]
+        order_ids = [bytes(order_id) for order_id in self.order_book.get_order_ids()]
         orders_bloom_filter = BloomFilter(0.005, max(len(order_ids), 1), prefix=b' ')
         if order_ids:
             orders_bloom_filter.add_keys(order_ids)
@@ -510,7 +510,7 @@ class MarketCommunity(Community, BlockListener):
             return
 
         for order_id in self.order_book.get_order_ids():
-            if str(order_id) not in payload.bloomfilter:
+            if bytes(order_id) not in payload.bloomfilter:
                 is_ask = self.order_book.ask_exists(order_id)
                 entry = self.order_book.get_ask(order_id) if is_ask else self.order_book.get_bid(order_id)
 

--- a/Tribler/community/market/core/assetamount.py
+++ b/Tribler/community/market/core/assetamount.py
@@ -1,3 +1,7 @@
+from __future__ import absolute_import
+
+from six import string_types
+
 # pylint: disable=long-builtin,redefined-builtin
 try:
     long
@@ -26,7 +30,7 @@ class AssetAmount(object):
         if not isinstance(amount, long):
             raise ValueError("Price must be a long")
 
-        if not isinstance(asset_id, str):
+        if not isinstance(asset_id, string_types):
             raise ValueError("Asset id must be a string")
 
         self._amount = amount

--- a/Tribler/community/market/core/matching_engine.py
+++ b/Tribler/community/market/core/matching_engine.py
@@ -80,10 +80,14 @@ class PriceTimeStrategy(MatchingStrategy):
         quantity_to_match = quantity
 
         # First check whether we can match our order at all in the order book
-        if is_ask and price > self.order_book.get_bid_price(price.numerator, price.denominator):
-            return []
-        if not is_ask and price < self.order_book.get_ask_price(price.numerator, price.denominator):
-            return []
+        if is_ask:
+            bid_price = self.order_book.get_bid_price(price.numerator, price.denominator)
+            if not bid_price or price > bid_price:
+                return []
+        if not is_ask:
+            ask_price = self.order_book.get_ask_price(price.numerator, price.denominator)
+            if not ask_price or price < ask_price:
+                return []
 
         # Next, check whether we have a price level we can start our match search from
         if is_ask:

--- a/Tribler/community/market/core/message.py
+++ b/Tribler/community/market/core/message.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+from binascii import hexlify
+
 from six import binary_type
 
 from Tribler.community.market.core.timestamp import Timestamp
@@ -18,13 +20,8 @@ class TraderId(object):
 
         trader_id = trader_id if isinstance(trader_id, bytes) else binary_type(trader_id)
 
-        if not isinstance(trader_id, binary_type):
-            raise ValueError("Trader id must be a binary type")
-
-        try:
-            int(trader_id, 16)
-        except ValueError:  # Not a hexadecimal
-            raise ValueError("Trader id must be hexadecimal")
+        if len(trader_id) != 20:
+            raise ValueError("Trader ID must be 20 bytes")
 
         self._trader_id = trader_id  # type: bytes
 
@@ -33,6 +30,9 @@ class TraderId(object):
 
     def __bytes__(self):  # type: () -> bytes
         return self._trader_id
+
+    def as_hex(self):
+        return hexlify(bytes(self)).decode('utf-8')
 
     def __eq__(self, other):
         if not isinstance(other, TraderId):

--- a/Tribler/community/market/core/message.py
+++ b/Tribler/community/market/core/message.py
@@ -31,7 +31,7 @@ class TraderId(object):
     def __str__(self):
         return "%s" % self._trader_id
 
-    def to_bytes(self):  # type: () -> bytes
+    def __bytes__(self):  # type: () -> bytes
         return self._trader_id
 
     def __eq__(self, other):
@@ -40,7 +40,7 @@ class TraderId(object):
         elif self is other:
             return True
         else:
-            return self._trader_id == other.to_bytes()
+            return self._trader_id == bytes(other)
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/Tribler/community/market/core/order.py
+++ b/Tribler/community/market/core/order.py
@@ -10,7 +10,6 @@ from Tribler.community.market.core.message import TraderId
 from Tribler.community.market.core.timeout import Timeout
 from Tribler.community.market.core.timestamp import Timestamp
 from Tribler.pyipv8.ipv8.database import database_blob
-from Tribler.pyipv8.ipv8.util import cast_to_unicode
 
 
 class TickWasNotReserved(Exception):
@@ -89,7 +88,7 @@ class OrderId(object):
         """
         format: <trader_id>.<order_number>
         """
-        return "%s.%d" % (cast_to_unicode(bytes(self._trader_id)), self._order_number)
+        return "%s.%d" % (self._trader_id.as_hex(), self._order_number)
 
     def __eq__(self, other):
         if not isinstance(other, OrderId):
@@ -405,7 +404,7 @@ class Order(object):
         """
         completed_timestamp = float(self.completed_timestamp) if self.completed_timestamp else None
         return {
-            "trader_id": bytes(self.order_id.trader_id),
+            "trader_id": self.order_id.trader_id.as_hex(),
             "order_number": int(self.order_id.order_number),
             "assets": self.assets.to_dictionary(),
             "reserved_quantity": self.reserved_quantity,
@@ -423,7 +422,7 @@ class Order(object):
         Return a dictionary representation of this order (suitable for saving on the TrustChain)
         """
         return {
-            "trader_id": str(self.order_id.trader_id),
+            "trader_id": self.order_id.trader_id.as_hex(),
             "order_number": int(self.order_id.order_number),
             "assets": self.assets.to_dictionary(),
             "traded": self.traded_quantity,

--- a/Tribler/community/market/core/order.py
+++ b/Tribler/community/market/core/order.py
@@ -90,6 +90,9 @@ class OrderId(object):
         """
         return "%s.%d" % (self._trader_id.as_hex(), self._order_number)
 
+    def __bytes__(self):
+        return b"%s.%d" % (self._trader_id.as_hex().encode('utf-8'), self._order_number)
+
     def __eq__(self, other):
         if not isinstance(other, OrderId):
             return NotImplemented

--- a/Tribler/community/market/core/order.py
+++ b/Tribler/community/market/core/order.py
@@ -89,7 +89,7 @@ class OrderId(object):
         """
         format: <trader_id>.<order_number>
         """
-        return "%s.%d" % (cast_to_unicode(self._trader_id.to_bytes()), self._order_number)
+        return "%s.%d" % (cast_to_unicode(bytes(self._trader_id)), self._order_number)
 
     def __eq__(self, other):
         if not isinstance(other, OrderId):
@@ -168,7 +168,7 @@ class Order(object):
         :rtype: tuple
         """
         completed_timestamp = float(self.completed_timestamp) if self.completed_timestamp else None
-        return (database_blob(self.order_id.trader_id.to_bytes()), text_type(self.order_id.order_number),
+        return (database_blob(bytes(self.order_id.trader_id)), text_type(self.order_id.order_number),
                 self.assets.first.amount, text_type(self.assets.first.asset_id), self.assets.second.amount,
                 text_type(self.assets.second.asset_id), self.traded_quantity, int(self.timeout),
                 float(self.timestamp), completed_timestamp, self.is_ask(), self._cancelled, self._verified)
@@ -405,7 +405,7 @@ class Order(object):
         """
         completed_timestamp = float(self.completed_timestamp) if self.completed_timestamp else None
         return {
-            "trader_id": self.order_id.trader_id.to_bytes(),
+            "trader_id": bytes(self.order_id.trader_id),
             "order_number": int(self.order_id.order_number),
             "assets": self.assets.to_dictionary(),
             "reserved_quantity": self.reserved_quantity,

--- a/Tribler/community/market/core/order.py
+++ b/Tribler/community/market/core/order.py
@@ -169,11 +169,11 @@ class Order(object):
         Returns a database representation of an Order object.
         :rtype: tuple
         """
-        completed_timestamp = float(self.completed_timestamp) if self.completed_timestamp else None
+        completed_timestamp = int(self.completed_timestamp) if self.completed_timestamp else None
         return (database_blob(bytes(self.order_id.trader_id)), text_type(self.order_id.order_number),
                 self.assets.first.amount, text_type(self.assets.first.asset_id), self.assets.second.amount,
                 text_type(self.assets.second.asset_id), self.traded_quantity, int(self.timeout),
-                float(self.timestamp), completed_timestamp, self.is_ask(), self._cancelled, self._verified)
+                int(self.timestamp), completed_timestamp, self.is_ask(), self._cancelled, self._verified)
 
     @property
     def reserved_ticks(self):
@@ -405,7 +405,7 @@ class Order(object):
         """
         Return a dictionary representation of this order.
         """
-        completed_timestamp = float(self.completed_timestamp) if self.completed_timestamp else None
+        completed_timestamp = int(self.completed_timestamp) if self.completed_timestamp else None
         return {
             "trader_id": self.order_id.trader_id.as_hex(),
             "order_number": int(self.order_id.order_number),
@@ -413,7 +413,7 @@ class Order(object):
             "reserved_quantity": self.reserved_quantity,
             "traded": self.traded_quantity,
             "timeout": int(self.timeout),
-            "timestamp": float(self.timestamp),
+            "timestamp": int(self.timestamp),
             "completed_timestamp": completed_timestamp,
             "is_ask": self.is_ask(),
             "cancelled": self.cancelled,
@@ -430,5 +430,5 @@ class Order(object):
             "assets": self.assets.to_dictionary(),
             "traded": self.traded_quantity,
             "timeout": int(self.timeout),
-            "timestamp": float(self.timestamp)
+            "timestamp": int(self.timestamp)
         }

--- a/Tribler/community/market/core/order_repository.py
+++ b/Tribler/community/market/core/order_repository.py
@@ -55,11 +55,6 @@ class MemoryOrderRepository(OrderRepository):
 
         self._logger.info("Memory order repository used")
 
-        try:
-            int(mid, 16)
-        except ValueError:  # Not a hexadecimal
-            raise ValueError("Encoded member id must be hexadecimal")
-
         self._mid = mid
         self._next_id = 0  # Counter to keep track of the number of messages created by this repository
 

--- a/Tribler/community/market/core/order_repository.py
+++ b/Tribler/community/market/core/order_repository.py
@@ -1,8 +1,10 @@
+from __future__ import absolute_import
+
 import logging
 from abc import ABCMeta, abstractmethod
 
 from Tribler.community.market.core.message import TraderId
-from Tribler.community.market.core.order import OrderNumber, OrderId, Order
+from Tribler.community.market.core.order import OrderId, OrderNumber
 
 
 class OrderRepository(object):

--- a/Tribler/community/market/core/order_repository.py
+++ b/Tribler/community/market/core/order_repository.py
@@ -121,11 +121,6 @@ class DatabaseOrderRepository(OrderRepository):
 
         self._logger.info("Memory order repository used")
 
-        try:
-            int(mid, 16)
-        except ValueError:  # Not a hexadecimal
-            raise ValueError("Encoded member id must be hexadecimal")
-
         self._mid = mid
         self.persistence = persistence
 

--- a/Tribler/community/market/core/orderbook.py
+++ b/Tribler/community/market/core/orderbook.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 import logging
 import time
+from binascii import unhexlify
 
 from twisted.internet import reactor
 from twisted.internet.defer import fail
@@ -98,8 +99,10 @@ class OrderBook(TaskManager):
         :type traded_quantity: int
         :type unreserve: bool
         """
-        ask_order_id = OrderId(TraderId(ask_order_dict["trader_id"]), OrderNumber(ask_order_dict["order_number"]))
-        bid_order_id = OrderId(TraderId(bid_order_dict["trader_id"]), OrderNumber(bid_order_dict["order_number"]))
+        ask_order_id = OrderId(TraderId(unhexlify(ask_order_dict["trader_id"])),
+                               OrderNumber(ask_order_dict["order_number"]))
+        bid_order_id = OrderId(TraderId(unhexlify(bid_order_dict["trader_id"])),
+                               OrderNumber(bid_order_dict["order_number"]))
 
         self._logger.debug("Updating ticks in order book: %s and %s (traded quantity: %s)",
                            str(ask_order_id), str(bid_order_id), str(traded_quantity))

--- a/Tribler/community/market/core/orderbook.py
+++ b/Tribler/community/market/core/orderbook.py
@@ -248,15 +248,6 @@ class OrderBook(TaskManager):
                  self.get_bid_price(price_wallet_id, quantity_wallet_id).amount
         return Price(spread, price_wallet_id, quantity_wallet_id)
 
-    def get_mid_price(self, price_wallet_id, quantity_wallet_id):
-        """
-        Return the price in between the bid and the ask price
-        :rtype: Price
-        """
-        ask_price = self.get_ask_price(price_wallet_id, quantity_wallet_id).amount
-        bid_price = self.get_bid_price(price_wallet_id, quantity_wallet_id).amount
-        return Price((ask_price + bid_price) / 2, price_wallet_id, quantity_wallet_id)
-
     def bid_side_depth(self, price):
         """
         Return the depth of the price level with the given price on the bid side

--- a/Tribler/community/market/core/orderbook.py
+++ b/Tribler/community/market/core/orderbook.py
@@ -18,6 +18,7 @@ from Tribler.community.market.core.tick import Ask, Bid
 from Tribler.community.market.core.timeout import Timeout
 from Tribler.community.market.core.timestamp import Timestamp
 from Tribler.pyipv8.ipv8.taskmanager import TaskManager
+from Tribler.pyipv8.ipv8.util import old_round
 
 
 class OrderBook(TaskManager):
@@ -56,7 +57,7 @@ class OrderBook(TaskManager):
         """
         if not self._asks.tick_exists(ask.order_id) and ask.order_id not in self.completed_orders and ask.is_valid():
             self._asks.insert_tick(ask)
-            timeout_delay = float(ask.timestamp) + int(ask.timeout) - time.time()
+            timeout_delay = int(ask.timestamp) + int(ask.timeout) * 1000 - int(old_round(time.time() * 1000))
             task = deferLater(reactor, timeout_delay, self.timeout_ask, ask.order_id)
             self.register_task("ask_%s_timeout" % ask.order_id, task)
             return task.addErrback(self.on_timeout_error)
@@ -76,7 +77,7 @@ class OrderBook(TaskManager):
         """
         if not self._bids.tick_exists(bid.order_id) and bid.order_id not in self.completed_orders and bid.is_valid():
             self._bids.insert_tick(bid)
-            timeout_delay = float(bid.timestamp) + int(bid.timeout) - time.time()
+            timeout_delay = int(bid.timestamp) + int(bid.timeout) * 1000 - int(old_round(time.time() * 1000))
             task = deferLater(reactor, timeout_delay, self.timeout_bid, bid.order_id)
             self.register_task("bid_%s_timeout" % bid.order_id, task)
             return task.addErrback(self.on_timeout_error)

--- a/Tribler/community/market/core/payment.py
+++ b/Tribler/community/market/core/payment.py
@@ -108,7 +108,7 @@ class Payment(Message):
 
     def to_dictionary(self):
         return {
-            "trader_id": bytes(self.transaction_id.trader_id),
+            "trader_id": self.transaction_id.trader_id.as_hex(),
             "transaction_number": int(self.transaction_id.transaction_number),
             "transferred": self.transferred_assets.to_dictionary(),
             "payment_id": str(self.payment_id),

--- a/Tribler/community/market/core/payment.py
+++ b/Tribler/community/market/core/payment.py
@@ -42,7 +42,7 @@ class Payment(Message):
         Returns a database representation of a Payment object.
         :rtype: tuple
         """
-        return (database_blob(self.trader_id.to_bytes()), database_blob(self.transaction_id.trader_id.to_bytes()),
+        return (database_blob(bytes(self.trader_id)), database_blob(bytes(self.transaction_id.trader_id)),
                 int(self.transaction_id.transaction_number), text_type(self.payment_id), self.transferred_assets.amount,
                 text_type(self.transferred_assets.asset_id), text_type(self.address_from),
                 text_type(self.address_to), float(self.timestamp), self.success)
@@ -108,7 +108,7 @@ class Payment(Message):
 
     def to_dictionary(self):
         return {
-            "trader_id": self.transaction_id.trader_id.to_bytes(),
+            "trader_id": bytes(self.transaction_id.trader_id),
             "transaction_number": int(self.transaction_id.transaction_number),
             "transferred": self.transferred_assets.to_dictionary(),
             "payment_id": str(self.payment_id),

--- a/Tribler/community/market/core/payment.py
+++ b/Tribler/community/market/core/payment.py
@@ -35,7 +35,7 @@ class Payment(Message):
         transaction_id = TransactionId(TraderId(bytes(transaction_trader_id)), TransactionNumber(transaction_number))
         return cls(TraderId(bytes(trader_id)), transaction_id, AssetAmount(transferred_amount, str(transferred_id)),
                    WalletAddress(str(address_from)), WalletAddress(str(address_to)), PaymentId(str(payment_id)),
-                   Timestamp(float(timestamp)), bool(success))
+                   Timestamp(timestamp), bool(success))
 
     def to_database(self):
         """
@@ -45,7 +45,7 @@ class Payment(Message):
         return (database_blob(bytes(self.trader_id)), database_blob(bytes(self.transaction_id.trader_id)),
                 int(self.transaction_id.transaction_number), text_type(self.payment_id), self.transferred_assets.amount,
                 text_type(self.transferred_assets.asset_id), text_type(self.address_from),
-                text_type(self.address_to), float(self.timestamp), self.success)
+                text_type(self.address_to), int(self.timestamp), self.success)
 
     @property
     def transaction_id(self):
@@ -114,6 +114,6 @@ class Payment(Message):
             "payment_id": str(self.payment_id),
             "address_from": str(self.address_from),
             "address_to": str(self.address_to),
-            "timestamp": float(self.timestamp),
+            "timestamp": int(self.timestamp),
             "success": self.success
         }

--- a/Tribler/community/market/core/payment_id.py
+++ b/Tribler/community/market/core/payment_id.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+
+from six import string_types
+
+
 class PaymentId(object):
     """Used for having a validated instance of a payment id that we can monitor."""
 
@@ -9,7 +14,7 @@ class PaymentId(object):
         """
         super(PaymentId, self).__init__()
 
-        if not isinstance(payment_id, str):
+        if not isinstance(payment_id, string_types):
             raise ValueError("Payment id must be a string")
 
         self._payment_id = payment_id

--- a/Tribler/community/market/core/tick.py
+++ b/Tribler/community/market/core/tick.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 import time
-from binascii import hexlify
+from binascii import hexlify, unhexlify
 
 from six import text_type
 
@@ -183,7 +183,7 @@ class Tick(object):
         Return a block dictionary representation of the tick, will be stored on the TrustChain
         """
         return {
-            "trader_id": bytes(self.order_id.trader_id),
+            "trader_id": self.order_id.trader_id.as_hex(),
             "order_number": int(self.order_id.order_number),
             "assets": self.assets.to_dictionary(),
             "timeout": int(self.timeout),
@@ -196,7 +196,7 @@ class Tick(object):
         Return a dictionary with a representation of this tick.
         """
         return {
-            "trader_id": bytes(self.order_id.trader_id),
+            "trader_id": self.order_id.trader_id.as_hex(),
             "order_number": int(self.order_id.order_number),
             "assets": self.assets.to_dictionary(),
             "timeout": int(self.timeout),
@@ -244,7 +244,7 @@ class Ask(Tick):
         """
         tx_dict = block.transaction["tick"]
         return cls(
-            OrderId(TraderId(tx_dict["trader_id"]), OrderNumber(tx_dict["order_number"])),
+            OrderId(TraderId(unhexlify(tx_dict["trader_id"])), OrderNumber(tx_dict["order_number"])),
             AssetPair.from_dictionary(tx_dict["assets"]),
             Timeout(tx_dict["timeout"]),
             Timestamp(tx_dict["timestamp"]),
@@ -284,7 +284,7 @@ class Bid(Tick):
         """
         tx_dict = block.transaction["tick"]
         return cls(
-            OrderId(TraderId(tx_dict["trader_id"]), OrderNumber(tx_dict["order_number"])),
+            OrderId(TraderId(unhexlify(tx_dict["trader_id"])), OrderNumber(tx_dict["order_number"])),
             AssetPair.from_dictionary(tx_dict["assets"]),
             Timeout(tx_dict["timeout"]),
             Timestamp(tx_dict["timestamp"]),

--- a/Tribler/community/market/core/tick.py
+++ b/Tribler/community/market/core/tick.py
@@ -62,7 +62,7 @@ class Tick(object):
                         Timeout(timeout), Timestamp(timestamp), traded=traded, block_hash=str(block_hash))
 
     def to_database(self):
-        return (database_blob(self.order_id.trader_id.to_bytes()), int(self.order_id.order_number),
+        return (database_blob(bytes(self.order_id.trader_id)), int(self.order_id.order_number),
                 self.assets.first.amount, text_type(self.assets.first.asset_id), self.assets.second.amount,
                 text_type(self.assets.second.asset_id), int(self.timeout), float(self.timestamp), self.is_ask(),
                 self.traded, database_blob(self.block_hash))
@@ -183,7 +183,7 @@ class Tick(object):
         Return a block dictionary representation of the tick, will be stored on the TrustChain
         """
         return {
-            "trader_id": self.order_id.trader_id.to_bytes(),
+            "trader_id": bytes(self.order_id.trader_id),
             "order_number": int(self.order_id.order_number),
             "assets": self.assets.to_dictionary(),
             "timeout": int(self.timeout),
@@ -196,7 +196,7 @@ class Tick(object):
         Return a dictionary with a representation of this tick.
         """
         return {
-            "trader_id": self.order_id.trader_id.to_bytes(),
+            "trader_id": bytes(self.order_id.trader_id),
             "order_number": int(self.order_id.order_number),
             "assets": self.assets.to_dictionary(),
             "timeout": int(self.timeout),

--- a/Tribler/community/market/core/timeout.py
+++ b/Tribler/community/market/core/timeout.py
@@ -1,6 +1,9 @@
+from __future__ import absolute_import
+
 import time
 
 from Tribler.community.market.core.timestamp import Timestamp
+from Tribler.pyipv8.ipv8.util import old_round
 
 
 class Timeout(object):
@@ -31,7 +34,7 @@ class Timeout(object):
         :return: True if timeout has occurred, False otherwise
         :rtype: bool
         """
-        return time.time() - float(timestamp) >= self._timeout
+        return int(old_round(time.time() * 1000)) - int(timestamp) >= self._timeout * 1000
 
     def __int__(self):
         return self._timeout

--- a/Tribler/community/market/core/timestamp.py
+++ b/Tribler/community/market/core/timestamp.py
@@ -1,9 +1,11 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 import datetime
 import time
 
 from six import integer_types
+
+from Tribler.pyipv8.ipv8.util import old_round
 
 
 class Timestamp(object):
@@ -11,19 +13,19 @@ class Timestamp(object):
 
     def __init__(self, timestamp):
         """
-        :param timestamp: Float representation of a timestamp
-        :type timestamp: float
+        :param timestamp: Integer representation of a timestamp in milliseconds
+        :type timestamp: integer_types
         :raises ValueError: Thrown when one of the arguments are invalid
         """
         super(Timestamp, self).__init__()
 
-        if not isinstance(timestamp, (float, integer_types)):
-            raise ValueError("Timestamp must be a float or a integer")
+        if not isinstance(timestamp, integer_types):
+            raise ValueError("Timestamp must be an integer")
 
         if timestamp < 0:
             raise ValueError("Timestamp can not be negative")
 
-        self._timestamp = float(timestamp)
+        self._timestamp = timestamp
 
     @classmethod
     def now(cls):
@@ -33,38 +35,34 @@ class Timestamp(object):
         :return: A timestamp
         :rtype: Timestamp
         """
-        return cls(time.time())
+        return cls(int(old_round(time.time() * 1000)))
 
-    def __float__(self):
+    def __int__(self):
         return self._timestamp
 
     def __str__(self):
-        return "%s" % datetime.datetime.fromtimestamp(self._timestamp)
+        return "%s" % datetime.datetime.fromtimestamp(self._timestamp // 1000)
 
     def __lt__(self, other):
         if isinstance(other, Timestamp):
             return self._timestamp < other._timestamp
-        if isinstance(other, float):
+        if isinstance(other, integer_types):
             return self._timestamp < other
-        else:
-            return NotImplemented
+        return NotImplemented
 
     def __le__(self, other):
         if isinstance(other, Timestamp):
             return self._timestamp <= other._timestamp
-        if isinstance(other, float):
+        if isinstance(other, integer_types):
             return self._timestamp <= other
-        else:
-            return NotImplemented
+        return NotImplemented
 
     def __eq__(self, other):
         if not isinstance(other, Timestamp):
             return NotImplemented
         elif self is other:
             return True
-        else:
-            return self._timestamp == \
-                   other._timestamp
+        return self._timestamp == other._timestamp
 
     def __ne__(self, other):
         return not self.__eq__(other)
@@ -72,18 +70,16 @@ class Timestamp(object):
     def __gt__(self, other):
         if isinstance(other, Timestamp):
             return self._timestamp > other._timestamp
-        if isinstance(other, float):
+        if isinstance(other, integer_types):
             return self._timestamp > other
-        else:
-            return NotImplemented
+        return NotImplemented
 
     def __ge__(self, other):
         if isinstance(other, Timestamp):
             return self._timestamp >= other._timestamp
-        if isinstance(other, float):
+        if isinstance(other, integer_types):
             return self._timestamp >= other
-        else:
-            return NotImplemented
+        return NotImplemented
 
     def __hash__(self):
         return hash(self._timestamp)

--- a/Tribler/community/market/core/transaction.py
+++ b/Tribler/community/market/core/transaction.py
@@ -157,7 +157,7 @@ class Transaction(object):
                                     AssetAmount(asset2_amount, str(asset2_type))),
                           OrderId(TraderId(bytes(order_trader_id)), OrderNumber(order_number)),
                           OrderId(TraderId(bytes(partner_trader_id)), OrderNumber(partner_order_number)),
-                          Timestamp(float(transaction_timestamp)))
+                          Timestamp(transaction_timestamp))
 
         transaction._transferred_assets = AssetPair(AssetAmount(asset1_transferred, str(asset1_type)),
                                                     AssetAmount(asset2_transferred, str(asset2_type)))
@@ -204,7 +204,7 @@ class Transaction(object):
                                     AssetAmount(asset2_amount, str(asset2_type))),
                           OrderId(TraderId(order_trader_id), OrderNumber(order_number)),
                           OrderId(TraderId(partner_trader_id), OrderNumber(partner_order_number)),
-                          Timestamp(float(transaction_timestamp)))
+                          Timestamp(transaction_timestamp))
 
         transaction._transferred_assets = AssetPair(AssetAmount(asset1_transferred, str(asset1_type)),
                                                     AssetAmount(asset2_transferred, str(asset2_type)))
@@ -228,7 +228,7 @@ class Transaction(object):
                 database_blob(bytes(self.partner_order_id.trader_id)), int(self.partner_order_id.order_number),
                 self.assets.first.amount, text_type(self.assets.first.asset_id), self.transferred_assets.first.amount,
                 self.assets.second.amount, text_type(self.assets.second.asset_id),
-                self.transferred_assets.second.amount, float(self.timestamp), self.sent_wallet_info,
+                self.transferred_assets.second.amount, int(self.timestamp), self.sent_wallet_info,
                 self.received_wallet_info, text_type(self.incoming_address), text_type(self.outgoing_address),
                 text_type(self.partner_incoming_address), text_type(self.partner_outgoing_address),
                 text_type(self.match_id))
@@ -344,7 +344,7 @@ class Transaction(object):
             "transaction_number": int(self.transaction_id.transaction_number),
             "assets": self.assets.to_dictionary(),
             "transferred": self.transferred_assets.to_dictionary(),
-            "timestamp": float(self.timestamp),
+            "timestamp": int(self.timestamp),
             "payment_complete": self.is_payment_complete(),
             "status": self.status
         }

--- a/Tribler/community/market/core/transaction.py
+++ b/Tribler/community/market/core/transaction.py
@@ -85,7 +85,7 @@ class TransactionId(object):
         """
         format: <trader_id>.<transaction_number>
         """
-        return "%s.%d" % (cast_to_unicode(self._trader_id.to_bytes()), self._transaction_number)
+        return "%s.%d" % (cast_to_unicode(bytes(self._trader_id)), self._transaction_number)
 
     def __eq__(self, other):
         if not isinstance(other, TransactionId):
@@ -223,9 +223,9 @@ class Transaction(object):
         Returns a database representation of a Transaction object.
         :rtype: tuple
         """
-        return (database_blob(self.transaction_id.trader_id.to_bytes()), int(self.transaction_id.transaction_number),
-                database_blob(self.order_id.trader_id.to_bytes()), int(self.order_id.order_number),
-                database_blob(self.partner_order_id.trader_id.to_bytes()), int(self.partner_order_id.order_number),
+        return (database_blob(bytes(self.transaction_id.trader_id)), int(self.transaction_id.transaction_number),
+                database_blob(bytes(self.order_id.trader_id)), int(self.order_id.order_number),
+                database_blob(bytes(self.partner_order_id.trader_id)), int(self.partner_order_id.order_number),
                 self.assets.first.amount, text_type(self.assets.first.asset_id), self.transferred_assets.first.amount,
                 self.assets.second.amount, text_type(self.assets.second.asset_id),
                 self.transferred_assets.second.amount, float(self.timestamp), self.sent_wallet_info,
@@ -337,9 +337,9 @@ class Transaction(object):
         Return a dictionary with a representation of this transaction.
         """
         return {
-            "trader_id": self.transaction_id.trader_id.to_bytes(),
+            "trader_id": bytes(self.transaction_id.trader_id),
             "order_number": int(self.order_id.order_number),
-            "partner_trader_id": self.partner_order_id.trader_id.to_bytes(),
+            "partner_trader_id": bytes(self.partner_order_id.trader_id),
             "partner_order_number": int(self.partner_order_id.order_number),
             "transaction_number": int(self.transaction_id.transaction_number),
             "assets": self.assets.to_dictionary(),

--- a/Tribler/community/market/core/wallet_address.py
+++ b/Tribler/community/market/core/wallet_address.py
@@ -22,5 +22,9 @@ class WalletAddress(object):
     def __eq__(self, other):
         return str(other) == self._wallet_address
 
+    @property
+    def address(self):
+        return self._wallet_address
+
     def __str__(self):
         return "%s" % self._wallet_address

--- a/Tribler/community/market/database.py
+++ b/Tribler/community/market/database.py
@@ -106,14 +106,6 @@ CREATE TABLE IF NOT EXISTS orders(
   PRIMARY KEY (trader_id, order_number, reserved_trader_id, reserved_order_number)
  );
 
- CREATE TABLE IF NOT EXISTS traders(
-  trader_id            TEXT NOT NULL,
-  ip_address           TEXT NOT NULL,
-  port                 INTEGER NOT NULL,
-
-  PRIMARY KEY(trader_id)
- );
-
 CREATE TABLE IF NOT EXISTS option(key TEXT PRIMARY KEY, value BLOB);
 INSERT OR REPLACE INTO option(key, value) VALUES('database_version', '""" + str(LATEST_DB_VERSION) + u"""');
 """
@@ -343,18 +335,6 @@ class MarketDB(TrustChainDB):
         """
         return [Tick.from_database(db_tick) for db_tick in self.execute(u"SELECT * FROM ticks")]
 
-    def add_trader_identity(self, trader_id, ip, port):
-        self.execute(u"INSERT OR REPLACE INTO traders VALUES(?,?,?)", (database_blob(bytes(trader_id)),
-                                                                       text_type(ip), port))
-        self.commit()
-
-    def get_traders(self):
-        """
-        Return information about known traders in the database.
-        :return: A tuple
-        """
-        return [(TraderId(res[0]), (str(res[1]), res[2])) for res in self.execute(u"SELECT * FROM traders")]
-
     def open(self, initial_statements=True, prepare_visioning=True):
         return super(MarketDB, self).open(initial_statements, prepare_visioning)
 
@@ -365,7 +345,8 @@ class MarketDB(TrustChainDB):
                    u"DROP TABLE IF EXISTS payments;" \
                    u"DROP TABLE IF EXISTS ticks;" \
                    u"DROP TABLE IF EXISTS orders_reserved_ticks;" \
-                   u"DROP TABLE IF EXISTS option;"
+                   u"DROP TABLE IF EXISTS option;" \
+                   u"DROP TABLE IF EXISTS traders;"
 
     def check_database(self, database_version):
         """

--- a/Tribler/community/market/database.py
+++ b/Tribler/community/market/database.py
@@ -31,8 +31,8 @@ CREATE TABLE IF NOT EXISTS orders(
  asset2_type          TEXT NOT NULL,
  traded_quantity      BIGINT NOT NULL,
  timeout              INTEGER NOT NULL,
- order_timestamp      TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
- completed_timestamp  TIMESTAMP,
+ order_timestamp      BIGINT NOT NULL,
+ completed_timestamp  BIGINT,
  is_ask               INTEGER NOT NULL,
  cancelled            INTEGER NOT NULL,
  verified             INTEGER NOT NULL,
@@ -53,7 +53,7 @@ CREATE TABLE IF NOT EXISTS orders(
   asset2_amount            BIGINT NOT NULL,
   asset2_type              TEXT NOT NULL,
   asset2_transferred       BIGINT NOT NULL,
-  transaction_timestamp    TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  transaction_timestamp    BIGINT NOT NULL,
   sent_wallet_info         INTEGER NOT NULL,
   received_wallet_info     INTEGER NOT NULL,
   incoming_address         TEXT NOT NULL,
@@ -74,7 +74,7 @@ CREATE TABLE IF NOT EXISTS orders(
   transferred_type         TEXT NOT NULL,
   address_from             TEXT NOT NULL,
   address_to               TEXT NOT NULL,
-  timestamp                TIMESTAMP NOT NULL,
+  timestamp                BIGINT NOT NULL,
   success                  INTEGER NOT NULL,
 
   PRIMARY KEY (trader_id, payment_id, transaction_trader_id, transaction_number)
@@ -88,7 +88,7 @@ CREATE TABLE IF NOT EXISTS orders(
   asset2_amount        BIGINT NOT NULL,
   asset2_type          TEXT NOT NULL,
   timeout              INTEGER NOT NULL,
-  timestamp            TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  timestamp            BIGINT NOT NULL,
   is_ask               INTEGER NOT NULL,
   traded               BIGINT NOT NULL,
   block_hash           TEXT NOT NULL,
@@ -267,10 +267,10 @@ class MarketDB(TrustChainDB):
                                                transaction.transferred_assets.first.amount,
                                                transaction.assets.second.amount,
                                                transaction.transferred_assets.second.amount,
-                                               float(transaction.timestamp),
+                                               int(transaction.timestamp),
                                                database_blob(bytes(transaction.transaction_id.trader_id)),
                                                int(transaction.transaction_id.transaction_number),
-                                               float(transaction.timestamp))
+                                               int(transaction.timestamp))
         )
 
         self.commit()

--- a/Tribler/community/market/database.py
+++ b/Tribler/community/market/database.py
@@ -19,7 +19,7 @@ DATABASE_DIRECTORY = path.join(u"sqlite")
 # Path to the database location + dispersy._workingdirectory
 DATABASE_PATH = path.join(DATABASE_DIRECTORY, u"market.db")
 # Version to keep track if the db schema needs to be updated.
-LATEST_DB_VERSION = 3
+LATEST_DB_VERSION = 4
 # Schema for the Market DB.
 schema = u"""
 CREATE TABLE IF NOT EXISTS orders(
@@ -359,7 +359,7 @@ class MarketDB(TrustChainDB):
         return super(MarketDB, self).open(initial_statements, prepare_visioning)
 
     def get_upgrade_script(self, current_version):
-        if current_version == 1 or current_version == 2:
+        if current_version == 1 or current_version == 2 or current_version == 3:
             return u"DROP TABLE IF EXISTS orders;" \
                    u"DROP TABLE IF EXISTS transactions;" \
                    u"DROP TABLE IF EXISTS payments;" \

--- a/Tribler/community/market/database.py
+++ b/Tribler/community/market/database.py
@@ -146,7 +146,7 @@ class MarketDB(TrustChainDB):
         """
         try:
             db_result = next(self.execute(u"SELECT * FROM orders WHERE trader_id = ? AND order_number = ?",
-                                          (database_blob(order_id.trader_id.to_bytes()),
+                                          (database_blob(bytes(order_id.trader_id)),
                                            text_type(order_id.order_number))))
         except StopIteration:
             return None
@@ -172,7 +172,7 @@ class MarketDB(TrustChainDB):
         Delete a specific order from the database
         """
         self.execute(u"DELETE FROM orders WHERE trader_id = ? AND order_number = ?",
-                     (database_blob(order_id.trader_id.to_bytes()), text_type(order_id.order_number)))
+                     (database_blob(bytes(order_id.trader_id)), text_type(order_id.order_number)))
         self.delete_reserved_ticks(order_id)
 
     def get_next_order_number(self):
@@ -189,7 +189,7 @@ class MarketDB(TrustChainDB):
         Delete all reserved ticks from a specific order
         """
         self.execute(u"DELETE FROM orders_reserved_ticks WHERE trader_id = ? AND order_number = ?",
-                     (database_blob(order_id.trader_id.to_bytes()), text_type(order_id.order_number)))
+                     (database_blob(bytes(order_id.trader_id)), text_type(order_id.order_number)))
 
     def add_reserved_tick(self, order_id, reserved_order_id, amount):
         """
@@ -198,8 +198,8 @@ class MarketDB(TrustChainDB):
         self.execute(
             u"INSERT INTO orders_reserved_ticks (trader_id, order_number, reserved_trader_id, reserved_order_number,"
             u"quantity) VALUES(?,?,?,?,?)",
-            (database_blob(order_id.trader_id.to_bytes()), text_type(order_id.order_number),
-             database_blob(reserved_order_id.trader_id.to_bytes()), text_type(reserved_order_id.order_number), amount))
+            (database_blob(bytes(order_id.trader_id)), text_type(order_id.order_number),
+             database_blob(bytes(reserved_order_id.trader_id)), text_type(reserved_order_id.order_number), amount))
         self.commit()
 
     def get_reserved_ticks(self, order_id):
@@ -207,7 +207,7 @@ class MarketDB(TrustChainDB):
         Get all reserved ticks for a specific order.
         """
         db_results = self.execute(u"SELECT * FROM orders_reserved_ticks WHERE trader_id = ? AND order_number = ?",
-                                  (database_blob(order_id.trader_id.to_bytes()), text_type(order_id.order_number)))
+                                  (database_blob(bytes(order_id.trader_id)), text_type(order_id.order_number)))
         return [(OrderId(TraderId(bytes(data[2])), OrderNumber(data[3])), data[4]) for data in db_results]
 
     def get_all_transactions(self):
@@ -226,7 +226,7 @@ class MarketDB(TrustChainDB):
         """
         try:
             db_result = next(self.execute(u"SELECT * FROM transactions WHERE trader_id = ? AND transaction_number = ?",
-                                          (database_blob(transaction_id.trader_id.to_bytes()),
+                                          (database_blob(bytes(transaction_id.trader_id)),
                                            text_type(transaction_id.transaction_number))))
         except StopIteration:
             return None
@@ -268,7 +268,7 @@ class MarketDB(TrustChainDB):
                                                transaction.assets.second.amount,
                                                transaction.transferred_assets.second.amount,
                                                float(transaction.timestamp),
-                                               database_blob(transaction.transaction_id.trader_id.to_bytes()),
+                                               database_blob(bytes(transaction.transaction_id.trader_id)),
                                                int(transaction.transaction_id.transaction_number),
                                                float(transaction.timestamp))
         )
@@ -280,7 +280,7 @@ class MarketDB(TrustChainDB):
         Delete a specific transaction from the database
         """
         self.execute(u"DELETE FROM transactions WHERE trader_id = ? AND transaction_number = ?",
-                     (database_blob(transaction_id.trader_id.to_bytes()),
+                     (database_blob(bytes(transaction_id.trader_id)),
                       text_type(transaction_id.transaction_number)))
         self.delete_payments(transaction_id)
 
@@ -309,7 +309,7 @@ class MarketDB(TrustChainDB):
         """
         db_result = self.execute(u"SELECT * FROM payments WHERE transaction_trader_id = ? AND transaction_number = ?"
                                  u"ORDER BY timestamp ASC",
-                                 (database_blob(transaction_id.trader_id.to_bytes()),
+                                 (database_blob(bytes(transaction_id.trader_id)),
                                   text_type(transaction_id.transaction_number)))
         return [Payment.from_database(db_item) for db_item in db_result]
 
@@ -318,7 +318,7 @@ class MarketDB(TrustChainDB):
         Delete all payments that are associated with a specific transaction
         """
         self.execute(u"DELETE FROM payments WHERE transaction_trader_id = ? AND transaction_number = ?",
-                     (database_blob(transaction_id.trader_id.to_bytes()),
+                     (database_blob(bytes(transaction_id.trader_id)),
                       text_type(transaction_id.transaction_number)))
 
     def add_tick(self, tick):
@@ -344,7 +344,7 @@ class MarketDB(TrustChainDB):
         return [Tick.from_database(db_tick) for db_tick in self.execute(u"SELECT * FROM ticks")]
 
     def add_trader_identity(self, trader_id, ip, port):
-        self.execute(u"INSERT OR REPLACE INTO traders VALUES(?,?,?)", (database_blob(trader_id.to_bytes()),
+        self.execute(u"INSERT OR REPLACE INTO traders VALUES(?,?,?)", (database_blob(bytes(trader_id)),
                                                                        text_type(ip), port))
         self.commit()
 

--- a/Tribler/community/market/payload.py
+++ b/Tribler/community/market/payload.py
@@ -18,7 +18,7 @@ class MessagePayload(Payload):
     Payload for a generic message in the market community.
     """
 
-    format_list = ['varlenI', 'f']
+    format_list = ['varlenI', 'Q']
 
     def __init__(self, trader_id, timestamp):
         super(MessagePayload, self).__init__()
@@ -27,7 +27,7 @@ class MessagePayload(Payload):
 
     def to_pack_list(self):
         data = [('varlenI', bytes(self.trader_id)),
-                ('f', self.timestamp)]
+                ('Q', int(self.timestamp))]
 
         return data
 

--- a/Tribler/community/market/payload.py
+++ b/Tribler/community/market/payload.py
@@ -71,9 +71,9 @@ class OfferPayload(MessagePayload):
         data = super(OfferPayload, self).to_pack_list()
         data += [('I', int(self.order_number)),
                  ('Q', self.assets.first.amount),
-                 ('varlenI', self.assets.first.asset_id),
+                 ('varlenI', self.assets.first.asset_id.encode('utf-8')),
                  ('Q', self.assets.second.amount),
-                 ('varlenI', self.assets.second.asset_id),
+                 ('varlenI', self.assets.second.asset_id.encode('utf-8')),
                  ('I', int(self.timeout)),
                  ('Q', self.traded)]
         return data
@@ -99,9 +99,9 @@ class MatchPayload(OfferPayload):
         data = super(MatchPayload, self).to_pack_list()
         data += [('I', int(self.recipient_order_number)),
                  ('Q', self.match_quantity),
-                 ('varlenI', str(self.match_trader_id)),
-                 ('varlenI', str(self.matchmaker_trader_id)),
-                 ('varlenI', self.match_id)]
+                 ('varlenI', bytes(self.match_trader_id)),
+                 ('varlenI', bytes(self.matchmaker_trader_id)),
+                 ('varlenI', self.match_id.encode('utf-8'))]
         return data
 
     @classmethod
@@ -109,9 +109,11 @@ class MatchPayload(OfferPayload):
                          asset2_type, timeout, traded, recipient_order_number, match_quantity,
                          match_trader_id, matchmaker_trader_id, match_id):
         return MatchPayload(TraderId(trader_id), Timestamp(timestamp), OrderNumber(order_number),
-                            AssetPair(AssetAmount(asset1_amount, asset1_type), AssetAmount(asset2_amount, asset2_type)),
+                            AssetPair(AssetAmount(asset1_amount, asset1_type.decode('utf-8')),
+                                      AssetAmount(asset2_amount, asset2_type.decode('utf-8'))),
                             Timeout(timeout), traded, OrderNumber(recipient_order_number),
-                            match_quantity, TraderId(match_trader_id), TraderId(matchmaker_trader_id), match_id)
+                            match_quantity, TraderId(match_trader_id), TraderId(matchmaker_trader_id),
+                            match_id.decode('utf-8'))
 
 
 class AcceptMatchPayload(MessagePayload):
@@ -128,13 +130,13 @@ class AcceptMatchPayload(MessagePayload):
 
     def to_pack_list(self):
         data = super(AcceptMatchPayload, self).to_pack_list()
-        data += [('varlenI', self.match_id),
+        data += [('varlenI', self.match_id.encode('utf-8')),
                  ('Q', self.quantity)]
         return data
 
     @classmethod
     def from_unpack_list(cls, trader_id, timestamp, match_id, quantity):
-        return AcceptMatchPayload(TraderId(trader_id), Timestamp(timestamp), match_id, quantity)
+        return AcceptMatchPayload(TraderId(trader_id), Timestamp(timestamp), match_id.decode('utf-8'), quantity)
 
 
 class DeclineMatchPayload(MessagePayload):
@@ -151,13 +153,13 @@ class DeclineMatchPayload(MessagePayload):
 
     def to_pack_list(self):
         data = super(DeclineMatchPayload, self).to_pack_list()
-        data += [('varlenI', self.match_id),
+        data += [('varlenI', self.match_id.encode('utf-8')),
                  ('I', self.decline_reason)]
         return data
 
     @classmethod
     def from_unpack_list(cls, trader_id, timestamp, match_id, decline_reason):
-        return DeclineMatchPayload(TraderId(trader_id), Timestamp(timestamp), match_id, decline_reason)
+        return DeclineMatchPayload(TraderId(trader_id), Timestamp(timestamp), match_id.decode('utf-8'), decline_reason)
 
 
 class TradePayload(MessagePayload):
@@ -177,13 +179,13 @@ class TradePayload(MessagePayload):
     def to_pack_list(self):
         data = super(TradePayload, self).to_pack_list()
         data += [('I', int(self.order_number)),
-                 ('varlenI', str(self.recipient_order_id.trader_id)),
+                 ('varlenI', bytes(self.recipient_order_id.trader_id)),
                  ('I', int(self.recipient_order_id.order_number)),
                  ('I', self.proposal_id),
                  ('Q', self.assets.first.amount),
-                 ('varlenI', self.assets.first.asset_id),
+                 ('varlenI', self.assets.first.asset_id.encode('utf-8')),
                  ('Q', self.assets.second.amount),
-                 ('varlenI', self.assets.second.asset_id)]
+                 ('varlenI', self.assets.second.asset_id.encode('utf-8'))]
         return data
 
     @classmethod
@@ -191,7 +193,8 @@ class TradePayload(MessagePayload):
                          proposal_id, asset1_amount, asset1_type, asset2_amount, asset2_type):
         return TradePayload(TraderId(trader_id), Timestamp(timestamp), OrderNumber(order_number),
                             OrderId(TraderId(recipient_trader_id), OrderNumber(recipient_order_number)), proposal_id,
-                            AssetPair(AssetAmount(asset1_amount, asset1_type), AssetAmount(asset2_amount, asset2_type)))
+                            AssetPair(AssetAmount(asset1_amount, asset1_type.decode('utf-8')),
+                                      AssetAmount(asset2_amount, asset2_type.decode('utf-8'))))
 
 
 class DeclineTradePayload(MessagePayload):
@@ -208,7 +211,7 @@ class DeclineTradePayload(MessagePayload):
     def to_pack_list(self):
         data = super(DeclineTradePayload, self).to_pack_list()
         data += [('I', int(self.order_number)),
-                 ('varlenI', str(self.recipient_order_id.trader_id)),
+                 ('varlenI', bytes(self.recipient_order_id.trader_id)),
                  ('I', int(self.recipient_order_id.order_number)),
                  ('I', self.proposal_id),
                  ('I', self.decline_reason)]
@@ -235,7 +238,7 @@ class TransactionPayload(MessagePayload):
 
     def to_pack_list(self):
         data = super(TransactionPayload, self).to_pack_list()
-        data += [('varlenI', str(self.transaction_id.trader_id)),
+        data += [('varlenI', bytes(self.transaction_id.trader_id)),
                  ('I', int(self.transaction_id.transaction_number))]
         return data
 
@@ -257,15 +260,15 @@ class StartTransactionPayload(TransactionPayload):
 
     def to_pack_list(self):
         data = super(StartTransactionPayload, self).to_pack_list()
-        data += [('varlenI', str(self.order_id.trader_id)),
+        data += [('varlenI', bytes(self.order_id.trader_id)),
                  ('I', int(self.order_id.order_number)),
-                 ('varlenI', str(self.recipient_order_id.trader_id)),
+                 ('varlenI', bytes(self.recipient_order_id.trader_id)),
                  ('I', int(self.recipient_order_id.order_number)),
                  ('I', self.proposal_id),
                  ('Q', self.assets.first.amount),
-                 ('varlenI', self.assets.first.asset_id),
+                 ('varlenI', self.assets.first.asset_id.encode('utf-8')),
                  ('Q', self.assets.second.amount),
-                 ('varlenI', self.assets.second.asset_id)]
+                 ('varlenI', self.assets.second.asset_id.encode('utf-8'))]
         return data
 
     @classmethod
@@ -276,8 +279,8 @@ class StartTransactionPayload(TransactionPayload):
                                        TransactionId(TraderId(tx_trader_id), TransactionNumber(transaction_number)),
                                        OrderId(TraderId(order_trader_id), OrderNumber(order_number)),
                                        OrderId(TraderId(recipient_trader_id), OrderNumber(recipient_order_number)),
-                                       proposal_id, AssetPair(AssetAmount(asset1_amount, asset1_type),
-                                                              AssetAmount(asset2_amount, asset2_type)))
+                                       proposal_id, AssetPair(AssetAmount(asset1_amount, asset1_type.decode('utf-8')),
+                                                              AssetAmount(asset2_amount, asset2_type.decode('utf-8'))))
 
 
 class WalletInfoPayload(TransactionPayload):
@@ -294,8 +297,8 @@ class WalletInfoPayload(TransactionPayload):
 
     def to_pack_list(self):
         data = super(WalletInfoPayload, self).to_pack_list()
-        data += [('varlenI', str(self.incoming_address)),
-                 ('varlenI', str(self.outgoing_address))]
+        data += [('varlenI', self.incoming_address.address.encode('utf-8')),
+                 ('varlenI', self.outgoing_address.address.encode('utf-8'))]
         return data
 
     @classmethod
@@ -303,7 +306,8 @@ class WalletInfoPayload(TransactionPayload):
                          incoming_address, outgoing_address):
         return WalletInfoPayload(TraderId(trader_id), Timestamp(timestamp),
                                  TransactionId(TraderId(transaction_trader_id), TransactionNumber(transaction_number)),
-                                 WalletAddress(incoming_address), WalletAddress(outgoing_address))
+                                 WalletAddress(incoming_address.decode('utf-8')),
+                                 WalletAddress(outgoing_address.decode('utf-8')))
 
 
 class PaymentPayload(TransactionPayload):
@@ -325,10 +329,10 @@ class PaymentPayload(TransactionPayload):
     def to_pack_list(self):
         data = super(PaymentPayload, self).to_pack_list()
         data += [('Q', self.transferred_assets.amount),
-                 ('varlenI', self.transferred_assets.asset_id),
-                 ('varlenI', str(self.address_from)),
-                 ('varlenI', str(self.address_to)),
-                 ('varlenI', str(self.payment_id)),
+                 ('varlenI', self.transferred_assets.asset_id.encode('utf-8')),
+                 ('varlenI', self.address_from.address.encode('utf-8')),
+                 ('varlenI', self.address_to.address.encode('utf-8')),
+                 ('varlenI', self.payment_id.payment_id.encode('utf-8')),
                  ('?', self.success)]
         return data
 
@@ -337,8 +341,9 @@ class PaymentPayload(TransactionPayload):
                          transferred_amount, transferred_type, address_from, address_to, payment_id, success):
         return PaymentPayload(TraderId(trader_id), Timestamp(timestamp),
                               TransactionId(TraderId(transaction_trader_id), TransactionNumber(transaction_number)),
-                              AssetAmount(transferred_amount, transferred_type),
-                              WalletAddress(address_from), WalletAddress(address_to), PaymentId(payment_id), success)
+                              AssetAmount(transferred_amount, transferred_type.decode('utf-8')),
+                              WalletAddress(address_from.decode('utf-8')),
+                              WalletAddress(address_to.decode('utf-8')), PaymentId(payment_id.decode('utf-8')), success)
 
 
 class OrderStatusRequestPayload(MessagePayload):
@@ -355,7 +360,7 @@ class OrderStatusRequestPayload(MessagePayload):
 
     def to_pack_list(self):
         data = super(OrderStatusRequestPayload, self).to_pack_list()
-        data += [('varlenI', str(self.order_id.trader_id)),
+        data += [('varlenI', bytes(self.order_id.trader_id)),
                  ('I', int(self.order_id.order_number)),
                  ('I', self.identifier)]
         return data
@@ -386,8 +391,8 @@ class OrderStatusResponsePayload(OfferPayload):
     def from_unpack_list(cls, trader_id, timestamp, order_number, asset1_amount, asset1_type, asset2_amount,
                          asset2_type, timeout, traded, identifier):
         return OrderStatusResponsePayload(TraderId(trader_id), Timestamp(timestamp), OrderNumber(order_number),
-                                          AssetPair(AssetAmount(asset1_amount, asset1_type),
-                                                    AssetAmount(asset2_amount, asset2_type)),
+                                          AssetPair(AssetAmount(asset1_amount, asset1_type.decode('utf-8')),
+                                                    AssetAmount(asset2_amount, asset2_type.decode('utf-8'))),
                                           Timeout(timeout), traded, identifier)
 
 

--- a/Tribler/community/market/payload.py
+++ b/Tribler/community/market/payload.py
@@ -26,7 +26,7 @@ class MessagePayload(Payload):
         self.timestamp = timestamp
 
     def to_pack_list(self):
-        data = [('varlenI', self.trader_id.to_bytes()),
+        data = [('varlenI', bytes(self.trader_id)),
                 ('f', self.timestamp)]
 
         return data

--- a/Tribler/community/market/reputation/temporal_pagerank_manager.py
+++ b/Tribler/community/market/reputation/temporal_pagerank_manager.py
@@ -15,7 +15,7 @@ class TemporalPagerankReputationManager(ReputationManager):
         G = nx.DiGraph()
 
         for block in self.blocks:
-            if block.link_sequence_number == UNKNOWN_SEQ or block.type != 'tx_done' \
+            if block.link_sequence_number == UNKNOWN_SEQ or block.type != b'tx_done' \
                     or 'tx' not in block.transaction:
                 continue  # Don't consider half interactions
 


### PR DESCRIPTION
In this PR, I made the `MarketCommunity` Python 3 compatible. I also made a few other changes:
- Converted the `to_bytes` method of `TraderId` to `__bytes__`.
- Made the `TraderId` object a wrapper around a 20-byte string.
- Changed the type of `Timestamp` to integer, representing a timestamp in milliseconds from epoch time.

These changes are not backwards compatible and as such, I incremented the version and changed the community identifier. Also, the database version is incremented.