### PR TITLE
READY: Unicode-related fixes

### DIFF
--- a/Tribler/Core/Config/tribler_config.py
+++ b/Tribler/Core/Config/tribler_config.py
@@ -15,9 +15,9 @@ from validate import Validator
 from Tribler.Core.DownloadConfig import get_default_dest_dir
 from Tribler.Core.Utilities.install_dir import get_lib_path
 from Tribler.Core.Utilities.network_utils import get_random_port
+from Tribler.Core.Utilities.unicode import ensure_unicode
 from Tribler.Core.exceptions import InvalidConfigException
 from Tribler.Core.osutils import get_appstate_dir
-from Tribler.util import cast_to_unicode_utf8
 
 CONFIG_FILENAME = 'triblerd.conf'
 SPEC_FILENAME = 'config.spec'
@@ -152,7 +152,7 @@ class TriblerConfig(object):
         self._state_dir = state_dir
 
     def get_state_dir(self):
-        return cast_to_unicode_utf8(self._state_dir)
+        return ensure_unicode(self._state_dir, 'utf-8')
 
     def set_trustchain_keypair_filename(self, keypairfilename):
         self.config['trustchain']['ec_keypair_filename'] = self.norm_path(keypairfilename)

--- a/Tribler/Core/CreditMining/CreditMiningManager.py
+++ b/Tribler/Core/CreditMining/CreditMiningManager.py
@@ -19,9 +19,10 @@ from Tribler.Core.CreditMining.CreditMiningPolicy import InvestmentPolicy, MB
 from Tribler.Core.CreditMining.CreditMiningSource import ChannelSource
 from Tribler.Core.DownloadConfig import DownloadStartupConfig
 from Tribler.Core.TorrentDef import TorrentDefNoMetainfo
-from Tribler.Core.simpledefs import DLSTATUS_DOWNLOADING, DLSTATUS_SEEDING, DLSTATUS_STOPPED, \
-    DLSTATUS_STOPPED_ON_ERROR, NTFY_CREDIT_MINING, NTFY_ERROR, UPLOAD
-from Tribler.Core.simpledefs import DOWNLOAD
+from Tribler.Core.Utilities.unicode import ensure_unicode
+from Tribler.Core.simpledefs import (
+    DLSTATUS_DOWNLOADING, DLSTATUS_SEEDING, DLSTATUS_STOPPED, DLSTATUS_STOPPED_ON_ERROR, DOWNLOAD, NTFY_CREDIT_MINING,
+    NTFY_ERROR, UPLOAD)
 
 
 class CreditMiningTorrent(object):
@@ -122,7 +123,7 @@ class CreditMiningManager(TaskManager):
                 error_message = u"Credit mining directory [%s]  does not exist. Tribler will re-create the " \
                                 u"directory and resume again.<br/>If you wish to disable credit mining entirely, " \
                                 u"please go to Settings >> ANONYMITY >> Token mining. " % \
-                                self.settings.save_path.encode('utf-8')
+                                ensure_unicode(self.settings.save_path, 'utf-8')
             except OSError:
                 self.shutdown()
                 error_message = u"Credit mining directory [%s] was deleted or does not exist and Tribler could not " \

--- a/Tribler/Core/Libtorrent/LibtorrentDownloadImpl.py
+++ b/Tribler/Core/Libtorrent/LibtorrentDownloadImpl.py
@@ -32,11 +32,11 @@ from Tribler.Core.Libtorrent import checkHandleAndSynchronize
 from Tribler.Core.TorrentDef import TorrentDef, TorrentDefNoMetainfo
 from Tribler.Core.Utilities import maketorrent
 from Tribler.Core.Utilities.torrent_utils import get_info_from_handle
+from Tribler.Core.Utilities.unicode import ensure_unicode
 from Tribler.Core.exceptions import SaveResumeDataError
 from Tribler.Core.osutils import fix_filebasename
-from Tribler.Core.simpledefs import DLMODE_NORMAL, DLMODE_VOD, DLSTATUS_SEEDING, DLSTATUS_STOPPED, \
-    PERSISTENTSTATE_CURRENTVERSION, dlstatus_strings
-from Tribler.util import cast_to_unicode_utf8
+from Tribler.Core.simpledefs import (
+    DLMODE_NORMAL, DLMODE_VOD, DLSTATUS_SEEDING, DLSTATUS_STOPPED, PERSISTENTSTATE_CURRENTVERSION, dlstatus_strings)
 
 if sys.platform == "win32":
     try:
@@ -300,7 +300,7 @@ class LibtorrentDownloadImpl(DownloadConfigInterface, TaskManager):
                     # Rewrite save_path as a global path, if it is given as a relative path
                     if "save_path" in resume_data and not os.path.isabs(resume_data["save_path"]):
                         resume_data["save_path"] = six.text_type(
-                            os.path.join(self.state_dir, cast_to_unicode_utf8(resume_data["save_path"])))
+                            os.path.join(self.state_dir, ensure_unicode(resume_data["save_path"], 'utf-8')))
                     atp["resume_data"] = lt.bencode(resume_data)
             else:
                 atp["url"] = self.tdef.get_url() or "magnet:?xt=urn:btih:" + hexlify(self.tdef.get_infohash())
@@ -517,9 +517,10 @@ class LibtorrentDownloadImpl(DownloadConfigInterface, TaskManager):
 
         # Make save_path relative if the torrent is saved in the Tribler state directory
         if self.state_dir and 'save_path' in resume_data and os.path.abspath(resume_data['save_path']):
-            if self.state_dir == os.path.commonprefix([cast_to_unicode_utf8(resume_data['save_path']), self.state_dir]):
+            if self.state_dir == os.path.commonprefix([ensure_unicode(resume_data['save_path'], 'utf-8'),
+                                                       self.state_dir]):
                 resume_data['save_path'] = six.text_type(
-                    os.path.relpath(cast_to_unicode_utf8(resume_data['save_path']), self.state_dir))
+                    os.path.relpath(ensure_unicode(resume_data['save_path'], 'utf-8'), self.state_dir))
 
         self.pstate_for_restart.set('state', 'engineresumedata', resume_data)
         self._logger.debug("%s get resume data %s", hexlify(resume_data['info-hash']), resume_data)
@@ -603,7 +604,7 @@ class LibtorrentDownloadImpl(DownloadConfigInterface, TaskManager):
         self.checkpoint()
 
     def on_file_renamed_alert(self, alert):
-        unwanteddir_abs = os.path.join(self.get_save_path().decode('utf-8'), self.unwanted_directory_name)
+        unwanteddir_abs = os.path.join(ensure_unicode(self.get_save_path(), 'utf-8'), self.unwanted_directory_name)
         if os.path.exists(unwanteddir_abs) and all(self.handle.file_priorities()):
             shutil.rmtree(unwanteddir_abs, ignore_errors=True)
 

--- a/Tribler/Core/Modules/MetadataStore/OrmBindings/channel_metadata.py
+++ b/Tribler/Core/Modules/MetadataStore/OrmBindings/channel_metadata.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, division
 
 import os
 import random
-import sys
 from binascii import hexlify
 from datetime import datetime
 
@@ -15,13 +14,12 @@ import lz4.frame
 from pony import orm
 from pony.orm import db_session, raw_sql, select
 
-from Tribler.Core.Category.Category import default_category_filter
 from Tribler.Core.Modules.MetadataStore.OrmBindings.channel_node import (
     COMMITTED, LEGACY_ENTRY, NEW, PUBLIC_KEY_LEN, TODELETE, UPDATED)
 from Tribler.Core.Modules.MetadataStore.OrmBindings.torrent_metadata import tdef_to_metadata_dict
 from Tribler.Core.Modules.MetadataStore.serialization import CHANNEL_TORRENT, ChannelMetadataPayload, REGULAR_TORRENT
 from Tribler.Core.TorrentDef import TorrentDef
-from Tribler.Core.Utilities.tracker_utils import get_uniformed_tracker_url
+from Tribler.Core.Utilities.unicode import ensure_unicode
 from Tribler.Core.exceptions import DuplicateChannelIdError, DuplicateTorrentFileError
 
 CHANNEL_DIR_NAME_LENGTH = 32  # Its not 40 so it could be distinguished from infohash
@@ -534,9 +532,9 @@ def define_binding(db):
 
             # Build list of .torrents to process
             for f in filename_generator:
-                filepath = os.path.join(torrents_dir, f)
-                filename = str(filepath) if sys.platform == 'win32' else filepath.decode('utf-8')
-                if os.path.isfile(filepath) and filename.endswith(u'.torrent'):
+                filepath = ensure_unicode(
+                    os.path.join(ensure_unicode(torrents_dir, 'utf-8'), ensure_unicode(f, 'utf-8')), 'utf-8')
+                if os.path.isfile(filepath) and ensure_unicode(f, 'utf-8').endswith(u'.torrent'):
                     torrents_list.append(filepath)
 
             for chunk in chunks(torrents_list, 100):  # 100 is a reasonable chunk size for commits

--- a/Tribler/Core/Modules/restapi/search_endpoint.py
+++ b/Tribler/Core/Modules/restapi/search_endpoint.py
@@ -11,7 +11,7 @@ from twisted.web.server import NOT_DONE_YET
 import Tribler.Core.Utilities.json_util as json
 from Tribler.Core.Modules.MetadataStore.serialization import CHANNEL_TORRENT, REGULAR_TORRENT
 from Tribler.Core.Modules.restapi.metadata_endpoint import BaseMetadataEndpoint
-from Tribler.util import cast_to_unicode_utf8
+from Tribler.Core.Utilities.unicode import ensure_unicode
 
 
 class SearchEndpoint(BaseMetadataEndpoint):
@@ -178,7 +178,7 @@ class SearchCompletionsEndpoint(resource.Resource):
             request.setResponseCode(http.BAD_REQUEST)
             return json.twisted_dumps({"error": "query parameter missing"})
 
-        keywords = cast_to_unicode_utf8(request.args[b'q'][0]).lower()
+        keywords = ensure_unicode(request.args[b'q'][0], 'utf-8').lower()
         # TODO: add XXX filtering for completion terms
         results = self.session.lm.mds.TorrentMetadata.get_auto_complete_terms(keywords, max_terms=5)
         return json.twisted_dumps({"completions": results})

--- a/Tribler/Core/Modules/restapi/torrentinfo_endpoint.py
+++ b/Tribler/Core/Modules/restapi/torrentinfo_endpoint.py
@@ -77,6 +77,8 @@ class TorrentInfoEndpoint(resource.Resource):
 
             # Check if the torrent is already in the downloads
             metainfo['download_exists'] = infohash in self.session.lm.downloads
+            # FIXME: json.dumps garbles binary data that is used by the 'pieces' field
+            # However, this is fine as long as the GUI does not use this field.
             encoded_metainfo = hexlify(json.dumps(metainfo, ensure_ascii=False))
 
             request.write(json.twisted_dumps({"metainfo": encoded_metainfo}))

--- a/Tribler/Core/Modules/watch_folder.py
+++ b/Tribler/Core/Modules/watch_folder.py
@@ -44,7 +44,7 @@ class WatchFolder(TaskManager):
             return
 
         # Make sure that we pass a str to os.walk
-        watch_dir = self.session.config.get_watch_folder_path().encode('raw_unicode_escape')
+        watch_dir = self.session.config.get_watch_folder_path().encode('utf-8')
 
         for root, _, files in os.walk(watch_dir):
             for name in files:

--- a/Tribler/Test/Core/Libtorrent/test_libtorrent_download_impl.py
+++ b/Tribler/Test/Core/Libtorrent/test_libtorrent_download_impl.py
@@ -7,6 +7,7 @@ import shutil
 import libtorrent as lt
 from libtorrent import bdecode, bencode
 
+from six import text_type
 from six.moves import xrange
 
 from twisted.internet.defer import Deferred, inlineCallbacks, succeed
@@ -165,7 +166,7 @@ class TestLibtorrentDownloadImpl(TestAsServer):
 
         pstate = CallbackConfigParser()
         pstate.add_section("state")
-        pstate.set("state", "engineresumedata", {"save_path": str(os.path.abspath(self.state_dir))})
+        pstate.set("state", "engineresumedata", {"save_path": text_type(os.path.abspath(self.state_dir))})
         yield impl.network_create_engine_wrapper(pstate)
 
         pstate = CallbackConfigParser()

--- a/Tribler/Test/Core/Modules/RestApi/test_downloads_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_downloads_endpoint.py
@@ -19,6 +19,7 @@ from Tribler.Test.Core.base_test import MockObject
 from Tribler.Test.common import TESTS_DATA_DIR, TESTS_DIR, UBUNTU_1504_INFOHASH
 from Tribler.Test.tools import trial_timeout
 
+
 def get_hex_infohash(tdef):
     return hexlify(tdef.get_infohash())
 
@@ -654,7 +655,7 @@ class TestMetadataDownloadEndpoint(AbstractApiTest):
         """
         Test whether adding metadata with an invalid signature results in an error
         """
-        file_path = os.path.join(self.session_base_dir, "invalid.mdblob")
+        file_path = os.path.join(self.session_base_dir, u"invalid.mdblob")
         with open(file_path, "wb") as out_file:
             with db_session:
                 my_channel = self.session.lm.mds.ChannelMetadata.create_channel('test', 'test')
@@ -662,7 +663,7 @@ class TestMetadataDownloadEndpoint(AbstractApiTest):
             hexed = hexlify(my_channel.serialized())[:-5] + "aaaaa"
             out_file.write(unhexlify(hexed))
 
-        post_data = {'uri': 'file:%s' % file_path, 'metadata_download': '1'}
+        post_data = {u'uri': u'file:%s' % file_path, u'metadata_download': u'1'}
         expected_json = {'error': "Metadata has invalid signature"}
         self.should_check_equality = True
         return self.do_request('downloads', expected_code=400, request_type='PUT', post_data=post_data,

--- a/Tribler/Test/Core/Modules/test_watch_folder.py
+++ b/Tribler/Test/Core/Modules/test_watch_folder.py
@@ -36,8 +36,8 @@ class TestWatchFolder(TestAsServer):
         self.assertEqual(len(self.session.get_downloads()), 0)
 
     def test_watchfolder_utf8_dir(self):
-        os.mkdir(os.path.join(self.watch_dir, "\xe2\x82\xac"))
-        shutil.copyfile(TORRENT_UBUNTU_FILE, os.path.join(self.watch_dir, "\xe2\x82\xac", "\xe2\x82\xac.torrent"))
+        os.mkdir(os.path.join(self.watch_dir, u"\xe2\x82\xac"))
+        shutil.copyfile(TORRENT_UBUNTU_FILE, os.path.join(self.watch_dir, u"\xe2\x82\xac", u"\xe2\x82\xac.torrent"))
         self.session.config.set_watch_folder_path(self.watch_dir)
 
         self.session.lm.watch_folder.check_watch_folder()

--- a/Tribler/Test/Core/Upgrade/test_config_upgrade_70_71.py
+++ b/Tribler/Test/Core/Upgrade/test_config_upgrade_70_71.py
@@ -34,7 +34,7 @@ class TestConfigUpgrade70to71(TriblerCoreTest):
         """
         Test upgrading a libtribler configuration from 7.0 to 7.1
         """
-        os.environ['TSTATEDIR'] = self.session_base_dir
+        os.environ['TSTATEDIR'] = self.session_base_dir.encode('utf-8')
         old_config = RawConfigParser()
         old_config.read(os.path.join(self.CONFIG_PATH, "libtribler70.conf"))
         new_config = TriblerConfig()

--- a/Tribler/Test/test_as_server.py
+++ b/Tribler/Test/test_as_server.py
@@ -104,7 +104,7 @@ class AbstractServer(BaseTestCase):
     def setUp(self):
         self._logger = logging.getLogger(self.__class__.__name__)
 
-        self.session_base_dir = self.temporary_directory(suffix="_tribler_test_session_")
+        self.session_base_dir = self.temporary_directory(suffix=u"_tribler_test_session_")
         self.state_dir = os.path.join(self.session_base_dir, u"dot.Tribler")
         self.dest_dir = os.path.join(self.session_base_dir, u"TriblerDownloads")
 


### PR DESCRIPTION
This PR is a continuation of https://github.com/Tribler/tribler/pull/4562
Initially, I added some Unicode characters to Tribler test directory names, tmp directories, etc. I was able to fix about a dozen bugs in that mode. There was only one left (watch folder related), but solving it would require too much effort. Moving to Python3 (and/or Pathlib) would solve that. So, I omitted the patch that introduced Unicode characters into test dirs paths.

Nonetheless, this solves some Unicode-related problems.

Fixes #4524 