### PR TITLE
Replace down/up arrows with text

### DIFF
--- a/TriblerGUI/qt_resources/mainwindow.ui
+++ b/TriblerGUI/qt_resources/mainwindow.ui
@@ -7777,12 +7777,12 @@ padding-left: 2px;</string>
                    </column>
                    <column>
                     <property name="text">
-                     <string>↓ SPEED</string>
+                     <string>SPEED (DOWN)</string>
                     </property>
                    </column>
                    <column>
                     <property name="text">
-                     <string>↑ SPEED</string>
+                     <string>SPEED (UP)</string>
                     </property>
                    </column>
                    <column>
@@ -8404,12 +8404,12 @@ background-color: #303030;
                     </column>
                     <column>
                      <property name="text">
-                      <string>↓ SPEED</string>
+                      <string>SPEED (DOWN)</string>
                      </property>
                     </column>
                     <column>
                      <property name="text">
-                      <string>↑ SPEED</string>
+                      <string>SPEED (UP)</string>
                      </property>
                     </column>
                     <column>


### PR DESCRIPTION
This should hopefully fix the 'ascii' decoding crash. While I do not consider this as a long-term solution, we can at least see whether this fixes the issue.

Addresses #4666