### PR TITLE
Deduplication of SQL search results based on infohash

### DIFF
--- a/Tribler/Core/Modules/MetadataStore/OrmBindings/torrent_metadata.py
+++ b/Tribler/Core/Modules/MetadataStore/OrmBindings/torrent_metadata.py
@@ -71,8 +71,10 @@ def define_binding(db):
             if not query or query == "*":
                 return []
 
+            # TODO: optimize this query by removing unnecessary select nests (including Pony-manages selects)
             fts_ids = raw_sql(
-                'SELECT rowid FROM FtsIndex WHERE FtsIndex MATCH $query ORDER BY bm25(FtsIndex) LIMIT $lim')
+                """SELECT rowid FROM ChannelNode WHERE rowid IN (SELECT rowid FROM FtsIndex WHERE FtsIndex MATCH $query
+                ORDER BY bm25(FtsIndex) LIMIT $lim) GROUP BY infohash""")
 
             # TODO: Check for complex query
             normal_query = query.replace('"', '').replace("*", "")

--- a/Tribler/Test/Core/Modules/MetadataStore/test_torrent_metadata.py
+++ b/Tribler/Test/Core/Modules/MetadataStore/test_torrent_metadata.py
@@ -94,6 +94,18 @@ class TestTorrentMetadata(TriblerCoreTest):
         results = self.mds.TorrentMetadata.search_keyword("123")[:]
         self.assertEqual(len(results), 2)
 
+    @db_session
+    def test_search_deduplicated(self):
+        """
+        Test SQL-query base deduplication of search results with the same infohash
+        """
+        key2 = default_eccrypto.generate_key(u"curve25519")
+        torrent = rnd_torrent()
+        self.mds.TorrentMetadata.from_dict(dict(torrent, title="foo bar 123"))
+        self.mds.TorrentMetadata.from_dict(dict(torrent, title="eee 123", sign_with=key2))
+        results = self.mds.TorrentMetadata.search_keyword("foo")[:]
+        self.assertEqual(len(results), 1)
+
     def test_search_empty_query(self):
         """
         Test whether an empty query returns nothing


### PR DESCRIPTION
This little patch adds `GROUP BY` - based deduplication of metadata search results in SQL based on infohash. Note that it does not deduplicate the *entries* in the database, but only the results displayed (or the results sent over the Search community).