### PR TITLE
Using different metadata db on testnet

### DIFF
--- a/Tribler/Core/APIImplementation/LaunchManyCore.py
+++ b/Tribler/Core/APIImplementation/LaunchManyCore.py
@@ -276,7 +276,8 @@ class TriblerLaunchMany(TaskManager):
 
         if self.session.config.get_chant_enabled():
             channels_dir = os.path.join(self.session.config.get_chant_channels_dir())
-            database_path = os.path.join(self.session.config.get_state_dir(), 'sqlite', 'metadata.db')
+            metadata_db_name = 'metadata_db' if not self.session.config.get_testnet() else 'metadata_testnet_db'
+            database_path = os.path.join(self.session.config.get_state_dir(), 'sqlite', metadata_db_name)
             self.mds = MetadataStore(database_path, channels_dir, self.session.trustchain_keypair)
 
         if self.session.config.get_dummy_wallets_enabled():


### PR DESCRIPTION
This prevents channels from testnet leaking to mainnet, and vice versa.

Fixes #4746 