### PR TITLE
READY: Restart channel processing if it was stopped abruptly

### DIFF
--- a/Tribler/Core/Modules/MetadataStore/OrmBindings/channel_metadata.py
+++ b/Tribler/Core/Modules/MetadataStore/OrmBindings/channel_metadata.py
@@ -433,7 +433,8 @@ def define_binding(db):
         @classmethod
         @db_session
         def get_updated_channels(cls):
-            return select(g for g in cls if g.subscribed and (g.local_version < g.timestamp))
+            return select(g for g in cls if g.subscribed and (g.local_version < g.timestamp) and
+                          g.public_key != database_blob(cls._my_key.pub().key_to_bin()[10:]))
 
         @classmethod
         @db_session

--- a/Tribler/Core/Modules/MetadataStore/store.py
+++ b/Tribler/Core/Modules/MetadataStore/store.py
@@ -335,6 +335,9 @@ class MetadataStore(object):
             self._logger.debug(("Added payload batch to DB (entries, seconds): %i %f",
                                 (self.batch_size, float(batch_end_time.total_seconds()))))
             start = end
+            if self._shutting_down:
+                break
+
         return result
 
     @db_session

--- a/Tribler/Test/Core/Modules/MetadataStore/test_channel_download.py
+++ b/Tribler/Test/Core/Modules/MetadataStore/test_channel_download.py
@@ -54,6 +54,7 @@ class TestChannelDownload(TestAsServer):
         download, finished_deferred = self.session.lm.gigachannel_manager.download_channel(channel)
         download.add_peer(("127.0.0.1", self.seeder_session.config.get_libtorrent_port()))
         yield finished_deferred
+        yield self.session.lm.gigachannel_manager.process_queued_channels()
 
         with db_session:
             # There should be 4 torrents + 1 channel torrent


### PR DESCRIPTION
Before, if a channel was downloaded, but never processed, it would become stuck in `DOWNLOADING` state and never be processed by MetadataStore. This PR fixes this problem by introducing a channel dir processing queue in GigaChannel Manager and adding an additional check for downloaded, but unprocessed channels. Coincidentally, introducing this queue fixes potential race conditions and launching of more than one background channel-processing thread at a time.

Also, fixes #4578 