### PR TITLE
Fixed issues with homepage tiles

### DIFF
--- a/TriblerGUI/qt_resources/mainwindow.ui
+++ b/TriblerGUI/qt_resources/mainwindow.ui
@@ -1323,8 +1323,6 @@ padding-top: 10px;
 padding-left: 10px;
 }
 QTableWidget::item {
-padding-right: 10px;
-padding-bottom: 10px;
 border: none;
 }
 

--- a/TriblerGUI/widgets/home_recommended_item.py
+++ b/TriblerGUI/widgets/home_recommended_item.py
@@ -67,6 +67,8 @@ class HomeRecommendedItem(QWidget, fc_home_recommended_item):
         self.download_button.clicked.connect(self.on_download_button_clicked)
         self.download_button.hide()
 
+        self.setContentsMargins(0, 0, 10, 10)
+
     def on_download_button_clicked(self):
         if not self.torrent_info:
             return

--- a/TriblerGUI/widgets/homepage.py
+++ b/TriblerGUI/widgets/homepage.py
@@ -98,6 +98,7 @@ class HomePage(QWidget):
         correctly. As a workaround, call the resizeEvent after a small period of time.
         """
         self.resize_event_timer = QTimer()
+        self.resize_event_timer.setSingleShot(True)
         self.resize_event_timer.timeout.connect(lambda: self.window().resizeEvent(None))
         self.resize_event_timer.start(100)
 


### PR DESCRIPTION
Fixes the annoying streching of tiles on tab switch:
![afbeelding](https://user-images.githubusercontent.com/3630389/59853793-e25f6180-9371-11e9-8834-f226027e33be.png)

Fixes #4588.