### PR TITLE
READY: Fixed issue with loading torrent with Unicode characters

### DIFF
--- a/TriblerGUI/tribler_app.py
+++ b/TriblerGUI/tribler_app.py
@@ -13,6 +13,7 @@ class TriblerApplication(QtSingleApplication):
     """
     This class represents the main Tribler application.
     """
+
     def __init__(self, app_name, args):
         QtSingleApplication.__init__(self, app_name, args)
         self.code_executor = None
@@ -30,7 +31,7 @@ class TriblerApplication(QtSingleApplication):
     def parse_sys_args(self, args):
         for arg in args[1:]:
             if os.path.exists(arg):
-                self.handle_uri('file:%s' % arg)
+                self.handle_uri(u'file:%s' % arg.decode('utf-8'))
             elif arg.startswith('magnet'):
                 self.handle_uri(arg)
 


### PR DESCRIPTION
Fixes the issue with loading torrent with Unicode characters in the name while loading by clicking the torrent file. The crash happened for the case when Tribler was not running already.