### PR TITLE
Fix GUI state column tooltip crash

### DIFF
--- a/TriblerGUI/widgets/tablecontentmodel.py
+++ b/TriblerGUI/widgets/tablecontentmodel.py
@@ -150,7 +150,7 @@ class StateTooltipMixin(object):
         # Return tooltip for state indicator column
         if role == Qt.ToolTipRole:
             if index.column() == self.column_position[u'state']:
-                return self.data_items[index.row()][u'state']
+                return self.data_items[index.row()].get(u'state')
             return None
         else:
             return super(StateTooltipMixin, self).data(index, role)


### PR DESCRIPTION
Fixes #4525 

The crash happened when hovering over the "State" column for a non-legacy **torrent** entry in the Search tab.

