### PR TITLE
READY: Speed up channels view by removing unnecessary SQL queries

### DIFF
--- a/Tribler/Core/Modules/MetadataStore/OrmBindings/channel_metadata.py
+++ b/Tribler/Core/Modules/MetadataStore/OrmBindings/channel_metadata.py
@@ -471,6 +471,7 @@ def define_binding(db):
             Return a basic dictionary with information about the channel.
             """
             epoch = datetime.utcfromtimestamp(0)
+            # TODO: redo with super
             return {
                 "id": self.id_,
                 "public_key": hexlify(self.public_key),

--- a/Tribler/Core/Modules/MetadataStore/OrmBindings/channel_metadata.py
+++ b/Tribler/Core/Modules/MetadataStore/OrmBindings/channel_metadata.py
@@ -470,20 +470,14 @@ def define_binding(db):
             """
             Return a basic dictionary with information about the channel.
             """
-            epoch = datetime.utcfromtimestamp(0)
-            # TODO: redo with super
-            return {
-                "id": self.id_,
-                "public_key": hexlify(self.public_key),
-                "name": self.title,
+            result = super(ChannelMetadata, self).to_simple_dict()
+            result.update({
                 "torrents": self.num_entries,
                 "subscribed": self.subscribed,
                 "votes": self.votes/db.ChannelMetadata.votes_scaling,
-                "status": self.status,
-                "updated": int((self.torrent_date - epoch).total_seconds()),
-                "timestamp": self.timestamp,
                 "state": self.channel_state
-            }
+            })
+            return result
 
         @classmethod
         @db_session

--- a/Tribler/Core/Modules/MetadataStore/OrmBindings/channel_metadata.py
+++ b/Tribler/Core/Modules/MetadataStore/OrmBindings/channel_metadata.py
@@ -181,7 +181,7 @@ def define_binding(db):
             # Channel should get a new starting timestamp and its contents should get higher timestamps
             start_timestamp = self._clock.tick()
             for g in self.contents:
-                if g.status == COMMITTED:
+                if g.status in [COMMITTED, UPDATED]:
                     g.status = UPDATED
                     g.timestamp = self._clock.tick()
                     g.sign()

--- a/Tribler/Core/Modules/MetadataStore/OrmBindings/channel_metadata.py
+++ b/Tribler/Core/Modules/MetadataStore/OrmBindings/channel_metadata.py
@@ -438,18 +438,11 @@ def define_binding(db):
 
         @classmethod
         @db_session
-        def get_entries(cls, first=None, last=None, subscribed=False, metadata_type=CHANNEL_TORRENT, **kwargs):
-            """
-            Get some channels. Optionally sort the results by a specific field, or filter the channels based
-            on a keyword/whether you are subscribed to it.
-            :return: A tuple. The first entry is a list of ChannelMetadata entries. The second entry indicates
-                     the total number of results, regardless the passed first/last parameter.
-            """
-            pony_query, count = super(ChannelMetadata, cls).get_entries(metadata_type=metadata_type, **kwargs)
-            if subscribed:
-                pony_query = pony_query.where(subscribed=subscribed)
-
-            return pony_query[(first or 1) - 1:last] if first or last else pony_query, count
+        def get_entries_query(cls, metadata_type=CHANNEL_TORRENT, subscribed=None, **kwargs):
+            # This method filters channels-related arguments and translates them into Pony query parameters
+            pony_query = super(ChannelMetadata, cls).get_entries_query(metadata_type=metadata_type, **kwargs)
+            pony_query = pony_query.where(subscribed=subscribed) if subscribed is not None else pony_query
+            return pony_query
 
         @property
         @db_session

--- a/Tribler/Core/Modules/MetadataStore/OrmBindings/torrent_metadata.py
+++ b/Tribler/Core/Modules/MetadataStore/OrmBindings/torrent_metadata.py
@@ -4,12 +4,12 @@ from binascii import hexlify, unhexlify
 from datetime import datetime
 from struct import unpack
 
-from six import text_type
-
 from ipv8.database import database_blob
 
 from pony import orm
 from pony.orm import db_session, desc, raw_sql, select
+
+from six import text_type
 
 from Tribler.Core.Category.Category import default_category_filter
 from Tribler.Core.Category.FamilyFilter import default_xxx_filter
@@ -227,6 +227,7 @@ def define_binding(db):
             epoch = datetime.utcfromtimestamp(0)
             simple_dict = {
                 "id": self.id_,
+                "public_key": hexlify(self.public_key),
                 "name": self.title,
                 "infohash": hexlify(self.infohash),
                 "size": self.size,

--- a/Tribler/Core/Modules/MetadataStore/OrmBindings/torrent_metadata.py
+++ b/Tribler/Core/Modules/MetadataStore/OrmBindings/torrent_metadata.py
@@ -4,6 +4,8 @@ from binascii import hexlify, unhexlify
 from datetime import datetime
 from struct import unpack
 
+from six import text_type
+
 from ipv8.database import database_blob
 
 from pony import orm
@@ -246,7 +248,7 @@ def define_binding(db):
             # WARNING! This does NOT check the INFOHASH
             a = self.to_dict()
             for comp in ["title", "size", "tags", "torrent_date", "tracker_info"]:
-                if (comp not in b) or (str(a[comp]) == str(b[comp])):
+                if (comp not in b) or (text_type(a[comp]) == text_type(b[comp])):
                     continue
                 return True
             return False

--- a/Tribler/Core/Modules/MetadataStore/OrmBindings/torrent_metadata.py
+++ b/Tribler/Core/Modules/MetadataStore/OrmBindings/torrent_metadata.py
@@ -224,7 +224,7 @@ def define_binding(db):
             """
             epoch = datetime.utcfromtimestamp(0)
             simple_dict = {
-                "id": self.rowid,
+                "id": self.id_,
                 "name": self.title,
                 "infohash": hexlify(self.infohash),
                 "size": self.size,

--- a/Tribler/Core/Modules/MetadataStore/OrmBindings/torrent_metadata.py
+++ b/Tribler/Core/Modules/MetadataStore/OrmBindings/torrent_metadata.py
@@ -174,7 +174,6 @@ def define_binding(db):
             pony_query = cls.search_keyword(query_filter, lim=1000) if query_filter else select(g for g in cls)
 
             # Sort the query
-            sort_expression = None
             if sort_by:
                 if sort_by == "HEALTH":
                     pony_query = pony_query.sort_by("(g.health.seeders, g.health.leechers)") if sort_asc else \
@@ -183,9 +182,6 @@ def define_binding(db):
                     sort_expression = "g." + sort_by
                     sort_expression = sort_expression if sort_asc else desc(sort_expression)
                     pony_query = pony_query.sort_by(sort_expression)
-            # Workaround to always show legacy entries last
-            pony_query = pony_query.order_by(lambda g: (desc(g.status != LEGACY_ENTRY), sort_expression)) \
-                if sort_expression else pony_query.order_by(lambda g: desc(g.status != LEGACY_ENTRY))
             return pony_query
 
 

--- a/Tribler/Core/Modules/MetadataStore/store.py
+++ b/Tribler/Core/Modules/MetadataStore/store.py
@@ -424,7 +424,7 @@ class MetadataStore(object):
                 result.append((node, GOT_NEWER_VERSION))
             # Otherwise, we got the same version locally and do nothing.
             # The situation when something was marked for deletion, and then we got here (i.e. we have the same
-            # version) should never happen, because this version should have removed the above mentioned thing earlier
+            # version) should never happen, because this version should have removed the above mentioned node earlier
             if result:
                 self._logger.warning("Broken DB state!")
             return result

--- a/Tribler/Core/Modules/gigachannel_manager.py
+++ b/Tribler/Core/Modules/gigachannel_manager.py
@@ -57,9 +57,16 @@ class GigaChannelManager(TaskManager):
                             tdef = TorrentDef.load(torrent_path)
                         except IOError:
                             self._logger.warning("Can't open personal channel torrent file. Will try to regenerate it.")
-                    tdef = tdef if (tdef and tdef.infohash == str(my_channel.infohash)) else\
-                        TorrentDef.load_from_dict(my_channel.consolidate_channel_torrent())
-                    self.updated_my_channel(tdef)
+                    if tdef and tdef.infohash == str(my_channel.infohash):
+                        tdef = tdef
+                    else:
+                        regenerated = my_channel.consolidate_channel_torrent()
+                        # If the user created their channel, but added no torrents to it, the channel torrent will not
+                        # be created.
+                        if regenerated:
+                            tdef = TorrentDef.load_from_dict(regenerated)
+                    if tdef:
+                        self.updated_my_channel(tdef)
         except Exception:
             self._logger.exception("Error when tried to resume personal channel seeding on GigaChannel Manager startup")
 

--- a/Tribler/Core/Modules/gigachannel_manager.py
+++ b/Tribler/Core/Modules/gigachannel_manager.py
@@ -108,8 +108,11 @@ class GigaChannelManager(TaskManager):
         except Exception:
             self._logger.exception("Error when checking for channel updates")
 
-        if not self.processing:
-            return self.process_queued_channels()
+        try:
+            if not self.processing:
+                return self.process_queued_channels()
+        except Exception:
+            self._logger.exception("Error when tried to start processing queued channel torrents changes")
 
     @inlineCallbacks
     def process_queued_channels(self):

--- a/Tribler/Core/Modules/gigachannel_manager.py
+++ b/Tribler/Core/Modules/gigachannel_manager.py
@@ -79,7 +79,7 @@ class GigaChannelManager(TaskManager):
         :return: list of tuples (download_to_remove=download, remove_files=Bool)
         """
         with db_session:
-            channels, _ = self.session.lm.mds.ChannelMetadata.get_entries(last=10000, subscribed=True)
+            channels = self.session.lm.mds.ChannelMetadata.get_entries(last=10000, subscribed=True)
             subscribed_infohashes = [bytes(c.infohash) for c in list(channels)]
             dirnames = [c.dir_name for c in channels]
 

--- a/Tribler/Core/Modules/gigachannel_manager.py
+++ b/Tribler/Core/Modules/gigachannel_manager.py
@@ -7,7 +7,7 @@ from ipv8.taskmanager import TaskManager
 
 from pony.orm import db_session
 
-from twisted.internet.defer import succeed
+from twisted.internet.defer import inlineCallbacks
 from twisted.internet.task import LoopingCall
 from twisted.internet.threads import deferToThread
 
@@ -15,6 +15,10 @@ from Tribler.Core.DownloadConfig import DownloadStartupConfig
 from Tribler.Core.Modules.MetadataStore.OrmBindings.channel_node import COMMITTED
 from Tribler.Core.TorrentDef import TorrentDef, TorrentDefNoMetainfo
 from Tribler.Core.simpledefs import DLSTATUS_SEEDING, NTFY_CHANNEL_ENTITY, NTFY_UPDATE
+
+
+PROCESS_CHANNEL_DIR = 1
+REMOVE_CHANNEL_DOWNLOAD = 2
 
 
 class GigaChannelManager(TaskManager):
@@ -30,7 +34,7 @@ class GigaChannelManager(TaskManager):
 
         # We queue up processing of the channels because we do it in a separate thread, and we don't want
         # to run more that one of these simultaneously
-        self.channels_processing_queue = []
+        self.channels_processing_queue = {}
         self.processing = False
 
     def start(self):
@@ -79,7 +83,8 @@ class GigaChannelManager(TaskManager):
         :return: list of tuples (download_to_remove=download, remove_files=Bool)
         """
         with db_session:
-            channels = self.session.lm.mds.ChannelMetadata.get_entries(last=10000, subscribed=True)
+            # FIXME: if someone is subscribed to more than 1000 channels, they are in trouble...
+            channels = self.session.lm.mds.ChannelMetadata.get_entries(last=1000, subscribed=True)
             subscribed_infohashes = [bytes(c.infohash) for c in list(channels)]
             dirnames = [c.dir_name for c in channels]
 
@@ -87,9 +92,13 @@ class GigaChannelManager(TaskManager):
         cruft_list = [(d, d.get_def().get_name_utf8() not in dirnames)
                       for d in self.session.lm.get_channel_downloads()
                       if bytes(d.get_def().infohash) not in subscribed_infohashes]
-        self.remove_channels_downloads(cruft_list)
+
+        for d, remove_content in cruft_list:
+            self.channels_processing_queue[d.get_def().infohash] = (REMOVE_CHANNEL_DOWNLOAD, (d, remove_content))
 
     def service_channels(self):
+        if self.processing:
+            return
         try:
             self.remove_cruft_channels()
         except Exception:
@@ -99,12 +108,19 @@ class GigaChannelManager(TaskManager):
         except Exception:
             self._logger.exception("Error when checking for channel updates")
 
+        if not self.processing:
+            return self.process_queued_channels()
+
+    @inlineCallbacks
     def process_queued_channels(self):
-        if self.processing or not self.channels_processing_queue:
-            return succeed(None)
-        self.processing = True
-        channel = self.channels_processing_queue.pop(0)
-        return self.process_channel_dir(channel, self.session.get_download(str(channel.infohash)))
+        while self.channels_processing_queue:
+            infohash, (action, data) = next(iter(self.channels_processing_queue.items()))
+            self.channels_processing_queue.pop(infohash)
+            self.processing = True
+            if action == PROCESS_CHANNEL_DIR:
+                yield self.process_channel_dir_threaded(data)  # data is a channel
+            elif action == REMOVE_CHANNEL_DOWNLOAD:
+                yield self.remove_channel_download(data)  # data is a tuple (download, remove_content bool)
 
     def check_channels_updates(self):
         """
@@ -126,11 +142,10 @@ class GigaChannelManager(TaskManager):
                     self._logger.info("Processing previously downloaded, but unprocessed channel torrent %s ver %i->%i",
                                       hexlify(str(channel.public_key)),
                                       channel.local_version, channel.timestamp)
-                    self.channels_processing_queue.append(channel)
+                    self.channels_processing_queue[channel.infohash] = (PROCESS_CHANNEL_DIR, channel)
             except Exception:
                 self._logger.exception("Error when tried to download a newer version of channel %s",
                                        hexlify(channel.public_key))
-        return self.process_queued_channels()
 
     # TODO: finish this routine
     # This thing should check if the files in the torrent we're going to delete are used in another torrent for
@@ -153,9 +168,9 @@ class GigaChannelManager(TaskManager):
         return files_to_remove
     """
 
-    def remove_channels_downloads(self, to_remove_list):
+    def remove_channel_download(self, to_remove):
         """
-        :param to_remove_list: list of tuples (download_to_remove=download, remove_files=Bool)
+        :param to_remove: a tuple (download_to_remove=download, remove_files=Bool)
         """
 
         # TODO: make file removal from older versions safe (i.e. check if it overlaps with newer downloads)
@@ -166,15 +181,18 @@ class GigaChannelManager(TaskManager):
             files_to_remove.extend(self.safe_files_to_remove(download))
         """
 
-        def _on_remove_failure(failure):
+        def _on_failure(failure):
             self._logger.error("Error when removing the channel download: %s", failure)
+            self.processing = False
 
-        for i, dl_tuple in enumerate(to_remove_list):
-            d, remove_content = dl_tuple
-            deferred = self.session.remove_download(d, remove_content=remove_content)
-            deferred.addErrback(_on_remove_failure)
-            self.register_task(u'remove_channel' + d.tdef.get_name_utf8() + u'-' + hexlify(d.tdef.get_infohash()) +
-                               u'-' + str(i), deferred)
+        def _on_success(_):
+            self.processing = False
+
+        d, remove_content = to_remove
+        deferred = self.session.remove_download(d, remove_content=remove_content)
+        deferred.addCallbacks(_on_success, _on_failure)
+        self.register_task(u'remove_channel' + d.tdef.get_name_utf8() + u'-' + hexlify(d.tdef.get_infohash()),
+                           deferred)
 
         """
         def _on_torrents_removed(torrent):
@@ -183,6 +201,8 @@ class GigaChannelManager(TaskManager):
         dl.addCallback(_on_torrents_removed)
         self.register_task(u'remove_channels_files-' + "_".join([d.tdef.get_name_utf8() for d in to_remove_list]), dl)
         """
+
+        return deferred
 
     def download_channel(self, channel):
         """
@@ -196,16 +216,16 @@ class GigaChannelManager(TaskManager):
         download = self.session.start_download_from_tdef(tdef, dcfg)
 
         def _add_channel_to_processing_queue(_):
-            self.channels_processing_queue.append(channel)
+            self.channels_processing_queue[channel.infohash] = (PROCESS_CHANNEL_DIR, channel)
 
         finished_deferred = download.finished_deferred.addCallback(_add_channel_to_processing_queue)
 
         return download, finished_deferred
 
-    def process_channel_dir(self, channel, download):
+    def process_channel_dir_threaded(self, channel):
 
-        def _process_download(dl):
-            channel_dirname = os.path.join(self.session.lm.mds.channels_dir, dl.get_def().get_name())
+        def _process_download():
+            channel_dirname = os.path.join(self.session.lm.mds.channels_dir, channel.dir_name)
             self.session.lm.mds.process_channel_dir(channel_dirname, channel.public_key, channel.id_,
                                                     external_thread=True)
             self.session.lm.mds._db.disconnect()
@@ -223,7 +243,7 @@ class GigaChannelManager(TaskManager):
                                          channel_upd_dict)
             self.processing = False
 
-        return deferToThread(_process_download, download).addCallbacks(_on_success, _on_failure)
+        return deferToThread(_process_download).addCallbacks(_on_success, _on_failure)
 
     def updated_my_channel(self, tdef):
         """

--- a/Tribler/Core/Modules/restapi/metadata_endpoint.py
+++ b/Tribler/Core/Modules/restapi/metadata_endpoint.py
@@ -143,8 +143,10 @@ class ChannelsPopularEndpoint(BaseChannelsEndpoint):
                 request.setResponseCode(http.BAD_REQUEST)
                 return json.twisted_dumps({"error": "the limit parameter must be a positive number"})
 
-        popular_channels = self.session.lm.mds.ChannelMetadata.get_random_channels(limit=limit_channels)
-        return json.twisted_dumps({"channels": [channel.to_simple_dict() for channel in popular_channels]})
+        with db_session:
+            popular_channels = self.session.lm.mds.ChannelMetadata.get_random_channels(limit=limit_channels)
+            results = [channel.to_simple_dict() for channel in popular_channels]
+        return json.twisted_dumps({"channels": results})
 
 
 class ChannelPublicKeyEndpoint(BaseChannelsEndpoint):

--- a/Tribler/Core/Modules/restapi/metadata_endpoint.py
+++ b/Tribler/Core/Modules/restapi/metadata_endpoint.py
@@ -48,9 +48,20 @@ class BaseMetadataEndpoint(resource.Resource):
                 parameters['sort_by'][0]),
             "sort_asc": True if 'sort_asc' not in parameters else bool(int(parameters['sort_asc'][0])),
             "query_filter": None if 'filter' not in parameters else cast_to_unicode_utf8(parameters['filter'][0]),
-            "hide_xxx": False if 'hide_xxx' not in parameters else bool(int(parameters['hide_xxx'][0]) > 0)}
+            "hide_xxx": False if 'hide_xxx' not in parameters else bool(int(parameters['hide_xxx'][0]) > 0),
+        }
 
         return sanitized
+
+    @classmethod
+    def get_total_count(cls, md_class, sanitized, search_uuid=None):
+        for p in ["first", "last", "sort_by", "sort_asc"]:
+            sanitized.pop(p, None)
+        total_count = md_class.get_entries_count(**sanitized)
+        result = {"total": total_count}
+        if search_uuid:
+            result.update({"uuid": search_uuid})
+        return json.twisted_dumps(result)
 
     @staticmethod
     def convert_sort_param_to_pony_col(sort_param):
@@ -92,15 +103,17 @@ class BaseChannelsEndpoint(BaseMetadataEndpoint):
 class ChannelsEndpoint(BaseChannelsEndpoint):
 
     def getChild(self, path, request):
-        if path == "popular":
+        if path == b"popular":
             return ChannelsPopularEndpoint(self.session)
-
+        if path == b"count":
+            return ChannelsCountEndpoint(self.session)
         return ChannelPublicKeyEndpoint(self.session, path)
 
     def render_GET(self, request):
-        sanitized = ChannelsEndpoint.sanitize_parameters(request.args)
+        sanitized = self.sanitize_parameters(request.args)
+
         with db_session:
-            channels, total = self.session.lm.mds.ChannelMetadata.get_entries(**sanitized)
+            channels = self.session.lm.mds.ChannelMetadata.get_entries(**sanitized)
             channels_list = [channel.to_simple_dict() for channel in channels]
 
         return json.twisted_dumps({
@@ -109,9 +122,14 @@ class ChannelsEndpoint(BaseChannelsEndpoint):
             "last": sanitized["last"],
             "sort_by": sanitized["sort_by"],
             "sort_asc": int(sanitized["sort_asc"]),
-            "total": total
         })
 
+
+class ChannelsCountEndpoint(BaseChannelsEndpoint):
+
+    def render_GET(self, request):
+        sanitized = self.sanitize_parameters(request.args)
+        return self.get_total_count(self.session.lm.mds.ChannelMetadata, sanitized)
 
 class ChannelsPopularEndpoint(BaseChannelsEndpoint):
 
@@ -190,12 +208,14 @@ class SpecificChannelTorrentsEndpoint(BaseMetadataEndpoint):
         self.channel_pk = channel_pk
         self.channel_id = channel_id
 
+        self.putChild(b"count", SpecificChannelTorrentsCountEndpoint(session, self.channel_pk, self.channel_id))
+
     def render_GET(self, request):
-        sanitized = SpecificChannelTorrentsEndpoint.sanitize_parameters(request.args)
+        sanitized = self.sanitize_parameters(request.args)
+        sanitized.update(dict(channel_pk=self.channel_pk, origin_id=self.channel_id))
+
         with db_session:
-            torrents, total = self.session.lm.mds.TorrentMetadata.get_entries(channel_pk=self.channel_pk,
-                                                                              origin_id=self.channel_id,
-                                                                              **sanitized)
+            torrents = self.session.lm.mds.TorrentMetadata.get_entries(**sanitized)
             torrents_list = [torrent.to_simple_dict() for torrent in torrents]
 
         return json.twisted_dumps({
@@ -204,8 +224,20 @@ class SpecificChannelTorrentsEndpoint(BaseMetadataEndpoint):
             "last": sanitized['last'],
             "sort_by": sanitized['sort_by'],
             "sort_asc": int(sanitized['sort_asc']),
-            "total": total
         })
+
+
+class SpecificChannelTorrentsCountEndpoint(SpecificChannelTorrentsEndpoint):
+
+    def __init__(self, session, channel_pk, channel_id):
+        BaseMetadataEndpoint.__init__(self, session)
+        self.channel_pk = channel_pk
+        self.channel_id = channel_id
+
+    def render_GET(self, request):
+        sanitized = self.sanitize_parameters(request.args)
+        sanitized.update(dict(channel_pk=self.channel_pk, origin_id=self.channel_id))
+        return self.get_total_count(self.session.lm.mds.TorrentMetadata, sanitized)
 
 
 class TorrentsEndpoint(BaseMetadataEndpoint):

--- a/Tribler/Core/Upgrade/db72_to_pony.py
+++ b/Tribler/Core/Upgrade/db72_to_pony.py
@@ -105,6 +105,7 @@ class DispersyToPonyMigration(object):
                                  "size": 0,
                                  "subscribed": False,
                                  "status": LEGACY_ENTRY,
+                                 "votes": -1,
                                  "num_entries": int(nr_torrents or 0)})
         connection.close()
         return channels

--- a/Tribler/Core/Upgrade/db72_to_pony.py
+++ b/Tribler/Core/Upgrade/db72_to_pony.py
@@ -284,6 +284,7 @@ class DispersyToPonyMigration(object):
     @inlineCallbacks
     def update_convert_total(self, amount, elapsed):
         if self.notifier_callback:
+            elapsed = 0.0001 if elapsed == 0.0 else elapsed
             self.notifier_callback("%i entries converted in %i seconds (%i e/s)" % (amount, int(elapsed),
                                                                                     int(amount / elapsed)))
             yield deferLater(reactor, 0.001, lambda: None)

--- a/Tribler/Test/Core/Modules/MetadataStore/test_channel_metadata.py
+++ b/Tribler/Test/Core/Modules/MetadataStore/test_channel_metadata.py
@@ -349,21 +349,20 @@ class TestChannelMetadata(TriblerCoreTest):
             _ = self.mds.ChannelMetadata(title='channel%d' % ind, subscribed=(ind % 2 == 0),
                                          infohash=str(random.getrandbits(160)))
         channels = self.mds.ChannelMetadata.get_entries(first=1, last=5)
-        self.assertEqual(len(channels[0]), 5)
-        self.assertEqual(channels[1], 10)
+        self.assertEqual(len(channels), 5)
 
         # Test filtering
         channels = self.mds.ChannelMetadata.get_entries(first=1, last=5, query_filter='channel5')
-        self.assertEqual(len(channels[0]), 1)
+        self.assertEqual(len(channels), 1)
 
         # Test sorting
         channels = self.mds.ChannelMetadata.get_entries(first=1, last=10, sort_by='title', sort_asc=False)
-        self.assertEqual(len(channels[0]), 10)
-        self.assertEqual(channels[0][0].title, 'channel9')
+        self.assertEqual(len(channels), 10)
+        self.assertEqual(channels[0].title, 'channel9')
 
         # Test fetching subscribed channels
         channels = self.mds.ChannelMetadata.get_entries(first=1, last=10, sort_by='title', subscribed=True)
-        self.assertEqual(len(channels[0]), 5)
+        self.assertEqual(len(channels), 5)
 
     @db_session
     def test_get_channel_name(self):

--- a/Tribler/Test/Core/Modules/MetadataStore/test_channel_metadata.py
+++ b/Tribler/Test/Core/Modules/MetadataStore/test_channel_metadata.py
@@ -4,6 +4,7 @@ import os
 import random
 from binascii import unhexlify
 from datetime import datetime
+from time import sleep
 
 from ipv8.database import database_blob
 from ipv8.keyvault.crypto import default_eccrypto
@@ -284,6 +285,7 @@ class TestChannelMetadata(TriblerCoreTest):
         channel = self.mds.ChannelMetadata.create_channel('test', 'test')
         self.mds.vote_bump(channel.public_key, channel.id_, peer_key.pub().key_to_bin()[10:])
         self.mds.vote_bump(channel.public_key, channel.id_, peer_key.pub().key_to_bin()[10:])
+        sleep(0.1)  # Necessary mostly on Windows, because of the lower timer resolution
         self.assertLess(0.0, channel.votes)
         self.assertLess(1.0, self.mds.Vsids[0].bump_amount)
 

--- a/Tribler/Test/Core/Modules/MetadataStore/test_torrent_metadata.py
+++ b/Tribler/Test/Core/Modules/MetadataStore/test_torrent_metadata.py
@@ -243,7 +243,7 @@ class TestTorrentMetadata(TriblerCoreTest):
     @db_session
     def test_get_entries(self):
         """
-        Test whether we can get torrents
+        Test base method for getting torrents
         """
 
         # First we create a few channels and add some torrents to these channels
@@ -258,22 +258,28 @@ class TestTorrentMetadata(TriblerCoreTest):
         tlist[-1].xxx = 1
         tlist[-2].status = TODELETE
 
-        torrents, count = self.mds.TorrentMetadata.get_entries(first=1, last=5)
+        torrents = self.mds.TorrentMetadata.get_entries(first=1, last=5)
         self.assertEqual(5, len(torrents))
+
+        count = self.mds.TorrentMetadata.get_entries_count()
         self.assertEqual(25, count)
 
         # Test fetching torrents in a channel
         channel_pk = self.mds.ChannelNode._my_key.pub().key_to_bin()[10:]
-        torrents, count = self.mds.TorrentMetadata.get_entries(first=1, last=10, sort_by='title',
-                                                               channel_pk=channel_pk, origin_id=0)
-        self.assertEqual(5, len(torrents))
-        self.assertEqual(5, count)
 
-        torrents, count = self.mds.TorrentMetadata.get_entries(
-            channel_pk=channel_pk, hide_xxx=True, exclude_deleted=True)[:]
-
+        args = dict(channel_pk=channel_pk, hide_xxx=True, exclude_deleted=True)
+        torrents = self.mds.TorrentMetadata.get_entries_query(**args)[:]
         self.assertListEqual(tlist[-5:-2], list(torrents))
+
+        count = self.mds.TorrentMetadata.get_entries_count(**args)
         self.assertEqual(count, 3)
+
+        args = dict(sort_by='title', channel_pk=channel_pk, origin_id=0)
+        torrents = self.mds.TorrentMetadata.get_entries(first=1, last=10, **args)
+        self.assertEqual(5, len(torrents))
+
+        count = self.mds.TorrentMetadata.get_entries_count(**args)
+        self.assertEqual(5, count)
 
     @db_session
     def test_metadata_conflicting(self):

--- a/Tribler/Test/Core/Modules/MetadataStore/test_torrent_metadata.py
+++ b/Tribler/Test/Core/Modules/MetadataStore/test_torrent_metadata.py
@@ -177,9 +177,9 @@ class TestTorrentMetadata(TriblerCoreTest):
         self.assertEqual(torrent.rowid, results[0].rowid)
 
     @db_session
-    def test_infohash_search(self):
+    def test_infohash_text_search(self):
         """
-        Test searching for torrents with infohash works.
+        Test searching for torrents with infohash through text filter works.
         """
         infohash = b"e84213a794f3ccd890382a54a64ca68b7e925433"
         torrent = self.mds.TorrentMetadata.from_dict(dict(rnd_torrent(), infohash=codecs.decode(infohash, 'hex'),
@@ -187,22 +187,21 @@ class TestTorrentMetadata(TriblerCoreTest):
 
         # Search with the hex encoded infohash
         query = '"%s"*' % infohash
-        results = self.mds.TorrentMetadata.search_keyword(query)[:]
-        self.assertEqual(torrent.rowid, results[0].rowid)
+        results = self.mds.TorrentMetadata.get_entries(query_filter=query)[:]
+        self.assertEqual(torrent, results[0])
 
     @db_session
-    def test_channel_public_key_search(self):
+    def test_channel_public_key_text_search(self):
         """
-        Test searching for channels with public key works.
+        Test searching for channels with public key through text filter works.
         """
         self.mds.ChannelNode._my_key = default_eccrypto.generate_key('curve25519')
         channel = self.mds.ChannelMetadata(title='My channel', infohash=str(random.getrandbits(160)))
 
         # Search with the hex encoded channel public key
         query = '"%s"*' % codecs.encode(channel.public_key, 'hex')
-        results = self.mds.TorrentMetadata.search_keyword(query)[:]
-        self.assertIsNotNone(results)
-        self.assertTrue(channel.rowid, results[0].rowid)
+        results = self.mds.ChannelMetadata.get_entries(query_filter=query)[:]
+        self.assertEqual(results[0], channel)
 
     @db_session
     def test_get_autocomplete_terms(self):

--- a/Tribler/Test/Core/Modules/RestApi/test_metadata_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_metadata_endpoint.py
@@ -99,6 +99,17 @@ class TestChannelsEndpoint(BaseTestMetadataEndpoint):
         return self.do_request('metadata/channels?subscribed=1', expected_code=200).addCallback(on_response)
 
 
+class TestChannelsCountEndpoint(BaseTestMetadataEndpoint):
+
+    @inlineCallbacks
+    def test_get_channels_count(self):
+        # Test getting total count of results
+        self.should_check_equality = False
+        result = yield self.do_request('metadata/channels/count?subscribed=1', expected_code=200)
+        json_dict = json.twisted_loads(result)
+        self.assertEqual(json_dict['total'], 5)
+
+
 class TestSpecificChannelEndpoint(BaseTestMetadataEndpoint):
 
     def test_subscribe_missing_parameter(self):
@@ -171,6 +182,18 @@ class TestSpecificChannelTorrentsEndpoint(BaseTestMetadataEndpoint):
         channel_pk = hexlify(self.session.lm.mds.ChannelNode._my_key.pub().key_to_bin()[10:])
         return self.do_request('metadata/channels/%s/0/torrents' % channel_pk, expected_code=200).addCallback(
             on_response)
+
+
+class TestSpecificChannelTorrentsCountEndpoint(BaseTestMetadataEndpoint):
+    @inlineCallbacks
+    def test_get_torrents_count(self):
+        # Test getting total count of results
+        self.should_check_equality = False
+        channel_pk = hexlify(self.session.lm.mds.ChannelNode._my_key.pub().key_to_bin()[10:])
+        result = yield self.do_request('metadata/channels/%s/0/torrents/count' % channel_pk,
+                                       expected_code=200)
+        json_dict = json.twisted_loads(result)
+        self.assertEqual(json_dict['total'], 5)
 
 
 class TestPopularChannelsEndpoint(BaseTestMetadataEndpoint):

--- a/Tribler/Test/Core/Modules/RestApi/test_mychannel_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_mychannel_endpoint.py
@@ -167,18 +167,23 @@ class TestMyChannelTorrentsEndpoint(BaseTestMyChannelEndpoint):
         return self.do_request('mychannel/torrents', expected_code=404)
 
     @trial_timeout(10)
+    @inlineCallbacks
     def test_get_my_torrents(self):
         """
         Test whether we can query torrents from your channel
         """
-        def on_response(response):
-            json_response = json.twisted_loads(response)
-            self.assertEqual(len(json_response['results']), 9)
-            self.assertIn('status', json_response['results'][0])
 
         self.create_my_channel()
         self.should_check_equality = False
-        return self.do_request('mychannel/torrents', expected_code=200).addCallback(on_response)
+        result = yield self.do_request('mychannel/torrents', expected_code=200)
+        parsed = json.twisted_loads(result)
+        self.assertEqual(len(parsed['results']), 9)
+        self.assertIn('status', parsed['results'][0])
+
+        # Test getting total count of results
+        result = yield self.do_request('mychannel/torrents/count', expected_code=200)
+        parsed = json.twisted_loads(result)
+        self.assertEqual(parsed["total"], 9)
 
     @trial_timeout(10)
     def test_delete_all_torrents_no_channel(self):

--- a/Tribler/Test/Core/Modules/RestApi/test_search_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_search_endpoint.py
@@ -75,6 +75,16 @@ class TestSearchEndpoint(AbstractApiTest):
         parsed = json.twisted_loads(result)
         self.assertEqual(len(parsed["results"]), 1)
 
+        # Test getting total count of results
+        result = yield self.do_request('search/count?filter=needle', expected_code=200)
+        parsed = json.twisted_loads(result)
+        self.assertEqual(parsed["total"], 1)
+
+        # Test getting total count of results
+        result = yield self.do_request('search/count?filter=hay', expected_code=200)
+        parsed = json.twisted_loads(result)
+        self.assertEqual(parsed["total"], 100)
+
         # If uuid is passed in request, then the same uuid is returned in the response
         result = yield self.do_request('search?uuid=uuid1&filter=needle&sort_by=name', expected_code=200)
         parsed = json.twisted_loads(result)

--- a/Tribler/Test/Core/Upgrade/test_db72_to_pony.py
+++ b/Tribler/Test/Core/Upgrade/test_db72_to_pony.py
@@ -74,8 +74,8 @@ class TestUpgradeDB72ToPony(TriblerCoreTest):
             self.m.convert_discovered_channels()
             chans = self.mds.ChannelMetadata.get_entries()
 
-            self.assertEqual(len(chans[0]), 2)
-            for c in chans[0]:
+            self.assertEqual(len(chans), 2)
+            for c in chans:
                 self.assertNotEqual(self.m.personal_channel_title[:200], c.title[:200])
                 self.assertEqual(c.status, LEGACY_ENTRY)
                 self.assertTrue(c.contents_list)

--- a/Tribler/Test/GUI/test_gui.py
+++ b/Tribler/Test/GUI/test_gui.py
@@ -171,6 +171,13 @@ class AbstractTriblerGUITest(TestCase):
 
         raise TimeoutException("Did not receive settings within 10 seconds")
 
+    def wait_for_something(self, something, timeout=10):
+        for _ in range(0, timeout * 1000, 100):
+            QTest.qWait(100)
+            if something is not None:
+                return
+        raise TimeoutException("The value was not set within 10 seconds")
+
     def get_attr_recursive(self, attr_name):
         parts = attr_name.split(".")
         cur_attr = window
@@ -356,7 +363,8 @@ class TriblerGUITest(AbstractTriblerGUITest):
         window.edit_channel_torrents_container.content_table.sortByColumn(2, 1)  # Size
         self.wait_for_list_populated(window.edit_channel_torrents_container.content_table)
         self.screenshot(window, name="edit_channel_torrents_sorted")
-        max_items = min(window.discovered_channels_list.model().total_items, 50)
+        self.wait_for_something(window.edit_channel_torrents_container.content_table.model().total_items)
+        max_items = min(window.edit_channel_torrents_container.content_table.model().total_items, 50)
         self.assertLessEqual(window.discovered_channels_list.verticalHeader().count(), max_items)
 
         # Filter
@@ -436,6 +444,7 @@ class TriblerGUITest(AbstractTriblerGUITest):
         QTest.keyClick(window.top_search_bar, Qt.Key_Enter)
         self.wait_for_list_populated(window.search_results_list)
         self.screenshot(window, name="search_results_all")
+        self.wait_for_something(window.search_results_list.model().total_items)
 
         QTest.mouseClick(window.search_results_channels_button, Qt.LeftButton)
         self.wait_for_list_populated(window.search_results_list)

--- a/Tribler/community/gigachannel/community.py
+++ b/Tribler/community/gigachannel/community.py
@@ -195,8 +195,8 @@ class GigaChannelCommunity(Community):
 
         result_blob = None
         with db_session:
-            db_results, total = self.metadata_store.TorrentMetadata.get_entries(**request_dict)
-            if total > 0:
+            db_results = self.metadata_store.TorrentMetadata.get_entries(**request_dict)
+            if db_results:
                 result_blob = entries_to_chunk(db_results[:max_entries], maximum_payload_size)[0]
         if result_blob:
             self.endpoint.send(peer.address, self.ezr_pack(self.SEARCH_RESPONSE,

--- a/TriblerGUI/tribler_window.py
+++ b/TriblerGUI/tribler_window.py
@@ -254,8 +254,7 @@ class TriblerWindow(QMainWindow):
         self.core_manager.events_manager.credit_mining_signal.connect(self.on_credit_mining_error)
         self.core_manager.events_manager.tribler_shutdown_signal.connect(self.on_tribler_shutdown_state_update)
 
-        self.core_manager.events_manager.received_search_result.connect(
-            self.search_results_page.received_search_result)
+        self.core_manager.events_manager.received_search_result.connect(self.search_results_page.received_search_result)
 
         # Install signal handler for ctrl+c events
         def sigint_handler(*_):

--- a/TriblerGUI/widgets/channelpage.py
+++ b/TriblerGUI/widgets/channelpage.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QIcon
 from PyQt5.QtWidgets import QWidget
 
@@ -40,7 +41,7 @@ class ChannelPage(QWidget):
 
         # To reload the preview
         self.window().channel_preview_button.clicked.connect(self.preview_clicked)
-        self.controller.query_complete.connect(self._on_query_complete)
+        self.controller.count_query_complete.connect(self._on_query_complete)
 
     def on_node_info_update(self, update_dict):
         if "public_key" in update_dict and "id" in update_dict and self.channel_info and \
@@ -53,6 +54,8 @@ class ChannelPage(QWidget):
         self.initialize_with_channel(self.channel_info)
 
     def initialize_with_channel(self, channel_info):
+        # Turn off sorting by default to speed up SQL queries
+        self.window().channel_page_container.content_table.horizontalHeader().setSortIndicator(-1, Qt.AscendingOrder)
         self.channel_info = channel_info
         self.model.channel_pk = channel_info['public_key']
         self.model.channel_id = channel_info['id']
@@ -76,10 +79,9 @@ class ChannelPage(QWidget):
         self.window().channel_state_label.setText(self.channel_info["state"])
         self.window().subscription_widget.initialize_with_channel(self.channel_info)
 
-    def _on_query_complete(self, data, remote):
-        if not remote:
-            self.window().channel_num_torrents_label.setText("{}/{} torrents".format(data['total'],
-                                                                                     self.channel_info['torrents']))
+    def _on_query_complete(self, data):
+        self.window().channel_num_torrents_label.setText(
+            "{}/{} torrents".format(data['total'], self.channel_info['torrents']))
 
     def load_torrents(self):
         self.controller.model.reset()

--- a/TriblerGUI/widgets/downloadwidgetitem.py
+++ b/TriblerGUI/widgets/downloadwidgetitem.py
@@ -4,9 +4,7 @@ import logging
 from datetime import datetime
 
 from PyQt5.QtGui import QFont
-from PyQt5.QtWidgets import QProgressBar, QTreeWidgetItem
-from PyQt5.QtWidgets import QVBoxLayout
-from PyQt5.QtWidgets import QWidget
+from PyQt5.QtWidgets import QProgressBar, QTreeWidgetItem, QVBoxLayout, QWidget
 
 from TriblerGUI.defs import *
 from TriblerGUI.utilities import duration_to_string, format_size, format_speed

--- a/TriblerGUI/widgets/editchannelpage.py
+++ b/TriblerGUI/widgets/editchannelpage.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import os
 from base64 import b64encode
 
-from PyQt5.QtCore import QDir, QTimer, pyqtSignal
+from PyQt5.QtCore import QDir, QTimer, Qt, pyqtSignal
 from PyQt5.QtWidgets import QAction, QFileDialog, QWidget
 
 from TriblerGUI.defs import BUTTON_TYPE_CONFIRM, BUTTON_TYPE_NORMAL, PAGE_EDIT_CHANNEL_OVERVIEW, \
@@ -259,6 +259,9 @@ class EditChannelPage(QWidget):
         channel_options_menu.exec_(self.mapToGlobal(options_btn_pos))
 
     def load_my_torrents(self):
+        # Turn off sorting by default to speed up SQL queries
+        self.window().edit_channel_torrents_container.content_table.horizontalHeader().setSortIndicator(
+            -1, Qt.AscendingOrder)
         self.controller.model.reset()
         self.controller.perform_query(first=1, last=50)  # Load the first 50 torrents
 

--- a/TriblerGUI/widgets/searchresultspage.py
+++ b/TriblerGUI/widgets/searchresultspage.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QWidget
 
 from TriblerGUI.utilities import get_gui_setting
@@ -44,6 +45,9 @@ class SearchResultsPage(QWidget):
 
         trimmed_query = query if len(query) < 50 else "%s..." % query[:50]
         self.window().search_results_header_label.setText("Search results for: %s" % trimmed_query)
+
+        # Turn off sorting by default to speed up SQL queries
+        self.window().search_results_list.horizontalHeader().setSortIndicator(-1, Qt.AscendingOrder)
 
         self.controller.query_text = query
         self.controller.perform_query(first=1, last=50)

--- a/TriblerGUI/widgets/tablecontentmodel.py
+++ b/TriblerGUI/widgets/tablecontentmodel.py
@@ -23,7 +23,7 @@ class RemoteTableModel(QAbstractTableModel):
         super(RemoteTableModel, self).__init__(parent)
         self.data_items = []
         self.item_load_batch = 50
-        self.total_items = 0  # The total number of items without pagination
+        self.total_items = None  # The total number of items without pagination
 
         # Unique identifier mapping for items. For torrents, it is infohash and for channels, it is concatenated value
         # of public key and channel id
@@ -37,7 +37,7 @@ class RemoteTableModel(QAbstractTableModel):
         self.beginResetModel()
         self.data_items = []
         self.item_uid_map = {}
-        self.total_items = 0
+        self.total_items = None
         self.endResetModel()
 
     def sort(self, column, order):
@@ -114,7 +114,7 @@ class TriblerContentModel(RemoteTableModel):
         u'votes': lambda data: "{0:.0%}".format(float(data)) if data else None,
     }
 
-    def __init__(self, hide_xxx=False):
+    def __init__(self, hide_xxx=None):
         RemoteTableModel.__init__(self, parent=None)
         self.data_items = []
         self.column_position = {name: i for i, name in enumerate(self.columns)}
@@ -209,7 +209,6 @@ class SearchResultsContentModel(VotesAlignmentMixin, TriblerContentModel):
         u'updated': lambda timestamp: pretty_date(timestamp) if timestamp > BITTORRENT_BIRTHDAY else 'N/A'
     }
 
-
     def __init__(self, **kwargs):
         TriblerContentModel.__init__(self, **kwargs)
         self.type_filter = ''
@@ -237,7 +236,7 @@ class ChannelsContentModel(VotesAlignmentMixin, TriblerContentModel):
         u'state': lambda data: str(data)[:1] if data == u'Downloading' else ""
     }
 
-    def __init__(self, subscribed=False, **kwargs):
+    def __init__(self, subscribed=None, **kwargs):
         TriblerContentModel.__init__(self, **kwargs)
         self.subscribed = subscribed
 


### PR DESCRIPTION
Fixes #4592  by removing and minimizing some SQL queries and REST requests.
Fixes #4593 (fixes slowdown).
Fixes #4610 
Fixes #4620 
Fixes #4613 
Fixes #4598 

This PR now also refactors GigaChannel Manager to use a dict-base queue for channel torrent related actions such as cruft channel torrents dir removal and processing already downloaded dirs. This should make it much safer, as this things are now never done simultaneously.