### PR TITLE
READY: Workaround for broken tdef metainfo argument

### DIFF
--- a/Tribler/Core/TorrentDef.py
+++ b/Tribler/Core/TorrentDef.py
@@ -72,12 +72,12 @@ class TorrentDef(object):
         self.files_list = []
         self.infohash = None
 
-
         if metainfo is not None:
             # This is a workaround to avoid feeding unicode objects to Libtorrent.
             # In fact, this conforms to the 'Unicode Sandwich' model for handling unicode in Python.
             # However, it is too bad that the low-level Libtorrent wrapper does not handle unicode.
-            metainfo = convert_dict_unicode_to_bytes(metainfo)
+            if isinstance(metainfo, dict):
+                metainfo = convert_dict_unicode_to_bytes(metainfo)
 
             # First, make sure the passed metainfo is valid
             try:


### PR DESCRIPTION
Fixes #4569 

Really, this only brings the code back to the state it was before. I don't know what kind of arguments Libtorrent wrappers is supposed to get, so I just pass it through if it is not dict.
We're going to refactor the wrapper soon anyway.
