### PR TITLE
Fixed Python 3 compatibility for configparser.py

### DIFF
--- a/Tribler/Core/Utilities/configparser.py
+++ b/Tribler/Core/Utilities/configparser.py
@@ -7,10 +7,10 @@ from __future__ import absolute_import
 
 import ast
 import codecs
+from threading import RLock
 
 from six import StringIO, text_type
 from six.moves.configparser import DEFAULTSECT, RawConfigParser
-from threading import RLock
 
 from Tribler.Core.exceptions import OperationNotPossibleAtRuntimeException
 
@@ -33,7 +33,7 @@ class CallbackConfigParser(RawConfigParser):
         # (e.g. when loading resumedata). Please do not remove.
         with codecs.open(filename, 'rb', encoding) as fp:
             buff = fp.read()
-        self.readfp(StringIO(buff))
+        self._read(StringIO(buff), None)
 
     def set(self, section, option, new_value):
         with self.lock:


### PR DESCRIPTION
```
jenkins@python3-tester:~/tribler$ nosetests3 Tribler/Test/Core/test_configparser.py 
/usr/lib/python3.5/importlib/_bootstrap.py:222: RuntimeWarning: to-Python converter for boost::shared_ptr<libtorrent::alert> already registered; second conversion method ignored.
  return f(*args, **kwds)
.......
----------------------------------------------------------------------
Ran 7 tests in 1.500s

OK
```