### PR TITLE
READY: Make personal channel use timestamp for id_

### DIFF
--- a/Tribler/Core/CreditMining/CreditMiningSource.py
+++ b/Tribler/Core/CreditMining/CreditMiningSource.py
@@ -51,7 +51,7 @@ class ChannelSource(BaseSource):
     def start(self):
         super(ChannelSource, self).start()
 
-        channel = self.session.lm.mds.ChannelMetadata.get_channel_with_id(self.source)
+        channel = self.session.lm.mds.ChannelMetadata.get_recent_channel_with_public_key(self.source)
         if not channel:
             self._logger.error("Could not find channel!")
             return

--- a/Tribler/Core/Modules/MetadataStore/store.py
+++ b/Tribler/Core/Modules/MetadataStore/store.py
@@ -22,8 +22,8 @@ from Tribler.Core.Modules.MetadataStore.serialization import (
 from Tribler.Core.exceptions import InvalidSignatureException
 
 
-BETA_DB_VERSIONS = [0, 1, 2, 3]
-CURRENT_DB_VERSION = 4
+BETA_DB_VERSIONS = [0, 1, 2, 3, 4]
+CURRENT_DB_VERSION = 5
 
 CLOCK_STATE_FILE = "clock.state"
 
@@ -430,10 +430,6 @@ class MetadataStore(object):
             return result
 
         return result
-
-    @db_session
-    def get_my_channel(self):
-        return self.ChannelMetadata.get_channel_with_id(self.my_key.pub().key_to_bin()[10:])
 
     @db_session
     def get_num_channels(self):

--- a/Tribler/Core/Modules/restapi/mychannel_endpoint.py
+++ b/Tribler/Core/Modules/restapi/mychannel_endpoint.py
@@ -103,7 +103,7 @@ class MyChannelEndpoint(BaseMyChannelEndpoint):
         my_channel_pk = my_key.pub().key_to_bin()
 
         # Do not allow to add a channel twice
-        if self.session.lm.mds.get_my_channel():
+        if self.session.lm.mds.ChannelMetadata.get_my_channel():
             request.setResponseCode(http.CONFLICT)
             return json.twisted_dumps({"error": "channel already exists"})
 
@@ -242,7 +242,7 @@ class MyChannelTorrentsEndpoint(BaseMyChannelEndpoint):
 
         def _on_torrent_def_loaded(torrent_def):
             with db_session:
-                channel = self.session.lm.mds.get_my_channel()
+                channel = self.session.lm.mds.ChannelMetadata.get_my_channel()
                 channel.add_torrent_to_channel(torrent_def, extra_info)
             return 1
 

--- a/Tribler/Core/Upgrade/db72_to_pony.py
+++ b/Tribler/Core/Upgrade/db72_to_pony.py
@@ -17,13 +17,11 @@ from twisted.internet import reactor
 from twisted.internet.defer import inlineCallbacks
 from twisted.internet.task import deferLater
 
-from Tribler.Core.Modules.MetadataStore.OrmBindings.channel_node import COMMITTED, LEGACY_ENTRY, NEW
+from Tribler.Core.Modules.MetadataStore.OrmBindings.channel_node import LEGACY_ENTRY, NEW
 from Tribler.Core.Modules.MetadataStore.OrmBindings.torrent_metadata import infohash_to_id
 from Tribler.Core.Modules.MetadataStore.serialization import REGULAR_TORRENT
 from Tribler.Core.Modules.MetadataStore.store import BETA_DB_VERSIONS, CURRENT_DB_VERSION
 from Tribler.Core.Utilities.tracker_utils import get_uniformed_tracker_url
-
-BATCH_SIZE = 10000
 
 DISCOVERED_CONVERSION_STARTED = "discovered_conversion_started"
 CHANNELS_CONVERSION_STARTED = "channels_conversion_started"
@@ -162,7 +160,7 @@ class DispersyToPonyMigration(object):
         connection.close()
         return result
 
-    def get_old_torrents(self, personal_channel_only=False, batch_size=BATCH_SIZE, offset=0,
+    def get_old_torrents(self, personal_channel_only=False, batch_size=10000, offset=0,
                          sign=False):
         connection = sqlite3.connect(self.tribler_db)
         cursor = connection.cursor()

--- a/Tribler/Test/Core/Modules/MetadataStore/test_channel_download.py
+++ b/Tribler/Test/Core/Modules/MetadataStore/test_channel_download.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import os
 
 from pony.orm import db_session
@@ -9,6 +11,7 @@ from Tribler.Core.TorrentDef import TorrentDef
 from Tribler.Core.Utilities.network_utils import get_random_port
 from Tribler.Test.test_as_server import TestAsServer
 from Tribler.Test.tools import trial_timeout
+from Tribler.pyipv8.ipv8.database import database_blob
 
 DATA_DIR = os.path.join(os.path.abspath(os.path.dirname(os.path.realpath(__file__))), '..', '..', 'data')
 CHANNEL_DIR = os.path.join(DATA_DIR, 'sample_channel')
@@ -54,7 +57,7 @@ class TestChannelDownload(TestAsServer):
 
         with db_session:
             # There should be 4 torrents + 1 channel torrent
-            channel2 = self.session.lm.mds.ChannelMetadata.get_channel_with_id(payload.public_key)
+            channel2 = self.session.lm.mds.ChannelMetadata.get(public_key=database_blob(payload.public_key))
             self.assertEqual(5, len(list(self.session.lm.mds.TorrentMetadata.select())))
             self.assertEqual(1551110113009, channel2.timestamp)
             self.assertEqual(channel2.timestamp, channel2.local_version)

--- a/Tribler/Test/Core/Modules/MetadataStore/test_channel_metadata.py
+++ b/Tribler/Test/Core/Modules/MetadataStore/test_channel_metadata.py
@@ -168,15 +168,6 @@ class TestChannelMetadata(TriblerCoreTest):
         self.assertEqual(channel_metadata, channel_result)
 
     @db_session
-    def test_get_channel_with_id(self):
-        """
-        Test retrieving a channel with a specific ID
-        """
-        self.assertIsNone(self.mds.ChannelMetadata.get_channel_with_id('a' * 20))
-        channel_metadata = self.mds.ChannelMetadata.create_channel('test', 'test')
-        self.assertIsNotNone(self.mds.ChannelMetadata.get_channel_with_id(channel_metadata.public_key))
-
-    @db_session
     def test_add_metadata_to_channel(self):
         """
         Test whether adding new torrents to a channel works as expected


### PR DESCRIPTION
This PR adds further support for nested channel feature. Before, user's channel always got a 0 `id_`. This is compatible with the planned nested channels scheme, but is inconvenient, because after moving to nested channels users will have their personal channels contents right at their root channel. Instead, we're now creating a nested personal channel with timestamp-based `id_` that resides in the user's root (`id_==0`) channel.

There is no real change in the database schema, but we still have to clean the previous beta database, because otherwise, our beta testers will end up with messy channels after the transition to nested channels in 7.4.