### PR TITLE
READY: Unicode-related fixes for 7.3

### DIFF
--- a/Tribler/Core/Config/tribler_config.py
+++ b/Tribler/Core/Config/tribler_config.py
@@ -17,6 +17,7 @@ from Tribler.Core.Utilities.install_dir import get_lib_path
 from Tribler.Core.Utilities.network_utils import get_random_port
 from Tribler.Core.exceptions import InvalidConfigException
 from Tribler.Core.osutils import get_appstate_dir
+from Tribler.util import cast_to_unicode_utf8
 
 CONFIG_FILENAME = 'triblerd.conf'
 SPEC_FILENAME = 'config.spec'
@@ -151,7 +152,7 @@ class TriblerConfig(object):
         self._state_dir = state_dir
 
     def get_state_dir(self):
-        return self._state_dir
+        return cast_to_unicode_utf8(self._state_dir)
 
     def set_trustchain_keypair_filename(self, keypairfilename):
         self.config['trustchain']['ec_keypair_filename'] = self.norm_path(keypairfilename)

--- a/Tribler/Core/Libtorrent/LibtorrentDownloadImpl.py
+++ b/Tribler/Core/Libtorrent/LibtorrentDownloadImpl.py
@@ -36,6 +36,7 @@ from Tribler.Core.exceptions import SaveResumeDataError
 from Tribler.Core.osutils import fix_filebasename
 from Tribler.Core.simpledefs import DLMODE_NORMAL, DLMODE_VOD, DLSTATUS_SEEDING, DLSTATUS_STOPPED, \
     PERSISTENTSTATE_CURRENTVERSION, dlstatus_strings
+from Tribler.util import cast_to_unicode_utf8
 
 if sys.platform == "win32":
     try:
@@ -298,7 +299,8 @@ class LibtorrentDownloadImpl(DownloadConfigInterface, TaskManager):
                 if resume_data and isinstance(resume_data, dict):
                     # Rewrite save_path as a global path, if it is given as a relative path
                     if "save_path" in resume_data and not os.path.isabs(resume_data["save_path"]):
-                        resume_data["save_path"] = str(os.path.join(self.state_dir, resume_data["save_path"]))
+                        resume_data["save_path"] = six.text_type(
+                            os.path.join(self.state_dir, cast_to_unicode_utf8(resume_data["save_path"])))
                     atp["resume_data"] = lt.bencode(resume_data)
             else:
                 atp["url"] = self.tdef.get_url() or "magnet:?xt=urn:btih:" + hexlify(self.tdef.get_infohash())
@@ -515,8 +517,9 @@ class LibtorrentDownloadImpl(DownloadConfigInterface, TaskManager):
 
         # Make save_path relative if the torrent is saved in the Tribler state directory
         if self.state_dir and 'save_path' in resume_data and os.path.abspath(resume_data['save_path']):
-            if self.state_dir == os.path.commonprefix([resume_data['save_path'], self.state_dir]):
-                resume_data['save_path'] = str(os.path.relpath(resume_data['save_path'], self.state_dir))
+            if self.state_dir == os.path.commonprefix([cast_to_unicode_utf8(resume_data['save_path']), self.state_dir]):
+                resume_data['save_path'] = six.text_type(
+                    os.path.relpath(cast_to_unicode_utf8(resume_data['save_path']), self.state_dir))
 
         self.pstate_for_restart.set('state', 'engineresumedata', resume_data)
         self._logger.debug("%s get resume data %s", hexlify(resume_data['info-hash']), resume_data)


### PR DESCRIPTION
This PR contains some fixes to make Tribler working directory path and `.state` files support non-ASCII characters.