### PR TITLE
Fixed six upgrade on linux

### DIFF
--- a/debian/tribler.postinst
+++ b/debian/tribler.postinst
@@ -4,5 +4,5 @@ if which pip >/dev/null 2>&1; then
     # 2019-02-13; Add lz4 compression ; Remove this once this library is updated in Debian repo
     pip install --user lz4
     # We need the latest version of six for the ensure_str method
-    pip install --user six
+    pip install --user --upgrade six>=1.12.0
 fi


### PR DESCRIPTION
Users who have an older version of six installed will not get the latest version without the --upgrade flag.

Fixes #4695