### PR TITLE
Multiple bootstrap files

### DIFF
--- a/Tribler/Core/Session.py
+++ b/Tribler/Core/Session.py
@@ -435,7 +435,13 @@ class Session(object):
             # TODO: move GigaChannel torrents into a separate session
             if self.lm.gigachannel_manager:
                 self.lm.gigachannel_manager.start()
-        return startup_deferred.addCallback(load_checkpoint).addCallback(start_gigachannel_manager)
+
+        def start_bootstrap_download(_):
+            if not self.lm.bootstrap:
+                self.lm.start_bootstrap_download()
+
+        return startup_deferred.addCallback(load_checkpoint).addCallback(start_gigachannel_manager)\
+            .addCallback(start_bootstrap_download)
 
     def shutdown(self):
         """

--- a/Tribler/Core/bootstrap.py
+++ b/Tribler/Core/bootstrap.py
@@ -33,24 +33,6 @@ class Bootstrap(object):
         self.bootstrap_nodes = {}
         self.load_bootstrap_nodes()
 
-    def start_initial_seeder(self, download_function, bootstrap_file, system_infohash):
-        """
-        Start as initial seeder for bootstrap_file
-        :param download_function: function to download via tdef
-        :return: download on bootstrap file
-        """
-        tdef = TorrentDef()
-        tdef.add_content(bootstrap_file)
-        tdef.set_piece_length(2 ** 16)
-        tdef.save()
-        self._logger.debug("Seeding bootstrap file %s", hexlify(tdef.infohash))
-        self.download = download_function(tdef, download_config=self.dcfg, hidden=True)
-        self.infohash = tdef.get_infohash()
-        if hexlify(self.infohash) != system_infohash:
-            self._logger.error(
-                "Infohash is not consistent with a system infohash %s != %s", hexlify(self.infohash),
-                system_infohash)
-
     def start_by_infohash(self, download_function, infohash):
         """
         Download bootstrap file from current seeders


### PR DESCRIPTION
Removes old bootstrap files when trying to resume downloads and always loads the latest bootstrap from the infohash present in the config file. This prevents the bootstrap file from being overridden by the old content and potentially fixes related SQL issues.

Fixes #4757 
Fixes #4847