### PR TITLE
READY: Fix horrible disk churn in converter

### DIFF
--- a/Tribler/Core/Modules/MetadataStore/store.py
+++ b/Tribler/Core/Modules/MetadataStore/store.py
@@ -130,6 +130,7 @@ class MetadataStore(object):
             def sqlite_disable_sync(_, connection):
                 cursor = connection.cursor()
                 cursor.execute("PRAGMA synchronous = 0")
+                cursor.execute("PRAGMA temp_store = 2")
             # pylint: enable=unused-variable
 
         self.MiscData = misc.define_binding(self._db)

--- a/Tribler/Core/Upgrade/db72_to_pony.py
+++ b/Tribler/Core/Upgrade/db72_to_pony.py
@@ -166,6 +166,7 @@ class DispersyToPonyMigration(object):
                          sign=False):
         connection = sqlite3.connect(self.tribler_db)
         cursor = connection.cursor()
+        cursor.execute("PRAGMA temp_store = 2")
 
         personal_channel_filter = ""
         if self.personal_channel_id:


### PR DESCRIPTION
Converter query for getting old entries from the legacy database creates and deletes several temporary files in /tmp/var/etilqs* for each row read from the old DB.
This results in gigabytes of useless disk writes on Linux during conversion of big databases.
This patch disables usage of temporary files by Sqlite3 wrapper during conversion.