### PR TITLE
READY: Fix non-deterministic results in squash_mdblobs tests

### DIFF
--- a/Tribler/Test/test_as_server.py
+++ b/Tribler/Test/test_as_server.py
@@ -157,6 +157,7 @@ class AbstractServer(BaseTestCase):
         self.annotate(self._testMethodName, start=True)
         self.watchdog.start()
         yield reactor_deferred
+        random.seed(123)
 
     def setUpFileServer(self, port, path):
         # Create a local file server, can be used to serve local files. This is preferred over an external network
@@ -216,6 +217,7 @@ class AbstractServer(BaseTestCase):
 
     @inlineCallbacks
     def tearDown(self):
+        random.seed()
         self.annotate(self._testMethodName, start=False)
 
         process_unhandled_exceptions()


### PR DESCRIPTION
Added `random.seed(123)` to the base test class to make everything as deterministic as possible.
On `tearDown` random generator is re-seeded with the system default generator.