### PR TITLE
Fixed discovered list not resizing

### DIFF
--- a/TriblerGUI/widgets/triblertablecontrollers.py
+++ b/TriblerGUI/widgets/triblertablecontrollers.py
@@ -134,16 +134,28 @@ class FilterInputMixin(object):
 
 class TableSelectionMixin(object):
 
+    def _brain_dead_refresh(self):
+        """
+        FIXME! Brain-dead way to show the rows covered by a newly-opened details_container
+        Note that none of then more civilized ways to fix it work:
+        various updateGeometry, viewport().update, adjustSize - nothing works!
+        """
+        window = self.table_view.window()
+        window.resize(window.geometry().width() + 1, window.geometry().height())
+        window.resize(window.geometry().width() - 1, window.geometry().height())
+
     def _on_selection_changed(self, _):
         selected_indices = self.table_view.selectedIndexes()
         if not selected_indices:
             self.details_container.hide()
             self.table_view.clearSelection()
+            self._brain_dead_refresh()
             return
 
         torrent_info = selected_indices[0].model().data_items[selected_indices[0].row()]
         if 'type' in torrent_info and torrent_info['type'] == 'channel':
             self.details_container.hide()
+            self._brain_dead_refresh()
             return
 
         first_show = False
@@ -153,12 +165,7 @@ class TableSelectionMixin(object):
         self.details_container.show()
         self.details_container.details_tab_widget.update_with_torrent(selected_indices[0], torrent_info)
         if first_show:
-            window = self.table_view.window()
-            # FIXME! Brain-dead way to show the rows covered by a newly-opened details_container
-            # Note that none of then more civilized ways to fix it work:
-            # various updateGeometry, viewport().update, adjustSize - nothing works!
-            window.resize(window.geometry().width() + 1, window.geometry().height())
-            window.resize(window.geometry().width() - 1, window.geometry().height())
+            self._brain_dead_refresh()
 
 
 class ContextMenuMixin(object):


### PR DESCRIPTION
This fixes the list view not resizing when deselecting a torrent in the discovered channel exploration list.

![afbeelding](https://user-images.githubusercontent.com/3630389/59859147-85b57400-937c-11e9-939a-c1bbe215401e.png)
![afbeelding](https://user-images.githubusercontent.com/3630389/59859251-b09fc800-937c-11e9-9829-eb1519b38428.png)

For the naming I stuck with @ichorid's original description.