### PR TITLE
READY: Torrent titles from GigaChannel

### DIFF
--- a/Tribler/Core/Modules/MetadataStore/OrmBindings/channel_metadata.py
+++ b/Tribler/Core/Modules/MetadataStore/OrmBindings/channel_metadata.py
@@ -371,11 +371,6 @@ def define_binding(db):
 
         @classmethod
         @db_session
-        def get_channel_with_infohash(cls, infohash):
-            return cls.get(infohash=database_blob(infohash))
-
-        @classmethod
-        @db_session
         def get_recent_channel_with_public_key(cls, public_key):
             return cls.select(lambda g: g.public_key == database_blob(public_key)).sort_by(
                 lambda g: desc(g.id_)).first() or None
@@ -483,7 +478,7 @@ def define_binding(db):
             :param infohash - infohash of the download.
             :return: Channel title as a string, prefixed with 'OLD:' for older versions
             """
-            channel = cls.get_channel_with_infohash(infohash)
+            channel = cls.get_with_infohash(infohash)
             if not channel:
                 try:
                     channel = cls.get_channel_with_dirname(name)

--- a/Tribler/Core/Modules/MetadataStore/OrmBindings/channel_metadata.py
+++ b/Tribler/Core/Modules/MetadataStore/OrmBindings/channel_metadata.py
@@ -274,7 +274,7 @@ def define_binding(db):
                                              and g.infohash == database_blob(infohash))
 
         @db_session
-        def add_torrent_to_channel(self, tdef, extra_info=None):
+        def add_torrent_to_channel(self, tdef, extra_info=None, title=None):
             """
             Add a torrent to your channel.
             :param tdef: The torrent definition file of the torrent to add
@@ -283,6 +283,8 @@ def define_binding(db):
             new_entry_dict = dict(tdef_to_metadata_dict(tdef), status=NEW)
             if extra_info:
                 new_entry_dict['tags'] = extra_info.get('description', '')
+            if title:
+                new_entry_dict['title'] = title
 
             # See if the torrent is already in the channel
             old_torrent = self.get_torrent(tdef.get_infohash())

--- a/Tribler/Core/Modules/MetadataStore/OrmBindings/torrent_metadata.py
+++ b/Tribler/Core/Modules/MetadataStore/OrmBindings/torrent_metadata.py
@@ -310,4 +310,15 @@ def define_binding(db):
             }
             return db.TorrentMetadata.from_dict(new_entry_dict)
 
+        @classmethod
+        @db_session
+        def get_with_infohash(cls, infohash):
+            return cls.select(lambda g: g.infohash == database_blob(infohash)).first()
+
+        @classmethod
+        @db_session
+        def get_torrent_title(cls, infohash):
+            md = cls.get_with_infohash(infohash)
+            return md.title if md else None
+
     return TorrentMetadata

--- a/Tribler/Core/Modules/restapi/downloads_endpoint.py
+++ b/Tribler/Core/Modules/restapi/downloads_endpoint.py
@@ -234,8 +234,12 @@ class DownloadsEndpoint(DownloadBaseEndpoint):
             num_seeds, num_peers = state.get_num_seeds_peers()
             num_connected_seeds, num_connected_peers = download.get_num_connected_seeds_peers()
 
-            download_name = self.session.lm.mds.ChannelMetadata.get_channel_name(
-                tdef.get_name_utf8(), tdef.get_infohash()) if download.get_channel_download() else tdef.get_name_utf8()
+            if download.get_channel_download():
+                download_name = self.session.lm.mds.ChannelMetadata.get_channel_name(
+                    tdef.get_name_utf8(), tdef.get_infohash())
+            else:
+                download_name = self.session.lm.mds.TorrentMetadata.get_torrent_title(tdef.get_infohash()) or \
+                                tdef.get_name_utf8()
 
             download_json = {
                 "name": download_name,
@@ -535,7 +539,7 @@ class DownloadSpecificEndpoint(DownloadBaseEndpoint):
                 return json.twisted_dumps({"error": "unknown state parameter"})
 
         return json.twisted_dumps({"modified": True,
-                           "infohash": hexlify(download.get_def().get_infohash())})
+                                   "infohash": hexlify(download.get_def().get_infohash())})
 
 
 class DownloadExportTorrentEndpoint(DownloadBaseEndpoint):

--- a/Tribler/Test/Core/Modules/RestApi/test_downloads_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_downloads_endpoint.py
@@ -29,6 +29,7 @@ class TestDownloadsEndpoint(AbstractApiTest):
     def setUpPreSession(self):
         super(TestDownloadsEndpoint, self).setUpPreSession()
         self.config.set_libtorrent_enabled(True)
+        self.config.set_chant_enabled(True)
 
     @trial_timeout(10)
     def test_get_downloads_no_downloads(self):

--- a/Tribler/Test/Core/Modules/RestApi/test_mychannel_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_mychannel_endpoint.py
@@ -355,7 +355,7 @@ class TestMyChannelTorrentsEndpoint(BaseTestMyChannelEndpoint):
             base64_content = base64.b64encode(torrent_file.read())
 
             self.should_check_equality = False
-            post_params = {'torrent': base64_content}
+            post_params = {'torrent': base64_content, 'title': 'bla'}
             return self.do_request('mychannel/torrents', request_type='PUT', post_data=post_params, expected_code=200)
 
     @trial_timeout(10)

--- a/TriblerGUI/dialogs/createtorrentdialog.py
+++ b/TriblerGUI/dialogs/createtorrentdialog.py
@@ -46,6 +46,7 @@ class CreateTorrentDialog(DialogContainer):
         self.on_main_window_resize()
 
         self.request_mgr = None
+        self.name = None
 
     def close_dialog(self):
         if self.request_mgr:
@@ -106,10 +107,10 @@ class CreateTorrentDialog(DialogContainer):
                                           "Error: %s" % error)
             return
 
-        name = self.dialog_widget.create_torrent_name_field.text()
+        self.name = self.dialog_widget.create_torrent_name_field.text()
         description = self.dialog_widget.create_torrent_description_field.toPlainText()
         post_data = {
-            "name": name,
+            "name": self.name,
             "description": description,
             "files": files_list,
             "export_dir": export_dir
@@ -134,8 +135,11 @@ class CreateTorrentDialog(DialogContainer):
 
     def add_torrent_to_channel(self, torrent):
         self.request_mgr = TriblerRequestManager()
+        data = {"torrent": torrent}
+        if self.name:
+            data.update({"title": self.name.decode('utf-8')})
         self.request_mgr.perform_request("mychannel/torrents", self.on_torrent_to_channel_added,
-                                         data={"torrent": torrent}, method='PUT')
+                                         data=data, method='PUT')
 
     def on_torrent_to_channel_added(self, result):
         if not result:


### PR DESCRIPTION
Fixes #4674 by doing two things:
 1. when showing downloads, tries to replace the downloads' names by searching the local DB;
 2. when creating a torrent, uses the title given by the user to add it to the personal channel.