### PR TITLE
Fix for loading torrent or magnet link in Tribler via external click

### DIFF
--- a/Tribler/Test/GUI/test_gui.py
+++ b/Tribler/Test/GUI/test_gui.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 import logging
 import os
+import subprocess
 import sys
 import threading
 import time
@@ -16,11 +17,13 @@ from PyQt5.QtWidgets import QTableView
 from six.moves import xrange
 
 from Tribler.Core.Utilities.network_utils import get_random_port
+from Tribler.Test.common import TORRENT_UBUNTU_FILE
 
 import TriblerGUI
 import TriblerGUI.core_manager as core_manager
 import TriblerGUI.defs
 from TriblerGUI.dialogs.feedbackdialog import FeedbackDialog
+from TriblerGUI.tribler_app import TriblerApplication
 from TriblerGUI.tribler_window import TriblerWindow
 from TriblerGUI.widgets.home_recommended_item import HomeRecommendedItem
 from TriblerGUI.widgets.loading_list_item import LoadingListItem
@@ -30,8 +33,9 @@ if os.environ.get("TEST_GUI") == "yes":
     core_manager.START_FAKE_API = True
     TriblerGUI.defs.DEFAULT_API_PORT = api_port
 
-    app = QApplication(sys.argv)
+    app = TriblerApplication("triblerapp", sys.argv)
     window = TriblerWindow(api_port=api_port)
+    app.set_activation_window(window)
     QTest.qWaitForWindowExposed(window)
 else:
     window = None
@@ -222,6 +226,29 @@ class TriblerGUITest(AbstractTriblerGUITest):
     """
     GUI tests for the GUI written in PyQt. These methods are using the QTest framework to simulate mouse clicks.
     """
+
+    @skipIf(sys.platform == "win32", "This test is unreliable on Windows")
+    def test_run_tribler(self):
+        """
+        Tests running a second instance of Tribler with a torrent file. Simulates user clicking on a Ubuntu torrent
+        file.
+        """
+        def on_app_message(msg):
+            self.assertEqual(msg, "file:%s" % TORRENT_UBUNTU_FILE)
+
+        app.messageReceived.connect(on_app_message)
+
+        # Start a second Tribler instance with a torrent file
+        tribler_executable = "%s/run_tribler.py" % os.path.dirname(os.path.dirname(TriblerGUI.__file__))
+        tribler_instance_2 = subprocess.Popen(['python', tribler_executable, TORRENT_UBUNTU_FILE])
+        _process_stream = tribler_instance_2.communicate()[0]
+        self.assertEqual(tribler_instance_2.returncode, 1)
+
+        QTest.qWait(200)
+
+        torrent_name_in_dialog = window.dialog.dialog_widget.torrent_name_label.text()
+        self.assertEqual(torrent_name_in_dialog, TORRENT_UBUNTU_FILE)
+        self.screenshot(window, name="start_download_dialog_on_startup")
 
     def test_home_page_torrents(self):
         QTest.mouseClick(window.left_menu_button_home, Qt.LeftButton)

--- a/Tribler/Test/GUI/test_gui.py
+++ b/Tribler/Test/GUI/test_gui.py
@@ -419,8 +419,8 @@ class TriblerGUITest(AbstractTriblerGUITest):
 
     @skipIf(sys.platform == "win32", "This test is unreliable on Windows")
     def test_add_download_url(self):
-        window.on_add_torrent_from_url()
         self.go_to_and_wait_for_downloads()
+        window.on_add_torrent_from_url()
         old_count = window.downloads_list.topLevelItemCount()
         self.screenshot(window, name="add_torrent_url_dialog")
         window.dialog.dialog_widget.dialog_input.setText("http://test.url/test.torrent")

--- a/TriblerGUI/dialogs/confirmationdialog.py
+++ b/TriblerGUI/dialogs/confirmationdialog.py
@@ -59,6 +59,7 @@ class ConfirmationDialog(DialogContainer):
 
         error_dialog.button_clicked.connect(on_close)
         error_dialog.show()
+        return error_dialog
 
     @classmethod
     def show_message(cls, window, title, message_text, button_text):
@@ -69,6 +70,7 @@ class ConfirmationDialog(DialogContainer):
 
         error_dialog.button_clicked.connect(on_close)
         error_dialog.show()
+        return error_dialog
 
     def create_button(self, index, button_text, _):
         button = EllipseButton(self.dialog_widget)

--- a/TriblerGUI/qt_resources/mainwindow.ui
+++ b/TriblerGUI/qt_resources/mainwindow.ui
@@ -12546,7 +12546,7 @@ color: #eee;</string>
    <header>TriblerGUI.widgets.homepage.h</header>
    <container>1</container>
   </customwidget>
-  <customwidget>
+  <customwidget>clickablewidgets
    <class>DownloadsDetailsTabWidget</class>
    <extends>QTabWidget</extends>
    <header>TriblerGUI.widgets.downloadsdetailstabwidget.h</header>
@@ -12664,7 +12664,7 @@ color: #eee;</string>
   <customwidget>
    <class>ClickableLineEdit</class>
    <extends>QLineEdit</extends>
-   <header>TriblerGUI.widgets.ClickableLineEdit.h</header>
+   <header>TriblerGUI.widgets.clickablewidgets.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/TriblerGUI/qt_resources/startdownloaddialog.ui
+++ b/TriblerGUI/qt_resources/startdownloaddialog.ui
@@ -123,7 +123,7 @@ color: white;
         <property name="styleSheet">
          <string notr="true">font-size: 14px;
 color: white;</string>
-        </property>
+        </property>ClickableLabel
         <property name="text">
          <string>Download torrent</string>
         </property>
@@ -433,7 +433,7 @@ background-color: transparent;
        </widget>
       </item>
       <item>
-       <widget class="QLabel" name="loading_files_label">
+       <widget class="ClickableLabel" name="loading_files_label">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
           <horstretch>0</horstretch>
@@ -643,6 +643,14 @@ background-color: transparent;
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ClickableLabel</class>
+   <extends>QLabel</extends>
+   <header>TriblerGUI.widgets.clickablewidgets.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
+ <slots/>
 </ui>

--- a/TriblerGUI/tribler_window.py
+++ b/TriblerGUI/tribler_window.py
@@ -707,6 +707,8 @@ class TriblerWindow(QMainWindow):
                 self.fetch_settings()
                 self.dialog = ConfirmationDialog.show_error(self, "Download Error", "Tribler settings is not available\
                                                                    yet. Fetching it now. Please try again later.")
+                # By re-adding the download uri to the pending list, the request is re-processed
+                # when the settings is received
                 self.pending_uri_requests.append(uri)
                 return
             # Clear any previous dialog if exists

--- a/TriblerGUI/tribler_window.py
+++ b/TriblerGUI/tribler_window.py
@@ -532,6 +532,12 @@ class TriblerWindow(QMainWindow):
         if 'error' in settings:
             raise RuntimeError(TriblerRequestManager.get_message_from_error(settings))
 
+        # If there is any pending dialog (likely download dialog or error dialog of setting not available),
+        # close the dialog
+        if self.dialog:
+            self.dialog.close_dialog()
+            self.dialog = None
+
         self.tribler_settings = settings['settings']
 
         # Set the video server port
@@ -699,8 +705,9 @@ class TriblerWindow(QMainWindow):
             # If tribler settings is not available, fetch the settings and inform the user to try again.
             if not self.tribler_settings:
                 self.fetch_settings()
-                ConfirmationDialog.show_error(self, "Download Error", "Tribler settings is not available yet. "
-                                                                      "Fetching it now. Please try again later.")
+                self.dialog = ConfirmationDialog.show_error(self, "Download Error", "Tribler settings is not available\
+                                                                   yet. Fetching it now. Please try again later.")
+                self.pending_uri_requests.append(uri)
                 return
             # Clear any previous dialog if exists
             if self.dialog:

--- a/TriblerGUI/widgets/ClickableLineEdit.py
+++ b/TriblerGUI/widgets/ClickableLineEdit.py
@@ -7,16 +7,16 @@ from PyQt5.QtWidgets import QLineEdit
 class ClickableLineEdit(QLineEdit):
 
     clicked = pyqtSignal()
-    create_torrent_notification = pyqtSignal(bool)
+    on_focus_notification = pyqtSignal(bool)
 
     def mousePressEvent(self, event):
         self.clicked.emit()
         QLineEdit.mousePressEvent(self, event)
 
     def focusInEvent(self, event):
-        self.create_torrent_notification.emit(True)
+        self.on_focus_notification.emit(True)
         QLineEdit.focusInEvent(self, event)
 
     def focusOutEvent(self, event):
-        self.create_torrent_notification.emit(False)
+        self.on_focus_notification.emit(False)
         QLineEdit.focusOutEvent(self, event)

--- a/TriblerGUI/widgets/clickablewidgets.py
+++ b/TriblerGUI/widgets/clickablewidgets.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 from PyQt5.QtCore import pyqtSignal
-from PyQt5.QtWidgets import QLineEdit
+from PyQt5.QtWidgets import QLineEdit, QLabel
 
 
 class ClickableLineEdit(QLineEdit):
@@ -20,3 +20,12 @@ class ClickableLineEdit(QLineEdit):
     def focusOutEvent(self, event):
         self.on_focus_notification.emit(False)
         QLineEdit.focusOutEvent(self, event)
+
+
+class ClickableLabel(QLabel):
+
+    clicked = pyqtSignal()
+
+    def mousePressEvent(self, event):
+        self.clicked.emit()
+        QLabel.mousePressEvent(self, event)

--- a/TriblerGUI/widgets/editchannelpage.py
+++ b/TriblerGUI/widgets/editchannelpage.py
@@ -125,7 +125,7 @@ class EditChannelPage(QWidget):
         self.window().edit_channel_name_label.setReadOnly(True)
         self.window().edit_channel_name_label.clicked.connect(self.on_click_channel_name)
         self.window().edit_channel_name_label.returnPressed.connect(self.on_update_channel_name)
-        self.window().edit_channel_name_label.create_torrent_notification.connect(self.on_focus_channel_name)
+        self.window().edit_channel_name_label.on_focus_notification.connect(self.on_focus_channel_name)
 
         # Channel public key
         self.window().edit_channel_cid_label.setHidden(False)

--- a/run_tribler.py
+++ b/run_tribler.py
@@ -115,16 +115,18 @@ if __name__ == "__main__":
             from TriblerGUI.tribler_window import TriblerWindow
 
             app = TriblerApplication("triblerapp", sys.argv)
-
+            if app.is_running():
+                for arg in sys.argv[1:]:
+                    if os.path.exists(arg) and arg.endswith(".torrent"):
+                        app.send_message("file:%s" % arg)
+                    elif arg.startswith('magnet'):
+                        app.send_message(arg)
+                sys.exit(1)
 
             window = TriblerWindow()
             window.setWindowTitle("Tribler")
             app.set_activation_window(window)
             app.parse_sys_args(sys.argv)
-
-            # If app is already running, simply exit the current instance, else continue
-            if app.is_running():
-                sys.exit(0)
             sys.exit(app.exec_())
 
         except ImportError as ie:


### PR DESCRIPTION
This PR fixes the issues mentioned in https://github.com/Tribler/tribler/issues/4438.

Fixes the failure to load torrent or magnet link when Trible is already running. Additionally, adds an option to retry fetching the meta info in download dialog if it times out to load the files on the first request. 