### PR TITLE
Disabling IPv8 during wallet tests

### DIFF
--- a/Tribler/Test/Core/Modules/RestApi/test_wallets_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_wallets_endpoint.py
@@ -15,7 +15,6 @@ class TestWalletsEndpoint(AbstractApiTest):
 
     def setUpPreSession(self):
         super(TestWalletsEndpoint, self).setUpPreSession()
-        self.config.set_ipv8_enabled(True)
         self.config.set_dummy_wallets_enabled(True)
         self.config.set_bitcoinlib_enabled(True)
 


### PR DESCRIPTION
It was making connections to the bootstrap servers and listening for TrustChain blocks.