### PR TITLE
Make GigaChan community spread only downloaded channels

### DIFF
--- a/Tribler/Test/Community/gigachannel/test_community.py
+++ b/Tribler/Test/Community/gigachannel/test_community.py
@@ -13,7 +13,6 @@ from six.moves import xrange
 from twisted.internet.defer import inlineCallbacks
 
 from Tribler.Core.Modules.MetadataStore.OrmBindings.channel_node import COMMITTED, NEW
-from Tribler.Core.Modules.MetadataStore.serialization import NULL_KEY
 from Tribler.Core.Modules.MetadataStore.store import MetadataStore
 from Tribler.Core.Utilities.random_utils import random_infohash
 from Tribler.Test.Core.base_test import MockObject

--- a/Tribler/community/gigachannel/community.py
+++ b/Tribler/community/gigachannel/community.py
@@ -71,7 +71,8 @@ class GigaChannelCommunity(Community):
         md_list = []
         with db_session:
             # TODO: when the health table will be there, send popular torrents instead
-            channel_l = list(self.metadata_store.ChannelMetadata.get_random_channels(1, only_subscribed=True))
+            channel_l = list(
+                self.metadata_store.ChannelMetadata.get_random_channels(1, only_subscribed=True, only_downloaded=True))
             if not channel_l:
                 return
             md_list.extend(channel_l + list(channel_l[0].get_random_torrents(max_entries - 1)))


### PR DESCRIPTION
Fixes #4579 

If the channel's `local_version` is non-zero, that means it was at least partially added from a downloaded torrent. This means the swarm is reachable.