### PR TITLE
Flush logs before shutting down

### DIFF
--- a/Tribler/Core/Modules/restapi/shutdown_endpoint.py
+++ b/Tribler/Core/Modules/restapi/shutdown_endpoint.py
@@ -45,6 +45,9 @@ class ShutdownEndpoint(resource.Resource):
             reactor.addSystemEventTrigger('after', 'shutdown', os._exit, code)
             reactor.stop()
             self.process_checker.remove_lock_file()
+            # Flush the logs to the file before exiting
+            for handler in logging.getLogger().handlers:
+                handler.flush()
 
         def log_and_shutdown(failure):
             self._logger.error(failure.value)


### PR DESCRIPTION
With the use of memory handler, the logging is efficient but when shutting down it causes some of the logs not being written to the file because the memory handler is not full. This will flush the logs so it is safely written to the file while shutting down.