### PR TITLE
Make GigaChannel gossip only complete channels

### DIFF
--- a/Tribler/Core/Modules/MetadataStore/OrmBindings/channel_metadata.py
+++ b/Tribler/Core/Modules/MetadataStore/OrmBindings/channel_metadata.py
@@ -415,7 +415,7 @@ def define_binding(db):
             query = db.ChannelMetadata.select(
                 lambda g: g.status not in [LEGACY_ENTRY, NEW, UPDATED, TODELETE] and g.num_entries > 0)
             query = query.where(subscribed=True) if only_subscribed else query
-            query = query.where(lambda g: g.local_version > 0) if only_downloaded else query
+            query = query.where(lambda g: g.local_version == g.timestamp) if only_downloaded else query
             return query.random(limit)
 
         @db_session


### PR DESCRIPTION
Before, we could be gossiping channels in semi-complete state. This meant more dead channels propagating through the network.

This little change ensures that the channel will be gossiped only in case its current version was completely downloaded.