### PR TITLE
Small fixes for beta6

### DIFF
--- a/Tribler/Core/Modules/MetadataStore/OrmBindings/torrent_metadata.py
+++ b/Tribler/Core/Modules/MetadataStore/OrmBindings/torrent_metadata.py
@@ -155,7 +155,7 @@ def define_binding(db):
 
         @classmethod
         @db_session
-        def get_entries_query(cls, metadata_type=REGULAR_TORRENT, channel_pk=None,
+        def get_entries_query(cls, metadata_type=None, channel_pk=None,
                               exclude_deleted=False, hide_xxx=False, exclude_legacy=False, origin_id=None,
                               sort_by=None, sort_asc=True, query_filter=None, infohash=None):
             # Warning! For Pony magic to work, iteration variable name (e.g. 'g') should be the same everywhere!
@@ -183,10 +183,11 @@ def define_binding(db):
             if isinstance(metadata_type, list):
                 pony_query = pony_query.where(lambda g: g.metadata_type in metadata_type)
             else:
-                pony_query = pony_query.where(metadata_type=metadata_type)
+                pony_query = pony_query.where(
+                    metadata_type=metadata_type if metadata_type is not None else cls._discriminator_)
 
-            pony_query = pony_query.where(public_key=channel_pk) if channel_pk else pony_query
-            # origin_id can be zero, for e.g. root channel
+            # Note that origin_id and channel_pk can be 0 and "" respectively, for, say, root channel and FFA entry
+            pony_query = pony_query.where(public_key=channel_pk) if channel_pk is not None else pony_query
             pony_query = pony_query.where(origin_id=origin_id) if origin_id is not None else pony_query
             pony_query = pony_query.where(lambda g: g.status != TODELETE) if exclude_deleted else pony_query
             pony_query = pony_query.where(lambda g: g.xxx == 0) if hide_xxx else pony_query

--- a/Tribler/Test/Core/Modules/RestApi/test_metadata_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_metadata_endpoint.py
@@ -186,6 +186,7 @@ class TestSpecificChannelTorrentsEndpoint(BaseTestMetadataEndpoint):
         return self.do_request('metadata/channels/%s/123/torrents' % channel_pk).addCallback(
             on_response)
 
+    @inlineCallbacks
     def test_get_torrents_ffa_channel(self):
         """
         Test whether we can query channel contents for unsigned (legacy/FFA) channels
@@ -201,7 +202,9 @@ class TestSpecificChannelTorrentsEndpoint(BaseTestMetadataEndpoint):
             self.assertEqual(len(json_dict['results']), 1)
 
         self.should_check_equality = False
-        return self.do_request('metadata/channels//123/torrents').addCallback(on_response)
+        # We test for both forms of querying null-key channels
+        yield self.do_request('metadata/channels//123/torrents').addCallback(on_response)
+        yield self.do_request('metadata/channels/00/123/torrents').addCallback(on_response)
 
 
 class TestSpecificChannelTorrentsCountEndpoint(BaseTestMetadataEndpoint):

--- a/TriblerGUI/widgets/triblertablecontrollers.py
+++ b/TriblerGUI/widgets/triblertablecontrollers.py
@@ -94,7 +94,7 @@ class TriblerTableViewController(QObject):
         if 'query_filter' in kwargs:
             kwargs.update({"filter": to_fts_query(kwargs.pop('query_filter'))})
         elif self.query_text:
-            kwargs.update({"filter": self.query_text})
+            kwargs.update({"filter": to_fts_query(self.query_text)})
 
         if self.model.hide_xxx is not None:
             kwargs.update({"hide_xxx": self.model.hide_xxx})

--- a/TriblerGUI/widgets/triblertablecontrollers.py
+++ b/TriblerGUI/widgets/triblertablecontrollers.py
@@ -337,10 +337,13 @@ class TorrentsTableViewController(TableSelectionMixin, FilterInputMixin, Context
         self.enable_context_menu(self.table_view)
 
     def perform_query(self, **kwargs):
+        # On some systems, URLs containing double slashes are handled incorrectly.
+        # To circumvent this limitation, for empty public key we use a special substitute
         if "rest_endpoint_url" not in kwargs:
             kwargs.update({
-                "rest_endpoint_url": "metadata/channels/%s/%i/torrents" % (self.model.channel_pk,
-                                                                           self.model.channel_id)})
+                "rest_endpoint_url": "metadata/channels/%s/%i/torrents" %
+                                     (self.model.channel_pk,
+                                      self.model.channel_id)})
         super(TorrentsTableViewController, self).perform_query(**kwargs)
 
     def fetch_preview(self):


### PR DESCRIPTION
Fixes #4669 
Fixes #4667  by introducing a workaround for buggy URL handling.

Also, adds a test for querying REST enpoint for an FFA channel.