### PR TITLE
Changed IPv8 import

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -5,7 +5,7 @@
 
 # Python code to execute, usually for sys.path manipulation such as
 # pygtk.require().
-#init-hook=
+init-hook='import sys; import os; sys.path.append(os.path.join("Tribler", "pyipv8"))'
 
 # Add files or directories to the blacklist. They should be base names, not
 # paths.

--- a/Tribler/Core/APIImplementation/LaunchManyCore.py
+++ b/Tribler/Core/APIImplementation/LaunchManyCore.py
@@ -15,6 +15,16 @@ from glob import iglob
 from threading import Event, enumerate as enumerate_threads
 from traceback import print_exc
 
+from ipv8.dht.provider import DHTCommunityProvider
+from ipv8.messaging.anonymization.community import TunnelSettings
+from ipv8.peer import Peer
+from ipv8.peerdiscovery.churn import RandomChurn
+from ipv8.peerdiscovery.community import DiscoveryCommunity, PeriodicSimilarity
+from ipv8.peerdiscovery.discovery import EdgeWalk, RandomWalk
+from ipv8.taskmanager import TaskManager
+
+from ipv8_service import IPv8
+
 from twisted.internet import reactor
 from twisted.internet.defer import Deferred, DeferredList, inlineCallbacks, succeed
 from twisted.internet.task import LoopingCall
@@ -41,14 +51,6 @@ from Tribler.Core.simpledefs import (DLSTATUS_DOWNLOADING, DLSTATUS_SEEDING, DLS
                                      NTFY_FINISHED, NTFY_STARTED, NTFY_TORRENT, NTFY_TRIBLER,
                                      STATE_START_API_ENDPOINTS, STATE_START_CREDIT_MINING,
                                      STATE_START_LIBTORRENT, STATE_START_TORRENT_CHECKER, STATE_START_WATCH_FOLDER)
-from Tribler.pyipv8.ipv8.dht.provider import DHTCommunityProvider
-from Tribler.pyipv8.ipv8.messaging.anonymization.community import TunnelSettings
-from Tribler.pyipv8.ipv8.peer import Peer
-from Tribler.pyipv8.ipv8.peerdiscovery.churn import RandomChurn
-from Tribler.pyipv8.ipv8.peerdiscovery.community import DiscoveryCommunity, PeriodicSimilarity
-from Tribler.pyipv8.ipv8.peerdiscovery.discovery import EdgeWalk, RandomWalk
-from Tribler.pyipv8.ipv8.taskmanager import TaskManager
-from Tribler.pyipv8.ipv8_service import IPv8
 
 
 class TriblerLaunchMany(TaskManager):
@@ -131,7 +133,7 @@ class TriblerLaunchMany(TaskManager):
 
         # IPv8
         if self.session.config.get_ipv8_enabled():
-            from Tribler.pyipv8.ipv8.configuration import get_default_configuration
+            from ipv8.configuration import get_default_configuration
             ipv8_config = get_default_configuration()
             ipv8_config['port'] = self.session.config.get_ipv8_port()
             ipv8_config['address'] = self.session.config.get_ipv8_address()
@@ -139,7 +141,7 @@ class TriblerLaunchMany(TaskManager):
             ipv8_config['keys'] = []  # We load the keys ourselves
 
             if self.session.config.get_ipv8_bootstrap_override():
-                import Tribler.pyipv8.ipv8.community as community_file
+                import ipv8.community as community_file
                 community_file._DEFAULT_ADDRESSES = [self.session.config.get_ipv8_bootstrap_override()]
                 community_file._DNS_ADDRESSES = []
 
@@ -164,7 +166,7 @@ class TriblerLaunchMany(TaskManager):
 
         # TrustChain Community
         if self.session.config.get_trustchain_enabled():
-            from Tribler.pyipv8.ipv8.attestation.trustchain.community import TrustChainCommunity, \
+            from ipv8.attestation.trustchain.community import TrustChainCommunity, \
                 TrustChainTestnetCommunity
 
             community_cls = TrustChainTestnetCommunity if self.session.config.get_testnet() else TrustChainCommunity
@@ -179,7 +181,7 @@ class TriblerLaunchMany(TaskManager):
 
         # DHT Community
         if self.session.config.get_dht_enabled():
-            from Tribler.pyipv8.ipv8.dht.discovery import DHTDiscoveryCommunity
+            from ipv8.dht.discovery import DHTDiscoveryCommunity
 
             self.dht_community = DHTDiscoveryCommunity(peer, self.ipv8.endpoint, self.ipv8.network)
             self.ipv8.overlays.append(self.dht_community)

--- a/Tribler/Core/CreditMining/CreditMiningManager.py
+++ b/Tribler/Core/CreditMining/CreditMiningManager.py
@@ -6,6 +6,8 @@ import time
 from binascii import hexlify, unhexlify
 from glob import glob
 
+from ipv8.taskmanager import TaskManager
+
 import psutil
 
 from six import string_types
@@ -20,7 +22,6 @@ from Tribler.Core.TorrentDef import TorrentDefNoMetainfo
 from Tribler.Core.simpledefs import DLSTATUS_DOWNLOADING, DLSTATUS_SEEDING, DLSTATUS_STOPPED, \
     DLSTATUS_STOPPED_ON_ERROR, NTFY_CREDIT_MINING, NTFY_ERROR, UPLOAD
 from Tribler.Core.simpledefs import DOWNLOAD
-from Tribler.pyipv8.ipv8.taskmanager import TaskManager
 
 
 class CreditMiningTorrent(object):

--- a/Tribler/Core/CreditMining/CreditMiningSource.py
+++ b/Tribler/Core/CreditMining/CreditMiningSource.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import logging
 from binascii import hexlify
 
-from Tribler.pyipv8.ipv8.taskmanager import TaskManager
+from ipv8.taskmanager import TaskManager
 
 
 class BaseSource(TaskManager):

--- a/Tribler/Core/DownloadState.py
+++ b/Tribler/Core/DownloadState.py
@@ -7,10 +7,11 @@ from __future__ import absolute_import
 
 import logging
 
+from ipv8.messaging.anonymization.tunnel import PEER_FLAG_EXIT_ANY
+
 from Tribler.Core.simpledefs import (DLSTATUS_ALLOCATING_DISKSPACE, DLSTATUS_CIRCUITS, DLSTATUS_DOWNLOADING,
                                      DLSTATUS_EXIT_NODES, DLSTATUS_HASHCHECKING, DLSTATUS_METADATA, DLSTATUS_SEEDING,
                                      DLSTATUS_STOPPED, DLSTATUS_STOPPED_ON_ERROR, DLSTATUS_WAITING4HASHCHECK, UPLOAD)
-from Tribler.pyipv8.ipv8.messaging.anonymization.tunnel import PEER_FLAG_EXIT_ANY
 
 # Map used to convert libtorrent -> Tribler download status
 DLSTATUS_MAP = [DLSTATUS_WAITING4HASHCHECK,

--- a/Tribler/Core/Libtorrent/LibtorrentDownloadImpl.py
+++ b/Tribler/Core/Libtorrent/LibtorrentDownloadImpl.py
@@ -14,6 +14,8 @@ import time
 from binascii import hexlify
 from threading import RLock
 
+from ipv8.taskmanager import TaskManager
+
 import libtorrent as lt
 
 import six
@@ -34,7 +36,6 @@ from Tribler.Core.exceptions import SaveResumeDataError
 from Tribler.Core.osutils import fix_filebasename
 from Tribler.Core.simpledefs import DLMODE_NORMAL, DLMODE_VOD, DLSTATUS_SEEDING, DLSTATUS_STOPPED, \
     PERSISTENTSTATE_CURRENTVERSION, dlstatus_strings
-from Tribler.pyipv8.ipv8.taskmanager import TaskManager
 
 if sys.platform == "win32":
     try:

--- a/Tribler/Core/Libtorrent/LibtorrentMgr.py
+++ b/Tribler/Core/Libtorrent/LibtorrentMgr.py
@@ -15,6 +15,8 @@ from copy import deepcopy
 from distutils.version import LooseVersion
 from shutil import rmtree
 
+from ipv8.taskmanager import TaskManager
+
 import libtorrent as lt
 from libtorrent import bdecode, torrent_handle
 
@@ -35,7 +37,6 @@ from Tribler.Core.exceptions import TorrentFileException
 from Tribler.Core.simpledefs import (NTFY_INSERT, NTFY_MAGNET_CLOSE, NTFY_MAGNET_GOT_PEERS, NTFY_MAGNET_STARTED,
                                      NTFY_REACHABLE, NTFY_TORRENTS)
 from Tribler.Core.version import version_id
-from Tribler.pyipv8.ipv8.taskmanager import TaskManager
 
 LTSTATE_FILENAME = "lt.state"
 METAINFO_CACHE_PERIOD = 5 * 60

--- a/Tribler/Core/Modules/MetadataStore/OrmBindings/channel_metadata.py
+++ b/Tribler/Core/Modules/MetadataStore/OrmBindings/channel_metadata.py
@@ -6,6 +6,8 @@ import sys
 from binascii import hexlify
 from datetime import datetime
 
+from ipv8.database import database_blob
+
 from libtorrent import add_files, bencode, create_torrent, file_storage, set_piece_hashes, torrent_info
 
 import lz4.frame
@@ -20,7 +22,6 @@ from Tribler.Core.Modules.MetadataStore.serialization import CHANNEL_TORRENT, Ch
 from Tribler.Core.TorrentDef import TorrentDef
 from Tribler.Core.Utilities.tracker_utils import get_uniformed_tracker_url
 from Tribler.Core.exceptions import DuplicateChannelIdError, DuplicateTorrentFileError
-from Tribler.pyipv8.ipv8.database import database_blob
 
 CHANNEL_DIR_NAME_LENGTH = 32  # Its not 40 so it could be distinguished from infohash
 BLOB_EXTENSION = '.mdblob'

--- a/Tribler/Core/Modules/MetadataStore/OrmBindings/channel_node.py
+++ b/Tribler/Core/Modules/MetadataStore/OrmBindings/channel_node.py
@@ -3,14 +3,15 @@ from __future__ import absolute_import
 from binascii import hexlify
 from datetime import datetime
 
+from ipv8.database import database_blob
+from ipv8.keyvault.crypto import default_eccrypto
+
 from pony import orm
 from pony.orm.core import DEFAULT
 
 from Tribler.Core.Modules.MetadataStore.serialization import CHANNEL_NODE, ChannelNodePayload, DELETED, \
     DeletedMetadataPayload
 from Tribler.Core.exceptions import InvalidSignatureException
-from Tribler.pyipv8.ipv8.database import database_blob
-from Tribler.pyipv8.ipv8.keyvault.crypto import default_eccrypto
 
 # Metadata, torrents and channel statuses
 NEW = 0  # The entry is newly created and is not published yet. It will be committed at the next commit.

--- a/Tribler/Core/Modules/MetadataStore/OrmBindings/torrent_metadata.py
+++ b/Tribler/Core/Modules/MetadataStore/OrmBindings/torrent_metadata.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import
 from binascii import hexlify, unhexlify
 from datetime import datetime
 
+from ipv8.database import database_blob
+
 from pony import orm
 from pony.orm import db_session, desc, raw_sql, select
 
@@ -11,7 +13,6 @@ from Tribler.Core.Modules.MetadataStore.OrmBindings.channel_node import LEGACY_E
 from Tribler.Core.Modules.MetadataStore.serialization import REGULAR_TORRENT, TorrentMetadataPayload
 from Tribler.Core.Utilities.tracker_utils import get_uniformed_tracker_url
 from Tribler.Core.Utilities.utilities import is_channel_public_key, is_hex_string, is_infohash
-from Tribler.pyipv8.ipv8.database import database_blob
 
 
 def define_binding(db):

--- a/Tribler/Core/Modules/MetadataStore/OrmBindings/torrent_state.py
+++ b/Tribler/Core/Modules/MetadataStore/OrmBindings/torrent_state.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import
 
-from pony import orm
+from ipv8.database import database_blob
 
-from Tribler.pyipv8.ipv8.database import database_blob
+from pony import orm
 
 
 def define_binding(db):

--- a/Tribler/Core/Modules/MetadataStore/serialization.py
+++ b/Tribler/Core/Modules/MetadataStore/serialization.py
@@ -4,11 +4,12 @@ import struct
 from binascii import hexlify
 from datetime import datetime, timedelta
 
+from ipv8.database import database_blob
+from ipv8.keyvault.crypto import default_eccrypto
+from ipv8.messaging.payload import Payload
+from ipv8.messaging.serialization import default_serializer
+
 from Tribler.Core.exceptions import InvalidSignatureException
-from Tribler.pyipv8.ipv8.database import database_blob
-from Tribler.pyipv8.ipv8.keyvault.crypto import default_eccrypto
-from Tribler.pyipv8.ipv8.messaging.payload import Payload
-from Tribler.pyipv8.ipv8.messaging.serialization import default_serializer
 
 EPOCH = datetime(1970, 1, 1)
 INFOHASH_SIZE = 20  # bytes

--- a/Tribler/Core/Modules/MetadataStore/store.py
+++ b/Tribler/Core/Modules/MetadataStore/store.py
@@ -6,6 +6,8 @@ from binascii import hexlify
 from datetime import datetime, timedelta
 from time import sleep
 
+from ipv8.database import database_blob
+
 import lz4.frame
 
 from pony import orm
@@ -17,7 +19,6 @@ from Tribler.Core.Modules.MetadataStore.OrmBindings.channel_metadata import BLOB
 from Tribler.Core.Modules.MetadataStore.serialization import (
     CHANNEL_TORRENT, DELETED, REGULAR_TORRENT, read_payload_with_offset, time2int)
 from Tribler.Core.exceptions import InvalidSignatureException
-from Tribler.pyipv8.ipv8.database import database_blob
 
 CLOCK_STATE_FILE = "clock.state"
 

--- a/Tribler/Core/Modules/dht_health_manager.py
+++ b/Tribler/Core/Modules/dht_health_manager.py
@@ -3,13 +3,13 @@ from __future__ import absolute_import, division
 import math
 from binascii import hexlify
 
+from ipv8.dht.routing import distance, id_to_binary_string
+from ipv8.taskmanager import TaskManager
+
 import libtorrent as lt
 
 from twisted.internet import reactor
 from twisted.internet.defer import Deferred
-
-from Tribler.pyipv8.ipv8.dht.routing import distance, id_to_binary_string
-from Tribler.pyipv8.ipv8.taskmanager import TaskManager
 
 
 class DHTHealthManager(TaskManager):

--- a/Tribler/Core/Modules/gigachannel_manager.py
+++ b/Tribler/Core/Modules/gigachannel_manager.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import
 import os
 from binascii import hexlify
 
+from ipv8.taskmanager import TaskManager
+
 from pony.orm import db_session
 
 from twisted.internet.task import LoopingCall
@@ -12,7 +14,6 @@ from Tribler.Core.DownloadConfig import DownloadStartupConfig
 from Tribler.Core.Modules.MetadataStore.OrmBindings.channel_node import COMMITTED
 from Tribler.Core.TorrentDef import TorrentDef, TorrentDefNoMetainfo
 from Tribler.Core.simpledefs import NTFY_CHANNEL_ENTITY, NTFY_UPDATE
-from Tribler.pyipv8.ipv8.taskmanager import TaskManager
 
 
 class GigaChannelManager(TaskManager):

--- a/Tribler/Core/Modules/payout_manager.py
+++ b/Tribler/Core/Modules/payout_manager.py
@@ -3,8 +3,9 @@ from __future__ import absolute_import
 import logging
 from binascii import hexlify
 
+from ipv8.util import addCallback
+
 from Tribler.Core.Modules.wallet.tc_wallet import TrustchainWallet
-from Tribler.pyipv8.ipv8.util import addCallback
 
 
 class PayoutManager(object):

--- a/Tribler/Core/Modules/resource_monitor.py
+++ b/Tribler/Core/Modules/resource_monitor.py
@@ -1,12 +1,16 @@
+from __future__ import absolute_import
+
 import logging
 import os
 import time
 
+from ipv8.taskmanager import TaskManager
+
 import psutil
+
 from twisted.internet.task import LoopingCall
 
 from Tribler.Core.simpledefs import SIGNAL_LOW_SPACE, SIGNAL_RESOURCE_CHECK
-from Tribler.pyipv8.ipv8.taskmanager import TaskManager
 
 # Attempt to import yappi
 try:

--- a/Tribler/Core/Modules/restapi/events_endpoint.py
+++ b/Tribler/Core/Modules/restapi/events_endpoint.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import
 import time
 from binascii import hexlify
 
+from ipv8.messaging.anonymization.tunnel import Circuit
+
 from twisted.web import resource, server
 
 import Tribler.Core.Utilities.json_util as json
@@ -15,7 +17,6 @@ from Tribler.Core.simpledefs import (
     NTFY_WATCH_FOLDER_CORRUPT_TORRENT, SIGNAL_GIGACHANNEL_COMMUNITY, SIGNAL_LOW_SPACE, SIGNAL_ON_SEARCH_RESULTS,
     SIGNAL_RESOURCE_CHECK, STATE_SHUTDOWN)
 from Tribler.Core.version import version_id
-from Tribler.pyipv8.ipv8.messaging.anonymization.tunnel import Circuit
 
 
 class EventsEndpoint(resource.Resource):

--- a/Tribler/Core/Modules/restapi/metadata_endpoint.py
+++ b/Tribler/Core/Modules/restapi/metadata_endpoint.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import
 import logging
 from binascii import unhexlify
 
+from ipv8.database import database_blob
+
 from pony.orm import db_session
 
 from twisted.internet import reactor
@@ -10,7 +12,6 @@ from twisted.web import http, resource
 from twisted.web.server import NOT_DONE_YET
 
 import Tribler.Core.Utilities.json_util as json
-from Tribler.pyipv8.ipv8.database import database_blob
 from Tribler.util import cast_to_unicode_utf8
 
 

--- a/Tribler/Core/Modules/restapi/mychannel_endpoint.py
+++ b/Tribler/Core/Modules/restapi/mychannel_endpoint.py
@@ -7,6 +7,8 @@ import logging
 import os
 from binascii import hexlify, unhexlify
 
+from ipv8.database import database_blob
+
 from pony.orm import db_session
 
 from six import viewitems
@@ -22,7 +24,6 @@ from Tribler.Core.Modules.restapi.metadata_endpoint import SpecificChannelTorren
 from Tribler.Core.TorrentDef import TorrentDef
 from Tribler.Core.Utilities.utilities import http_get, is_infohash, parse_magnetlink
 from Tribler.Core.exceptions import DuplicateTorrentFileError
-from Tribler.pyipv8.ipv8.database import database_blob
 
 
 class BaseMyChannelEndpoint(resource.Resource):

--- a/Tribler/Core/Modules/restapi/rest_manager.py
+++ b/Tribler/Core/Modules/restapi/rest_manager.py
@@ -4,6 +4,8 @@ import logging
 import os
 from traceback import format_tb
 
+from ipv8.taskmanager import TaskManager
+
 from six import text_type
 
 from twisted.internet import reactor
@@ -15,7 +17,6 @@ from twisted.web import http, server
 
 import Tribler.Core.Utilities.json_util as json
 from Tribler.Core.Modules.restapi.root_endpoint import RootEndpoint
-from Tribler.pyipv8.ipv8.taskmanager import TaskManager
 
 
 class RESTManager(TaskManager):

--- a/Tribler/Core/Modules/restapi/root_endpoint.py
+++ b/Tribler/Core/Modules/restapi/root_endpoint.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+from ipv8.REST.root_endpoint import RootEndpoint as IPV8RootEndpoint
+
 from twisted.web import resource
 
 from Tribler.Core.Modules.restapi.create_torrent_endpoint import CreateTorrentEndpoint
@@ -20,7 +22,6 @@ from Tribler.Core.Modules.restapi.trustchain_endpoint import TrustchainEndpoint
 from Tribler.Core.Modules.restapi.trustview_endpoint import TrustViewEndpoint
 from Tribler.Core.Modules.restapi.upgrader_endpoint import UpgraderEndpoint
 from Tribler.Core.Modules.restapi.wallets_endpoint import WalletsEndpoint
-from Tribler.pyipv8.ipv8.REST.root_endpoint import RootEndpoint as IPV8RootEndpoint
 
 
 class RootEndpoint(resource.Resource):

--- a/Tribler/Core/Modules/versioncheck_manager.py
+++ b/Tribler/Core/Modules/versioncheck_manager.py
@@ -1,18 +1,23 @@
+from __future__ import absolute_import
+
 import logging
 from distutils.version import LooseVersion
+
+from ipv8.taskmanager import TaskManager
+
 from twisted.internet.error import ConnectError, DNSLookupError
 from twisted.internet.task import LoopingCall
 from twisted.web.error import SchemeNotSupported
 
-from Tribler.Core.Utilities.utilities import http_get
 import Tribler.Core.Utilities.json_util as json
+from Tribler.Core.Utilities.utilities import http_get
 from Tribler.Core.exceptions import HttpError
 from Tribler.Core.simpledefs import NTFY_INSERT, NTFY_NEW_VERSION
 from Tribler.Core.version import version_id
-from Tribler.pyipv8.ipv8.taskmanager import TaskManager
 
 VERSION_CHECK_URL = 'https://api.github.com/repos/tribler/tribler/releases/latest'
 VERSION_CHECK_INTERVAL = 86400  # One day
+
 
 class VersionCheckManager(TaskManager):
 

--- a/Tribler/Core/Modules/wallet/bandwidth_block.py
+++ b/Tribler/Core/Modules/wallet/bandwidth_block.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import
 
-from Tribler.pyipv8.ipv8.attestation.trustchain.block import EMPTY_SIG, GENESIS_HASH, GENESIS_SEQ, TrustChainBlock, \
+from ipv8.attestation.trustchain.block import EMPTY_SIG, GENESIS_HASH, GENESIS_SEQ, TrustChainBlock, \
     ValidationResult
-from Tribler.pyipv8.ipv8.messaging.deprecated.encoding import encode
+from ipv8.messaging.deprecated.encoding import encode
 
 
 class TriblerBandwidthBlock(TrustChainBlock):

--- a/Tribler/Core/Modules/wallet/tc_wallet.py
+++ b/Tribler/Core/Modules/wallet/tc_wallet.py
@@ -3,15 +3,16 @@ from __future__ import absolute_import, division
 from base64 import b64encode
 from binascii import hexlify, unhexlify
 
+from ipv8.attestation.trustchain.listener import BlockListener
+from ipv8.keyvault.crypto import ECCrypto
+from ipv8.peer import Peer
+from ipv8.util import addCallback
+
 from twisted.internet.defer import Deferred, fail, succeed
 from twisted.internet.task import LoopingCall
 
 from Tribler.Core.Modules.wallet.bandwidth_block import TriblerBandwidthBlock
 from Tribler.Core.Modules.wallet.wallet import InsufficientFunds, Wallet
-from Tribler.pyipv8.ipv8.attestation.trustchain.listener import BlockListener
-from Tribler.pyipv8.ipv8.keyvault.crypto import ECCrypto
-from Tribler.pyipv8.ipv8.peer import Peer
-from Tribler.pyipv8.ipv8.util import addCallback
 
 MEGA_DIV = 1024.0 * 1024.0
 MIN_TRANSACTION_SIZE = 1024 * 1024

--- a/Tribler/Core/Modules/wallet/wallet.py
+++ b/Tribler/Core/Modules/wallet/wallet.py
@@ -5,9 +5,9 @@ import logging
 import random
 import string
 
-import six
+from ipv8.taskmanager import TaskManager
 
-from Tribler.pyipv8.ipv8.taskmanager import TaskManager
+import six
 
 
 class InsufficientFunds(Exception):

--- a/Tribler/Core/Modules/watch_folder.py
+++ b/Tribler/Core/Modules/watch_folder.py
@@ -3,13 +3,14 @@ from __future__ import absolute_import
 import logging
 import os
 
+from ipv8.taskmanager import TaskManager
+
 from twisted.internet.task import LoopingCall
 
 from Tribler.Core.DownloadConfig import DefaultDownloadStartupConfig
 from Tribler.Core.TorrentDef import TorrentDef
 from Tribler.Core.Utilities.utilities import fix_torrent
 from Tribler.Core.simpledefs import NTFY_INSERT, NTFY_WATCH_FOLDER_CORRUPT_TORRENT
-from Tribler.pyipv8.ipv8.taskmanager import TaskManager
 
 WATCH_FOLDER_CHECK_INTERVAL = 10
 

--- a/Tribler/Core/TorrentChecker/session.py
+++ b/Tribler/Core/TorrentChecker/session.py
@@ -9,6 +9,9 @@ import time
 from abc import ABCMeta, abstractmethod, abstractproperty
 from binascii import hexlify
 
+from ipv8.messaging.deprecated.encoding import add_url_params
+from ipv8.taskmanager import TaskManager
+
 from libtorrent import bdecode
 
 from six import text_type
@@ -16,12 +19,9 @@ from six import text_type
 from twisted.internet import defer, reactor
 from twisted.internet.defer import Deferred, inlineCallbacks
 from twisted.internet.protocol import DatagramProtocol
-from twisted.python.failure import Failure
 from twisted.web.client import Agent, HTTPConnectionPool, RedirectAgent, readBody
 
 from Tribler.Core.Utilities.tracker_utils import parse_tracker_url
-from Tribler.pyipv8.ipv8.messaging.deprecated.encoding import add_url_params
-from Tribler.pyipv8.ipv8.taskmanager import TaskManager
 
 # Although these are the actions for UDP trackers, they can still be used as
 # identifiers.

--- a/Tribler/Core/TorrentChecker/torrent_checker.py
+++ b/Tribler/Core/TorrentChecker/torrent_checker.py
@@ -6,6 +6,9 @@ import socket
 import time
 from binascii import hexlify
 
+from ipv8.database import database_blob
+from ipv8.taskmanager import TaskManager
+
 from pony.orm import db_session
 
 from twisted.internet import reactor
@@ -21,8 +24,6 @@ from Tribler.Core.TorrentChecker.session import FakeDHTSession, UdpSocketManager
 from Tribler.Core.Utilities.tracker_utils import MalformedTrackerURLException
 from Tribler.Core.Utilities.utilities import has_bep33_support, is_valid_url
 from Tribler.Core.simpledefs import NTFY_TORRENT, NTFY_UPDATE
-from Tribler.pyipv8.ipv8.database import database_blob
-from Tribler.pyipv8.ipv8.taskmanager import TaskManager
 
 
 TRACKER_SELECTION_INTERVAL = 20    # The interval for querying a random tracker

--- a/Tribler/Core/Upgrade/db72_to_pony.py
+++ b/Tribler/Core/Upgrade/db72_to_pony.py
@@ -7,6 +7,8 @@ import os
 import sqlite3
 from binascii import unhexlify
 
+from ipv8.database import database_blob
+
 from pony import orm
 from pony.orm import CacheIndexError, TransactionIntegrityError, db_session
 
@@ -19,7 +21,6 @@ from twisted.internet.task import deferLater
 from Tribler.Core.Modules.MetadataStore.OrmBindings.channel_node import LEGACY_ENTRY, NEW
 from Tribler.Core.Modules.MetadataStore.serialization import REGULAR_TORRENT
 from Tribler.Core.Utilities.tracker_utils import get_uniformed_tracker_url
-from Tribler.pyipv8.ipv8.database import database_blob
 
 BATCH_SIZE = 10000
 

--- a/Tribler/Core/permid.py
+++ b/Tribler/Core/permid.py
@@ -3,9 +3,11 @@ Permanent Identifier.
 
 Author(s): Arno Bakker
 """
+from __future__ import absolute_import
+
 import logging
 
-from Tribler.pyipv8.ipv8.keyvault.private.libnaclkey import LibNaCLSK
+from ipv8.keyvault.private.libnaclkey import LibNaCLSK
 
 logger = logging.getLogger(__name__)
 

--- a/Tribler/Test/Community/Market/Reputation/test_reputation_base.py
+++ b/Tribler/Test/Community/Market/Reputation/test_reputation_base.py
@@ -1,9 +1,12 @@
+from __future__ import absolute_import
+
 import os
+
+from ipv8.attestation.trustchain.block import TrustChainBlock
+from ipv8.attestation.trustchain.database import TrustChainDB
 
 from Tribler.Test.test_as_server import AbstractServer
 from Tribler.community.market.reputation.temporal_pagerank_manager import TemporalPagerankReputationManager
-from Tribler.pyipv8.ipv8.attestation.trustchain.block import TrustChainBlock
-from Tribler.pyipv8.ipv8.attestation.trustchain.database import TrustChainDB
 
 
 class TestReputationBase(AbstractServer):

--- a/Tribler/Test/Community/Market/test_community.py
+++ b/Tribler/Test/Community/Market/test_community.py
@@ -1,5 +1,8 @@
 from __future__ import absolute_import
 
+from ipv8.test.base import TestBase
+from ipv8.test.mocking.ipv8 import MockIPv8
+
 from nose.tools import raises
 
 from twisted.internet.defer import fail, inlineCallbacks
@@ -19,8 +22,6 @@ from Tribler.community.market.core.tick import Ask, Bid
 from Tribler.community.market.core.timeout import Timeout
 from Tribler.community.market.core.timestamp import Timestamp
 from Tribler.community.market.core.transaction import Transaction, TransactionId, TransactionNumber
-from Tribler.pyipv8.ipv8.test.base import TestBase
-from Tribler.pyipv8.ipv8.test.mocking.ipv8 import MockIPv8
 
 
 class TestMarketCommunityBase(TestBase):

--- a/Tribler/Test/Community/Market/test_order.py
+++ b/Tribler/Test/Community/Market/test_order.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import
 import time
 import unittest
 
+from ipv8.util import old_round
+
 from Tribler.community.market.core.assetamount import AssetAmount
 from Tribler.community.market.core.assetpair import AssetPair
 from Tribler.community.market.core.message import TraderId
@@ -12,7 +14,6 @@ from Tribler.community.market.core.timeout import Timeout
 from Tribler.community.market.core.timestamp import Timestamp
 from Tribler.community.market.core.trade import Trade
 from Tribler.community.market.core.transaction import Transaction, TransactionId, TransactionNumber
-from Tribler.pyipv8.ipv8.util import old_round
 
 
 class OrderTestSuite(unittest.TestCase):

--- a/Tribler/Test/Community/Market/test_timeout.py
+++ b/Tribler/Test/Community/Market/test_timeout.py
@@ -3,9 +3,10 @@ from __future__ import absolute_import
 import time
 import unittest
 
+from ipv8.util import old_round
+
 from Tribler.community.market.core.timeout import Timeout
 from Tribler.community.market.core.timestamp import Timestamp
-from Tribler.pyipv8.ipv8.util import old_round
 
 
 class TimeoutTestSuite(unittest.TestCase):

--- a/Tribler/Test/Community/Market/test_timestamp.py
+++ b/Tribler/Test/Community/Market/test_timestamp.py
@@ -3,8 +3,9 @@ from __future__ import absolute_import
 import time
 import unittest
 
+from ipv8.util import old_round
+
 from Tribler.community.market.core.timestamp import Timestamp
-from Tribler.pyipv8.ipv8.util import old_round
 
 
 class TimestampTestSuite(unittest.TestCase):

--- a/Tribler/Test/Community/Tunnel/FullSession/test_hidden_services.py
+++ b/Tribler/Test/Community/Tunnel/FullSession/test_hidden_services.py
@@ -1,10 +1,11 @@
 from __future__ import absolute_import, print_function
 
+from ipv8.messaging.anonymization.tunnel import CIRCUIT_TYPE_IP_SEEDER
+
 from twisted.internet.defer import Deferred, inlineCallbacks
 
 from Tribler.Core.simpledefs import DLSTATUS_SEEDING
 from Tribler.Test.Community.Tunnel.FullSession.test_tunnel_base import TestTunnelBase
-from Tribler.pyipv8.ipv8.messaging.anonymization.tunnel import CIRCUIT_TYPE_IP_SEEDER
 
 
 class TestHiddenServices(TestTunnelBase):

--- a/Tribler/Test/Community/Tunnel/FullSession/test_tunnel_base.py
+++ b/Tribler/Test/Community/Tunnel/FullSession/test_tunnel_base.py
@@ -2,6 +2,13 @@ from __future__ import absolute_import
 
 import os
 
+from ipv8.keyvault.crypto import ECCrypto
+from ipv8.messaging.anonymization.tunnel import PEER_FLAG_EXIT_ANY
+from ipv8.peer import Peer
+from ipv8.peerdiscovery.community import DiscoveryCommunity
+from ipv8.peerdiscovery.network import Network
+from ipv8.test.messaging.anonymization.test_community import MockDHTProvider
+
 from six.moves import xrange
 
 from twisted.internet import reactor
@@ -13,12 +20,6 @@ from Tribler.Core.TorrentDef import TorrentDef
 from Tribler.Core.simpledefs import dlstatus_strings
 from Tribler.Test.test_as_server import TESTS_DATA_DIR, TestAsServer
 from Tribler.community.triblertunnel.community import TriblerTunnelCommunity
-from Tribler.pyipv8.ipv8.keyvault.crypto import ECCrypto
-from Tribler.pyipv8.ipv8.messaging.anonymization.tunnel import PEER_FLAG_EXIT_ANY
-from Tribler.pyipv8.ipv8.peer import Peer
-from Tribler.pyipv8.ipv8.peerdiscovery.community import DiscoveryCommunity
-from Tribler.pyipv8.ipv8.peerdiscovery.network import Network
-from Tribler.pyipv8.ipv8.test.messaging.anonymization.test_community import MockDHTProvider
 
 
 class TestTunnelBase(TestAsServer):

--- a/Tribler/Test/Community/Tunnel/test_community.py
+++ b/Tribler/Test/Community/Tunnel/test_community.py
@@ -3,18 +3,19 @@ from __future__ import absolute_import
 from os.path import join
 from tempfile import mkdtemp
 
+from ipv8.attestation.trustchain.community import TrustChainCommunity
+from ipv8.messaging.anonymization.tunnel import CIRCUIT_TYPE_RP_DOWNLOADER, PEER_FLAG_EXIT_ANY
+from ipv8.peer import Peer
+from ipv8.test.base import TestBase
+from ipv8.test.messaging.anonymization.test_community import MockDHTProvider
+from ipv8.test.mocking.exit_socket import MockTunnelExitSocket
+from ipv8.test.mocking.ipv8 import MockIPv8
+
 from twisted.internet.defer import Deferred, inlineCallbacks
 
 from Tribler.Core.Modules.wallet.tc_wallet import TrustchainWallet
 from Tribler.Test.Core.base_test import MockObject
 from Tribler.community.triblertunnel.community import TriblerTunnelCommunity
-from Tribler.pyipv8.ipv8.attestation.trustchain.community import TrustChainCommunity
-from Tribler.pyipv8.ipv8.messaging.anonymization.tunnel import CIRCUIT_TYPE_RP_DOWNLOADER, PEER_FLAG_EXIT_ANY
-from Tribler.pyipv8.ipv8.peer import Peer
-from Tribler.pyipv8.ipv8.test.base import TestBase
-from Tribler.pyipv8.ipv8.test.messaging.anonymization.test_community import MockDHTProvider
-from Tribler.pyipv8.ipv8.test.mocking.exit_socket import MockTunnelExitSocket
-from Tribler.pyipv8.ipv8.test.mocking.ipv8 import MockIPv8
 
 
 class TestTriblerTunnelCommunity(TestBase):

--- a/Tribler/Test/Community/Tunnel/test_discovery.py
+++ b/Tribler/Test/Community/Tunnel/test_discovery.py
@@ -2,10 +2,11 @@ from __future__ import absolute_import
 
 from unittest import TestCase
 
+from ipv8.keyvault.crypto import default_eccrypto
+from ipv8.peer import Peer
+from ipv8.peerdiscovery.network import Network
+
 from Tribler.community.triblertunnel.discovery import GoldenRatioStrategy
-from Tribler.pyipv8.ipv8.keyvault.crypto import default_eccrypto
-from Tribler.pyipv8.ipv8.peer import Peer
-from Tribler.pyipv8.ipv8.peerdiscovery.network import Network
 
 
 class FakeOverlay(object):

--- a/Tribler/Test/Community/Tunnel/test_dispatcher.py
+++ b/Tribler/Test/Community/Tunnel/test_dispatcher.py
@@ -1,12 +1,12 @@
 from __future__ import absolute_import
 
+from ipv8.messaging.anonymization.tunnel import CIRCUIT_STATE_EXTENDING, CIRCUIT_STATE_READY, CIRCUIT_TYPE_DATA
+
 from twisted.internet.defer import inlineCallbacks
 
 from Tribler.Test.Core.base_test import MockObject
 from Tribler.Test.test_as_server import AbstractServer
 from Tribler.community.triblertunnel.dispatcher import TunnelDispatcher
-from Tribler.pyipv8.ipv8.messaging.anonymization.tunnel import CIRCUIT_STATE_EXTENDING, CIRCUIT_STATE_READY, \
-    CIRCUIT_TYPE_DATA
 
 
 class TestTunnelDispatcher(AbstractServer):

--- a/Tribler/Test/Community/gigachannel/test_community.py
+++ b/Tribler/Test/Community/gigachannel/test_community.py
@@ -2,6 +2,10 @@ from __future__ import absolute_import
 
 import os
 
+from ipv8.keyvault.crypto import default_eccrypto
+from ipv8.peer import Peer
+from ipv8.test.base import TestBase
+
 from pony.orm import db_session
 
 from six.moves import xrange
@@ -13,9 +17,6 @@ from Tribler.Core.Modules.MetadataStore.store import MetadataStore
 from Tribler.Core.Utilities.random_utils import random_infohash
 from Tribler.Test.Core.base_test import MockObject
 from Tribler.community.gigachannel.community import GigaChannelCommunity
-from Tribler.pyipv8.ipv8.keyvault.crypto import default_eccrypto
-from Tribler.pyipv8.ipv8.peer import Peer
-from Tribler.pyipv8.ipv8.test.base import TestBase
 
 
 class TestGigaChannelUnits(TestBase):

--- a/Tribler/Test/Community/gigachannel/test_sync_strategy.py
+++ b/Tribler/Test/Community/gigachannel/test_sync_strategy.py
@@ -1,7 +1,10 @@
+from __future__ import absolute_import
+
+from ipv8.keyvault.crypto import default_eccrypto
+from ipv8.peer import Peer
+from ipv8.test.base import TestBase
+
 from Tribler.community.gigachannel.sync_strategy import SyncChannels
-from Tribler.pyipv8.ipv8.keyvault.crypto import default_eccrypto
-from Tribler.pyipv8.ipv8.peer import Peer
-from Tribler.pyipv8.ipv8.test.base import TestBase
 
 
 class MockCommunity(object):

--- a/Tribler/Test/Community/popularity/test_community.py
+++ b/Tribler/Test/Community/popularity/test_community.py
@@ -3,6 +3,10 @@ from __future__ import absolute_import
 import os
 import time
 
+from ipv8.keyvault.crypto import default_eccrypto
+from ipv8.test.base import TestBase
+from ipv8.test.mocking.ipv8 import MockIPv8
+
 from pony.orm import db_session
 
 from six.moves import xrange
@@ -12,9 +16,6 @@ from twisted.internet.defer import inlineCallbacks
 from Tribler.Core.Modules.MetadataStore.store import MetadataStore
 from Tribler.Test.Core.base_test import MockObject
 from Tribler.community.popularity.community import PopularityCommunity
-from Tribler.pyipv8.ipv8.keyvault.crypto import default_eccrypto
-from Tribler.pyipv8.ipv8.test.base import TestBase
-from Tribler.pyipv8.ipv8.test.mocking.ipv8 import MockIPv8
 
 
 class TestPopularityCommunity(TestBase):

--- a/Tribler/Test/Core/Modules/MetadataStore/gen_test_data.py
+++ b/Tribler/Test/Core/Modules/MetadataStore/gen_test_data.py
@@ -4,6 +4,8 @@ import os
 import random
 from datetime import datetime
 
+from ipv8.keyvault.crypto import default_eccrypto
+
 from pony.orm import db_session
 
 from Tribler.Core.Modules.MetadataStore.OrmBindings.channel_node import NEW
@@ -12,7 +14,6 @@ from Tribler.Core.TorrentDef import TorrentDef
 from Tribler.Test.Core.Modules.MetadataStore.test_channel_download import CHANNEL_METADATA, CHANNEL_METADATA_UPDATED, \
     CHANNEL_TORRENT, CHANNEL_TORRENT_UPDATED
 from Tribler.Test.common import TORRENT_UBUNTU_FILE, TORRENT_VIDEO_FILE
-from Tribler.pyipv8.ipv8.keyvault.crypto import default_eccrypto
 
 DATA_DIR = os.path.join(os.path.abspath(os.path.dirname(os.path.realpath(__file__))), '..', '..', 'data')
 SAMPLE_DIR = os.path.join(DATA_DIR, 'sample_channel')

--- a/Tribler/Test/Core/Modules/MetadataStore/test_channel_metadata.py
+++ b/Tribler/Test/Core/Modules/MetadataStore/test_channel_metadata.py
@@ -5,6 +5,9 @@ import random
 from binascii import unhexlify
 from datetime import datetime
 
+from ipv8.database import database_blob
+from ipv8.keyvault.crypto import default_eccrypto
+
 from pony.orm import db_session
 
 from six.moves import xrange
@@ -20,8 +23,6 @@ from Tribler.Core.TorrentDef import TorrentDef
 from Tribler.Core.exceptions import DuplicateChannelIdError, DuplicateTorrentFileError
 from Tribler.Test.Core.base_test import TriblerCoreTest
 from Tribler.Test.common import TORRENT_UBUNTU_FILE
-from Tribler.pyipv8.ipv8.database import database_blob
-from Tribler.pyipv8.ipv8.keyvault.crypto import default_eccrypto
 
 
 class TestChannelMetadata(TriblerCoreTest):

--- a/Tribler/Test/Core/Modules/MetadataStore/test_metadata.py
+++ b/Tribler/Test/Core/Modules/MetadataStore/test_metadata.py
@@ -2,6 +2,9 @@ from __future__ import absolute_import
 
 import os
 
+from ipv8.database import database_blob
+from ipv8.keyvault.crypto import default_eccrypto
+
 from pony import orm
 from pony.orm import db_session
 
@@ -11,8 +14,6 @@ from Tribler.Core.Modules.MetadataStore.serialization import ChannelNodePayload,
 from Tribler.Core.Modules.MetadataStore.store import MetadataStore
 from Tribler.Core.exceptions import InvalidSignatureException
 from Tribler.Test.Core.base_test import TriblerCoreTest
-from Tribler.pyipv8.ipv8.database import database_blob
-from Tribler.pyipv8.ipv8.keyvault.crypto import default_eccrypto
 
 
 class TestMetadata(TriblerCoreTest):

--- a/Tribler/Test/Core/Modules/MetadataStore/test_store.py
+++ b/Tribler/Test/Core/Modules/MetadataStore/test_store.py
@@ -5,6 +5,9 @@ import random
 import string
 from binascii import unhexlify
 
+from ipv8.database import database_blob
+from ipv8.keyvault.crypto import default_eccrypto
+
 from pony.orm import db_session
 
 from twisted.internet.defer import inlineCallbacks
@@ -16,8 +19,6 @@ from Tribler.Core.Modules.MetadataStore.serialization import (
 from Tribler.Core.Modules.MetadataStore.store import (
     DELETED_METADATA, GOT_NEWER_VERSION, MetadataStore, UNKNOWN_CHANNEL, UNKNOWN_TORRENT, UPDATED_OUR_VERSION)
 from Tribler.Test.Core.base_test import TriblerCoreTest
-from Tribler.pyipv8.ipv8.database import database_blob
-from Tribler.pyipv8.ipv8.keyvault.crypto import default_eccrypto
 
 
 def make_wrong_payload(filename):

--- a/Tribler/Test/Core/Modules/MetadataStore/test_torrent_metadata.py
+++ b/Tribler/Test/Core/Modules/MetadataStore/test_torrent_metadata.py
@@ -5,6 +5,8 @@ import codecs
 import random
 from datetime import datetime
 
+from ipv8.keyvault.crypto import default_eccrypto
+
 from pony import orm
 from pony.orm import db_session
 
@@ -15,7 +17,6 @@ from twisted.internet.defer import inlineCallbacks
 from Tribler.Core.Modules.MetadataStore.OrmBindings.channel_node import TODELETE
 from Tribler.Core.Modules.MetadataStore.store import MetadataStore
 from Tribler.Test.Core.base_test import TriblerCoreTest
-from Tribler.pyipv8.ipv8.keyvault.crypto import default_eccrypto
 
 
 def rnd_torrent():

--- a/Tribler/Test/Core/Modules/MetadataStore/test_tracker_state.py
+++ b/Tribler/Test/Core/Modules/MetadataStore/test_tracker_state.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+from ipv8.keyvault.crypto import default_eccrypto
+
 from pony.orm import db_session
 
 from twisted.internet.defer import inlineCallbacks
@@ -7,7 +9,6 @@ from twisted.internet.defer import inlineCallbacks
 from Tribler.Core.Modules.MetadataStore.store import MetadataStore
 from Tribler.Core.Utilities.tracker_utils import MalformedTrackerURLException
 from Tribler.Test.Core.base_test import TriblerCoreTest
-from Tribler.pyipv8.ipv8.keyvault.crypto import default_eccrypto
 
 
 class TestTrackerState(TriblerCoreTest):

--- a/Tribler/Test/Core/Modules/RestApi/test_events_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_events_endpoint.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import
 
 import logging
 
+from ipv8.messaging.anonymization.tunnel import Circuit
+
 from twisted.internet import reactor
 from twisted.internet.defer import Deferred, inlineCallbacks
 from twisted.internet.protocol import Protocol
@@ -20,7 +22,6 @@ from Tribler.Core.simpledefs import (
 from Tribler.Core.version import version_id
 from Tribler.Test.Core.Modules.RestApi.base_api_test import AbstractApiTest
 from Tribler.Test.tools import trial_timeout
-from Tribler.pyipv8.ipv8.messaging.anonymization.tunnel import Circuit
 
 
 class EventDataProtocol(Protocol):

--- a/Tribler/Test/Core/Modules/RestApi/test_market_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_market_endpoint.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+from ipv8.test.mocking.ipv8 import MockIPv8
+
 from twisted.internet.defer import inlineCallbacks, succeed
 
 import Tribler.Core.Utilities.json_util as json
@@ -19,7 +21,6 @@ from Tribler.community.market.core.timeout import Timeout
 from Tribler.community.market.core.timestamp import Timestamp
 from Tribler.community.market.core.trade import Trade
 from Tribler.community.market.core.wallet_address import WalletAddress
-from Tribler.pyipv8.ipv8.test.mocking.ipv8 import MockIPv8
 
 
 class TestMarketEndpoint(AbstractApiTest):

--- a/Tribler/Test/Core/Modules/RestApi/test_metadata_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_metadata_endpoint.py
@@ -4,6 +4,8 @@ import sys
 from binascii import hexlify
 from unittest import skipIf
 
+from ipv8.keyvault.crypto import default_eccrypto
+
 from pony.orm import db_session
 
 from six.moves import xrange
@@ -22,7 +24,6 @@ from Tribler.Test.Core.base_test import MockObject
 from Tribler.Test.tools import trial_timeout
 from Tribler.Test.util.Tracker.HTTPTracker import HTTPTracker
 from Tribler.Test.util.Tracker.UDPTracker import UDPTracker
-from Tribler.pyipv8.ipv8.keyvault.crypto import default_eccrypto
 
 
 class BaseTestMetadataEndpoint(AbstractApiTest):

--- a/Tribler/Test/Core/Modules/RestApi/test_search_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_search_endpoint.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import
 
 import random
 
+from ipv8.database import database_blob
+
 from pony.orm import db_session
 
 from six.moves import xrange
@@ -11,7 +13,6 @@ from twisted.internet.defer import inlineCallbacks
 import Tribler.Core.Utilities.json_util as json
 from Tribler.Test.Core.Modules.RestApi.base_api_test import AbstractApiTest
 from Tribler.Test.tools import trial_timeout
-from Tribler.pyipv8.ipv8.database import database_blob
 
 
 class TestSearchEndpoint(AbstractApiTest):

--- a/Tribler/Test/Core/Modules/RestApi/test_statistics_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_statistics_endpoint.py
@@ -2,15 +2,16 @@ from __future__ import absolute_import
 
 import os
 
+from ipv8.attestation.trustchain.community import TrustChainCommunity
+from ipv8.keyvault.crypto import default_eccrypto
+from ipv8.test.mocking.ipv8 import MockIPv8
+
 from twisted.internet.defer import inlineCallbacks
 
 import Tribler.Core.Utilities.json_util as json
 from Tribler.Core.Modules.MetadataStore.store import MetadataStore
 from Tribler.Test.Core.Modules.RestApi.base_api_test import AbstractApiTest
 from Tribler.Test.tools import trial_timeout
-from Tribler.pyipv8.ipv8.attestation.trustchain.community import TrustChainCommunity
-from Tribler.pyipv8.ipv8.keyvault.crypto import default_eccrypto
-from Tribler.pyipv8.ipv8.test.mocking.ipv8 import MockIPv8
 
 
 class TestStatisticsEndpoint(AbstractApiTest):

--- a/Tribler/Test/Core/Modules/RestApi/test_trustchain_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_trustchain_endpoint.py
@@ -1,15 +1,16 @@
 from __future__ import absolute_import
 
+from ipv8.attestation.trustchain.block import TrustChainBlock
+from ipv8.attestation.trustchain.community import TrustChainCommunity
+from ipv8.messaging.deprecated.encoding import encode
+from ipv8.test.mocking.ipv8 import MockIPv8
+
 from twisted.internet.defer import inlineCallbacks
 
 import Tribler.Core.Utilities.json_util as json
 from Tribler.Core.Modules.wallet.tc_wallet import TrustchainWallet
 from Tribler.Test.Core.Modules.RestApi.base_api_test import AbstractApiTest
 from Tribler.Test.tools import trial_timeout
-from Tribler.pyipv8.ipv8.attestation.trustchain.block import TrustChainBlock
-from Tribler.pyipv8.ipv8.attestation.trustchain.community import TrustChainCommunity
-from Tribler.pyipv8.ipv8.messaging.deprecated.encoding import encode
-from Tribler.pyipv8.ipv8.test.mocking.ipv8 import MockIPv8
 
 
 class TestTrustchainStatsEndpoint(AbstractApiTest):

--- a/Tribler/Test/Core/Modules/RestApi/test_trustview_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_trustview_endpoint.py
@@ -2,16 +2,17 @@ from __future__ import absolute_import
 
 import random
 
+from ipv8.attestation.trustchain.block import TrustChainBlock
+from ipv8.attestation.trustchain.community import TrustChainCommunity
+from ipv8.messaging.deprecated.encoding import encode
+from ipv8.test.mocking.ipv8 import MockIPv8
+
 from twisted.internet.defer import inlineCallbacks
 
 import Tribler.Core.Utilities.json_util as json
 from Tribler.Test.Core.Modules.RestApi.base_api_test import AbstractApiTest
 from Tribler.Test.Core.base_test import MockObject
 from Tribler.Test.tools import trial_timeout
-from Tribler.pyipv8.ipv8.attestation.trustchain.block import TrustChainBlock
-from Tribler.pyipv8.ipv8.attestation.trustchain.community import TrustChainCommunity
-from Tribler.pyipv8.ipv8.messaging.deprecated.encoding import encode
-from Tribler.pyipv8.ipv8.test.mocking.ipv8 import MockIPv8
 
 
 class TestTrustViewEndpoint(AbstractApiTest):

--- a/Tribler/Test/Core/Modules/Wallet/test_bandwidth_block.py
+++ b/Tribler/Test/Core/Modules/Wallet/test_bandwidth_block.py
@@ -1,14 +1,15 @@
 from __future__ import absolute_import
 
-from hashlib import sha256
 import random
+from hashlib import sha256
+
+from ipv8.attestation.trustchain.block import EMPTY_SIG, GENESIS_HASH, GENESIS_SEQ, ValidationResult
+from ipv8.keyvault.crypto import ECCrypto
+from ipv8.messaging.deprecated.encoding import encode
+from ipv8.util import cast_to_bin
 
 from Tribler.Core.Modules.wallet.bandwidth_block import TriblerBandwidthBlock
 from Tribler.Test.test_as_server import AbstractServer
-from Tribler.pyipv8.ipv8.attestation.trustchain.block import GENESIS_SEQ, GENESIS_HASH, ValidationResult, EMPTY_SIG
-from Tribler.pyipv8.ipv8.messaging.deprecated.encoding import encode
-from Tribler.pyipv8.ipv8.keyvault.crypto import ECCrypto
-from Tribler.pyipv8.ipv8.util import cast_to_bin
 
 
 class TriblerBandwidthTestBlock(TriblerBandwidthBlock):

--- a/Tribler/Test/Core/Modules/Wallet/test_trustchain_wallet.py
+++ b/Tribler/Test/Core/Modules/Wallet/test_trustchain_wallet.py
@@ -2,14 +2,15 @@ from __future__ import absolute_import
 
 from binascii import hexlify
 
+from ipv8.attestation.trustchain.community import TrustChainCommunity
+from ipv8.test.base import TestBase
+from ipv8.test.mocking.ipv8 import MockIPv8
+
 from twisted.internet.defer import Deferred, inlineCallbacks
 
 from Tribler.Core.Modules.wallet.tc_wallet import TrustchainWallet
 from Tribler.Core.Modules.wallet.wallet import InsufficientFunds
 from Tribler.Test.tools import trial_timeout
-from Tribler.pyipv8.ipv8.attestation.trustchain.community import TrustChainCommunity
-from Tribler.pyipv8.ipv8.test.base import TestBase
-from Tribler.pyipv8.ipv8.test.mocking.ipv8 import MockIPv8
 
 
 class TestTrustchainWallet(TestBase):

--- a/Tribler/Test/Core/Modules/test_gigachannel_manager.py
+++ b/Tribler/Test/Core/Modules/test_gigachannel_manager.py
@@ -3,6 +3,9 @@ from __future__ import absolute_import
 import random
 from datetime import datetime
 
+from ipv8.database import database_blob
+from ipv8.keyvault.crypto import default_eccrypto
+
 from pony.orm import db_session
 
 from twisted.internet.defer import Deferred, inlineCallbacks
@@ -13,8 +16,6 @@ from Tribler.Core.Modules.gigachannel_manager import GigaChannelManager
 from Tribler.Core.TorrentDef import TorrentDef
 from Tribler.Test.Core.base_test import MockObject, TriblerCoreTest
 from Tribler.Test.common import TORRENT_UBUNTU_FILE
-from Tribler.pyipv8.ipv8.database import database_blob
-from Tribler.pyipv8.ipv8.keyvault.crypto import default_eccrypto
 
 
 class TestGigaChannelManager(TriblerCoreTest):

--- a/Tribler/Test/Core/Upgrade/test_db72_to_pony.py
+++ b/Tribler/Test/Core/Upgrade/test_db72_to_pony.py
@@ -4,6 +4,8 @@ import os
 import shutil
 import sqlite3
 
+from ipv8.keyvault.crypto import default_eccrypto
+
 from pony.orm import db_session
 
 from twisted.internet.defer import inlineCallbacks
@@ -15,7 +17,6 @@ from Tribler.Core.Upgrade.db72_to_pony import (
     CONVERSION_FROM_72_PERSONAL, CONVERSION_STARTED, DispersyToPonyMigration, already_upgraded,
     cleanup_pony_experimental_db, new_db_version_ok, old_db_version_ok, should_upgrade)
 from Tribler.Test.Core.base_test import MockObject, TriblerCoreTest
-from Tribler.pyipv8.ipv8.keyvault.crypto import default_eccrypto
 
 OLD_DB_SAMPLE = os.path.join(os.path.abspath(os.path.dirname(os.path.realpath(__file__))), '..', 'data',
                              'upgrade_databases', 'tribler_v29.sdb')

--- a/Tribler/Test/Core/test_bootstrap.py
+++ b/Tribler/Test/Core/test_bootstrap.py
@@ -2,12 +2,13 @@ from __future__ import absolute_import
 
 from binascii import unhexlify
 
+from ipv8.keyvault.crypto import ECCrypto
+from ipv8.test.base import TestBase
+
 from twisted.internet.defer import inlineCallbacks, succeed
 
 from Tribler.Core.bootstrap import Bootstrap
 from Tribler.Test.Core.base_test import MockObject
-from Tribler.pyipv8.ipv8.keyvault.crypto import ECCrypto
-from Tribler.pyipv8.ipv8.test.base import TestBase
 
 
 class FakeDHT(object):

--- a/Tribler/Test/Core/test_launch_many_cores.py
+++ b/Tribler/Test/Core/test_launch_many_cores.py
@@ -4,6 +4,8 @@ import os
 from binascii import unhexlify
 from threading import RLock
 
+from ipv8.attestation.trustchain.community import TrustChainCommunity
+
 from twisted.internet.defer import Deferred, inlineCallbacks
 
 from Tribler.Core.APIImplementation.LaunchManyCore import TriblerLaunchMany
@@ -18,7 +20,6 @@ from Tribler.Test.test_as_server import TestAsServer
 from Tribler.Test.tools import trial_timeout
 from Tribler.community.gigachannel.community import GigaChannelCommunity
 from Tribler.community.market.community import MarketCommunity
-from Tribler.pyipv8.ipv8.attestation.trustchain.community import TrustChainCommunity
 
 
 class TestLaunchManyCore(TriblerCoreTest):

--- a/Tribler/Test/Core/test_permid.py
+++ b/Tribler/Test/Core/test_permid.py
@@ -2,11 +2,12 @@ from __future__ import absolute_import
 
 import os
 
+from ipv8.keyvault.private.libnaclkey import LibNaCLSK
+
 from twisted.internet.defer import inlineCallbacks
 
 from Tribler.Core import permid
 from Tribler.Test.Core.base_test import TriblerCoreTest
-from Tribler.pyipv8.ipv8.keyvault.private.libnaclkey import LibNaCLSK
 
 
 class TriblerCoreTestPermid(TriblerCoreTest):

--- a/Tribler/Test/Core/test_utilities.py
+++ b/Tribler/Test/Core/test_utilities.py
@@ -1,9 +1,10 @@
 from __future__ import absolute_import
 
+from ipv8.messaging.deprecated.encoding import add_url_params
+
 from Tribler.Core.Utilities.utilities import http_get, parse_magnetlink
 from Tribler.Test.Core.base_test import TriblerCoreTest
 from Tribler.Test.tools import trial_timeout
-from Tribler.pyipv8.ipv8.messaging.deprecated.encoding import add_url_params
 
 
 class TriblerCoreTestUtilities(TriblerCoreTest):

--- a/Tribler/__init__.py
+++ b/Tribler/__init__.py
@@ -1,3 +1,11 @@
 """
 Tribler is a privacy enhanced BitTorrent client with P2P content discovery.
 """
+from __future__ import absolute_import
+
+import os
+import sys
+
+# Make sure IPv8 can be imported
+dir_path = os.path.dirname(os.path.realpath(__file__))
+sys.path.insert(0, os.path.join(dir_path, "pyipv8"))

--- a/Tribler/community/gigachannel/community.py
+++ b/Tribler/community/gigachannel/community.py
@@ -2,6 +2,12 @@ from __future__ import absolute_import
 
 from binascii import unhexlify
 
+from ipv8.community import Community
+from ipv8.lazy_community import lazy_wrapper
+from ipv8.messaging.lazy_payload import VariablePayload
+from ipv8.peer import Peer
+from ipv8.requestcache import RequestCache
+
 from pony.orm import CacheIndexError, TransactionIntegrityError, db_session
 
 from twisted.internet.defer import inlineCallbacks
@@ -15,11 +21,6 @@ from Tribler.Core.simpledefs import (
     NTFY_CHANNEL, NTFY_DISCOVERED, SIGNAL_GIGACHANNEL_COMMUNITY, SIGNAL_ON_SEARCH_RESULTS)
 from Tribler.community.gigachannel.payload import SearchRequestPayload, SearchResponsePayload
 from Tribler.community.gigachannel.request import SearchRequestCache
-from Tribler.pyipv8.ipv8.community import Community
-from Tribler.pyipv8.ipv8.lazy_community import lazy_wrapper
-from Tribler.pyipv8.ipv8.messaging.lazy_payload import VariablePayload
-from Tribler.pyipv8.ipv8.peer import Peer
-from Tribler.pyipv8.ipv8.requestcache import RequestCache
 
 minimal_blob_size = 200
 maximum_payload_size = 1024

--- a/Tribler/community/gigachannel/payload.py
+++ b/Tribler/community/gigachannel/payload.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from Tribler.pyipv8.ipv8.messaging.lazy_payload import VariablePayload
+from ipv8.messaging.lazy_payload import VariablePayload
 
 
 class SearchRequestPayload(VariablePayload):

--- a/Tribler/community/gigachannel/request.py
+++ b/Tribler/community/gigachannel/request.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from binascii import hexlify
 
-from Tribler.pyipv8.ipv8.requestcache import RandomNumberCache
+from ipv8.requestcache import RandomNumberCache
 
 
 class SearchRequestCache(RandomNumberCache):

--- a/Tribler/community/gigachannel/sync_strategy.py
+++ b/Tribler/community/gigachannel/sync_strategy.py
@@ -1,6 +1,8 @@
+from __future__ import absolute_import
+
 from random import choice
 
-from Tribler.pyipv8.ipv8.peerdiscovery.discovery import DiscoveryStrategy
+from ipv8.peerdiscovery.discovery import DiscoveryStrategy
 
 
 class SyncChannels(DiscoveryStrategy):

--- a/Tribler/community/market/block.py
+++ b/Tribler/community/market/block.py
@@ -1,9 +1,10 @@
 from __future__ import absolute_import
 
+from ipv8.attestation.trustchain.block import TrustChainBlock
+
 from six import integer_types, string_types
 
 from Tribler.community.market import MAX_ORDER_TIMEOUT
-from Tribler.pyipv8.ipv8.attestation.trustchain.block import TrustChainBlock
 
 
 class MarketBlock(TrustChainBlock):

--- a/Tribler/community/market/community.py
+++ b/Tribler/community/market/community.py
@@ -4,6 +4,16 @@ from base64 import b64decode
 from binascii import hexlify, unhexlify
 from functools import wraps
 
+from ipv8.attestation.trustchain.listener import BlockListener
+from ipv8.attestation.trustchain.payload import HalfBlockPairPayload
+from ipv8.community import Community, lazy_wrapper
+from ipv8.messaging.bloomfilter import BloomFilter
+from ipv8.messaging.payload_headers import BinMemberAuthenticationPayload
+from ipv8.messaging.payload_headers import GlobalTimeDistributionPayload
+from ipv8.peer import Peer
+from ipv8.requestcache import NumberCache, RandomNumberCache, RequestCache
+from ipv8.util import addCallback
+
 from twisted.internet import reactor
 from twisted.internet.defer import Deferred, inlineCallbacks, succeed
 
@@ -37,15 +47,6 @@ from Tribler.community.market.payload import AcceptMatchPayload, DeclineMatchPay
     MatchPayload, OrderStatusRequestPayload, OrderStatusResponsePayload, OrderbookSyncPayload, PaymentPayload,\
     PingPongPayload, StartTransactionPayload, TradePayload, WalletInfoPayload
 from Tribler.community.market.reputation.temporal_pagerank_manager import TemporalPagerankReputationManager
-from Tribler.pyipv8.ipv8.attestation.trustchain.listener import BlockListener
-from Tribler.pyipv8.ipv8.attestation.trustchain.payload import HalfBlockPairPayload
-from Tribler.pyipv8.ipv8.community import Community, lazy_wrapper
-from Tribler.pyipv8.ipv8.messaging.bloomfilter import BloomFilter
-from Tribler.pyipv8.ipv8.messaging.payload_headers import BinMemberAuthenticationPayload
-from Tribler.pyipv8.ipv8.messaging.payload_headers import GlobalTimeDistributionPayload
-from Tribler.pyipv8.ipv8.peer import Peer
-from Tribler.pyipv8.ipv8.requestcache import NumberCache, RandomNumberCache, RequestCache
-from Tribler.pyipv8.ipv8.util import addCallback
 
 
 # Message definitions

--- a/Tribler/community/market/core/order.py
+++ b/Tribler/community/market/core/order.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import
 
 import logging
 
+from ipv8.database import database_blob
+
 from six import integer_types, text_type
 
 from Tribler.community.market.core.assetamount import AssetAmount
@@ -9,7 +11,6 @@ from Tribler.community.market.core.assetpair import AssetPair
 from Tribler.community.market.core.message import TraderId
 from Tribler.community.market.core.timeout import Timeout
 from Tribler.community.market.core.timestamp import Timestamp
-from Tribler.pyipv8.ipv8.database import database_blob
 
 
 class TickWasNotReserved(Exception):

--- a/Tribler/community/market/core/orderbook.py
+++ b/Tribler/community/market/core/orderbook.py
@@ -4,6 +4,9 @@ import logging
 import time
 from binascii import unhexlify
 
+from ipv8.taskmanager import TaskManager
+from ipv8.util import old_round
+
 from twisted.internet import reactor
 from twisted.internet.defer import fail
 from twisted.internet.task import deferLater
@@ -17,8 +20,6 @@ from Tribler.community.market.core.side import Side
 from Tribler.community.market.core.tick import Ask, Bid
 from Tribler.community.market.core.timeout import Timeout
 from Tribler.community.market.core.timestamp import Timestamp
-from Tribler.pyipv8.ipv8.taskmanager import TaskManager
-from Tribler.pyipv8.ipv8.util import old_round
 
 
 class OrderBook(TaskManager):

--- a/Tribler/community/market/core/payment.py
+++ b/Tribler/community/market/core/payment.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+from ipv8.database import database_blob
+
 from six import text_type
 
 from Tribler.community.market.core.assetamount import AssetAmount
@@ -8,7 +10,6 @@ from Tribler.community.market.core.payment_id import PaymentId
 from Tribler.community.market.core.timestamp import Timestamp
 from Tribler.community.market.core.transaction import TransactionId, TransactionNumber
 from Tribler.community.market.core.wallet_address import WalletAddress
-from Tribler.pyipv8.ipv8.database import database_blob
 
 
 class Payment(Message):

--- a/Tribler/community/market/core/tick.py
+++ b/Tribler/community/market/core/tick.py
@@ -3,6 +3,10 @@ from __future__ import absolute_import
 import time
 from binascii import hexlify, unhexlify
 
+from ipv8.attestation.trustchain.block import GENESIS_HASH
+from ipv8.database import database_blob
+from ipv8.util import old_round
+
 from six import text_type
 
 from Tribler.community.market import MAX_ORDER_TIMEOUT
@@ -12,9 +16,6 @@ from Tribler.community.market.core.message import TraderId
 from Tribler.community.market.core.order import OrderId, OrderNumber
 from Tribler.community.market.core.timeout import Timeout
 from Tribler.community.market.core.timestamp import Timestamp
-from Tribler.pyipv8.ipv8.attestation.trustchain.block import GENESIS_HASH
-from Tribler.pyipv8.ipv8.database import database_blob
-from Tribler.pyipv8.ipv8.util import old_round
 
 
 class Tick(object):

--- a/Tribler/community/market/core/tickentry.py
+++ b/Tribler/community/market/core/tickentry.py
@@ -1,9 +1,12 @@
+from __future__ import absolute_import
+
 import logging
+
+from ipv8.taskmanager import TaskManager
 
 from twisted.internet import reactor
 
 from Tribler.community.market.core.tick import Tick
-from Tribler.pyipv8.ipv8.taskmanager import TaskManager
 
 
 class TickEntry(TaskManager):

--- a/Tribler/community/market/core/timeout.py
+++ b/Tribler/community/market/core/timeout.py
@@ -2,8 +2,9 @@ from __future__ import absolute_import
 
 import time
 
+from ipv8.util import old_round
+
 from Tribler.community.market.core.timestamp import Timestamp
-from Tribler.pyipv8.ipv8.util import old_round
 
 
 class Timeout(object):

--- a/Tribler/community/market/core/timestamp.py
+++ b/Tribler/community/market/core/timestamp.py
@@ -3,9 +3,9 @@ from __future__ import absolute_import, division
 import datetime
 import time
 
-from six import integer_types
+from ipv8.util import old_round
 
-from Tribler.pyipv8.ipv8.util import old_round
+from six import integer_types
 
 
 class Timestamp(object):

--- a/Tribler/community/market/core/transaction.py
+++ b/Tribler/community/market/core/transaction.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import
 import logging
 from binascii import unhexlify
 
+from ipv8.database import database_blob
+
 from six import text_type
 
 from Tribler.community.market.core.assetamount import AssetAmount
@@ -12,7 +14,6 @@ from Tribler.community.market.core.order import OrderId, OrderNumber
 from Tribler.community.market.core.timestamp import Timestamp
 from Tribler.community.market.core.trade import ProposedTrade
 from Tribler.community.market.core.wallet_address import WalletAddress
-from Tribler.pyipv8.ipv8.database import database_blob
 
 
 class TransactionNumber(object):

--- a/Tribler/community/market/database.py
+++ b/Tribler/community/market/database.py
@@ -5,6 +5,9 @@ from __future__ import absolute_import
 
 from os import path
 
+from ipv8.attestation.trustchain.database import TrustChainDB
+from ipv8.database import database_blob
+
 from six import text_type
 
 from Tribler.community.market.core.message import TraderId
@@ -12,8 +15,6 @@ from Tribler.community.market.core.order import Order, OrderId, OrderNumber
 from Tribler.community.market.core.payment import Payment
 from Tribler.community.market.core.tick import Tick
 from Tribler.community.market.core.transaction import Transaction, TransactionId, TransactionNumber
-from Tribler.pyipv8.ipv8.attestation.trustchain.database import TrustChainDB
-from Tribler.pyipv8.ipv8.database import database_blob
 
 DATABASE_DIRECTORY = path.join(u"sqlite")
 # Path to the database location + dispersy._workingdirectory

--- a/Tribler/community/market/payload.py
+++ b/Tribler/community/market/payload.py
@@ -1,5 +1,8 @@
 from __future__ import absolute_import
 
+from ipv8.messaging.bloomfilter import BloomFilter
+from ipv8.messaging.payload import Payload
+
 from Tribler.community.market.core.assetamount import AssetAmount
 from Tribler.community.market.core.assetpair import AssetPair
 from Tribler.community.market.core.message import TraderId
@@ -9,8 +12,6 @@ from Tribler.community.market.core.timeout import Timeout
 from Tribler.community.market.core.timestamp import Timestamp
 from Tribler.community.market.core.transaction import TransactionId, TransactionNumber
 from Tribler.community.market.core.wallet_address import WalletAddress
-from Tribler.pyipv8.ipv8.messaging.bloomfilter import BloomFilter
-from Tribler.pyipv8.ipv8.messaging.payload import Payload
 
 
 class MessagePayload(Payload):

--- a/Tribler/community/market/reputation/temporal_pagerank_manager.py
+++ b/Tribler/community/market/reputation/temporal_pagerank_manager.py
@@ -1,7 +1,10 @@
+from __future__ import absolute_import
+
+from ipv8.attestation.trustchain.block import UNKNOWN_SEQ
+
 import networkx as nx
 
 from Tribler.community.market.reputation.reputation_manager import ReputationManager
-from Tribler.pyipv8.ipv8.attestation.trustchain.block import UNKNOWN_SEQ
 
 
 class TemporalPagerankReputationManager(ReputationManager):

--- a/Tribler/community/popularity/community.py
+++ b/Tribler/community/popularity/community.py
@@ -3,15 +3,16 @@ from __future__ import absolute_import
 import random
 from binascii import hexlify, unhexlify
 
+from ipv8.community import Community
+from ipv8.lazy_community import lazy_wrapper
+from ipv8.messaging.payload_headers import BinMemberAuthenticationPayload
+from ipv8.peer import Peer
+
 from pony.orm import db_session
 
 from twisted.internet.task import LoopingCall
 
 from Tribler.community.popularity.payload import TorrentsHealthPayload
-from Tribler.pyipv8.ipv8.community import Community
-from Tribler.pyipv8.ipv8.lazy_community import lazy_wrapper
-from Tribler.pyipv8.ipv8.messaging.payload_headers import BinMemberAuthenticationPayload
-from Tribler.pyipv8.ipv8.peer import Peer
 
 
 PUBLISH_INTERVAL = 5

--- a/Tribler/community/popularity/payload.py
+++ b/Tribler/community/popularity/payload.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 import struct
 
-from Tribler.pyipv8.ipv8.messaging.payload import Payload
+from ipv8.messaging.payload import Payload
 
 
 TORRENT_INFO_FORMAT = '20sIIQ'  # Infohash, seeders, leechers and a timestamp

--- a/Tribler/community/triblertunnel/caches.py
+++ b/Tribler/community/triblertunnel/caches.py
@@ -1,4 +1,6 @@
-from Tribler.pyipv8.ipv8.requestcache import NumberCache
+from __future__ import absolute_import
+
+from ipv8.requestcache import NumberCache
 
 
 class BalanceRequestCache(NumberCache):

--- a/Tribler/community/triblertunnel/community.py
+++ b/Tribler/community/triblertunnel/community.py
@@ -8,6 +8,18 @@ from binascii import hexlify, unhexlify
 from collections import Counter
 from distutils.version import LooseVersion
 
+from ipv8.attestation.trustchain.block import EMPTY_PK
+from ipv8.messaging.anonymization.caches import CreateRequestCache
+from ipv8.messaging.anonymization.community import message_to_payload
+from ipv8.messaging.anonymization.hidden_services import HiddenTunnelCommunity
+from ipv8.messaging.anonymization.payload import LinkedE2EPayload, NO_CRYPTO_PACKETS
+from ipv8.messaging.anonymization.tunnel import CIRCUIT_STATE_CLOSING, CIRCUIT_STATE_READY, \
+                                                               CIRCUIT_TYPE_DATA, CIRCUIT_TYPE_IP_SEEDER,\
+                                                               CIRCUIT_TYPE_RP_DOWNLOADER, CIRCUIT_TYPE_RP_SEEDER,\
+                                                               EXIT_NODE, PEER_FLAG_EXIT_ANY, RelayRoute
+from ipv8.peer import Peer
+from ipv8.peerdiscovery.network import Network
+
 from twisted.internet.defer import Deferred, inlineCallbacks, succeed
 
 from Tribler.Core.Modules.wallet.bandwidth_block import TriblerBandwidthBlock
@@ -19,17 +31,6 @@ from Tribler.community.triblertunnel.caches import BalanceRequestCache
 from Tribler.community.triblertunnel.discovery import GoldenRatioStrategy
 from Tribler.community.triblertunnel.dispatcher import TunnelDispatcher
 from Tribler.community.triblertunnel.payload import BalanceRequestPayload, BalanceResponsePayload, PayoutPayload
-from Tribler.pyipv8.ipv8.attestation.trustchain.block import EMPTY_PK
-from Tribler.pyipv8.ipv8.messaging.anonymization.caches import CreateRequestCache
-from Tribler.pyipv8.ipv8.messaging.anonymization.community import message_to_payload
-from Tribler.pyipv8.ipv8.messaging.anonymization.hidden_services import HiddenTunnelCommunity
-from Tribler.pyipv8.ipv8.messaging.anonymization.payload import LinkedE2EPayload, NO_CRYPTO_PACKETS
-from Tribler.pyipv8.ipv8.messaging.anonymization.tunnel import CIRCUIT_STATE_CLOSING, CIRCUIT_STATE_READY, \
-                                                               CIRCUIT_TYPE_DATA, CIRCUIT_TYPE_IP_SEEDER,\
-                                                               CIRCUIT_TYPE_RP_DOWNLOADER, CIRCUIT_TYPE_RP_SEEDER,\
-                                                               EXIT_NODE, PEER_FLAG_EXIT_ANY, RelayRoute
-from Tribler.pyipv8.ipv8.peer import Peer
-from Tribler.pyipv8.ipv8.peerdiscovery.network import Network
 
 
 class TriblerTunnelCommunity(HiddenTunnelCommunity):

--- a/Tribler/community/triblertunnel/discovery.py
+++ b/Tribler/community/triblertunnel/discovery.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division
 
 from random import sample
 
-from Tribler.pyipv8.ipv8.peerdiscovery.discovery import DiscoveryStrategy
+from ipv8.peerdiscovery.discovery import DiscoveryStrategy
 
 
 class GoldenRatioStrategy(DiscoveryStrategy):

--- a/Tribler/community/triblertunnel/dispatcher.py
+++ b/Tribler/community/triblertunnel/dispatcher.py
@@ -2,9 +2,10 @@ from __future__ import absolute_import
 
 import logging
 
-from Tribler.Core.Socks5 import conversion
-from Tribler.pyipv8.ipv8.messaging.anonymization.tunnel import CIRCUIT_ID_PORT, CIRCUIT_STATE_READY,\
+from ipv8.messaging.anonymization.tunnel import CIRCUIT_ID_PORT, CIRCUIT_STATE_READY,\
     CIRCUIT_TYPE_RP_DOWNLOADER, CIRCUIT_TYPE_RP_SEEDER
+
+from Tribler.Core.Socks5 import conversion
 
 
 class TunnelDispatcher(object):

--- a/Tribler/community/triblertunnel/payload.py
+++ b/Tribler/community/triblertunnel/payload.py
@@ -1,5 +1,7 @@
-from Tribler.pyipv8.ipv8.attestation.trustchain.payload import HalfBlockPayload
-from Tribler.pyipv8.ipv8.messaging.payload import Payload
+from __future__ import absolute_import
+
+from ipv8.attestation.trustchain.payload import HalfBlockPayload
+from ipv8.messaging.payload import Payload
 
 
 class PayoutPayload(HalfBlockPayload):


### PR DESCRIPTION
Instead of importing IPv8 like `from Tribler.pyipv8.ipv8 import X`, we now treat IPv8 as a system library. In order for it to be found, we add it to the `sys.path` in the `__init__.py` method of the `Tribler` package.

By doing so, we can work towards a consistent way of importing IPv8 that works across different libraries. This is in particular helpful for Gumby, where we import IPv8 from different paths.