### PR TITLE
Fixed pip package issues

### DIFF
--- a/debian/tribler.postinst
+++ b/debian/tribler.postinst
@@ -1,4 +1,6 @@
 if which pip >/dev/null 2>&1; then
+    # 2019-08-26 wheel is necessary for other pip installs
+    pip install --user wheel
     # Install pony orm with pip since it is not available in Debian repository
     pip install --user pony>=0.7.9
     # 2019-02-13; Add lz4 compression ; Remove this once this library is updated in Debian repo

--- a/debian/tribler.postinst
+++ b/debian/tribler.postinst
@@ -1,8 +1,8 @@
 if which pip >/dev/null 2>&1; then
     # 2019-08-26 wheel is necessary for other pip installs
-    pip install --user wheel
+    pip install --upgrade wheel
     # Install pony orm with pip since it is not available in Debian repository
-    pip install --user pony>=0.7.9
+    pip install --upgrade pony==0.7.9
     # 2019-02-13; Add lz4 compression ; Remove this once this library is updated in Debian repo
-    pip install --user lz4
+    pip install --upgrade lz4
 fi

--- a/debian/tribler.prerm
+++ b/debian/tribler.prerm
@@ -3,4 +3,6 @@ if which pip >/dev/null 2>&1; then
     pip uninstall -y pony
     # Remove lz4 from pip
     pip uninstall -y lz4
+    # Remove wheel the last
+    pip uninstall -y wheel
 fi


### PR DESCRIPTION
Installing pip packages with `--user` with `sudo` previlege during installation is causing these packages to be installed for only root, while user simply runs tribler in user mode. This causes those packages not being available in user mode. With this PR, I'm removing the `--user` flag so it is installed globally and should be available to all users. Moreover, `wheel` pip dependency is also added which is necessary for systems with older version of pip.

Fixes https://github.com/Tribler/tribler/issues/4767