### PR TITLE
Add "Votes" column to GUI and DB

### DIFF
--- a/Tribler/Core/Modules/MetadataStore/OrmBindings/channel_metadata.py
+++ b/Tribler/Core/Modules/MetadataStore/OrmBindings/channel_metadata.py
@@ -95,7 +95,7 @@ def define_binding(db):
 
         # Local
         subscribed = orm.Optional(bool, default=False)
-        votes = orm.Optional(int, size=64, default=0)
+        votes = orm.Set('ChannelPeer', reverse='votes')
         local_version = orm.Optional(int, size=64, default=0)
 
         _payload_class = ChannelMetadataPayload
@@ -486,7 +486,7 @@ def define_binding(db):
                 "name": self.title,
                 "torrents": self.num_entries,
                 "subscribed": self.subscribed,
-                "votes": self.votes,
+                "votes": self.votes.count(),
                 "status": self.status,
                 "updated": int((self.torrent_date - epoch).total_seconds()),
                 "timestamp": self.timestamp,

--- a/Tribler/Core/Modules/MetadataStore/OrmBindings/channel_peer.py
+++ b/Tribler/Core/Modules/MetadataStore/OrmBindings/channel_peer.py
@@ -1,0 +1,15 @@
+from __future__ import absolute_import
+
+from pony import orm
+
+from Tribler.pyipv8.ipv8.database import database_blob
+
+
+# This binding stores public keys of IPv8 peers that sent us some GigaChannel data
+def define_binding(db):
+    class ChannelPeer(db.Entity):
+        rowid = orm.PrimaryKey(int, size=64, auto=True)
+        public_key = orm.Required(database_blob, unique=True)
+        votes = orm.Set('ChannelMetadata', reverse='votes')
+
+    return ChannelPeer

--- a/Tribler/Core/Modules/restapi/metadata_endpoint.py
+++ b/Tribler/Core/Modules/restapi/metadata_endpoint.py
@@ -122,8 +122,10 @@ class ChannelsPopularEndpoint(BaseChannelsEndpoint):
                 request.setResponseCode(http.BAD_REQUEST)
                 return json.twisted_dumps({"error": "the limit parameter must be a positive number"})
 
-        popular_channels = self.session.lm.mds.ChannelMetadata.get_random_channels(limit=limit_channels)
-        return json.twisted_dumps({"channels": [channel.to_simple_dict() for channel in popular_channels]})
+        with db_session:
+            popular_channels = [channel.to_simple_dict() for channel in
+                                self.session.lm.mds.ChannelMetadata.get_random_channels(limit=limit_channels)]
+        return json.twisted_dumps({"channels": popular_channels})
 
 
 class SpecificChannelEndpoint(BaseChannelsEndpoint):

--- a/Tribler/Core/Upgrade/db72_to_pony.py
+++ b/Tribler/Core/Upgrade/db72_to_pony.py
@@ -102,7 +102,6 @@ class DispersyToPonyMigration(object):
                                  "title": name or '',
                                  "public_key": dispesy_cid_to_pk(id_),
                                  "timestamp": final_timestamp(),
-                                 "votes": int(nr_favorite or 0),
                                  "origin_id": 0,
                                  "signature": pseudo_signature(),
                                  "skip_key_check": True,

--- a/Tribler/Test/Core/Modules/MetadataStore/test_channel_metadata.py
+++ b/Tribler/Test/Core/Modules/MetadataStore/test_channel_metadata.py
@@ -68,7 +68,7 @@ class TestChannelMetadata(TriblerCoreTest):
         """
         Utility method to return a dictionary with a channel information.
         """
-        return dict(TestChannelMetadata.get_sample_torrent_dict(my_key), votes=222, subscribed=False, timestamp=1)
+        return dict(TestChannelMetadata.get_sample_torrent_dict(my_key), subscribed=False, timestamp=1)
 
     @db_session
     def test_serialization(self):

--- a/Tribler/community/gigachannel/community.py
+++ b/Tribler/community/gigachannel/community.py
@@ -88,7 +88,7 @@ class GigaChannelCommunity(Community):
         try:
             with db_session:
                 try:
-                    md_list = self.metadata_store.process_compressed_mdblob(blob.raw_blob)
+                    md_list = self.metadata_store.process_compressed_mdblob(blob.raw_blob, source=peer.public_key)
                 except (TransactionIntegrityError, CacheIndexError) as err:
                     self._logger.error("DB transaction error when tried to process payload: %s", str(err))
                     return

--- a/TriblerGUI/widgets/lazytableview.py
+++ b/TriblerGUI/widgets/lazytableview.py
@@ -199,11 +199,12 @@ class SearchResultsTableView(ItemClickedMixin, DownloadButtonMixin, PlayButtonMi
     def resizeEvent(self, _):
         self.setColumnWidth(0, 20)
         self.setColumnWidth(1, 40)
-        self.setColumnWidth(2, 100)
-        self.setColumnWidth(3, self.width() - 460)  # Few pixels offset so the horizontal scrollbar does not appear
-        self.setColumnWidth(4, 100)
+        self.setColumnWidth(2, 40)
+        self.setColumnWidth(3, 100)
+        self.setColumnWidth(4, self.width() - 500)  # Few pixels offset so the horizontal scrollbar does not appear
         self.setColumnWidth(5, 100)
         self.setColumnWidth(6, 100)
+        self.setColumnWidth(7, 100)
 
 
 class TorrentsTableView(ItemClickedMixin, DeleteButtonMixin, DownloadButtonMixin, PlayButtonMixin,
@@ -267,6 +268,7 @@ class ChannelsTableView(ItemClickedMixin, SubscribeButtonMixin,
     def resizeEvent(self, _):
         self.setColumnWidth(0, 20)
         self.setColumnWidth(1, 40)
-        self.setColumnWidth(2, self.width() - 260)  # Few pixels offset so the horizontal scrollbar does not appear
-        self.setColumnWidth(3, 100)
+        self.setColumnWidth(2, 40)
+        self.setColumnWidth(3, self.width() - 300)  # Few pixels offset so the horizontal scrollbar does not appear
         self.setColumnWidth(4, 100)
+        self.setColumnWidth(5, 100)

--- a/TriblerGUI/widgets/tablecontentmodel.py
+++ b/TriblerGUI/widgets/tablecontentmodel.py
@@ -108,7 +108,6 @@ class TriblerContentModel(RemoteTableModel):
         if orientation == Qt.Horizontal and role == Qt.DisplayRole:
             return self.column_headers[num]
 
-
     def get_item_uid(self, item):
         item_uid = None
         if "infohash" in item:
@@ -156,13 +155,24 @@ class StateTooltipMixin(object):
             return super(StateTooltipMixin, self).data(index, role)
 
 
-class SearchResultsContentModel(StateTooltipMixin, TriblerContentModel):
+class VotesAlignmentMixin(object):
+    def data(self, index, role):
+        # Return tooltip for state indicator column
+        if role == Qt.TextAlignmentRole:
+            if index.column() == self.column_position[u'votes']:
+                return Qt.AlignRight | Qt.AlignVCenter
+            return None
+        else:
+            return super(VotesAlignmentMixin, self).data(index, role)
+
+
+class SearchResultsContentModel(StateTooltipMixin, VotesAlignmentMixin, TriblerContentModel):
     """
     Model for a list that shows search results.
     """
-    columns = [u'state', u'subscribed', u'category', u'name', u'torrents', u'size', u'updated', u'health',
+    columns = [u'state', u'votes', u'subscribed', u'category', u'name', u'torrents', u'size', u'updated', u'health',
                ACTION_BUTTONS]
-    column_headers = [u'', u'', u'Category', u'Name', u'Torrents', u'Size', u'Updated', u'health', u'']
+    column_headers = [u'', u'', u'', u'Category', u'Name', u'Torrents', u'Size', u'Updated', u'health', u'']
     column_flags = {
         u'subscribed': Qt.ItemIsEnabled | Qt.ItemIsSelectable,
         u'category': Qt.ItemIsEnabled | Qt.ItemIsSelectable,
@@ -171,6 +181,7 @@ class SearchResultsContentModel(StateTooltipMixin, TriblerContentModel):
         u'size': Qt.ItemIsEnabled | Qt.ItemIsSelectable,
         u'updated': Qt.ItemIsEnabled | Qt.ItemIsSelectable,
         u'health': Qt.ItemIsEnabled | Qt.ItemIsSelectable,
+        u'votes': Qt.ItemIsEnabled | Qt.ItemIsSelectable,
         u'state': Qt.ItemIsEnabled | Qt.ItemIsSelectable,
         ACTION_BUTTONS: Qt.ItemIsEnabled | Qt.ItemIsSelectable
     }
@@ -185,17 +196,18 @@ class SearchResultsContentModel(StateTooltipMixin, TriblerContentModel):
         self.type_filter = ''
 
 
-class ChannelsContentModel(StateTooltipMixin, TriblerContentModel):
+class ChannelsContentModel(StateTooltipMixin, VotesAlignmentMixin, TriblerContentModel):
     """
     This model represents a list of channels that can be displayed in a table view.
     """
-    columns = [u'state', u'subscribed', u'name', u'torrents', u'updated']
-    column_headers = [u'', u'', u'Channel name', u'Torrents', u'Updated']
+    columns = [u'state', u'votes', u'subscribed', u'name', u'torrents', u'updated']
+    column_headers = [u'', u'', u'', u'Channel name', u'Torrents', u'Updated']
     column_flags = {
         u'subscribed': Qt.ItemIsEnabled | Qt.ItemIsSelectable,
         u'name': Qt.ItemIsEnabled | Qt.ItemIsSelectable,
         u'torrents': Qt.ItemIsEnabled | Qt.ItemIsSelectable,
         u'updated': Qt.ItemIsEnabled | Qt.ItemIsSelectable,
+        u'votes': Qt.ItemIsEnabled | Qt.ItemIsSelectable,
         u'state': Qt.ItemIsEnabled | Qt.ItemIsSelectable,
         ACTION_BUTTONS: Qt.ItemIsEnabled | Qt.ItemIsSelectable
     }


### PR DESCRIPTION
This PR adds "votes collecting" feature to GigaChannel. It works like this: whenever a Channel entry is received by the GigaChannel Community gossip mechanism, GigaChannel adds the IPv8 peer that sent the gossip to the new ChannelPeer class and associates it with the received gossip.

Multiple peers can be associated with a single gossip, and vice-versa. Effectively, the power of the ChannelPeers set associated with a given ChannelMetadata gossip is the number of votes for the channel.
Basically, we count the number of distinct people who have send us the channel.

The votes count is shown in the GUI as a new column.
![votes_gui](https://user-images.githubusercontent.com/2509103/58108023-567bdd80-7beb-11e9-8ced-88f31638bb91.png)