### PR TITLE
Added check for dependencies during startup

### DIFF
--- a/Tribler/dependencies.py
+++ b/Tribler/dependencies.py
@@ -1,0 +1,72 @@
+"""
+This file lists the python dependencies for Tribler.
+
+Note that this file should not depend on any external modules itself other than builtin ones.
+"""
+from __future__ import absolute_import, print_function
+
+import importlib
+import sys
+
+dependencies = [
+    {'module': 'PyQt5', 'pip_install': 'pip3 install PyQt5', 'optional': False, 'scope': 'gui'},
+    {'module': 'twisted', 'pip_install': 'pip3 install Twisted', 'optional': False, 'scope': 'core'},
+    {'module': 'libtorrent', 'pip_install': 'apt install python-libtorrent', 'optional': False, 'scope': 'core'},
+    {'module': 'cryptography', 'pip_install': 'pip3 install cryptograpy>=2.3', 'optional': False, 'scope': 'core'},
+    {'module': 'libnacl', 'pip_install': 'pip3 install libnacl', 'optional': False, 'scope': 'core'},
+    {'module': 'pony', 'pip_install': 'pip3 install pony', 'optional': False, 'scope': 'core'},
+    {'module': 'lz4', 'pip_install': 'pip3 install lz4', 'optional': False, 'scope': 'core'},
+    {'module': 'psutil', 'pip_install': 'pip3 install psutil', 'optional': False, 'scope': 'both'},
+    {'module': 'networkx', 'pip_install': 'pip3 install networkx', 'optional': False, 'scope': 'both'},
+    {'module': 'pyqtgraph', 'pip_install': 'pip3 install pyqtgraph', 'optional': False, 'scope': 'gui'},
+    {'module': 'matplotlib', 'pip_install': 'pip3 install matplotlib', 'optional': False, 'scope': 'gui'},
+    {'module': 'chardet', 'pip_install': 'pip3 install chardet', 'optional': False, 'scope': 'core'},
+    {'module': 'cherrypy', 'pip_install': 'pip3 install cherrypy', 'optional': False, 'scope': 'core'},
+    {'module': 'configobj', 'pip_install': 'pip3 install configobj', 'optional': False, 'scope': 'both'},
+    {'module': 'netifaces', 'pip_install': 'pip install netifaces', 'optional': False, 'scope': 'core'},
+    {'module': 'six', 'pip_install': 'pip install six', 'optional': False, 'scope': 'both'},
+    {'module': 'bitcoinlib', 'pip_install': 'pip install bitcoinlib', 'optional': True, 'scope': 'core'},
+]
+
+
+def show_system_popup(title, text):
+    """
+    Create a native pop-up without any third party dependency.
+
+    :param title: the pop-up title
+    :param text: the pop-up body
+    """
+    try:
+        import win32api
+        win32api.MessageBox(0, text, title)
+    except ImportError:
+        import subprocess
+        subprocess.Popen(['xmessage', '-center', text], shell=False)
+    sep = "*" * 80
+    print('\n'.join([sep, title, sep, text, sep]), file=sys.stderr)
+
+
+def check_for_missing_dependencies(scope='both'):
+    """
+    Checks modules installed with pip, especially via linux post installation script.
+    Program exits with a dialog if there are any missing dependencies.
+
+    :param scope: Defines the scope of the dependencies. Can have three values: core, gui, both. Default value is both.
+    """
+    missing_deps = []
+    for dep in dependencies:
+        if scope == 'both' or dep['scope'] == 'both' or dep['scope'] == scope:
+            try:
+                importlib.import_module(dep['module'])
+            except ImportError:
+                if not dep['optional']:
+                    missing_deps.append(dep)
+
+    if missing_deps:
+        formatted_message = "\n ".join([miss_dep['pip_install'] for miss_dep in missing_deps])
+        show_system_popup("Dependencies missing!",
+                          "Tribler -  found missing dependencies in %s!\n"
+                          "Please install the following dependencies to continue:"
+                          "\n\n %s \n\n" % (scope, formatted_message)
+                          )
+        exit(1)

--- a/Tribler/dependencies.py
+++ b/Tribler/dependencies.py
@@ -9,27 +9,29 @@ import importlib
 import sys
 
 dependencies = [
-    {'module': 'PyQt5', 'pip_install': 'pip3 install PyQt5', 'optional': False, 'scope': 'gui'},
-    {'module': 'twisted', 'pip_install': 'pip3 install Twisted', 'optional': False, 'scope': 'core'},
-    {'module': 'libtorrent', 'pip_install': 'apt install python-libtorrent', 'optional': False, 'scope': 'core'},
-    {'module': 'cryptography', 'pip_install': 'pip3 install cryptograpy>=2.3', 'optional': False, 'scope': 'core'},
-    {'module': 'libnacl', 'pip_install': 'pip3 install libnacl', 'optional': False, 'scope': 'core'},
-    {'module': 'pony', 'pip_install': 'pip3 install pony', 'optional': False, 'scope': 'core'},
-    {'module': 'lz4', 'pip_install': 'pip3 install lz4', 'optional': False, 'scope': 'core'},
-    {'module': 'psutil', 'pip_install': 'pip3 install psutil', 'optional': False, 'scope': 'both'},
-    {'module': 'networkx', 'pip_install': 'pip3 install networkx', 'optional': False, 'scope': 'both'},
-    {'module': 'pyqtgraph', 'pip_install': 'pip3 install pyqtgraph', 'optional': False, 'scope': 'gui'},
-    {'module': 'matplotlib', 'pip_install': 'pip3 install matplotlib', 'optional': False, 'scope': 'gui'},
-    {'module': 'chardet', 'pip_install': 'pip3 install chardet', 'optional': False, 'scope': 'core'},
-    {'module': 'cherrypy', 'pip_install': 'pip3 install cherrypy', 'optional': False, 'scope': 'core'},
-    {'module': 'configobj', 'pip_install': 'pip3 install configobj', 'optional': False, 'scope': 'both'},
-    {'module': 'netifaces', 'pip_install': 'pip install netifaces', 'optional': False, 'scope': 'core'},
-    {'module': 'six', 'pip_install': 'pip install six', 'optional': False, 'scope': 'both'},
-    {'module': 'bitcoinlib', 'pip_install': 'pip install bitcoinlib', 'optional': True, 'scope': 'core'},
+    {'module': 'PyQt5', 'install_type': 'pip3', 'package': 'PyQt5', 'optional': False, 'scope': 'gui'},
+    {'module': 'twisted', 'install_type': 'pip3', 'package': 'Twisted', 'optional': False, 'scope': 'core'},
+    {'module': 'libtorrent', 'install_type': 'apt', 'package': 'python-libtorrent', 'optional': False,
+     'scope': 'core'},
+    {'module': 'cryptography', 'install_type': 'pip3', 'package': 'cryptograpy>=2.3', 'optional': False,
+     'scope': 'core'},
+    {'module': 'libnacl', 'install_type': 'pip3', 'package': 'libnacl', 'optional': False, 'scope': 'core'},
+    {'module': 'pony', 'install_type': 'pip3', 'package': 'pony>=0.7.10', 'optional': False, 'scope': 'core'},
+    {'module': 'lz4', 'install_type': 'pip3', 'package': 'lz4', 'optional': False, 'scope': 'core'},
+    {'module': 'psutil', 'install_type': 'pip3', 'package': 'psutil', 'optional': False, 'scope': 'both'},
+    {'module': 'networkx', 'install_type': 'pip3', 'package': 'networkx', 'optional': False, 'scope': 'both'},
+    {'module': 'pyqtgraph', 'install_type': 'pip3', 'package': 'pyqtgraph', 'optional': False, 'scope': 'gui'},
+    {'module': 'matplotlib', 'install_type': 'pip3', 'package': 'matplotlib', 'optional': False, 'scope': 'gui'},
+    {'module': 'chardet', 'install_type': 'pip3', 'package': 'chardet', 'optional': False, 'scope': 'core'},
+    {'module': 'cherrypy', 'install_type': 'pip3', 'package': 'cherrypy', 'optional': False, 'scope': 'core'},
+    {'module': 'configobj', 'install_type': 'pip3', 'package': 'configobj', 'optional': False, 'scope': 'both'},
+    {'module': 'netifaces', 'install_type': 'pip3', 'package': 'netifaces', 'optional': False, 'scope': 'core'},
+    {'module': 'six', 'install_type': 'pip3', 'package': 'six', 'optional': False, 'scope': 'both'},
+    {'module': 'bitcoinlib', 'install_type': 'pip3', 'package': 'bitcoinlib', 'optional': True, 'scope': 'core'},
 ]
 
 
-def show_system_popup(title, text):
+def _show_system_popup(title, text):
     """
     Create a native pop-up without any third party dependency.
 
@@ -53,20 +55,24 @@ def check_for_missing_dependencies(scope='both'):
 
     :param scope: Defines the scope of the dependencies. Can have three values: core, gui, both. Default value is both.
     """
-    missing_deps = []
+    missing_deps = {'pip3': [], 'apt': []}
     for dep in dependencies:
         if scope == 'both' or dep['scope'] == 'both' or dep['scope'] == scope:
             try:
                 importlib.import_module(dep['module'])
             except ImportError:
                 if not dep['optional']:
-                    missing_deps.append(dep)
+                    if dep['install_type'] == 'pip3':
+                        missing_deps['pip3'].append(dep['package'])
+                    elif dep['install_type'] == 'apt':
+                        missing_deps['apt'].append(dep['package'])
 
-    if missing_deps:
-        formatted_message = "\n ".join([miss_dep['pip_install'] for miss_dep in missing_deps])
-        show_system_popup("Dependencies missing!",
-                          "Tribler -  found missing dependencies in %s!\n"
-                          "Please install the following dependencies to continue:"
-                          "\n\n %s \n\n" % (scope, formatted_message)
-                          )
+    if missing_deps['pip3'] or missing_deps['apt']:
+        pip3_install = "\n pip3 install %s" % ' '.join(missing_deps['pip3']) if missing_deps['pip3'] else ''
+        apt_install = "\n apt install %s" % ' '.join(missing_deps['apt']) if missing_deps['apt'] else ''
+        _show_system_popup("Dependencies missing!",
+                           "Tribler -  found missing dependencies in %s!\n"
+                           "Please install the following dependencies to continue:"
+                           "\n %s%s \n\n" % (scope, pip3_install, apt_install)
+                           )
         exit(1)

--- a/check_os.py
+++ b/check_os.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, print_function
 
-import importlib
 import logging.config
 import os
 import sys
@@ -10,28 +9,12 @@ import traceback
 
 import psutil
 
+from Tribler.dependencies import show_system_popup
 from Tribler.Core.Config.tribler_config import TriblerConfig
 from Tribler.Core.Modules.process_checker import ProcessChecker
 
 FORCE_RESTART_MESSAGE = "An existing Tribler core process (PID:%s) is already running. \n\n" \
                         "Do you want to stop the process and do a clean restart instead?"
-
-
-def _do_popup(title, text):
-    """
-    Create a native pop-up without any third party dependency.
-
-    :param title: the pop-up title
-    :param text: the pop-up body
-    """
-    try:
-        import win32api
-        win32api.MessageBox(0, text, title)
-    except ImportError:
-        import subprocess
-        subprocess.Popen(['xmessage', '-center', text], shell=False)
-    sep = "*" * 20
-    print('\n'.join([sep, title, sep, text, sep]), file=sys.stderr)
 
 
 def error_and_exit(title, main_text):
@@ -41,7 +24,7 @@ def error_and_exit(title, main_text):
     :param title: the short error description
     :param main_text: the long error description
     """
-    _do_popup(title, main_text)
+    show_system_popup(title, main_text)
 
     # Exit the program
     sys.exit(1)
@@ -63,13 +46,11 @@ def check_environment():
     """
     Perform all of the pre-Tribler checks to see if we can run on this platform.
     """
-    check_pip_dependencies()
     check_read_write()
 
 
 def check_free_space():
     try:
-        import psutil
         free_space = psutil.disk_usage(".").free/(1024 * 1024.0)
         if free_space < 100:
             error_and_exit("Insufficient disk space",
@@ -335,26 +316,3 @@ def trace_exceptions(file_handler, frame, event, args):
             exc_type.__name__, exc_value, "".join(traceback.format_tb(exc_traceback)))
         file_handler.write(trace_line)
         file_handler.flush()
-
-
-def check_pip_dependencies():
-    """
-    Checks modules installed with pip, especially via linux post installation script.
-    Program exits with a dialog if there are any missing dependencies.
-
-    TODO: Right now with TKinter dialog, it is not possible to copy the missing dependencies
-    scripts shown in the dialog box. When we update the dialog, we should support that as well.
-    """
-    required_deps = ['pony', 'lz4']
-    missing_deps = []
-
-    for dep in required_deps:
-        try:
-            importlib.import_module(dep)
-        except ImportError:
-            missing_deps.append(dep)
-
-    if missing_deps:
-        error_and_exit("Dependencies missing!",
-                       "Please report to the developers and install the following missing dependencies "
-                       "to continue:\n\n pip install --user %s \n\n" % " ".join(missing_deps))

--- a/check_os.py
+++ b/check_os.py
@@ -9,9 +9,9 @@ import traceback
 
 import psutil
 
-from Tribler.dependencies import show_system_popup
 from Tribler.Core.Config.tribler_config import TriblerConfig
 from Tribler.Core.Modules.process_checker import ProcessChecker
+from Tribler.dependencies import show_system_popup
 
 FORCE_RESTART_MESSAGE = "An existing Tribler core process (PID:%s) is already running. \n\n" \
                         "Do you want to stop the process and do a clean restart instead?"

--- a/check_os.py
+++ b/check_os.py
@@ -11,7 +11,7 @@ import psutil
 
 from Tribler.Core.Config.tribler_config import TriblerConfig
 from Tribler.Core.Modules.process_checker import ProcessChecker
-from Tribler.dependencies import show_system_popup
+from Tribler.dependencies import _show_system_popup
 
 FORCE_RESTART_MESSAGE = "An existing Tribler core process (PID:%s) is already running. \n\n" \
                         "Do you want to stop the process and do a clean restart instead?"
@@ -24,7 +24,7 @@ def error_and_exit(title, main_text):
     :param title: the short error description
     :param main_text: the long error description
     """
-    show_system_popup(title, main_text)
+    _show_system_popup(title, main_text)
 
     # Exit the program
     sys.exit(1)

--- a/run_tribler.py
+++ b/run_tribler.py
@@ -34,6 +34,7 @@ def start_tribler_core(base_path, api_port):
     Note that there is no direct communication between the GUI process and the core: all communication is performed
     through the HTTP API.
     """
+    from check_os import check_and_enable_code_tracing, set_process_priority, setup_core_logging
     from twisted.internet import reactor
     setup_core_logging()
 
@@ -88,7 +89,6 @@ if __name__ == "__main__":
     if 'CORE_PROCESS' in os.environ:
         # Check for missing Core dependencies
         check_for_missing_dependencies(scope='core')
-        from check_os import *
 
         base_path = os.environ['CORE_BASE_PATH']
         api_port = os.environ['CORE_API_PORT']
@@ -97,7 +97,9 @@ if __name__ == "__main__":
         # Check for missing GUI dependencies
         check_for_missing_dependencies(scope='gui')
 
-        from check_os import *
+        # Do imports only after dependencies check
+        from check_os import check_and_enable_code_tracing, check_environment, check_free_space, enable_fault_handler, \
+            error_and_exit, setup_gui_logging, should_kill_other_tribler_instances
         from Tribler.Core.exceptions import TriblerException
 
         try:

--- a/run_tribler.py
+++ b/run_tribler.py
@@ -5,12 +5,7 @@ import os
 import signal
 import sys
 
-from check_os import check_and_enable_code_tracing, check_environment, check_free_space, enable_fault_handler, \
-    error_and_exit, set_process_priority, setup_gui_logging, should_kill_other_tribler_instances
-
-from Tribler.Core.Config.tribler_config import TriblerConfig
-from Tribler.Core.exceptions import TriblerException
-
+from Tribler.dependencies import check_for_missing_dependencies
 
 # https://github.com/Tribler/tribler/issues/3702
 # We need to make sure that anyone running cp65001 can print to the stdout before we print anything.
@@ -40,9 +35,9 @@ def start_tribler_core(base_path, api_port):
     through the HTTP API.
     """
     from twisted.internet import reactor
-    from check_os import setup_core_logging
     setup_core_logging()
 
+    from Tribler.Core.Config.tribler_config import TriblerConfig
     from Tribler.Core.Modules.process_checker import ProcessChecker
     from Tribler.Core.Session import Session
 
@@ -91,10 +86,20 @@ def start_tribler_core(base_path, api_port):
 if __name__ == "__main__":
     # Check whether we need to start the core or the user interface
     if 'CORE_PROCESS' in os.environ:
+        # Check for missing Core dependencies
+        check_for_missing_dependencies(scope='core')
+        from check_os import *
+
         base_path = os.environ['CORE_BASE_PATH']
         api_port = os.environ['CORE_API_PORT']
         start_tribler_core(base_path, api_port)
     else:
+        # Check for missing GUI dependencies
+        check_for_missing_dependencies(scope='gui')
+
+        from check_os import *
+        from Tribler.Core.exceptions import TriblerException
+
         try:
             # Enable tracer using commandline args: --trace-debug or --trace-exceptions
             trace_logger = check_and_enable_code_tracing('gui')

--- a/run_tribler.py
+++ b/run_tribler.py
@@ -94,8 +94,8 @@ if __name__ == "__main__":
         api_port = os.environ['CORE_API_PORT']
         start_tribler_core(base_path, api_port)
     else:
-        # Check for missing GUI dependencies
-        check_for_missing_dependencies(scope='gui')
+        # Check for missing both(GUI, Core) dependencies
+        check_for_missing_dependencies(scope='both')
 
         # Do imports only after dependencies check
         from check_os import check_and_enable_code_tracing, check_environment, check_free_space, enable_fault_handler, \


### PR DESCRIPTION
I have updated `run_tribler.py` to check for missing dependencies before anything else is loaded. This will help us find out dependency issues. Note that, I added a `dependencies.py` file which includes a list of all dependencies. We should keep this file updated whenever we change any dependency.

Also, note that for each dependency `scope` and `optional` fields are set. This separates where the dependency is used ('gui', 'core' or 'both') and if it is optional so both GUI and Core can be separately tested for the dependencies.


Missing dependencies will be shown in a system popup as shown below:
![missing-deps](https://user-images.githubusercontent.com/1442867/65128906-9bc5e580-d9fa-11e9-90a0-86c15c6787e9.png)

