### PR TITLE
Start GigaChanMan after resuming downloads

### DIFF
--- a/Tribler/Core/APIImplementation/LaunchManyCore.py
+++ b/Tribler/Core/APIImplementation/LaunchManyCore.py
@@ -308,7 +308,8 @@ class TriblerLaunchMany(TaskManager):
 
         if self.session.config.get_chant_enabled():
             self.gigachannel_manager = GigaChannelManager(self.session)
-            self.gigachannel_manager.start()
+            # GigaChannel Manager startup routines are started asynchronously by Session
+            # after resuming Libtorrent downloads.
 
         if self.api_manager:
             self.session.readable_status = STATE_START_API_ENDPOINTS

--- a/Tribler/Core/Session.py
+++ b/Tribler/Core/Session.py
@@ -429,7 +429,13 @@ class Session(object):
                 self.load_checkpoint()
             self.readable_status = STATE_READABLE_STARTED
 
-        return startup_deferred.addCallback(load_checkpoint)
+        def start_gigachannel_manager(_):
+            # GigaChannel Manager should be started *after* resuming the downloads,
+            # because it depends on the states of torrent downloads
+            # TODO: move GigaChannel torrents into a separate session
+            if self.lm.gigachannel_manager:
+                self.lm.gigachannel_manager.start()
+        return startup_deferred.addCallback(load_checkpoint).addCallback(start_gigachannel_manager)
 
     def shutdown(self):
         """


### PR DESCRIPTION
Fixes #4558 by moving the call to GigaChannel Manager startup method into Session deferred callback.
Now it will run *after* resuming torrents from checkpoints.