### PR TITLE
READY: VSIDS-based channel rating system

### DIFF
--- a/Tribler/Core/Modules/MetadataStore/OrmBindings/channel_metadata.py
+++ b/Tribler/Core/Modules/MetadataStore/OrmBindings/channel_metadata.py
@@ -100,6 +100,8 @@ def define_binding(db):
         individual_votes = orm.Set("ChannelVote", reverse="channel")
         local_version = orm.Optional(int, size=64, default=0)
 
+        votes_scaling = 1.0
+
         _payload_class = ChannelMetadataPayload
         _channels_dir = None
         _category_filter = None
@@ -486,9 +488,7 @@ def define_binding(db):
                 "name": self.title,
                 "torrents": self.num_entries,
                 "subscribed": self.subscribed,
-                # "votes": (math.log1p(self.votes / db.ChannelMetadata.vsids_total_activity)
-                #          if db.ChannelMetadata.vsids_total_activity > 0.0 else 0),
-                "votes": self.votes,
+                "votes": self.votes/db.ChannelMetadata.votes_scaling,
                 "status": self.status,
                 "updated": int((self.torrent_date - epoch).total_seconds()),
                 "timestamp": self.timestamp,

--- a/Tribler/Core/Modules/MetadataStore/OrmBindings/channel_peer.py
+++ b/Tribler/Core/Modules/MetadataStore/OrmBindings/channel_peer.py
@@ -1,0 +1,18 @@
+from __future__ import absolute_import
+
+from datetime import datetime
+
+from pony import orm
+
+from Tribler.pyipv8.ipv8.database import database_blob
+
+
+# This binding stores public keys of IPv8 peers that sent us some GigaChannel data
+def define_binding(db):
+    class ChannelPeer(db.Entity):
+        rowid = orm.PrimaryKey(int, size=64, auto=True)
+        public_key = orm.Required(database_blob, unique=True)
+        individual_votes = orm.Set("ChannelVote", reverse='voter')
+        added_on = orm.Optional(datetime, default=datetime.utcnow)
+
+    return ChannelPeer

--- a/Tribler/Core/Modules/MetadataStore/OrmBindings/channel_vote.py
+++ b/Tribler/Core/Modules/MetadataStore/OrmBindings/channel_vote.py
@@ -1,0 +1,17 @@
+from __future__ import absolute_import
+
+from datetime import datetime
+
+from pony import orm
+
+
+def define_binding(db):
+    class ChannelVote(db.Entity):
+        rowid = orm.PrimaryKey(int, size=64, auto=True)
+        voter = orm.Required("ChannelPeer")
+        channel = orm.Required("ChannelMetadata", reverse='individual_votes')
+        orm.composite_key(voter, channel)
+        last_amount = orm.Optional(float, default=0.0)
+        vote_date = orm.Optional(datetime, default=datetime.utcnow)
+
+    return ChannelVote

--- a/Tribler/Core/Modules/MetadataStore/OrmBindings/vsids.py
+++ b/Tribler/Core/Modules/MetadataStore/OrmBindings/vsids.py
@@ -1,0 +1,90 @@
+from __future__ import absolute_import, division
+
+import math
+from datetime import datetime
+
+from pony import orm
+from pony.orm import db_session
+
+from Tribler.Core.Modules.MetadataStore.OrmBindings.channel_node import LEGACY_ENTRY
+
+
+def define_binding(db):
+    # ACHTUNG! This thing should be used as a singleton, i.e. there should be only a single row there!
+    # We store it as a DB object only to make the counters persistent.
+
+    # VSIDS-based votes ratings
+    # We use VSIDS since it provides an efficient way to add temporal decay to the voting system.
+    # Temporal decay is necessary for two reasons:
+    # 1. We do not gossip _unsubscription_ events, but we want votes decline for channels that go out of favor
+    # 2. We want to promote the fresh content
+    #
+    # There are two differences with the classic VSIDS:
+    # a. We scale the bump amount with passage of time, instead of on each bump event.
+    #    By default, the bump amount scales 2.71 per 23hrs. Note though, that we only count Tribler uptime
+    #    for this purpose. This is intentional, so the ratings do not suddenly drop after the user skips a week
+    #    of uptime.
+    # b. Repeated votes by some peer to some channel _do not add up_. Instead, the vote is refreshed by substracting
+    #    the old amount from the current vote (it is stored in the DB), and adding the new one (1.0 votes, scaled). This
+    #    is the reason why we have to keep the old votes in the DB, and normalize the old votes last_amount values - to
+    #    keep them in the same "normalization space" to be compatible with the current votes values.
+
+    # This binding is used to store normalization data and stats for VSIDS
+    class Vsids(db.Entity):
+        rowid = orm.PrimaryKey(int)
+        bump_amount = orm.Required(float)
+        total_activity = orm.Required(float)
+        last_bump = orm.Required(datetime)
+        rescale_threshold = orm.Optional(float, default=10.0 ** 100)
+        exp_period = orm.Optional(float, default=24.0 * 60 * 60)  # decay e times over this period
+
+        @db_session
+        def rescale(self, norm):
+            for channel in db.ChannelMetadata.select(lambda g: g.status != LEGACY_ENTRY):
+                channel.votes /= norm
+            for vote in db.ChannelVote.select():
+                vote.last_amount /= norm
+
+            self.total_activity /= norm
+            self.bump_amount /= norm
+            db.ChannelMetadata.votes_scaling = self.bump_amount
+
+        # Normalization routine should normally be called only in case the values in the DB do not look normal
+        @db_session
+        def normalize(self):
+            # If we run the normalization for the first time during the runtime, we have to gather the activity from DB
+            self.total_activity = self.total_activity or orm.sum(g.votes for g in db.ChannelMetadata)
+            channel_count = orm.count(db.ChannelMetadata.select(lambda g: g.status != LEGACY_ENTRY))
+            if not channel_count:
+                return
+            if self.total_activity > 0.0:
+                self.rescale(self.total_activity/channel_count)
+                self.bump_amount = 1.0
+            db.ChannelMetadata.votes_scaling = self.bump_amount
+
+        @db_session
+        def bump_channel(self, channel, vote):
+            # Substract the last vote by the same peer from the total vote amount for this channel.
+            # This effectively puts a cap of 1.0 vote from a peer on a channel
+            channel.votes -= vote.last_amount
+            self.total_activity -= vote.last_amount
+
+            vote.last_amount = self.bump_amount
+            channel.votes += self.bump_amount
+
+            self.total_activity += self.bump_amount
+            self.bump_amount *= math.exp((datetime.utcnow() - self.last_bump).total_seconds() / self.exp_period)
+            self.last_bump = datetime.utcnow()
+            if self.bump_amount > self.rescale_threshold:
+                self.rescale(self.bump_amount)
+
+            db.ChannelMetadata.votes_scaling = self.bump_amount
+
+        @classmethod
+        @db_session
+        def create_default_vsids(cls):
+            return cls(rowid=0,
+                       bump_amount=1.0,
+                       total_activity=(orm.sum(g.votes for g in db.ChannelMetadata) or 0.0),
+                       last_bump=datetime.utcnow())
+    return Vsids

--- a/Tribler/Core/Modules/MetadataStore/store.py
+++ b/Tribler/Core/Modules/MetadataStore/store.py
@@ -14,14 +14,14 @@ from pony import orm
 from pony.orm import db_session
 
 from Tribler.Core.Modules.MetadataStore.OrmBindings import (
-    channel_metadata, channel_node, misc, torrent_metadata, torrent_state, tracker_state)
+    channel_metadata, channel_node, misc, torrent_metadata, torrent_state, tracker_state, channel_vote, channel_peer)
 from Tribler.Core.Modules.MetadataStore.OrmBindings.channel_metadata import BLOB_EXTENSION
 from Tribler.Core.Modules.MetadataStore.serialization import (
     CHANNEL_TORRENT, DELETED, REGULAR_TORRENT, read_payload_with_offset, time2int)
 from Tribler.Core.exceptions import InvalidSignatureException
 
-BETA_DB_VERSIONS = [0]
-CURRENT_DB_VERSION = 1
+BETA_DB_VERSIONS = [0, 1]
+CURRENT_DB_VERSION = 2
 
 CLOCK_STATE_FILE = "clock.state"
 
@@ -140,6 +140,8 @@ class MetadataStore(object):
         self.ChannelNode = channel_node.define_binding(self._db, logger=self._logger, key=my_key, clock=self.clock)
         self.TorrentMetadata = torrent_metadata.define_binding(self._db)
         self.ChannelMetadata = channel_metadata.define_binding(self._db)
+        self.ChannelVote = channel_vote.define_binding(self._db)
+        self.ChannelPeer = channel_peer.define_binding(self._db)
 
         self.ChannelMetadata._channels_dir = channels_dir
 

--- a/Tribler/Core/Modules/MetadataStore/store.py
+++ b/Tribler/Core/Modules/MetadataStore/store.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division
 
 import logging
+import math
 import os
 from binascii import hexlify
 from datetime import datetime, timedelta
@@ -14,8 +15,9 @@ from pony import orm
 from pony.orm import db_session
 
 from Tribler.Core.Modules.MetadataStore.OrmBindings import (
-    channel_metadata, channel_node, misc, torrent_metadata, torrent_state, tracker_state, channel_vote, channel_peer)
+    channel_metadata, channel_node, channel_peer, channel_vote, misc, torrent_metadata, torrent_state, tracker_state)
 from Tribler.Core.Modules.MetadataStore.OrmBindings.channel_metadata import BLOB_EXTENSION
+from Tribler.Core.Modules.MetadataStore.OrmBindings.channel_node import LEGACY_ENTRY
 from Tribler.Core.Modules.MetadataStore.serialization import (
     CHANNEL_TORRENT, DELETED, REGULAR_TORRENT, read_payload_with_offset, time2int)
 from Tribler.Core.exceptions import InvalidSignatureException
@@ -97,6 +99,72 @@ class DiscreteClock(object):
         return self.clock
 
 
+# VSIDS-based votes ratings
+# We use VSIDS since it provides an efficient way to add temporal decay to the voting system.
+# Temporal decay is necessary for two reasons:
+# 1. We do not gossip _unsubscription_ events, but we want votes decline for channels that go out of favor
+# 2. We want to promote the fresh content
+#
+# There are two differences with the classic VSIDS:
+# a. We scale the bump amount with passage of time, instead of on each bump event.
+#    By default, the bump amount scales 2.71 per 23hrs. Note though, that we only count Tribler uptime
+#    for this purpose. This is intentional, so the ratings do not suddenly drop after the user skips a week
+#    of uptime.
+# b. Repeated votes by some peer to some channel _do not add up_. Instead, the vote is refreshed by substracting
+#    the old amount from the current vote (it is stored in the DB), and adding the new one (1.0 votes, scaled). This
+#    is the reason why we have to keep the old votes in the DB, and normalize the old votes last_amount values - to
+#    keep them in the same "normalization space" to be compatible with the current votes values.
+class Vsids(object):
+    def __init__(self, mds_channel, mds_vote, mds_peer):
+        self.ChannelMetadata = mds_channel
+        self.ChannelVote = mds_vote
+        self.ChannelPeer = mds_peer
+
+        self.rescale_threshold = 10.0 ** 100
+        self.exp_period = 24.0 * 60 * 60  # decay e times over this period
+        self.total_activity = 0.0
+
+        self.bump_amount = 1.0
+        self.last_bump = datetime.utcnow()
+
+    @db_session
+    def rescale(self, norm):
+        for channel in self.ChannelMetadata.select(lambda g: g.status != LEGACY_ENTRY):
+            channel.votes /= norm
+        for vote in self.ChannelVote.select():
+            vote.last_amount /= norm
+
+        self.total_activity /= norm
+        self.bump_amount /= norm
+
+    @db_session
+    def normalize(self):
+        # If we run the normalization for the first time during the runtime, we have to gather the activity from DB
+        self.total_activity = self.total_activity or orm.sum(g.votes for g in self.ChannelMetadata)
+        channel_count = orm.count(self.ChannelMetadata.select(lambda g: g.status != LEGACY_ENTRY))
+        if not channel_count:
+            return
+        if self.total_activity > 0.0:
+            self.rescale(self.total_activity/channel_count)
+            self.bump_amount = 1.0
+
+    @db_session
+    def bump_channel(self, channel, vote):
+        # Substract the last vote by the same peer from the total vote amount for this channel.
+        # This effectively puts a cap of 1.0 vote from a peer on a channel
+        channel.votes -= vote.last_amount
+        self.total_activity -= vote.last_amount
+
+        vote.last_amount = self.bump_amount
+        channel.votes += self.bump_amount
+
+        self.total_activity += self.bump_amount
+        self.bump_amount *= math.exp((datetime.utcnow() - self.last_bump).total_seconds() / self.exp_period)
+        self.last_bump = datetime.utcnow()
+        if self.bump_amount > self.rescale_threshold:
+            self.rescale(self.bump_amount)
+
+
 class MetadataStore(object):
     def __init__(self, db_filename, channels_dir, my_key, disable_sync=False):
         self.db_filename = db_filename
@@ -142,6 +210,7 @@ class MetadataStore(object):
         self.ChannelMetadata = channel_metadata.define_binding(self._db)
         self.ChannelVote = channel_vote.define_binding(self._db)
         self.ChannelPeer = channel_peer.define_binding(self._db)
+        self.vsids = Vsids(self.ChannelMetadata, self.ChannelVote, self.ChannelPeer)
 
         self.ChannelMetadata._channels_dir = channels_dir
 
@@ -164,7 +233,28 @@ class MetadataStore(object):
                 self.MiscData(name="db_version", value=str(CURRENT_DB_VERSION))
 
         self.clock.init_clock()
-        self.ChannelMetadata.vsids_normalize()
+        self.vsids.normalize()
+
+    @db_session
+    def upsert_vote(self, channel, peer_pk):
+        voter = self.ChannelPeer.get(public_key=peer_pk)
+        if not voter:
+            voter = self.ChannelPeer(public_key=peer_pk)
+        vote = self.ChannelVote.get(voter=voter, channel=channel)
+        if not vote:
+            vote = self.ChannelVote(voter=voter, channel=channel)
+        else:
+            vote.vote_date = datetime.utcnow()
+        return vote
+
+    @db_session
+    def vote_bump(self, public_key, id_, voter_pk):
+        channel = self.ChannelMetadata.get_for_update(public_key=public_key, id_=id_)
+        if not channel:
+            return
+        vote = self.upsert_vote(channel, voter_pk)
+
+        self.vsids.bump_channel(channel, vote)
 
     def shutdown(self):
         self._shutting_down = True

--- a/Tribler/Core/Modules/MetadataStore/store.py
+++ b/Tribler/Core/Modules/MetadataStore/store.py
@@ -162,6 +162,7 @@ class MetadataStore(object):
                 self.MiscData(name="db_version", value=str(CURRENT_DB_VERSION))
 
         self.clock.init_clock()
+        self.ChannelMetadata.vsids_normalize()
 
     def shutdown(self):
         self._shutting_down = True
@@ -339,6 +340,11 @@ class MetadataStore(object):
         # Check the payload timestamp<->id_ correctness
         if payload.timestamp < payload.id_:
             return []
+
+        # Check if we already have this payload
+        node = self.ChannelNode.get_for_update(signature=payload.signature, public_key=payload.public_key)
+        if node:
+            return [(node, NO_ACTION)]
 
         # Check for a node with the same infohash
         result = []

--- a/Tribler/Core/Modules/resource_monitor.py
+++ b/Tribler/Core/Modules/resource_monitor.py
@@ -21,6 +21,7 @@ except ImportError:
 
 DEFAULT_RESOURCE_FILENAME = "resources.log"
 
+
 class ResourceMonitor(TaskManager):
     """
     This class contains code to monitor resources (memory usage and CPU). Can be toggled using the config file.

--- a/Tribler/Core/Modules/restapi/metadata_endpoint.py
+++ b/Tribler/Core/Modules/restapi/metadata_endpoint.py
@@ -53,6 +53,7 @@ class BaseMetadataEndpoint(resource.Resource):
             u'updated': "torrent_date",
             u'status': 'status',
             u'torrents': 'num_entries',
+            u'votes': 'votes',
             u'health': 'HEALTH'
         }
 

--- a/Tribler/Core/Upgrade/db72_to_pony.py
+++ b/Tribler/Core/Upgrade/db72_to_pony.py
@@ -104,7 +104,6 @@ class DispersyToPonyMigration(object):
                                  "title": name or '',
                                  "public_key": dispesy_cid_to_pk(id_),
                                  "timestamp": final_timestamp(),
-                                 "votes": int(nr_favorite or 0),
                                  "origin_id": 0,
                                  "signature": pseudo_signature(),
                                  "skip_key_check": True,

--- a/Tribler/Test/Core/Modules/MetadataStore/test_channel_metadata.py
+++ b/Tribler/Test/Core/Modules/MetadataStore/test_channel_metadata.py
@@ -286,6 +286,20 @@ class TestChannelMetadata(TriblerCoreTest):
         self.assertEqual(0, len(channel_metadata.contents_list))
 
     @db_session
+    def test_vsids(self):
+        self.assertEqual(1.0, self.mds.ChannelMetadata.bump_amount)
+
+        channel = self.mds.ChannelMetadata.create_channel('test', 'test')
+        channel.vote_bump()
+        self.assertLess(0.0, channel.votes)
+        self.assertLess(1.0, self.mds.ChannelMetadata.bump_amount)
+
+        # Make sure the rescale works right for the channels
+        self.mds.ChannelMetadata.vsids_normalize()
+        self.assertEqual(1.0, self.mds.ChannelMetadata.bump_amount)
+        self.assertEqual(1.0, channel.votes)
+
+    @db_session
     def test_commit_channel_torrent(self):
         channel = self.mds.ChannelMetadata.create_channel('test', 'test')
         tdef = TorrentDef.load(TORRENT_UBUNTU_FILE)

--- a/Tribler/Test/Core/Modules/MetadataStore/test_channel_metadata.py
+++ b/Tribler/Test/Core/Modules/MetadataStore/test_channel_metadata.py
@@ -287,16 +287,18 @@ class TestChannelMetadata(TriblerCoreTest):
 
     @db_session
     def test_vsids(self):
-        self.assertEqual(1.0, self.mds.ChannelMetadata.bump_amount)
+        peer_key = default_eccrypto.generate_key(u"curve25519")
+        self.assertEqual(1.0, self.mds.vsids.bump_amount)
 
         channel = self.mds.ChannelMetadata.create_channel('test', 'test')
-        channel.vote_bump()
+        self.mds.vote_bump(channel.public_key, channel.id_, peer_key.pub().key_to_bin()[10:])
+        self.mds.vote_bump(channel.public_key, channel.id_, peer_key.pub().key_to_bin()[10:])
         self.assertLess(0.0, channel.votes)
-        self.assertLess(1.0, self.mds.ChannelMetadata.bump_amount)
+        self.assertLess(1.0, self.mds.vsids.bump_amount)
 
         # Make sure the rescale works right for the channels
-        self.mds.ChannelMetadata.vsids_normalize()
-        self.assertEqual(1.0, self.mds.ChannelMetadata.bump_amount)
+        self.mds.vsids.normalize()
+        self.assertEqual(1.0, self.mds.vsids.bump_amount)
         self.assertEqual(1.0, channel.votes)
 
     @db_session

--- a/Tribler/Test/Core/Modules/MetadataStore/test_channel_metadata.py
+++ b/Tribler/Test/Core/Modules/MetadataStore/test_channel_metadata.py
@@ -288,17 +288,20 @@ class TestChannelMetadata(TriblerCoreTest):
     @db_session
     def test_vsids(self):
         peer_key = default_eccrypto.generate_key(u"curve25519")
-        self.assertEqual(1.0, self.mds.vsids.bump_amount)
+        self.assertEqual(1.0, self.mds.Vsids[0].bump_amount)
 
         channel = self.mds.ChannelMetadata.create_channel('test', 'test')
         self.mds.vote_bump(channel.public_key, channel.id_, peer_key.pub().key_to_bin()[10:])
         self.mds.vote_bump(channel.public_key, channel.id_, peer_key.pub().key_to_bin()[10:])
         self.assertLess(0.0, channel.votes)
-        self.assertLess(1.0, self.mds.vsids.bump_amount)
+        self.assertLess(1.0, self.mds.Vsids[0].bump_amount)
 
-        # Make sure the rescale works right for the channels
-        self.mds.vsids.normalize()
-        self.assertEqual(1.0, self.mds.vsids.bump_amount)
+        # Make sure normalization for display purposes work
+        self.assertAlmostEqual(channel.to_simple_dict()["votes"], 1.0)
+
+        # Make sure the rescale works for the channels
+        self.mds.Vsids[0].normalize()
+        self.assertEqual(1.0, self.mds.Vsids[0].bump_amount)
         self.assertEqual(1.0, channel.votes)
 
     @db_session

--- a/Tribler/community/gigachannel/community.py
+++ b/Tribler/community/gigachannel/community.py
@@ -106,19 +106,8 @@ class GigaChannelCommunity(Community):
             # TODO: make the bump decision based on packet type instead when we switch to nested channels!
             if len(md_list) > 1:
                 for c in [md for md, _ in md_list if md and (md.metadata_type == CHANNEL_TORRENT)]:
-                    channel = self.metadata_store.ChannelMetadata.get_for_update(rowid=c.rowid)
-                    if channel:
-                        peer_pk = peer.public_key.key_to_bin()[10:]
-
-                        voter = self.metadata_store.ChannelPeer.get(public_key=peer_pk)
-                        if not voter:
-                            voter = self.metadata_store.ChannelPeer(public_key=peer_pk)
-                        vote = self.metadata_store.ChannelVote.get(voter=voter, channel=channel)
-                        if not vote:
-                            vote = self.metadata_store.ChannelVote(voter=voter, channel=channel)
-
-                        channel.vote_bump(vote)
-                    break  # We only want to bump the leading channel entry in the payload, since others are content
+                    self.metadata_store.vote_bump(c.public_key, c.id_, peer.public_key.key_to_bin()[10:])
+                    break  # We only want to bump the leading channel entry in the payload, since the rest is content
 
         # Notify the discovered torrents and channels to the GUI
         self.notify_discovered_metadata(md_list)

--- a/TriblerGUI/widgets/channelpage.py
+++ b/TriblerGUI/widgets/channelpage.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import math
+
 from PyQt5.QtGui import QIcon
 from PyQt5.QtWidgets import QWidget
 
@@ -65,7 +67,7 @@ class ChannelPage(QWidget):
     def update_labels(self):
         # initialize the page about a channel
         self.window().channel_name_label.setText(self.channel_info['name'])
-        self.window().num_subs_label.setText(str(self.channel_info['votes']))
+        self.window().num_subs_label.setText(format(math.log1p(self.channel_info['votes']), "^-.2f"))
         self.window().channel_state_label.setText(self.channel_info["state"])
         self.window().subscription_widget.initialize_with_channel(self.channel_info)
 

--- a/TriblerGUI/widgets/discoveredpage.py
+++ b/TriblerGUI/widgets/discoveredpage.py
@@ -29,7 +29,7 @@ class DiscoveredPage(QWidget):
                                                                        is_bool=True) if self.gui_settings else True)
             self.window().core_manager.events_manager.node_info_updated.connect(self.model.update_node_info)
             # Set the default sorting column/order to num_torrents/descending
-            default_sort_column = self.model.columns.index(u'torrents')
+            default_sort_column = self.model.columns.index(u'votes')
             self.window().discovered_channels_list.horizontalHeader().setSortIndicator(
                 default_sort_column, Qt.AscendingOrder)
             self.controller = ChannelsTableViewController(self.model, self.window().discovered_channels_list,

--- a/TriblerGUI/widgets/lazytableview.py
+++ b/TriblerGUI/widgets/lazytableview.py
@@ -199,11 +199,12 @@ class SearchResultsTableView(ItemClickedMixin, DownloadButtonMixin, PlayButtonMi
     def resizeEvent(self, _):
         self.setColumnWidth(0, 20)
         self.setColumnWidth(1, 40)
-        self.setColumnWidth(2, 100)
-        self.setColumnWidth(3, self.width() - 460)  # Few pixels offset so the horizontal scrollbar does not appear
-        self.setColumnWidth(4, 100)
+        self.setColumnWidth(2, 40)
+        self.setColumnWidth(3, 100)
+        self.setColumnWidth(4, self.width() - 500)  # Few pixels offset so the horizontal scrollbar does not appear
         self.setColumnWidth(5, 100)
         self.setColumnWidth(6, 100)
+        self.setColumnWidth(7, 100)
 
 
 class TorrentsTableView(ItemClickedMixin, DeleteButtonMixin, DownloadButtonMixin, PlayButtonMixin,
@@ -267,6 +268,7 @@ class ChannelsTableView(ItemClickedMixin, SubscribeButtonMixin,
     def resizeEvent(self, _):
         self.setColumnWidth(0, 20)
         self.setColumnWidth(1, 40)
-        self.setColumnWidth(2, self.width() - 260)  # Few pixels offset so the horizontal scrollbar does not appear
-        self.setColumnWidth(3, 100)
+        self.setColumnWidth(2, 40)
+        self.setColumnWidth(3, self.width() - 300)  # Few pixels offset so the horizontal scrollbar does not appear
         self.setColumnWidth(4, 100)
+        self.setColumnWidth(5, 100)

--- a/TriblerGUI/widgets/subscriptionswidget.py
+++ b/TriblerGUI/widgets/subscriptionswidget.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import json
+import math
 
 from PyQt5.QtCore import pyqtSignal
 from PyQt5.QtGui import QIcon, QPixmap
@@ -47,7 +48,7 @@ class SubscriptionsWidget(QWidget):
 
         self.subscribe_button.setIcon(QIcon(QPixmap(get_image_path(
             'subscribed_yes.png' if int(self.channel_info["subscribed"]) else 'subscribed_not.png'))))
-        self.num_subs_label.setText(str(self.channel_info["votes"]))
+        self.num_subs_label.setText(format(math.log1p(self.channel_info['votes']), "^-.2f"))
 
         if self.window().tribler_settings:  # It could be that the settings are not loaded yet
             self.credit_mining_button.setHidden(not self.window().tribler_settings["credit_mining"]["enabled"])

--- a/TriblerGUI/widgets/subscriptionswidget.py
+++ b/TriblerGUI/widgets/subscriptionswidget.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import json
 
 from PyQt5.QtCore import pyqtSignal

--- a/TriblerGUI/widgets/tablecontentmodel.py
+++ b/TriblerGUI/widgets/tablecontentmodel.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import math
 from abc import abstractmethod
 
 from PyQt5.QtCore import QAbstractTableModel, QModelIndex, Qt, pyqtSignal
@@ -188,6 +189,7 @@ class SearchResultsContentModel(StateTooltipMixin, VotesAlignmentMixin, TriblerC
 
     column_display_filters = {
         u'size': lambda data: (format_size(float(data)) if data != '' else ''),
+        u'votes': lambda votes: format(math.log1p(float(votes)), "^-.2f") if votes else "",
         u'updated': pretty_date,
     }
 
@@ -214,6 +216,7 @@ class ChannelsContentModel(StateTooltipMixin, VotesAlignmentMixin, TriblerConten
 
     column_display_filters = {
         u'updated': pretty_date,
+        u'votes': lambda votes: format(math.log1p(float(votes)), "^-.2f") if votes else "",
         u'state': lambda data: str(data)[:1] if data == u'Downloading' else ""
     }
 

--- a/TriblerGUI/widgets/tablecontentmodel.py
+++ b/TriblerGUI/widgets/tablecontentmodel.py
@@ -108,7 +108,6 @@ class TriblerContentModel(RemoteTableModel):
         if orientation == Qt.Horizontal and role == Qt.DisplayRole:
             return self.column_headers[num]
 
-
     def get_item_uid(self, item):
         item_uid = None
         if "infohash" in item:
@@ -156,13 +155,24 @@ class StateTooltipMixin(object):
             return super(StateTooltipMixin, self).data(index, role)
 
 
-class SearchResultsContentModel(StateTooltipMixin, TriblerContentModel):
+class VotesAlignmentMixin(object):
+    def data(self, index, role):
+        # Return tooltip for state indicator column
+        if role == Qt.TextAlignmentRole:
+            if index.column() == self.column_position[u'votes']:
+                return Qt.AlignRight | Qt.AlignVCenter
+            return None
+        else:
+            return super(VotesAlignmentMixin, self).data(index, role)
+
+
+class SearchResultsContentModel(StateTooltipMixin, VotesAlignmentMixin, TriblerContentModel):
     """
     Model for a list that shows search results.
     """
-    columns = [u'state', u'subscribed', u'category', u'name', u'torrents', u'size', u'updated', u'health',
+    columns = [u'state', u'votes', u'subscribed', u'category', u'name', u'torrents', u'size', u'updated', u'health',
                ACTION_BUTTONS]
-    column_headers = [u'', u'', u'Category', u'Name', u'Torrents', u'Size', u'Updated', u'health', u'']
+    column_headers = [u'', u'', u'', u'Category', u'Name', u'Torrents', u'Size', u'Updated', u'health', u'']
     column_flags = {
         u'subscribed': Qt.ItemIsEnabled | Qt.ItemIsSelectable,
         u'category': Qt.ItemIsEnabled | Qt.ItemIsSelectable,
@@ -171,6 +181,7 @@ class SearchResultsContentModel(StateTooltipMixin, TriblerContentModel):
         u'size': Qt.ItemIsEnabled | Qt.ItemIsSelectable,
         u'updated': Qt.ItemIsEnabled | Qt.ItemIsSelectable,
         u'health': Qt.ItemIsEnabled | Qt.ItemIsSelectable,
+        u'votes': Qt.ItemIsEnabled | Qt.ItemIsSelectable,
         u'state': Qt.ItemIsEnabled | Qt.ItemIsSelectable,
         ACTION_BUTTONS: Qt.ItemIsEnabled | Qt.ItemIsSelectable
     }
@@ -185,17 +196,18 @@ class SearchResultsContentModel(StateTooltipMixin, TriblerContentModel):
         self.type_filter = ''
 
 
-class ChannelsContentModel(StateTooltipMixin, TriblerContentModel):
+class ChannelsContentModel(StateTooltipMixin, VotesAlignmentMixin, TriblerContentModel):
     """
     This model represents a list of channels that can be displayed in a table view.
     """
-    columns = [u'state', u'subscribed', u'name', u'torrents', u'updated']
-    column_headers = [u'', u'', u'Channel name', u'Torrents', u'Updated']
+    columns = [u'state', u'votes', u'subscribed', u'name', u'torrents', u'updated']
+    column_headers = [u'', u'', u'', u'Channel name', u'Torrents', u'Updated']
     column_flags = {
         u'subscribed': Qt.ItemIsEnabled | Qt.ItemIsSelectable,
         u'name': Qt.ItemIsEnabled | Qt.ItemIsSelectable,
         u'torrents': Qt.ItemIsEnabled | Qt.ItemIsSelectable,
         u'updated': Qt.ItemIsEnabled | Qt.ItemIsSelectable,
+        u'votes': Qt.ItemIsEnabled | Qt.ItemIsSelectable,
         u'state': Qt.ItemIsEnabled | Qt.ItemIsSelectable,
         ACTION_BUTTONS: Qt.ItemIsEnabled | Qt.ItemIsSelectable
     }


### PR DESCRIPTION
This PR implements a [VSIDS](https://arxiv.org/pdf/1506.08905.pdf)-like heuristics for channel popularity.
In short, whenever a gossip with a channel is received, the corresponding vote count is increased by +1, and then *all the other votes* are **multiplied** by a constant *decay factor*. As a result, the heuristic works like a temporal PageRank, bumping the most actively spread around channels to the top.

The decay factor for this version is 2.71 per 24 hours of Tribler online time. This means that when some channel gets a vote today, tomorrow by the same time the vote will be 2.71x times smaller. The decay is performed on per-vote basis, meaning that it happens gradually over time, as the votes come in. The algorithm is O(1) in regards to the number of DB calls for each vote update.

We keep each individual vote in the DB, along with its last update time and the amount that it added to the total vote count for the channel. Whenever a repeating vote is received, the previous vote amount for the same vote is *subtracted* from the vote sum, and the new amount is added instead. This results in votes *refresh* instead of *accumulation*, meaning that a single peer cannot aggressively bump their channel by bombarding another peer with gossip. Instead, persistence in vote support is key. 