### PR TITLE
Fix race condition in GigaChannel tests

### DIFF
--- a/Tribler/Core/Session.py
+++ b/Tribler/Core/Session.py
@@ -536,18 +536,6 @@ class Session(object):
         params = params or {}
         return threads.deferToThread(torrent_utils.create_torrent_file, file_path_list, params)
 
-    def create_channel(self, name, description, mode=u'closed'):
-        """
-        Creates a new Channel.
-
-        :param name: name of the Channel
-        :param description: description of the Channel
-        :param mode: mode of the Channel ('open', 'semi-open', or 'closed')
-        :return: a channel ID
-        :raises a DuplicateChannelIdError if name already exists
-        """
-        return self.lm.channel_manager.create_channel(name, description, mode)
-
     def check_torrent_health(self, infohash, timeout=20, scrape_now=False):
         """
         Checks the given torrent's health on its trackers.

--- a/Tribler/Test/Core/Modules/RestApi/test_downloads_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_downloads_endpoint.py
@@ -11,7 +11,6 @@ from six.moves.urllib.request import pathname2url
 from twisted.internet.defer import fail
 
 import Tribler.Core.Utilities.json_util as json
-from Tribler.Core import TorrentDef
 from Tribler.Core.Config.download_config import DownloadConfig
 from Tribler.Core.DownloadState import DownloadState
 from Tribler.Core.Utilities.network_utils import get_random_port
@@ -686,7 +685,7 @@ class TestMetadataDownloadEndpoint(AbstractApiTest):
         Testing whether the API returns the right download when a download is added
         """
 
-        test_channel_name = 'testchan'
+        test_channel_name = 'test_channel'
 
         def verify_download(downloads):
             downloads_json = json.twisted_loads(downloads)
@@ -698,12 +697,9 @@ class TestMetadataDownloadEndpoint(AbstractApiTest):
         self.session.start_download_from_tdef(video_tdef, DownloadConfig())
         self.session.start_download_from_uri("file:" + pathname2url(
             os.path.join(TESTS_DATA_DIR, "bak_single.torrent")))
-
         with db_session:
-            my_channel = self.session.lm.mds.ChannelMetadata.create_channel(test_channel_name, 'test')
-            my_channel.add_torrent_to_channel(video_tdef)
-            torrent_dict = my_channel.commit_channel_torrent()
-            self.session.lm.gigachannel_manager.updated_my_channel(TorrentDef.TorrentDef.load_from_dict(torrent_dict))
+            channel = self.session.lm.mds.ChannelMetadata.create_channel(test_channel_name, 'bla')
+            self.session.lm.gigachannel_manager.download_channel(channel)
 
         self.should_check_equality = False
         return self.do_request('downloads?get_peers=1&get_pieces=1',


### PR DESCRIPTION
fixes #4789 

This was tricky. When we create a personal channel, commit it to disk and add to Libtorrent session, sometimes Libtorrent is slow to release the contents. I.e. our wrapper reports that it has shut down, but Libtorrent still holds the files. Then, sometimes, Python tester can't delete the file on Windows because it is still locked by Libtorrent.

I solved the problem by stopping creating a real personal channel in the test. Creating a fictitious channel is enough for this test. However, we should be aware of this Libtorrent behavior in the future.

Also, deleted some unused code in the Session.