### PR TITLE
READY: Foreground DB upgrader

### DIFF
--- a/Tribler/Core/Modules/restapi/events_endpoint.py
+++ b/Tribler/Core/Modules/restapi/events_endpoint.py
@@ -31,7 +31,6 @@ class EventsEndpoint(resource.Resource):
       includes information about whether Tribler has started already or not and the version of Tribler used.
     - search_result_channel: This event dictionary contains a search result with a channel that has been found.
     - search_result_torrent: This event dictionary contains a search result with a torrent that has been found.
-    - upgrader_started: An indication that the Tribler upgrader has started.
     - upgrader_finished: An indication that the Tribler upgrader has finished.
     - upgrader_tick: An indication that the state of the upgrader has changed. The dictionary contains a human-readable
       string with the new state.
@@ -70,7 +69,6 @@ class EventsEndpoint(resource.Resource):
         self.infohashes_sent = set()
         self.channel_cids_sent = set()
 
-        self.session.add_observer(self.on_upgrader_started, NTFY_UPGRADER, [NTFY_STARTED])
         self.session.add_observer(self.on_upgrader_finished, NTFY_UPGRADER, [NTFY_FINISHED])
         self.session.add_observer(self.on_upgrader_tick, NTFY_UPGRADER_TICK, [NTFY_STARTED])
         self.session.add_observer(self.on_watch_folder_corrupt_torrent,
@@ -110,9 +108,6 @@ class EventsEndpoint(resource.Resource):
             return
         else:
             [request.write(message_str + '\n') for request in self.events_requests]
-
-    def on_upgrader_started(self, subject, changetype, objectID, *args):
-        self.write_data({"type": "upgrader_started"})
 
     def on_upgrader_finished(self, subject, changetype, objectID, *args):
         self.write_data({"type": "upgrader_finished"})

--- a/Tribler/Core/Modules/restapi/root_endpoint.py
+++ b/Tribler/Core/Modules/restapi/root_endpoint.py
@@ -18,6 +18,7 @@ from Tribler.Core.Modules.restapi.statistics_endpoint import StatisticsEndpoint
 from Tribler.Core.Modules.restapi.torrentinfo_endpoint import TorrentInfoEndpoint
 from Tribler.Core.Modules.restapi.trustchain_endpoint import TrustchainEndpoint
 from Tribler.Core.Modules.restapi.trustview_endpoint import TrustViewEndpoint
+from Tribler.Core.Modules.restapi.upgrader_endpoint import UpgraderEndpoint
 from Tribler.Core.Modules.restapi.wallets_endpoint import WalletsEndpoint
 from Tribler.pyipv8.ipv8.REST.root_endpoint import RootEndpoint as IPV8RootEndpoint
 
@@ -38,9 +39,11 @@ class RootEndpoint(resource.Resource):
         self.events_endpoint = EventsEndpoint(self.session)
         self.state_endpoint = StateEndpoint(self.session)
         self.shutdown_endpoint = ShutdownEndpoint(self.session)
+        self.upgrader_endpoint = UpgraderEndpoint(self.session)
         self.putChild(b"events", self.events_endpoint)
         self.putChild(b"state", self.state_endpoint)
         self.putChild(b"shutdown", self.shutdown_endpoint)
+        self.putChild(b"upgrader", self.upgrader_endpoint)
 
     def start_endpoints(self):
         """
@@ -52,7 +55,6 @@ class RootEndpoint(resource.Resource):
             b"downloads": DownloadsEndpoint,
             b"createtorrent": CreateTorrentEndpoint,
             b"debug": DebugEndpoint,
-            b"shutdown": ShutdownEndpoint,
             b"trustchain": TrustchainEndpoint,
             b"trustview": TrustViewEndpoint,
             b"statistics": StatisticsEndpoint,

--- a/Tribler/Core/Modules/restapi/upgrader_endpoint.py
+++ b/Tribler/Core/Modules/restapi/upgrader_endpoint.py
@@ -2,9 +2,13 @@ from __future__ import absolute_import
 
 import logging
 
-from twisted.web import resource
+from six import viewitems
+
+from twisted.web import http, resource
 
 import Tribler.Core.Utilities.json_util as json
+
+SKIP_DB_UPGRADE_STR = "skip_db_upgrade"
 
 
 class UpgraderEndpoint(resource.Resource):
@@ -17,28 +21,47 @@ class UpgraderEndpoint(resource.Resource):
         self._logger = logging.getLogger(self.__class__.__name__)
         self.session = session
 
-    def render_DELETE(self, _):
+    def render_POST(self, request):
         """
-        .. http:put:: /upgrader
+        .. http:post:: /upgrader
 
-        A PUT request to this endpoint will skip the DB upgrade process, if it is running.
+        A POST request to this endpoint will skip the DB upgrade process, if it is running.
 
             **Example request**:
 
-            .. sourcecode:: none
+            .. sourcecode:: javascript
 
-                curl -X DELETE http://localhost:8085/upgrader
+                {
+                    "skip_db_upgrade": true
+                }
+
+
+                curl -X POST http://localhost:8085/upgrader
 
             **Example response**:
 
             .. sourcecode:: javascript
 
                 {
-                    "skip": True
+                    "skip_db_upgrade": true
                 }
         """
 
-        if self.session.upgrader:
+        parameters_raw = http.parse_qs(request.content.read(), 1)
+        parameters = {}
+
+        # FIXME: make all endpoints Unicode-compatible in a unified way
+        for param, val in viewitems(parameters_raw):
+            parameters.update({param: [item.decode('utf-8') for item in val]})
+
+        if SKIP_DB_UPGRADE_STR not in parameters:
+            request.setResponseCode(http.BAD_REQUEST)
+            return json.twisted_dumps({"error": "attribute to change is missing"})
+        elif not self.session.upgrader:
+            request.setResponseCode(http.NOT_FOUND)
+            return json.twisted_dumps({"error": "upgrader is not running"})
+
+        if self.session.upgrader and parameters[SKIP_DB_UPGRADE_STR]:
             self.session.upgrader.skip()
 
-        return json.twisted_dumps({"skip": True})
+        return json.twisted_dumps({SKIP_DB_UPGRADE_STR: True})

--- a/Tribler/Core/Modules/restapi/upgrader_endpoint.py
+++ b/Tribler/Core/Modules/restapi/upgrader_endpoint.py
@@ -1,0 +1,44 @@
+from __future__ import absolute_import
+
+import logging
+
+from twisted.web import resource
+
+import Tribler.Core.Utilities.json_util as json
+
+
+class UpgraderEndpoint(resource.Resource):
+    """
+    With this endpoint you can control DB upgrade process of Tribler.
+    """
+
+    def __init__(self, session):
+        resource.Resource.__init__(self)
+        self._logger = logging.getLogger(self.__class__.__name__)
+        self.session = session
+
+    def render_DELETE(self, _):
+        """
+        .. http:put:: /upgrader
+
+        A PUT request to this endpoint will skip the DB upgrade process, if it is running.
+
+            **Example request**:
+
+            .. sourcecode:: none
+
+                curl -X DELETE http://localhost:8085/upgrader
+
+            **Example response**:
+
+            .. sourcecode:: javascript
+
+                {
+                    "skip": True
+                }
+        """
+
+        if self.session.upgrader:
+            self.session.upgrader.skip()
+
+        return json.twisted_dumps({"skip": True})

--- a/Tribler/Core/Upgrade/db72_to_pony.py
+++ b/Tribler/Core/Upgrade/db72_to_pony.py
@@ -274,7 +274,7 @@ class DispersyToPonyMigration(object):
         if self.notifier_callback:
             elapsed = 0.0001 if elapsed == 0.0 else elapsed
             amount = amount or 1
-            est_speed = amount/elapsed
+            est_speed = amount / elapsed
             eta = str(datetime.timedelta(seconds=int((total - amount) / est_speed)))
             self.notifier_callback("Converting old channels.\nTorrents converted: %i/%i (%i%%).\nTime remaining: %s" %
                                    (amount, total, (amount * 100) // total, eta))

--- a/Tribler/Core/Upgrade/upgrade.py
+++ b/Tribler/Core/Upgrade/upgrade.py
@@ -64,7 +64,9 @@ class TriblerUpgrader(object):
             mds.shutdown()
             self.notify_done()
 
-        return self._dtp72.do_migration().addCallbacks(finish_migration, lambda _: None)
+        def log_error(failure):
+            self._logger.error("Error in Upgrader callback chain: %s", failure)
+        return self._dtp72.do_migration().addCallbacks(finish_migration, log_error)
 
 
     def upgrade_config_to_71(self):

--- a/Tribler/Core/Upgrade/upgrade.py
+++ b/Tribler/Core/Upgrade/upgrade.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import
 import logging
 import os
 
+from twisted.internet.defer import succeed
+
 from Tribler.Core.Modules.MetadataStore.store import MetadataStore
 from Tribler.Core.Upgrade.config_converter import convert_config_to_tribler71
 from Tribler.Core.Upgrade.db72_to_pony import DispersyToPonyMigration, should_upgrade
@@ -18,10 +20,15 @@ class TriblerUpgrader(object):
         self.notified = False
         self.is_done = False
         self.failed = True
-        self.finished_deferred = None
-        self.pony_upgrader = None
 
         self.current_status = u"Initializing"
+        self._dtp72 = None
+        self.skip_upgrade_called = False
+
+    def skip(self):
+        self.skip_upgrade_called = True
+        if self._dtp72:
+            self._dtp72.shutting_down = True
 
     def run(self):
         """
@@ -30,11 +37,8 @@ class TriblerUpgrader(object):
         Note that by default, upgrading is enabled in the config. It is then disabled
         after upgrading to Tribler 7.
         """
-        self.notify_starting()
 
-        self.upgrade_72_to_pony()
-        # self.upgrade_config_to_71()
-        self.notify_done()
+        return self.upgrade_72_to_pony()
 
     def update_status(self, status_text):
         self.session.notifier.notify(NTFY_UPGRADER_TICK, NTFY_STARTED, None, status_text)
@@ -45,14 +49,23 @@ class TriblerUpgrader(object):
         new_database_path = os.path.join(self.session.config.get_state_dir(), 'sqlite', 'metadata.db')
         channels_dir = os.path.join(self.session.config.get_chant_channels_dir())
 
-        self.pony_upgrader = DispersyToPonyMigration(old_database_path, self.update_status, logger=self._logger)
+        self._dtp72 = DispersyToPonyMigration(old_database_path, self.update_status, logger=self._logger)
         if not should_upgrade(old_database_path, new_database_path, logger=self._logger):
-            return
+            self._dtp72 = None
+            return succeed(None)
+        # This thing is here mostly for the skip upgrade test to work...
+        self._dtp72.shutting_down = self.skip_upgrade_called
+        self.notify_starting()
         # We have to create the Metadata Store object because the LaunchManyCore has not been started yet
-        mds = MetadataStore(new_database_path, channels_dir, self.session.trustchain_keypair)
-        self.pony_upgrader.initialize(mds)
-        self.finished_deferred = self.pony_upgrader.do_migration()
-        mds.shutdown()
+        mds = MetadataStore(new_database_path, channels_dir, self.session.trustchain_keypair, disable_sync=True)
+        self._dtp72.initialize(mds)
+
+        def finish_migration(_):
+            mds.shutdown()
+            self.notify_done()
+
+        return self._dtp72.do_migration().addCallbacks(finish_migration, lambda _: None)
+
 
     def upgrade_config_to_71(self):
         """
@@ -76,7 +89,3 @@ class TriblerUpgrader(object):
         Broadcast a notification (event) that the upgrader is done.
         """
         self.session.notifier.notify(NTFY_UPGRADER, NTFY_FINISHED, None)
-
-    def shutdown(self):
-        if self.pony_upgrader:
-            self.pony_upgrader.shutting_down = True

--- a/Tribler/Core/simpledefs.py
+++ b/Tribler/Core/simpledefs.py
@@ -70,7 +70,7 @@ NTFY_CREATE_E2E = 'createendtoend'
 NTFY_ONCREATED_E2E = 'oncreatedendtoend'
 NTFY_IP_CREATED = 'intropointcreated'
 NTFY_RP_CREATED = 'rendezvouspointcreated'
-NTFY_UPGRADER = 'upgraderdone'
+NTFY_UPGRADER = 'upgrader'
 NTFY_UPGRADER_TICK = 'upgradertick'
 
 NTFY_STARTUP_TICK = 'startuptick'

--- a/Tribler/Test/Core/Modules/RestApi/test_events_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_events_endpoint.py
@@ -83,10 +83,9 @@ class TestEventsEndpoint(AbstractApiTest):
         """
         Testing whether various events are coming through the events endpoints
         """
-        self.messages_to_wait_for = 21
+        self.messages_to_wait_for = 20
 
         def send_notifications(_):
-            self.session.notifier.notify(NTFY_UPGRADER, NTFY_STARTED, None, None)
             self.session.notifier.notify(NTFY_UPGRADER_TICK, NTFY_STARTED, None, None)
             self.session.notifier.notify(NTFY_UPGRADER, NTFY_FINISHED, None, None)
             self.session.notifier.notify(NTFY_WATCH_FOLDER_CORRUPT_TORRENT, NTFY_INSERT, None, None)

--- a/Tribler/Test/Core/Modules/RestApi/test_upgrader_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_upgrader_endpoint.py
@@ -1,23 +1,26 @@
 from __future__ import absolute_import
 
+from twisted.internet.defer import inlineCallbacks
+
+from Tribler.Core.Modules.restapi.upgrader_endpoint import SKIP_DB_UPGRADE_STR
 from Tribler.Test.Core.Modules.RestApi.base_api_test import AbstractApiTest
 from Tribler.Test.Core.base_test import MockObject
 from Tribler.Test.tools import trial_timeout
 
 
-class TestShutdownEndpoint(AbstractApiTest):
-
+class TestUpgraderEndpoint(AbstractApiTest):
 
     @trial_timeout(10)
+    @inlineCallbacks
     def test_upgrader_skip(self):
         """
-        Testing whether the API triggers a Tribler shutdown
+        Test if the API call sets the "skip DB upgrade" flag in upgrader
         """
 
-        self.skip_called = False
+        post_params = {SKIP_DB_UPGRADE_STR: True}
+        yield self.do_request('upgrader', expected_code=404, post_data=post_params, request_type='POST')
 
-        def verify_skip_called(_):
-            self.assertTrue(self.skip_called)
+        self.skip_called = False
 
         def mock_skip():
             self.skip_called = True
@@ -25,6 +28,9 @@ class TestShutdownEndpoint(AbstractApiTest):
         self.session.upgrader = MockObject()
         self.session.upgrader.skip = mock_skip
 
-        expected_json = {"skip": True}
-        return self.do_request('upgrader', expected_code=200, expected_json=expected_json, request_type='DELETE') \
-            .addCallback(verify_skip_called)
+        yield self.do_request('upgrader', expected_code=400, expected_json={
+            u'error': u'attribute to change is missing'}, post_data={}, request_type='POST')
+
+        yield self.do_request('upgrader', expected_code=200, expected_json={SKIP_DB_UPGRADE_STR: True},
+                              post_data=post_params, request_type='POST')
+        self.assertTrue(self.skip_called)

--- a/Tribler/Test/Core/Modules/RestApi/test_upgrader_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_upgrader_endpoint.py
@@ -1,0 +1,30 @@
+from __future__ import absolute_import
+
+from Tribler.Test.Core.Modules.RestApi.base_api_test import AbstractApiTest
+from Tribler.Test.Core.base_test import MockObject
+from Tribler.Test.tools import trial_timeout
+
+
+class TestShutdownEndpoint(AbstractApiTest):
+
+
+    @trial_timeout(10)
+    def test_upgrader_skip(self):
+        """
+        Testing whether the API triggers a Tribler shutdown
+        """
+
+        self.skip_called = False
+
+        def verify_skip_called(_):
+            self.assertTrue(self.skip_called)
+
+        def mock_skip():
+            self.skip_called = True
+
+        self.session.upgrader = MockObject()
+        self.session.upgrader.skip = mock_skip
+
+        expected_json = {"skip": True}
+        return self.do_request('upgrader', expected_code=200, expected_json=expected_json, request_type='DELETE') \
+            .addCallback(verify_skip_called)

--- a/TriblerGUI/core_manager.py
+++ b/TriblerGUI/core_manager.py
@@ -78,7 +78,7 @@ class CoreManager(QObject):
             self.use_existing_core = False
             self.start_tribler_core(core_args=core_args, core_env=core_env)
 
-        self.events_manager.connect(reschedule_on_err=False)
+        self.events_manager.connect()
         self.events_manager.reply.error.connect(on_request_error)
 
     def start_tribler_core(self, core_args=None, core_env=None):

--- a/TriblerGUI/qt_resources/mainwindow.ui
+++ b/TriblerGUI/qt_resources/mainwindow.ui
@@ -8427,6 +8427,57 @@ font-weight:bold;</string>
                </property>
               </widget>
              </item>
+             <item>
+              <widget class="QPushButton" name="skip_conversion_btn">
+               <property name="enabled">
+                <bool>true</bool>
+               </property>
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="minimumSize">
+                <size>
+                 <width>180</width>
+                 <height>32</height>
+                </size>
+               </property>
+               <property name="maximumSize">
+                <size>
+                 <width>180</width>
+                 <height>32</height>
+                </size>
+               </property>
+               <property name="layoutDirection">
+                <enum>Qt::LeftToRight</enum>
+               </property>
+               <property name="autoFillBackground">
+                <bool>false</bool>
+               </property>
+               <property name="styleSheet">
+                <string notr="true">border-radius:16px;
+background-color:#e67300;
+color:#fff;
+padding:0 10px;
+text-transform:  uppercase;
+font-weight:bold;</string>
+               </property>
+               <property name="text">
+                <string>Skip</string>
+               </property>
+               <property name="autoDefault">
+                <bool>false</bool>
+               </property>
+               <property name="default">
+                <bool>false</bool>
+               </property>
+               <property name="flat">
+                <bool>false</bool>
+               </property>
+              </widget>
+             </item>
             </layout>
            </widget>
           </item>
@@ -12850,6 +12901,22 @@ color: #eee;</string>
    </hints>
   </connection>
   <connection>
+   <sender>skip_conversion_btn</sender>
+   <signal>clicked()</signal>
+   <receiver>MainWindow</receiver>
+   <slot>clicked_skip_conversion()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
    <sender>channel_back_button</sender>
    <signal>clicked()</signal>
    <receiver>MainWindow</receiver>
@@ -12936,6 +13003,7 @@ color: #eee;</string>
   <slot>on_trust_button_click()</slot>
   <slot>clicked_menu_button_search()</slot>
   <slot>clicked_force_shutdown()</slot>
+  <slot>clicked_skip_conversion()</slot>
   <slot>clicked_menu_button_trust_graph()</slot>
  </slots>
 </ui>

--- a/TriblerGUI/tribler_window.py
+++ b/TriblerGUI/tribler_window.py
@@ -960,7 +960,7 @@ class TriblerWindow(QMainWindow):
     def on_skip_conversion_dialog(self, action):
         if action == 0:
             request_mgr = TriblerRequestManager()
-            request_mgr.perform_request("upgrader", lambda _: None, method='DELETE')
+            request_mgr.perform_request("upgrader", lambda _: None, data={"skip_db_upgrade": True}, method='POST')
 
         if self.dialog:
             self.dialog.close_dialog()

--- a/TriblerGUI/tribler_window.py
+++ b/TriblerGUI/tribler_window.py
@@ -9,12 +9,14 @@ import time
 import traceback
 from binascii import hexlify
 
+
 from PyQt5 import uic
-from PyQt5.QtCore import QCoreApplication, QDir, QObject, QPoint, QSettings, QStringListModel, QTimer, QUrl, Qt, \
-    pyqtSignal, pyqtSlot
+from PyQt5.QtCore import (
+    QCoreApplication, QDir, QObject, QPoint, QSettings, QStringListModel, QTimer, QUrl, Qt, pyqtSignal, pyqtSlot)
 from PyQt5.QtGui import QDesktopServices, QIcon, QKeySequence, QPixmap
-from PyQt5.QtWidgets import QAction, QApplication, QCompleter, QFileDialog, QLineEdit, QListWidget, QMainWindow, \
-    QShortcut, QStyledItemDelegate, QSystemTrayIcon, QTreeWidget
+from PyQt5.QtWidgets import (
+    QAction, QApplication, QCompleter, QFileDialog, QLineEdit, QListWidget, QMainWindow, QShortcut, QStyledItemDelegate,
+    QSystemTrayIcon, QTreeWidget)
 
 import six
 from six.moves.urllib.parse import unquote, urlparse
@@ -24,10 +26,10 @@ from Tribler.Core.Modules.process_checker import ProcessChecker
 
 from TriblerGUI.core_manager import CoreManager
 from TriblerGUI.debug_window import DebugWindow
-from TriblerGUI.defs import BUTTON_TYPE_CONFIRM, BUTTON_TYPE_NORMAL, DEFAULT_API_PORT, PAGE_CHANNEL_DETAILS, \
-    PAGE_DISCOVERED, PAGE_DISCOVERING, PAGE_DOWNLOADS, PAGE_EDIT_CHANNEL, PAGE_HOME, PAGE_LOADING, \
-    PAGE_SEARCH_RESULTS, PAGE_SETTINGS, PAGE_SUBSCRIBED_CHANNELS, PAGE_TRUST, PAGE_TRUST_GRAPH_PAGE, \
-    PAGE_VIDEO_PLAYER, SHUTDOWN_WAITING_PERIOD
+from TriblerGUI.defs import (
+    BUTTON_TYPE_CONFIRM, BUTTON_TYPE_NORMAL, DEFAULT_API_PORT, PAGE_CHANNEL_DETAILS, PAGE_DISCOVERED, PAGE_DISCOVERING,
+    PAGE_DOWNLOADS, PAGE_EDIT_CHANNEL, PAGE_HOME, PAGE_LOADING, PAGE_SEARCH_RESULTS, PAGE_SETTINGS,
+    PAGE_SUBSCRIBED_CHANNELS, PAGE_TRUST, PAGE_TRUST_GRAPH_PAGE, PAGE_VIDEO_PLAYER, SHUTDOWN_WAITING_PERIOD)
 from TriblerGUI.dialogs.confirmationdialog import ConfirmationDialog
 from TriblerGUI.dialogs.feedbackdialog import FeedbackDialog
 from TriblerGUI.dialogs.startdownloaddialog import StartDownloadDialog
@@ -247,11 +249,6 @@ class TriblerWindow(QMainWindow):
         self.core_manager.events_manager.low_storage_signal.connect(self.on_low_storage)
         self.core_manager.events_manager.credit_mining_signal.connect(self.on_credit_mining_error)
         self.core_manager.events_manager.tribler_shutdown_signal.connect(self.on_tribler_shutdown_state_update)
-
-        self.core_manager.events_manager.upgrader_tick.connect(
-            lambda text: self.show_status_bar("Upgrading Tribler database: " + text))
-        self.core_manager.events_manager.upgrader_finished.connect(
-            lambda _: self.hide_status_bar())
 
         self.core_manager.events_manager.received_search_result.connect(
             self.search_results_page.received_search_result)
@@ -948,6 +945,26 @@ class TriblerWindow(QMainWindow):
             os.kill(int(core_pid), 9)
         # Stop the Qt application
         QApplication.quit()
+
+    def clicked_skip_conversion(self):
+        self.dialog = ConfirmationDialog(self, "Abort the conversion of old channels",
+                                         "The upgrade procedure is now converting torrents in channels "
+                                         "collected by the previous installation of Tribler.\n\n"
+                                         "Are you sure you want to abort the conversion process?\n"
+                                         "(Your personal channel will be converted anyway.)",
+                                         [('ABORT', BUTTON_TYPE_CONFIRM),
+                                          ('CONTINUE', BUTTON_TYPE_NORMAL)])
+        self.dialog.button_clicked.connect(self.on_skip_conversion_dialog)
+        self.dialog.show()
+
+    def on_skip_conversion_dialog(self, action):
+        if action == 0:
+            request_mgr = TriblerRequestManager()
+            request_mgr.perform_request("upgrader", lambda _: None, method='DELETE')
+
+        if self.dialog:
+            self.dialog.close_dialog()
+            self.dialog = None
 
     def on_tribler_shutdown_state_update(self, state):
         self.loading_text_label.setText(state)

--- a/TriblerGUI/widgets/loadingpage.py
+++ b/TriblerGUI/widgets/loadingpage.py
@@ -1,6 +1,7 @@
-from PyQt5.QtCore import QPoint, Qt
+from __future__ import absolute_import
+
 from PyQt5.QtSvg import QGraphicsSvgItem, QSvgRenderer
-from PyQt5.QtWidgets import QWidget, QGraphicsScene, QLabel
+from PyQt5.QtWidgets import QGraphicsScene, QWidget
 
 from TriblerGUI.utilities import get_image_path
 
@@ -13,6 +14,7 @@ class LoadingPage(QWidget):
     def __init__(self):
         QWidget.__init__(self)
         self.loading_label = None
+        self.upgrading = False
 
     def initialize_loading_page(self):
         svg_container = QGraphicsScene(self.window().loading_svg_view)
@@ -24,28 +26,19 @@ class LoadingPage(QWidget):
         svg_container.addItem(svg_item)
 
         self.window().loading_svg_view.setScene(svg_container)
-        self.window().core_manager.events_manager.upgrader_tick.connect(self.set_loading_text)
-        self.window().core_manager.events_manager.upgrader_started.connect(
-            lambda: self.set_loading_text("Upgrading..."))
-        self.window().core_manager.events_manager.upgrader_finished.connect(lambda: self.loading_label.hide())
-
-        # Create a loading label that displays the status during upgrading
-        self.loading_label = QLabel(self)
-        self.loading_label.setStyleSheet("color: #ddd; font-size: 22px;")
-        self.loading_label.setAlignment(Qt.AlignCenter)
-
-        self.on_window_resize()
-        self.loading_label.hide()
+        self.window().core_manager.events_manager.upgrader_tick.connect(self.on_upgrader_tick)
+        self.window().core_manager.events_manager.upgrader_finished.connect(self.upgrader_finished)
+        self.window().skip_conversion_btn.hide()
 
         # Hide the force shutdown button initially. Should be triggered by shutdown timer from main window.
         self.window().force_shutdown_btn.hide()
 
-    def set_loading_text(self, text):
-        self.loading_label.setText(text)
-        self.loading_label.show()
+    def upgrader_finished(self):
+        self.window().skip_conversion_btn.hide()
 
-    def on_window_resize(self):
-        self.loading_label.setFixedWidth(self.window().width())
-        self.loading_label.setFixedHeight(26)
+    def on_upgrader_tick(self, text):
+        if not self.upgrading:
+            self.upgrading = True
+            self.window().skip_conversion_btn.show()
+        self.window().loading_text_label.setText(text)
 
-        self.loading_label.move(QPoint(0, 60))


### PR DESCRIPTION
This PR moves 72 -> 73(Pony) upgrader out of the background thread to be run in the foreground at Tribler startup instead.

This greatly speed-ups the process by as we can use larger batches and **disable disk synchronization** during the upgrade process for the newly created DB. This is safe to do, since the old DB is read-only, and the conversion process can always be started from a clean slate if power fails during the upgrade process.
Disabling sync makes the upgrade process **run on an HDD as fast as on an SSD**. On my machine, a 400Mb `tribler.sdb` is converted in less than 1 minute.

To give users some control over the process, a "skip" button along with a text indicator of the state of the upgrade process are added to the "spinning gears" screen. Pressing the button produces a confirmation dialog. Even if a user decides to skip the conversion process, their personal channel will still be converted.
![upgrader](https://user-images.githubusercontent.com/2509103/57090643-8da35100-6d07-11e9-9c68-3596dd38a03a.png)

Closes #4441 
Closes #4439 
Closes #4440