### PR TITLE
Add flake8/black/isort pre-commit hooks

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,5 @@
+[flake8]
+jobs = auto 
+max-line-length = 120 
+select=E901,E999,F821,F822,F823,I100,I101,I201,I202
+ignore=E203,W503,C0330

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,13 @@
+[settings]
+order_by_type = False
+multi_line_output=3
+case_sensitive = True
+include_trailing_comma=True
+force_grid_wrap=0
+use_parentheses = True
+combine_as_imports=True
+force_sort_within_sections=True
+line_length=118
+known_future_library=future
+known_first_party=Tribler,TriblerGUI
+known_third_party=pony,twisted,six,anydex,ipv8,libtorrent,lz4,PyQt5,zope

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+repos:
+-   repo: https://github.com/Tribler/mirrors-autoflake
+    rev: v1.1
+    hooks:
+      - id: autoflake
+        args: ['--in-place', '--remove-all-unused-imports', '--remove-unused-variable']
+
+-   repo: https://github.com/Tribler/isort
+    rev: 4.3.21-2-tribler
+    hooks:
+    - id: isort
+
+-   repo: https://github.com/ambv/black
+    rev: 19.3b0
+    hooks:
+    - id: black
+
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.2.3
+    hooks:
+    -  id: flake8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,9 @@
 line-length = 120
 py27 = true
 skip-string-normalization = true
-include = '\.pyi?$'
+include = 'Tribler\Core\Modules\MetadataStore\*.pyi?$'
+include = 'TriblerGUI\*.pyi?$'
+
 exclude = '''
 /(
     \.git

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[tool.black]
+line-length = 120
+py27 = true
+skip-string-normalization = true
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.git
+  | \.venv
+  | \.idea 
+  | snap
+  | doc
+)/
+'''


### PR DESCRIPTION
This commit adds config files necessary to enable Python `pre-commit` package-based pre-commit hooks. The hooks include automatic removal of unused imports, customized `isort` version [hosted at Tribler GitHub](https://github.com/Tribler/isort), "black" Python code formatter and Flake8 checks.

Fixes #4104 

To use the hooks, one needs to install the `pre-commit` package by doing `pip install pre-commit` and then enable the hooks in the current (Tribler) repository by doing `pre-commit install`. Otherwise, the files from this PR have no effect.