### PR TITLE
Polished torrent creation dialog

### DIFF
--- a/TriblerGUI/qt_resources/createtorrentdialog.ui
+++ b/TriblerGUI/qt_resources/createtorrentdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>538</width>
-    <height>922</height>
+    <height>523</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -55,6 +55,12 @@ padding-right: 4px;
 QToolButton::hover {
 border: 1px solid white;
 color: white;
+}
+QLineEdit, QTextEdit {
+background-color: #444;
+border: none;
+color: #C0C0C0;
+padding: 4px;
 }</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
@@ -82,16 +88,16 @@ color: white;
       <number>0</number>
      </property>
      <property name="leftMargin">
-      <number>0</number>
+      <number>12</number>
      </property>
      <property name="topMargin">
-      <number>0</number>
+      <number>12</number>
      </property>
      <property name="rightMargin">
-      <number>0</number>
+      <number>12</number>
      </property>
      <property name="bottomMargin">
-      <number>0</number>
+      <number>12</number>
      </property>
      <item>
       <widget class="QWidget" name="form_header" native="true">
@@ -113,31 +119,25 @@ color: white;
         </property>
         <item>
          <widget class="QLabel" name="form_title">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>30</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>16777215</width>
+            <height>30</height>
+           </size>
+          </property>
           <property name="styleSheet">
-           <string notr="true">padding: 12px 12px 8px 12px;
-font-size: 16px;
+           <string notr="true">font-size: 16px;
 font-weight: bold;
 color: white;</string>
           </property>
           <property name="text">
            <string>Create a new torrent</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QToolButton" name="btn_cancel">
-          <property name="cursor">
-           <cursorShape>PointingHandCursor</cursorShape>
-          </property>
-          <property name="styleSheet">
-           <string notr="true">border-radius: 4px;
-padding: 4px;
-margin-right:8px;
-border: None;
-background-color:#555;</string>
-          </property>
-          <property name="text">
-           <string>CANCEL (X)</string>
           </property>
          </widget>
         </item>
@@ -156,20 +156,32 @@ background-color:#555;</string>
         <property name="fieldGrowthPolicy">
          <enum>QFormLayout::ExpandingFieldsGrow</enum>
         </property>
-        <item row="0" column="1">
+        <property name="horizontalSpacing">
+         <number>0</number>
+        </property>
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
+        <item row="1" column="1">
          <widget class="QLineEdit" name="create_torrent_name_field">
           <property name="styleSheet">
-           <string notr="true">color:#000;
-border:1px solid #555;
-background-color:#555;
-padding:4px;</string>
+           <string notr="true"/>
           </property>
           <property name="placeholderText">
            <string>Torrent name</string>
           </property>
          </widget>
         </item>
-        <item row="1" column="1">
+        <item row="3" column="1">
          <widget class="QTextEdit" name="create_torrent_description_field">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -190,16 +202,14 @@ padding:4px;</string>
            </size>
           </property>
           <property name="styleSheet">
-           <string notr="true">color:#000;border: 1px solid #555;
-background-color:#555;
-padding:4px;</string>
+           <string notr="true"/>
           </property>
           <property name="placeholderText">
            <string>Torrent description</string>
           </property>
          </widget>
         </item>
-        <item row="3" column="1">
+        <item row="5" column="1">
          <widget class="QListWidget" name="create_torrent_files_list">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -225,8 +235,8 @@ padding:4px;</string>
           <property name="styleSheet">
            <string notr="true">background-color: #303030;
 border: 1px solid #555;
-color: #000;
-background-color:#555;
+color: #c0c0c0;
+background-color:#444;
 padding:4px;</string>
           </property>
           <item>
@@ -241,20 +251,20 @@ padding:4px;</string>
           </item>
          </widget>
         </item>
-        <item row="6" column="1">
+        <item row="9" column="1">
          <widget class="QCheckBox" name="seed_after_adding_checkbox">
           <property name="styleSheet">
            <string notr="true">color: #bbb;</string>
           </property>
           <property name="text">
-           <string>Seed this torrent after adding it</string>
+           <string>Seed this torrent after creation</string>
           </property>
           <property name="checked">
            <bool>true</bool>
           </property>
          </widget>
         </item>
-        <item row="4" column="1">
+        <item row="6" column="1">
          <widget class="QWidget" name="file_chooser" native="true">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -308,12 +318,10 @@ padding:4px;</string>
               <cursorShape>PointingHandCursor</cursorShape>
              </property>
              <property name="styleSheet">
-              <string notr="true">border-radius: 13px;
-padding-left: 4px;
-padding-right: 4px;</string>
+              <string notr="true"/>
              </property>
              <property name="text">
-              <string>Choose Diretory</string>
+              <string>ADD DIRECTORY</string>
              </property>
             </widget>
            </item>
@@ -357,12 +365,10 @@ padding-right: 4px;</string>
               <cursorShape>PointingHandCursor</cursorShape>
              </property>
              <property name="styleSheet">
-              <string notr="true">border-radius: 13px;
-padding-left: 4px;
-padding-right: 4px;</string>
+              <string notr="true"/>
              </property>
              <property name="text">
-              <string>Choose Files</string>
+              <string>ADD FILES</string>
              </property>
             </widget>
            </item>
@@ -382,30 +388,30 @@ padding-right: 4px;</string>
           </layout>
          </widget>
         </item>
-        <item row="2" column="1">
+        <item row="4" column="1">
          <widget class="QLabel" name="label">
           <property name="styleSheet">
-           <string notr="true">margin-top:8px; color: #fff;</string>
+           <string notr="true"/>
           </property>
           <property name="text">
-           <string>Torrent files</string>
+           <string>Torrent files:</string>
           </property>
          </widget>
         </item>
-        <item row="7" column="1">
+        <item row="10" column="1">
          <widget class="QCheckBox" name="add_to_channel_checkbox">
           <property name="styleSheet">
            <string notr="true">color: #bbb;</string>
           </property>
           <property name="text">
-           <string>Add this torrent to My Channel</string>
+           <string>Add this torrent to your channel</string>
           </property>
           <property name="checked">
            <bool>true</bool>
           </property>
          </widget>
         </item>
-        <item row="5" column="1">
+        <item row="8" column="1">
          <widget class="QWidget" name="file_selector" native="true">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -415,8 +421,8 @@ padding-right: 4px;</string>
           </property>
           <property name="minimumSize">
            <size>
-            <width>40</width>
-            <height>40</height>
+            <width>0</width>
+            <height>0</height>
            </size>
           </property>
           <layout class="QHBoxLayout" name="horizontalLayout_33">
@@ -438,10 +444,7 @@ padding-right: 4px;</string>
            <item>
             <widget class="QLineEdit" name="file_export_dir">
              <property name="styleSheet">
-              <string notr="true">color:#000;
-  border:1px solid #555;
-  background-color:#555;
-  padding:4px;</string>
+              <string notr="true">margin-right: 10px;</string>
              </property>
              <property name="text">
               <string>/home/tribler</string>
@@ -475,17 +478,35 @@ padding-right: 4px;</string>
               <cursorShape>PointingHandCursor</cursorShape>
              </property>
              <property name="styleSheet">
-              <string notr="true">border-radius: 13px;
-padding-left: 4px;
-padding-right: 4px;
-margin-left: 8px;</string>
+              <string notr="true"/>
              </property>
              <property name="text">
-              <string>Browse</string>
+              <string>BROWSE</string>
              </property>
             </widget>
            </item>
           </layout>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QLabel" name="label_2">
+          <property name="text">
+           <string>Name:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="QLabel" name="label_3">
+          <property name="text">
+           <string>Description:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="7" column="1">
+         <widget class="QLabel" name="label_4">
+          <property name="text">
+           <string>Torrent file destination:</string>
+          </property>
          </widget>
         </item>
        </layout>
@@ -493,44 +514,56 @@ margin-left: 8px;</string>
      </item>
      <item>
       <widget class="QWidget" name="form_footer" native="true">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>30</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>30</height>
+        </size>
+       </property>
        <property name="styleSheet">
         <string notr="true">background-color:#333;</string>
        </property>
        <layout class="QHBoxLayout" name="horizontalLayout_32">
         <property name="leftMargin">
-         <number>8</number>
+         <number>0</number>
         </property>
         <property name="topMargin">
-         <number>8</number>
+         <number>0</number>
         </property>
         <property name="rightMargin">
-         <number>8</number>
+         <number>0</number>
         </property>
         <property name="bottomMargin">
-         <number>8</number>
+         <number>0</number>
         </property>
-        <item>
-         <spacer name="hspace_footer_1">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>570</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
         <item>
          <widget class="QLabel" name="edit_channel_create_torrent_progress_label">
           <property name="styleSheet">
            <string notr="true">color:#fff;</string>
           </property>
           <property name="text">
-           <string>Creating torrent. Please wait...</string>
+           <string>Creating torrent...</string>
           </property>
          </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
         </item>
         <item>
          <widget class="QToolButton" name="btn_create">
@@ -550,12 +583,32 @@ margin-left: 8px;</string>
            <cursorShape>PointingHandCursor</cursorShape>
           </property>
           <property name="styleSheet">
-           <string notr="true">border-radius: 12px;
-padding-left: 4px;
-padding-right: 4px;</string>
+           <string notr="true"/>
           </property>
           <property name="text">
            <string>CREATE TORRENT</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QToolButton" name="btn_cancel">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>24</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>16777215</width>
+            <height>24</height>
+           </size>
+          </property>
+          <property name="cursor">
+           <cursorShape>PointingHandCursor</cursorShape>
+          </property>
+          <property name="text">
+           <string>CANCEL</string>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
Fixed various layout inconsistencies, including a typo. Also moved the cancel button to the bottom of the dialog, which is more consistent with the layout in our other dialogs.

![39db215431041ceb1319bf0a6a33c190](https://user-images.githubusercontent.com/1707075/62773686-123e0200-baa3-11e9-8509-7ea36b259a36.png)
