### PR TITLE
Fix black-related pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,11 @@ repos:
     rev: 19.3b0
     hooks:
     - id: black
+      files: |
+          (?x)(
+          ^TriblerGUI/|
+          ^Tribler/Core/Modules/MetadataStore/
+          )
 
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.2.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 line-length = 120
 py27 = true
 skip-string-normalization = true
-include = 'Tribler\/Core\/Modules\/MetadataStore\/*.pyi?$|TriblerGUI\/*.pyi?$'
+include = '(TriblerGUI|Tribler/Core/Modules/MetadataStore)/.*\.pyi?$'
 
 exclude = '''
 /(


### PR DESCRIPTION
`black` [ignores](https://github.com/psf/black/issues/395) `include` and `exclude` config entries when running on a single exact file path. This is exactly how `pre-commit` works: running singular checks on singular changed files one-by-one. This means that to really exclude something from `black` scope we need to specify it in `.pre-commit-config.yaml`.