### PR TITLE
READY: Prioritize gossiping personal channel

### DIFF
--- a/Tribler/Core/Modules/MetadataStore/OrmBindings/channel_metadata.py
+++ b/Tribler/Core/Modules/MetadataStore/OrmBindings/channel_metadata.py
@@ -410,7 +410,8 @@ def define_binding(db):
             :rtype: list
             """
             query = db.ChannelMetadata.select(
-                lambda g: g.status not in [LEGACY_ENTRY, NEW, UPDATED, TODELETE] and g.num_entries > 0)
+                lambda g: g.status not in [LEGACY_ENTRY, NEW, UPDATED, TODELETE] and g.num_entries > 0 and
+                g.public_key != database_blob(cls._my_key.pub().key_to_bin()[10:]))
             query = query.where(subscribed=True) if only_subscribed else query
             query = query.where(lambda g: g.local_version == g.timestamp) if only_downloaded else query
             return query.random(limit)


### PR DESCRIPTION
This  PR makes GigaChannel community send two packets on each walk step instead of one:
the first packet contains gossip with the user's personal channel, the second one contains a random subscribed channel. The format remains the same, everything is compatible with the previous version of the GigaChannel community.

During the last month, observation of GigaChannel dynamics showed that the original content propagates slowly. One reason for that is that if a user subscribes for several channels, their personal channel has a really low chance to sent to others. User's personal channel should always get the highest priority in gossip. This is how interpersonal relationships work: we ask "How are *you* doing?" and tell others of things that matter to *us* first.