### PR TITLE
Message does not exist on Exceptions in Python 3

### DIFF
--- a/Tribler/Core/Modules/restapi/rest_manager.py
+++ b/Tribler/Core/Modules/restapi/rest_manager.py
@@ -4,6 +4,8 @@ import logging
 import os
 from traceback import format_tb
 
+from six import text_type
+
 from twisted.internet import reactor
 from twisted.internet.defer import maybeDeferred
 from twisted.internet.error import CannotListenError
@@ -78,15 +80,16 @@ class RESTRequest(server.Request):
 
     def processingFailed(self, failure):
         self._logger.exception(failure)
+        failure_message = failure.value.message if hasattr(failure.value, 'message') else text_type(failure.value)
         response = {
-            u"error": {
-                u"handled": False,
-                u"code": failure.value.__class__.__name__,
-                u"message": failure.value.message
+            "error": {
+                "handled": False,
+                "code": failure.value.__class__.__name__,
+                "message": failure_message
             }
         }
         if self.site and self.site.displayTracebacks:
-            response[u"error"][u"trace"] = format_tb(failure.getTracebackObject())
+            response["error"]["trace"] = format_tb(failure.getTracebackObject())
 
         body = json.twisted_dumps(response)
         self.setResponseCode(http.INTERNAL_SERVER_ERROR)

--- a/Tribler/Test/Core/Modules/RestApi/test_rest_manager.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_rest_manager.py
@@ -12,6 +12,7 @@ from Tribler.Test.tools import trial_timeout
 def RaiseException(*args, **kwargs):
     raise TriblerException(u"Oops! Something went wrong. Please restart Tribler")
 
+
 class RestRequestTest(AbstractApiTest):
 
     @trial_timeout(10)
@@ -21,15 +22,9 @@ class RestRequestTest(AbstractApiTest):
         """
 
         def verify_error_message(body):
-            error_response = json.twisted_loads(body)
-            expected_response = {
-                u"error": {
-                    u"handled": False,
-                    u"code": u"TriblerException",
-                    u"message": u"Oops! Something went wrong. Please restart Tribler"
-                }
-            }
-            self.assertDictContainsSubset(expected_response[u"error"], error_response[u"error"])
+            error_response = json.twisted_loads(body)['error']
+            self.assertFalse(error_response['handled'])
+            self.assertEqual(error_response['code'], "TriblerException")
 
         post_data = json.dumps({"settings": "bla", "ports": "bla"})
         SettingsEndpoint.parse_settings_dict = RaiseException


### PR DESCRIPTION
This will return more helpful messages when fixing the REST API tests under Python 3.

```
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Core/Modules/restapi/rest_manager.py", line 114, in process
    server.Request.process(self)
  File "/home/jenkins/.local/lib/python3.5/site-packages/twisted/web/server.py", line 201, in process
    self.processingFailed(failure.Failure())
  File "/home/jenkins/workspace/test_tribler_python3/tribler/Tribler/Core/Modules/restapi/rest_manager.py", line 85, in processingFailed
    u"message": failure.value.message
builtins.AttributeError: 'KeyError' object has no attribute 'message'
```