### PR TITLE
Disable finished notification for channel download

### DIFF
--- a/Tribler/Core/Modules/gigachannel_manager.py
+++ b/Tribler/Core/Modules/gigachannel_manager.py
@@ -221,7 +221,7 @@ class GigaChannelManager(TaskManager):
         dcfg.set_dest_dir(self.session.lm.mds.channels_dir)
         dcfg.set_channel_download(True)
         tdef = TorrentDefNoMetainfo(infohash=str(channel.infohash), name=channel.dirname)
-        download = self.session.start_download_from_tdef(tdef, dcfg)
+        download = self.session.start_download_from_tdef(tdef, dcfg, hidden=True)
 
         def _add_channel_to_processing_queue(_):
             self.channels_processing_queue[channel.infohash] = (PROCESS_CHANNEL_DIR, channel)

--- a/Tribler/Core/Modules/restapi/downloads_endpoint.py
+++ b/Tribler/Core/Modules/restapi/downloads_endpoint.py
@@ -8,7 +8,6 @@ from libtorrent import bencode, create_torrent
 
 from pony.orm import db_session
 
-import six
 from six import unichr  # pylint: disable=redefined-builtin
 from six.moves.urllib.parse import unquote_plus
 from six.moves.urllib.request import url2pathname
@@ -221,7 +220,8 @@ class DownloadsEndpoint(DownloadBaseEndpoint):
         downloads_json = []
         downloads = self.session.get_downloads()
         for download in downloads:
-            if download.hidden:
+            if download.hidden and not download.get_channel_download():
+                # We still want to send channel downloads since they are displayed in the GUI
                 continue
             state = download.get_state()
             tdef = download.get_def()


### PR DESCRIPTION
Channel downloads are now hidden, however, they are still sent to the GUI (since they are displayed in the channels tab on the downloads page).

Fixes #4744