### PR TITLE
Checking for existence of mediaplayer object

### DIFF
--- a/TriblerGUI/widgets/videoplayerpage.py
+++ b/TriblerGUI/widgets/videoplayerpage.py
@@ -236,8 +236,10 @@ class VideoPlayerPage(QWidget):
         self.active_index = -1
         self.window().left_menu_playlist.clear()
         self.window().video_player_header_label.setText("")
-        self.mediaplayer.stop()
-        self.mediaplayer.set_media(None)
+
+        if self.mediaplayer:
+            self.mediaplayer.stop()
+            self.mediaplayer.set_media(None)
         self.media = None
         self.window().video_player_play_pause_button.setIcon(self.play_icon)
         self.window().video_player_play_pause_button.setEnabled(False)

--- a/check_os.py
+++ b/check_os.py
@@ -28,7 +28,8 @@ def _do_popup(title, text):
         import win32api
         win32api.MessageBox(0, text, title)
     except ImportError:
-        os.system('xmessage -center "$(printf "%s")"' % (text))
+        import subprocess
+        subprocess.Popen(['xmessage', '-center', text], shell=False)
     sep = "*" * 20
     print('\n'.join([sep, title, sep, text, sep]), file=sys.stderr)
 


### PR DESCRIPTION
When removing a download and resetting the player.

Fixes #4775