### PR TITLE
Limited trust graph

### DIFF
--- a/Tribler/Core/Modules/restapi/root_endpoint.py
+++ b/Tribler/Core/Modules/restapi/root_endpoint.py
@@ -46,6 +46,7 @@ class RootEndpoint(resource.Resource):
         self.putChild(b"state", self.state_endpoint)
         self.putChild(b"shutdown", self.shutdown_endpoint)
         self.putChild(b"upgrader", self.upgrader_endpoint)
+        self.trustview_endpoint = None
 
     def start_endpoints(self):
         """
@@ -58,7 +59,6 @@ class RootEndpoint(resource.Resource):
             b"createtorrent": CreateTorrentEndpoint,
             b"debug": DebugEndpoint,
             b"trustchain": TrustchainEndpoint,
-            b"trustview": TrustViewEndpoint,
             b"statistics": StatisticsEndpoint,
             b"libtorrent": LibTorrentEndpoint,
             b"torrentinfo": TorrentInfoEndpoint,
@@ -79,3 +79,6 @@ class RootEndpoint(resource.Resource):
         self.putChild(b"wallets", WalletsEndpoint(self.session.lm.ipv8))
 
         self.getChildWithDefault(b"search", None).events_endpoint = self.events_endpoint
+
+        self.trustview_endpoint = TrustViewEndpoint(self.session)
+        self.putChild(b"trustview", self.trustview_endpoint)

--- a/Tribler/Core/Modules/restapi/trustview_endpoint.py
+++ b/Tribler/Core/Modules/restapi/trustview_endpoint.py
@@ -21,8 +21,11 @@ MAX_TRANSACTIONS = 2500
 
 class TrustGraph(nx.DiGraph):
 
-    def __init__(self, root_key):
+    def __init__(self, root_key, max_peers=MAX_PEERS, max_transactions=MAX_TRANSACTIONS):
         nx.DiGraph.__init__(self)
+        self.max_peers = max_peers
+        self.max_transactions = max_transactions
+
         self.root_node = 0
 
         self.peers = []
@@ -38,12 +41,16 @@ class TrustGraph(nx.DiGraph):
         self.transactions = {}
         self.token_balance = {}
 
+    def set_limits(self, max_peers, max_transactions):
+        self.max_peers = max_peers
+        self.max_transactions = max_transactions
+
     def get_node(self, peer_key, add_if_not_exist=True):
         if peer_key in self.peers:
             return self.node[self.peers.index(peer_key)]
         if add_if_not_exist:
             next_node_id = len(self.peers)
-            if next_node_id >= MAX_PEERS:
+            if next_node_id >= self.max_peers:
                 raise TrustGraphException("Max node peers reached in graph")
             super(TrustGraph, self).add_node(next_node_id, id=next_node_id, key=peer_key)
             self.peers.append(peer_key)
@@ -51,7 +58,7 @@ class TrustGraph(nx.DiGraph):
         return None
 
     def add_block(self, block):
-        if len(self.transactions) >= MAX_TRANSACTIONS:
+        if len(self.transactions) >= self.max_transactions:
             raise TrustGraphException("Max transactions reached in the graph")
 
         if block.hash not in self.transactions and block.type == b'tribler_bandwidth':

--- a/Tribler/Core/Modules/restapi/trustview_endpoint.py
+++ b/Tribler/Core/Modules/restapi/trustview_endpoint.py
@@ -4,6 +4,8 @@ import logging
 import math
 from binascii import unhexlify
 
+import networkx as nx
+
 from twisted.web import resource
 
 import Tribler.Core.Utilities.json_util as json
@@ -12,7 +14,6 @@ from Tribler.Core.Utilities.unicode import hexlify
 from Tribler.Core.exceptions import TrustGraphException
 from Tribler.Core.simpledefs import DOWNLOAD, UPLOAD
 
-import networkx as nx
 
 MAX_PEERS = 500
 MAX_TRANSACTIONS = 2500
@@ -69,9 +70,6 @@ class TrustGraph(nx.DiGraph):
             if peer2['id'] not in self.successors(peer1['id']):
                 self.add_edge(peer1['id'], peer2['id'], weight=diff)
             self.transactions[block.hash] = block
-        else:
-            print("not a correct block:", block.type)
-            print("already in tx:", block.hash in self.transactions, block.hash)
 
     def add_blocks(self, blocks):
         for block in blocks:

--- a/Tribler/Core/Modules/restapi/trustview_endpoint.py
+++ b/Tribler/Core/Modules/restapi/trustview_endpoint.py
@@ -4,6 +4,8 @@ import logging
 import math
 from binascii import unhexlify
 
+import networkx as nx
+
 from twisted.web import resource
 
 import Tribler.Core.Utilities.json_util as json
@@ -11,8 +13,6 @@ from Tribler.Core.Modules.TrustCalculation.graph_positioning import GraphPositio
 from Tribler.Core.Utilities.unicode import hexlify
 from Tribler.Core.exceptions import TrustGraphException
 from Tribler.Core.simpledefs import DOWNLOAD, UPLOAD
-
-import networkx as nx
 
 MAX_PEERS = 500
 MAX_TRANSACTIONS = 2500

--- a/Tribler/Core/Modules/restapi/trustview_endpoint.py
+++ b/Tribler/Core/Modules/restapi/trustview_endpoint.py
@@ -1,16 +1,21 @@
 from __future__ import absolute_import
 
+import logging
 import math
 from binascii import unhexlify
-
-import networkx as nx
 
 from twisted.web import resource
 
 import Tribler.Core.Utilities.json_util as json
 from Tribler.Core.Modules.TrustCalculation.graph_positioning import GraphPositioning as gpos
 from Tribler.Core.Utilities.unicode import hexlify
+from Tribler.Core.exceptions import TrustGraphException
 from Tribler.Core.simpledefs import DOWNLOAD, UPLOAD
+
+import networkx as nx
+
+MAX_PEERS = 500
+MAX_TRANSACTIONS = 2500
 
 
 class TrustGraph(nx.DiGraph):
@@ -25,20 +30,28 @@ class TrustGraph(nx.DiGraph):
         self.transactions = {}
         self.token_balance = {}
 
-    def get_node(self, peer_key):
-        if peer_key not in self.peers:
-            node_id = len(self.peers)
+    def get_node(self, peer_key, add_if_not_exist=True):
+        if peer_key in self.peers:
+            return self.node[self.peers.index(peer_key)]
+        if add_if_not_exist:
+            next_node_id = len(self.peers)
+            if next_node_id > MAX_PEERS:
+                raise TrustGraphException("Max node peers reached in graph")
+            super(TrustGraph, self).add_node(next_node_id, id=next_node_id, key=peer_key)
             self.peers.append(peer_key)
-            super(TrustGraph, self).add_node(node_id, id=node_id, key=peer_key)
-        return self.node[self.peers.index(peer_key)]
+            return self.node[self.peers.index(peer_key)]
+        return None
 
     def add_block(self, block):
+        if len(self.transactions) > MAX_TRANSACTIONS:
+            raise TrustGraphException("Max transactions reached in the graph")
+
         if block.hash not in self.transactions and block.type == b'tribler_bandwidth':
             peer1_key = hexlify(block.public_key)
             peer2_key = hexlify(block.link_public_key)
 
-            peer1 = self.get_node(peer1_key)
-            peer2 = self.get_node(peer2_key)
+            peer1 = self.get_node(peer1_key, add_if_not_exist=True)
+            peer2 = self.get_node(peer2_key, add_if_not_exist=True)
 
             if block.sequence_number > peer1.get('sequence_number', 0):
                 peer1['sequence_number'] = block.sequence_number
@@ -48,6 +61,7 @@ class TrustGraph(nx.DiGraph):
             diff = block.transaction[b'up'] - block.transaction[b'down']
             if peer2['id'] not in self.successors(peer1['id']):
                 self.add_edge(peer1['id'], peer2['id'], weight=diff)
+            self.transactions[block.hash] = block
 
     def add_blocks(self, blocks):
         for block in blocks:
@@ -105,6 +119,7 @@ class TrustGraph(nx.DiGraph):
 class TrustViewEndpoint(resource.Resource):
     def __init__(self, session):
         resource.Resource.__init__(self)
+        self.logger = logging.getLogger(self.__class__.__name__)
         self.session = session
 
         self.trustchain_db = None
@@ -125,10 +140,10 @@ class TrustViewEndpoint(resource.Resource):
         if not self.trust_graph:
             self.initialize_graph()
 
-        def get_bandwidth_blocks(public_key, limit=64):
+        def get_bandwidth_blocks(public_key, limit=5):
             return self.trustchain_db.get_latest_blocks(public_key, limit=limit, block_types=[b'tribler_bandwidth'])
 
-        def get_friends(public_key, limit=64):
+        def get_friends(public_key, limit=5):
             return self.trustchain_db.get_connected_users(public_key, limit=limit)
 
         depth = 0
@@ -138,19 +153,22 @@ class TrustViewEndpoint(resource.Resource):
         # If depth is zero or not provided then fetch all depth levels
         fetch_all = depth == 0
 
-        if fetch_all or depth == 1:
-            self.trust_graph.add_blocks(get_bandwidth_blocks(self.public_key))
-        if fetch_all or depth == 2:
-            for friend in get_friends(self.public_key):
-                self.trust_graph.add_blocks(get_bandwidth_blocks(unhexlify(friend['public_key'])))
-        if fetch_all or depth == 3:
-            for friend in get_friends(self.public_key):
-                self.trust_graph.add_blocks(get_bandwidth_blocks(unhexlify(friend['public_key'])))
-                for fof in get_friends(unhexlify(friend['public_key'])):
-                    self.trust_graph.add_blocks(get_bandwidth_blocks(unhexlify(fof['public_key'])))
-        if fetch_all or depth == 4:
-            for user_block in self.trustchain_db.get_users():
-                self.trust_graph.add_blocks(get_bandwidth_blocks(unhexlify(user_block['public_key'])))
+        try:
+            if fetch_all or depth == 1:
+                self.trust_graph.add_blocks(get_bandwidth_blocks(self.public_key, limit=100))
+            if fetch_all or depth == 2:
+                for friend in get_friends(self.public_key):
+                    self.trust_graph.add_blocks(get_bandwidth_blocks(unhexlify(friend['public_key']), limit=10))
+            if fetch_all or depth == 3:
+                for friend in get_friends(self.public_key):
+                    self.trust_graph.add_blocks(get_bandwidth_blocks(unhexlify(friend['public_key'])))
+                    for fof in get_friends(unhexlify(friend['public_key'])):
+                        self.trust_graph.add_blocks(get_bandwidth_blocks(unhexlify(fof['public_key'])))
+            if fetch_all or depth == 4:
+                for user_block in self.trustchain_db.get_users():
+                    self.trust_graph.add_blocks(get_bandwidth_blocks(unhexlify(user_block['public_key'])))
+        except TrustGraphException as tgex:
+            self.logger.warn(tgex)
 
         graph_data = self.trust_graph.compute_node_graph()
 

--- a/Tribler/Core/Modules/restapi/trustview_endpoint.py
+++ b/Tribler/Core/Modules/restapi/trustview_endpoint.py
@@ -20,12 +20,19 @@ MAX_TRANSACTIONS = 2500
 
 class TrustGraph(nx.DiGraph):
 
-    def __init__(self, root_node):
+    def __init__(self, root_key):
         nx.DiGraph.__init__(self)
         self.root_node = 0
 
         self.peers = []
-        self.get_node(root_node)
+        self.get_node(root_key)
+
+        self.transactions = {}
+        self.token_balance = {}
+
+    def reset(self, root_key):
+        self.peers = []
+        self.get_node(root_key)
 
         self.transactions = {}
         self.token_balance = {}
@@ -154,6 +161,8 @@ class TrustViewEndpoint(resource.Resource):
         fetch_all = depth == 0
 
         try:
+            if fetch_all:
+                self.trust_graph.reset(hexlify(self.public_key))
             if fetch_all or depth == 1:
                 self.trust_graph.add_blocks(get_bandwidth_blocks(self.public_key, limit=100))
             if fetch_all or depth == 2:

--- a/Tribler/Core/exceptions.py
+++ b/Tribler/Core/exceptions.py
@@ -44,14 +44,12 @@ class InvalidSignatureException(TriblerException):
     """
     Raised when encountering an invalid signature.
     """
-    pass
 
 
 class InvalidChannelNodeException(TriblerException):
     """
     Raised when trying to create an inconsistent GigaChannel entry
     """
-    pass
 
 
 class DuplicateChannelIdError(TriblerException):
@@ -59,17 +57,14 @@ class DuplicateChannelIdError(TriblerException):
     The Channel name already exists in the ChannelManager channel list,
     i.e., one of your own Channels with the same name already exists.
     """
-    pass
 
 
 class DuplicateTorrentFileError(TriblerException):
     """The Torrent already exists in the Channel you try to add it to."""
-    pass
 
 
 class SaveResumeDataError(TriblerException):
     """This error is used when the resume data of a download fails to save."""
-    pass
 
 
 class DuplicateDownloadException(TriblerException):
@@ -89,5 +84,12 @@ class TorrentFileException(TriblerException):
 
 class InvalidConfigException(TriblerException):
     """The config file doesn't adhere to the config specification."""
+    def __init__(self, msg=None):
+        TriblerException.__init__(self, msg)
+
+
+class TrustGraphException(TriblerException):
+    """Exception specific to Trust graph."""
+
     def __init__(self, msg=None):
         TriblerException.__init__(self, msg)

--- a/Tribler/Test/Core/Modules/RestApi/test_trustview_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_trustview_endpoint.py
@@ -78,7 +78,7 @@ class TestTrustGraph(BaseTestCase):
         db = MockDatabase()
         block = TestBlock()
 
-        for _i in xrange(MAX_TRANSACTIONS):
+        for _ in xrange(MAX_TRANSACTIONS):
             tx = {b"total_up": random.randint(1, 100), b"total_down": random.randint(1, 100),
                   b"up": random.randint(1, 100), b"down": random.randint(1, 100)}
             new_block = TrustChainBlock.create(b'tribler_bandwidth', tx, db, block.public_key)


### PR DESCRIPTION
Set max nodes to 500 and max transactions to 2500 for trust graph rendering.