### PR TITLE
Fix torrent health conversion

### DIFF
--- a/Tribler/Core/Modules/MetadataStore/OrmBindings/channel_metadata.py
+++ b/Tribler/Core/Modules/MetadataStore/OrmBindings/channel_metadata.py
@@ -157,6 +157,7 @@ def define_binding(db):
             my_channel.sign()
             return my_channel
 
+        @db_session
         def consolidate_channel_torrent(self):
             """
             Delete the channel dir contents and create it anew.
@@ -164,7 +165,8 @@ def define_binding(db):
             :param key: The public/private key, used to sign the data
             """
 
-            self.commit_channel_torrent()
+            # Cleanup entries marked for deletion
+            self.deleted_contents.delete(bulk=True)
 
             folder = os.path.join(self._channels_dir, self.dir_name)
             # We check if we need to re-create the channel dir in case it was deleted for some reason

--- a/Tribler/Core/Modules/gigachannel_manager.py
+++ b/Tribler/Core/Modules/gigachannel_manager.py
@@ -47,7 +47,7 @@ class GigaChannelManager(TaskManager):
                             tdef = TorrentDef.load(torrent_path)
                         except IOError:
                             self._logger.warning("Can't open personal channel torrent file. Will try to regenerate it.")
-                    tdef = tdef if (tdef and tdef.infohash != str(my_channel.infohash)) else\
+                    tdef = tdef if (tdef and tdef.infohash == str(my_channel.infohash)) else\
                         TorrentDef.load_from_dict(my_channel.consolidate_channel_torrent())
                     self.updated_my_channel(tdef)
         except Exception:

--- a/Tribler/Core/Upgrade/db72_to_pony.py
+++ b/Tribler/Core/Upgrade/db72_to_pony.py
@@ -19,7 +19,7 @@ from twisted.internet.task import deferLater
 
 from Tribler.Core.Modules.MetadataStore.OrmBindings.channel_node import LEGACY_ENTRY, NEW
 from Tribler.Core.Modules.MetadataStore.OrmBindings.torrent_metadata import infohash_to_id
-from Tribler.Core.Modules.MetadataStore.serialization import REGULAR_TORRENT
+from Tribler.Core.Modules.MetadataStore.serialization import REGULAR_TORRENT, int2time, time2int
 from Tribler.Core.Modules.MetadataStore.store import BETA_DB_VERSIONS, CURRENT_DB_VERSION
 from Tribler.Core.Utilities.tracker_utils import get_uniformed_tracker_url
 
@@ -72,6 +72,7 @@ class DispersyToPonyMigration(object):
         self.tribler_db = tribler_db
         self.mds = None
         self.shutting_down = False
+        self.conversion_start_timestamp_int = time2int(datetime.datetime.utcnow())
 
         self.personal_channel_id = None
         self.personal_channel_title = None
@@ -172,49 +173,58 @@ class DispersyToPonyMigration(object):
                                       (" %i " % self.personal_channel_id)
 
         torrents = []
+        batch_not_empty = False # This is a dumb way to indicate that this batch got zero entries from DB
+
         for tracker_url, channel_id, name, infohash, length, creation_date, torrent_id, category, num_seeders, \
             num_leechers, last_tracker_check in \
                 cursor.execute(
                     self.select_full + personal_channel_filter + " group by infohash" +
                     (" LIMIT " + str(batch_size) + " OFFSET " + str(offset))):
+            batch_not_empty = True
             # check if name is valid unicode data
             try:
                 name = text_type(name)
             except UnicodeDecodeError:
                 continue
 
-            try:
-                if len(base64.decodestring(infohash)) != 20:
-                    continue
-                if not torrent_id or int(torrent_id) == 0:
-                    continue
 
-                if not length:
+            try:
+                if (len(base64.decodestring(infohash)) != 20) or \
+                        (not torrent_id or int(torrent_id) == 0) or \
+                        (not length or (int(length) <= 0) or (int(length) > (1 << 45))) or \
+                        not name:
                     continue
 
                 infohash = base64.decodestring(infohash)
 
+                torrent_date = datetime.datetime.utcfromtimestamp(creation_date or 0)
+                torrent_date = torrent_date if 0 <= time2int(torrent_date) <= self.conversion_start_timestamp_int \
+                    else int2time(0)
                 torrent_dict = {
                     "status": NEW,
                     "infohash": infohash,
                     "size": int(length),
-                    "torrent_date": datetime.datetime.utcfromtimestamp(creation_date or 0),
+                    "torrent_date": torrent_date,
                     "title": name or '',
                     "tags": category or '',
                     "tracker_info": tracker_url or '',
                     "xxx": int(category == u'xxx')}
                 if not sign:
                     torrent_dict.update({"origin_id": infohash_to_id(channel_id)})
+                seeders = int(num_seeders or 0)
+                leechers = int(num_leechers or 0)
+                last_tracker_check = int(last_tracker_check or 0)
                 health_dict = {
-                    "seeders": int(num_seeders or 0),
-                    "leechers": int(num_leechers or 0),
-                    "last_check": int(last_tracker_check or 0)}
+                    "seeders": seeders,
+                    "leechers": leechers,
+                    "last_check": last_tracker_check
+                } if (last_tracker_check >= 0 and seeders >= 0 and leechers >= 0) else None
                 torrents.append((torrent_dict, health_dict))
             except:
                 continue
 
         connection.close()
-        return torrents
+        return torrents if batch_not_empty else None
 
     @inlineCallbacks
     def convert_personal_channel(self):
@@ -248,7 +258,7 @@ class DispersyToPonyMigration(object):
             with db_session:
                 self.mds.ChannelMetadata.create_channel(title=self.personal_channel_title, description='')
             yield self.convert_async(add_to_pony, get_old_stuff, total_to_convert,
-                                     offset=0, message="Converting old torrents.")
+                                     offset=0, message="Converting personal channel torrents.")
 
             with db_session:
                 self.mds.ChannelMetadata.get_my_channel().consolidate_channel_torrent()
@@ -292,23 +302,22 @@ class DispersyToPonyMigration(object):
         start = 0 + offset
         elapsed = 1
         while start < total_to_convert:
-            batch = get_old_stuff(batch_size=batch_size, offset=offset)
+            batch = get_old_stuff(batch_size=batch_size, offset=start)
 
-            if not batch or self.shutting_down:
+            if batch is None or self.shutting_down:
                 break
 
-            end = start + len(batch)
+            end = start + batch_size
 
             batch_start_time = datetime.datetime.now()
-            try:
-                with db_session:
-                    for (t, _) in batch:
-                        try:
-                            add_to_pony(t)
-                        except (TransactionIntegrityError, CacheIndexError):
-                            pass
-            except (TransactionIntegrityError, CacheIndexError):
-                pass
+            with db_session:
+                for (torrent_dict, health) in batch:
+                    try:
+                        torrent = add_to_pony(torrent_dict)
+                        if torrent and health:
+                            torrent.health.set(**health)
+                    except:
+                        pass
             batch_end_time = datetime.datetime.now() - batch_start_time
 
             elapsed = (datetime.datetime.utcnow() - start_time).total_seconds()
@@ -374,7 +383,6 @@ class DispersyToPonyMigration(object):
                     break
                 try:
                     self.mds.ChannelMetadata(**c)
-
                 except:
                     continue
 


### PR DESCRIPTION
This adds conversion of the health info from 7.2.2 database to Pony. Also, it fixes a bug with torrents conversion introduced in #4572 that resulted in skipping conversion of most entries. 