### PR TITLE
READY: Check timestamp of entry against the channel ver

### DIFF
--- a/Tribler/Core/Modules/MetadataStore/OrmBindings/channel_node.py
+++ b/Tribler/Core/Modules/MetadataStore/OrmBindings/channel_node.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import random
 from binascii import hexlify
 from datetime import datetime
 
@@ -104,11 +105,11 @@ def define_binding(db, logger=None, key=None, clock=None):
             # For putting legacy/test stuff in
             skip_key_check = kwargs.pop("skip_key_check", skip_key_check)
 
-            if "id_" not in kwargs:
-                kwargs["id_"] = self._clock.tick()
-
             if "timestamp" not in kwargs:
-                kwargs["timestamp"] = kwargs["id_"]
+                kwargs["timestamp"] = self._clock.tick()
+
+            if "id_" not in kwargs:
+                kwargs["id_"] = int(random.getrandbits(63))
 
             if not private_key_override and not skip_key_check:
                 # No key/signature given, sign with our own key.

--- a/Tribler/Core/Modules/MetadataStore/OrmBindings/torrent_metadata.py
+++ b/Tribler/Core/Modules/MetadataStore/OrmBindings/torrent_metadata.py
@@ -277,7 +277,7 @@ def define_binding(db):
 
         @classmethod
         @db_session
-        def copy_to_channel(cls, infohash, public_key=None):
+        def copy_to_channel(cls, infohash, channel_id, public_key=None):
             """
             Create a new signed copy of the given torrent metadata
             :param infohash:
@@ -298,7 +298,8 @@ def define_binding(db):
                 "size": existing.size,
                 "torrent_date": existing.torrent_date,
                 "tracker_info": existing.tracker_info,
-                "status": NEW
+                "status": NEW,
+                "origin_id": channel_id
             }
             return db.TorrentMetadata.from_dict(new_entry_dict)
 

--- a/Tribler/Core/Modules/MetadataStore/store.py
+++ b/Tribler/Core/Modules/MetadataStore/store.py
@@ -394,13 +394,12 @@ class MetadataStore(object):
             return [(None, NO_ACTION)]
 
         # Check if we already have this payload
-        node = self.ChannelNode.get_for_update(signature=payload.signature, public_key=payload.public_key)
+        node = self.ChannelNode.get(signature=payload.signature, public_key=payload.public_key)
         if node:
             return [(node, NO_ACTION)]
 
         # Signed entry > FFA entry. Old FFA entry > new FFA entry
-        ffa_node = self.TorrentMetadata.get_for_update(public_key=database_blob(""),
-                                                       infohash=database_blob(payload.infohash))
+        ffa_node = self.TorrentMetadata.get(public_key=database_blob(""), infohash=database_blob(payload.infohash))
         if ffa_node:
             ffa_node.delete()
 

--- a/Tribler/Core/Modules/MetadataStore/store.py
+++ b/Tribler/Core/Modules/MetadataStore/store.py
@@ -122,7 +122,6 @@ class MetadataStore(object):
         # !!! ACHTUNG !!! This should be used only for special cases (e.g. DB upgrades), because
         # losing power during a write will corrupt the database.
         if disable_sync:
-
             # This attribute is internally called by Pony on startup, though pylint cannot detect it
             # with the static analysis.
             # pylint: disable=unused-variable
@@ -202,7 +201,7 @@ class MetadataStore(object):
         self._shutting_down = True
         self._db.disconnect()
 
-    def process_channel_dir(self, dirname, public_key, id_, skip_personal_metadata_payload=True, external_thread=True):
+    def process_channel_dir(self, dirname, public_key, id_, skip_personal_metadata_payload=True, external_thread=False):
         """
         Load all metadata blobs in a given directory.
         :param dirname: The directory containing the metadata blobs.
@@ -266,7 +265,7 @@ class MetadataStore(object):
             if not channel:
                 return
             self._logger.debug("Finished processing channel dir %s. Channel %s local/max version %i/%i",
-                           dirname, hexlify(str(channel.public_key)), channel.local_version,
+                               dirname, hexlify(str(channel.public_key)), channel.local_version,
                                channel.timestamp)
 
     def process_mdblob_file(self, filepath, skip_personal_metadata_payload=True, external_thread=False):
@@ -325,16 +324,9 @@ class MetadataStore(object):
 
             # We separate the sessions to minimize database locking.
             with db_session:
-                my_channel = self.ChannelMetadata.get_my_channel()
                 for payload in batch:
-                    # If we received our metadata payload of torrent we have in our channel, we simply ignore it since
-                    # We always have the latest version ourselves.  This prevents from adding already deleted torrents
-                    # again in My channel.
-                    if skip_personal_metadata_payload and my_channel \
-                            and payload.public_key == str(my_channel.public_key) \
-                            and payload.metadata_type == REGULAR_TORRENT:
-                        continue
-                    result.extend(self.process_payload(payload))
+                    result.extend(self.process_payload(payload,
+                                                       skip_personal_metadata_payload=skip_personal_metadata_payload))
             if external_thread:
                 sleep(self.sleep_on_external_thread)
 
@@ -357,13 +349,15 @@ class MetadataStore(object):
         return result
 
     @db_session
-    def process_payload(self, payload):
+    def process_payload(self, payload, skip_personal_metadata_payload=True):
         """
         This routine decides what to do with a given payload and executes the necessary actions.
         To do so, it looks into the database, compares version numbers, etc.
         It returns a list of tuples each of which contain the corresponding new/old object and the actions
         that were performed on that object.
         :param payload: payload to work on
+        :param skip_personal_metadata_payload: if this is set to True, personal torrent metadata payload received
+                through gossip will be ignored. The default value is True.
         :return: a list of tuples of (<metadata or payload>, <action type>)
         """
 
@@ -385,14 +379,10 @@ class MetadataStore(object):
         # update conditions:
         # A: (pk, id1, ih1)
         # B: (pk, id2, ih2)
-        # Now, when we receive the payload C1:(pk, id1, ih2) or C2:(pk, id2, ih1), we have to
+        # When we receive the payload C1:(pk, id1, ih2) or C2:(pk, id2, ih1), we have to
         # replace _both_ entries with a single one, to honor the DB uniqueness constraints.
 
         if payload.metadata_type not in [CHANNEL_TORRENT, REGULAR_TORRENT]:
-            return []
-
-        # Check the payload timestamp<->id_ correctness
-        if payload.timestamp < payload.id_:
             return []
 
         # FFA payloads get special treatment:
@@ -414,8 +404,27 @@ class MetadataStore(object):
         if ffa_node:
             ffa_node.delete()
 
-        # Check for a node with the same infohash
+        def check_update_opportunity():
+            # Check for possible update sending opportunity.
+            node = self.TorrentMetadata.get(lambda g: g.public_key == database_blob(payload.public_key) and \
+                                                      g.id_ == payload.id_ and \
+                                                      g.timestamp > payload.timestamp)
+            return [(node, GOT_NEWER_VERSION)] if node else [(None, NO_ACTION)]
+
+        # Check if the received payload is a deleted entry from a channel that we already have
+        parent_channel = self.ChannelMetadata.get(public_key=database_blob(payload.public_key),
+                                                  id_=payload.origin_id)
+        if parent_channel and parent_channel.local_version > payload.timestamp:
+            return check_update_opportunity()
+
+        # If we received a metadata payload signed by ourselves we simply ignore it since we are the only authoritative
+        # source of information about our own channel.
+        if skip_personal_metadata_payload and \
+                payload.public_key == str(database_blob(self.my_key.pub().key_to_bin()[10:])):
+            return check_update_opportunity()
+
         result = []
+        # Check for a node with the same infohash
         node = self.TorrentMetadata.get_for_update(public_key=database_blob(payload.public_key),
                                                    infohash=database_blob(payload.infohash))
         if node:

--- a/Tribler/Core/Modules/gigachannel_manager.py
+++ b/Tribler/Core/Modules/gigachannel_manager.py
@@ -57,9 +57,7 @@ class GigaChannelManager(TaskManager):
                             tdef = TorrentDef.load(torrent_path)
                         except IOError:
                             self._logger.warning("Can't open personal channel torrent file. Will try to regenerate it.")
-                    if tdef and tdef.infohash == str(my_channel.infohash):
-                        tdef = tdef
-                    else:
+                    if not(tdef and tdef.infohash == str(my_channel.infohash)):
                         regenerated = my_channel.consolidate_channel_torrent()
                         # If the user created their channel, but added no torrents to it, the channel torrent will not
                         # be created.

--- a/Tribler/Test/Core/CreditMining/test_credit_mining_sources.py
+++ b/Tribler/Test/Core/CreditMining/test_credit_mining_sources.py
@@ -31,7 +31,8 @@ class TestCreditMiningSources(TestAsServer):
 
         with db_session:
             my_channel = self.session.lm.mds.ChannelMetadata.create_channel('test', 'test')
-            _ = self.session.lm.mds.TorrentMetadata(title='testtorrent', infohash=str(random.getrandbits(160)))
+            self.session.lm.mds.TorrentMetadata(origin_id=my_channel.id_, title='testtorrent',
+                                                infohash=str(random.getrandbits(160)))
 
         source = ChannelSource(self.session, str(my_channel.public_key), lambda *_: test_deferred.callback(None))
         source.start()

--- a/Tribler/Test/Core/Modules/test_gigachannel_manager.py
+++ b/Tribler/Test/Core/Modules/test_gigachannel_manager.py
@@ -149,10 +149,11 @@ class TestGigaChannelManager(TriblerCoreTest):
             my_chan = self.generate_personal_channel()
             my_chan.commit_channel_torrent()
             my_chan_old_infohash = my_chan.infohash
-            _ = self.mock_session.lm.mds.TorrentMetadata.from_dict(dict(self.torrent_template, status=NEW))
+            _ = self.mock_session.lm.mds.TorrentMetadata.from_dict(dict(self.torrent_template, origin_id=my_chan.id_,
+                                                                        status=NEW))
             my_chan.commit_channel_torrent()
 
-            # Now we add external channel we are subscribed to.
+            # Now we add an external channel we are subscribed to.
             chan2 = self.mock_session.lm.mds.ChannelMetadata(title="bla1", infohash=database_blob(str(123)),
                                                              public_key=database_blob(str(123)),
                                                              signature=database_blob(str(345)), skip_key_check=True,
@@ -181,7 +182,7 @@ class TestGigaChannelManager(TriblerCoreTest):
 
         # Double conversion is required to make sure that buffers signatures are not the same
         mock_dl_list = [
-            # Downloads for our personal channel
+            # Downloads for the personal channel
             MockDownload(database_blob(bytes(my_chan_old_infohash)), my_chan.dir_name),
             MockDownload(database_blob(bytes(my_chan.infohash)), my_chan.dir_name),
 

--- a/Tribler/Test/Core/Upgrade/test_db72_to_pony.py
+++ b/Tribler/Test/Core/Upgrade/test_db72_to_pony.py
@@ -53,6 +53,7 @@ class TestUpgradeDB72ToPony(TriblerCoreTest):
         def check_channel():
             self.m.convert_personal_channel()
             my_channel = self.mds.ChannelMetadata.get_my_channel()
+
             self.assertEqual(len(my_channel.contents_list), 2)
             self.assertEqual(my_channel.num_entries, 2)
             for t in my_channel.contents_list:


### PR DESCRIPTION
Timestamps of incoming GigaChannel payloads are now checked against the parent channel's `local_version`. This allows us to stop getting old deleted results from previous channel versions.
Also, fixed a severe bug in channel commit procedure. When committing the personal channel, mdblob files should only contain entries with timestamps <= to the mdblob filename, but the last mdblob must have the same timestamp as the channel entry itself. Before, this was only true if the channel entry was never edited (e.g. renamed) before commit.

Now we assign filenames based on the timestamp of the last entry in the mdblob, except for the last file. For this, we create a new timestamp and then assign it to _both_ the filename and the updated channel entry.

Fixes #4639 properly.