### PR TITLE
Fixed torrent checker events not propagating

### DIFF
--- a/Tribler/Core/TorrentChecker/torrent_checker.py
+++ b/Tribler/Core/TorrentChecker/torrent_checker.py
@@ -221,6 +221,11 @@ class TorrentChecker(TaskManager):
         final_response = {}
         if not result or not isinstance(result, list):
             self._logger.info("Received invalid torrent checker result")
+            self.tribler_session.notifier.notify(NTFY_TORRENT, NTFY_UPDATE, infohash,
+                                                 {"num_seeders": 0,
+                                                  "num_leechers": 0,
+                                                  "last_tracker_check": int(time.time()),
+                                                  "health": "updated"})
             return final_response
 
         torrent_update_dict = {'infohash': infohash, 'seeders': 0, 'leechers': 0, 'last_check': int(time.time())}
@@ -305,7 +310,6 @@ class TorrentChecker(TaskManager):
         And trap CancelledErrors that can be thrown when shutting down.
         :param failure: The failure object raised by Twisted.
         """
-        failure.trap(ValueError, CancelledError, ConnectingCancelledError, ConnectionLost, RuntimeError)
         self._logger.warning(u"Got session error for URL %s: %s", session.tracker_url,
                              str(failure).replace(u'\n]', u']'))
 

--- a/TriblerGUI/widgets/tablecontentmodel.py
+++ b/TriblerGUI/widgets/tablecontentmodel.py
@@ -167,7 +167,7 @@ class TriblerContentModel(RemoteTableModel):
     def update_node_info(self, update_dict):
         row = self.item_uid_map.get(update_dict["infohash"] if "infohash" in update_dict
                                     else combine_pk_id(update_dict["public_key"], update_dict["id"]))
-        if row:
+        if row is not None:
             self.data_items[row].update(**update_dict)
             self.dataChanged.emit(self.index(row, 0), self.index(row, len(self.columns)), [])
 


### PR DESCRIPTION
Fixes:

 - Not sending a response on torrent checking failure.
 - Not updating row 0.