### PR TITLE
Make requests window show non-printable characters

### DIFF
--- a/TriblerGUI/debug_window.py
+++ b/TriblerGUI/debug_window.py
@@ -300,7 +300,7 @@ class DebugWindow(QMainWindow):
         for endpoint, method, data, timestamp, status_code in sorted(tribler_performed_requests,
                                                                      key=lambda x: x[3]):
             item = QTreeWidgetItem(self.window().requests_tree_widget)
-            item.setText(0, "%s %s %s" % (method, endpoint, data))
+            item.setText(0, "%s %s %s" % (method, repr(endpoint), repr(data)))
             item.setText(1, ("%d" % status_code) if status_code else "unknown")
             item.setText(2, "%s" % strftime("%H:%M:%S", localtime(timestamp)))
             self.window().requests_tree_widget.addTopLevelItem(item)


### PR DESCRIPTION
This adds support for showing non-printable characters in the "Requests" list of the Debug panel.