### PR TITLE
READY: Remove redundant dirty channel queries

### DIFF
--- a/Tribler/Core/Modules/MetadataStore/OrmBindings/channel_metadata.py
+++ b/Tribler/Core/Modules/MetadataStore/OrmBindings/channel_metadata.py
@@ -91,13 +91,13 @@ def define_binding(db):
         _discriminator_ = CHANNEL_TORRENT
 
         # Serializable
-        num_entries = orm.Optional(int, size=64, default=0)
+        num_entries = orm.Optional(int, size=64, default=0, index=True)
         start_timestamp = orm.Optional(int, size=64, default=0)
 
         # Local
-        subscribed = orm.Optional(bool, default=False)
-        share = orm.Optional(bool, default=False)
-        votes = orm.Optional(float, default=0.0)
+        subscribed = orm.Optional(bool, default=False, index=True)
+        share = orm.Optional(bool, default=False, index=True)
+        votes = orm.Optional(float, default=0.0, index=True)
         individual_votes = orm.Set("ChannelVote", reverse="channel")
         local_version = orm.Optional(int, size=64, default=0)
 

--- a/Tribler/Core/Modules/MetadataStore/OrmBindings/channel_node.py
+++ b/Tribler/Core/Modules/MetadataStore/OrmBindings/channel_node.py
@@ -48,9 +48,9 @@ def define_binding(db, logger=None, key=None, clock=None):
         # Serializable
         metadata_type = orm.Discriminator(int, size=16)
         reserved_flags = orm.Optional(int, size=16, default=0)
-        origin_id = orm.Optional(int, size=64, default=0)
+        origin_id = orm.Optional(int, size=64, default=0, index=True)
 
-        public_key = orm.Required(database_blob)
+        public_key = orm.Required(database_blob, index=True)
         id_ = orm.Required(int, size=64)
         orm.composite_key(public_key, id_)
 
@@ -62,7 +62,7 @@ def define_binding(db, logger=None, key=None, clock=None):
 
         # Local
         added_on = orm.Optional(datetime, default=datetime.utcnow)
-        status = orm.Optional(int, default=COMMITTED)
+        status = orm.Optional(int, default=COMMITTED, index=True)
 
         # Special properties
         _payload_class = ChannelNodePayload

--- a/Tribler/Core/Modules/MetadataStore/store.py
+++ b/Tribler/Core/Modules/MetadataStore/store.py
@@ -60,10 +60,6 @@ sql_add_fts_trigger_update = """
         INSERT INTO FtsIndex(rowid, title) VALUES (new.rowid, new.title);
     END;"""
 
-sql_add_signature_index = "CREATE INDEX SignatureIndex ON ChannelNode(signature);"
-sql_add_public_key_index = "CREATE INDEX PublicKeyIndex ON ChannelNode(public_key);"
-sql_add_infohash_index = "CREATE INDEX InfohashIndex ON ChannelNode(infohash);"
-
 
 class BadChunkException(Exception):
     pass
@@ -158,9 +154,6 @@ class MetadataStore(object):
                 self._db.execute(sql_add_fts_trigger_insert)
                 self._db.execute(sql_add_fts_trigger_delete)
                 self._db.execute(sql_add_fts_trigger_update)
-                self._db.execute(sql_add_signature_index)
-                self._db.execute(sql_add_public_key_index)
-                self._db.execute(sql_add_infohash_index)
 
         if create_db:
             with db_session:

--- a/TriblerGUI/widgets/editchannelpage.py
+++ b/TriblerGUI/widgets/editchannelpage.py
@@ -334,6 +334,8 @@ class EditChannelPage(QWidget):
         if 'success' in json_result and json_result['success']:
             self.on_all_torrents_removed.emit()
             self.load_my_torrents()
+            self.channel_dirty = True
+            self.update_channel_commit_views()
 
     # Torrent addition-related methods
     def on_add_torrents_browse_dir(self):
@@ -392,8 +394,8 @@ class EditChannelPage(QWidget):
             try:
                 if overview and overview['mychannel']['dirty']:
                     self.editchannel_request_mgr = TriblerRequestManager()
-                    self.editchannel_request_mgr.perform_request("mychannel/commit", lambda _: None, method='POST',
-                                                                 capture_errors=False)
+                    self.editchannel_request_mgr.perform_request("mychannel/commit", self.on_channel_committed,
+                                                                 method='POST', capture_errors=False)
             except KeyError:
                 return
 
@@ -447,4 +449,6 @@ class EditChannelPage(QWidget):
             return
 
         if 'added' in result:
+            self.channel_dirty = True
+            self.update_channel_commit_views()
             self.load_my_torrents()

--- a/TriblerGUI/widgets/lazytableview.py
+++ b/TriblerGUI/widgets/lazytableview.py
@@ -140,7 +140,9 @@ class CommitControlMixin(TriblerContentTableView):
         if 'success' in json_result and json_result['success']:
             index.model().data_items[index.row()][u'status'] = json_result['new_status']
 
-            self.window().edit_channel_page.channel_dirty = json_result['dirty']
+            self.window().edit_channel_page.channel_dirty = \
+                self.table_view.window().edit_channel_page.channel_dirty or \
+                (json_result['new_status'] != COMMIT_STATUS_COMMITTED)
             self.window().edit_channel_page.update_channel_commit_views(deleted_index=index)
 
 

--- a/TriblerGUI/widgets/triblertablecontrollers.py
+++ b/TriblerGUI/widgets/triblertablecontrollers.py
@@ -12,7 +12,7 @@ from PyQt5.QtWidgets import QAction
 
 from six import text_type
 
-from TriblerGUI.defs import COMMIT_STATUS_UPDATED
+from TriblerGUI.defs import COMMIT_STATUS_COMMITTED, COMMIT_STATUS_UPDATED
 from TriblerGUI.tribler_action_menu import TriblerActionMenu
 from TriblerGUI.tribler_request_manager import TriblerRequestManager
 
@@ -378,7 +378,9 @@ class MyTorrentsTableViewController(TorrentsTableViewController):
 
     def _on_row_update_results(self, response):
         if response:
-            self.table_view.window().edit_channel_page.channel_dirty = response['dirty']
+            self.table_view.window().edit_channel_page.channel_dirty = \
+                self.table_view.window().edit_channel_page.channel_dirty or \
+                (response['new_status'] != COMMIT_STATUS_COMMITTED)
             self.table_view.window().edit_channel_page.update_channel_commit_views()
 
     def perform_query(self, **kwargs):
@@ -386,8 +388,3 @@ class MyTorrentsTableViewController(TorrentsTableViewController):
             "rest_endpoint_url": "mychannel/torrents",
             "exclude_deleted": self.model.exclude_deleted})
         super(MyTorrentsTableViewController, self).perform_query(**kwargs)
-
-    def on_query_results(self, response):
-        if super(MyTorrentsTableViewController, self).on_query_results(response):
-            self.table_view.window().edit_channel_page.channel_dirty = response['dirty']
-            self.table_view.window().edit_channel_page.update_channel_commit_views()


### PR DESCRIPTION
To determine if user modifications to their channel leave it in the "dirty" state that should be committed to torrent, we scan all the contents of the personal channel. This operation is very slow on big channels and should be avoided. The query is served each time the `.dirty` property of ChannelMetadata is accessed.

Previously, we used to do this scan on each query into MyChannel endpoint, which made scrolling through big personal channels very slow. This PR solves the problem by only querying the `.dirty` property if really necessary, making channel state tracking responsibility of the GUI.

Also, this adds some more indexes to the database to speed up common queries.