### PR TITLE
Catch RuntimeError when bdecoding metainfo

### DIFF
--- a/Tribler/Core/Modules/restapi/torrentinfo_endpoint.py
+++ b/Tribler/Core/Modules/restapi/torrentinfo_endpoint.py
@@ -108,7 +108,12 @@ class TorrentInfoEndpoint(resource.Resource):
                     return
 
             # Otherwise, we directly invoke the on_got_metainfo method
-            on_got_metainfo(bdecode(response))
+            try:
+                decoded_response = bdecode(response)
+                on_got_metainfo(decoded_response)
+            except RuntimeError:
+                # The decoding failed - handle it like a None metainfo
+                on_got_metainfo(None)
 
         def on_file():
             try:


### PR DESCRIPTION
This crash will prevent Tribler from crashing when bdecoding metainfo fails in libtorrent 1.2.0.0. This is quite hard to test since it requires replacement of the bdecode method so it throws a RuntimeError. I tested it manually and the crash seems to be fixed.

Fixes #4741