### PR TITLE
READY: Added debug level logging to pstate parsing exception

### DIFF
--- a/Tribler/Core/Upgrade/upgrade.py
+++ b/Tribler/Core/Upgrade/upgrade.py
@@ -55,7 +55,8 @@ def cleanup_noncompliant_channel_torrents(state_dir):
                     if name and len(name) != CHANNEL_DIR_NAME_LENGTH:
                         os.unlink(file_path)
                 except (TypeError, KeyError, ValueError):
-                    logger.debug("Malformed .pstate file %s", file_path)
+                    logger.debug("Malfored .pstate file %s found during cleanup of non-compliant channel torrents.",
+                                 file_path)
 
 
 class TriblerUpgrader(object):

--- a/Tribler/Core/Upgrade/upgrade.py
+++ b/Tribler/Core/Upgrade/upgrade.py
@@ -55,7 +55,7 @@ def cleanup_noncompliant_channel_torrents(state_dir):
                     if name and len(name) != CHANNEL_DIR_NAME_LENGTH:
                         os.unlink(file_path)
                 except (TypeError, KeyError, ValueError):
-                    pass
+                    logger.debug("Malformed .pstate file %s", file_path)
 
 
 class TriblerUpgrader(object):


### PR DESCRIPTION
Added a debug level logging statement to the exception of a malformed .pstate file as per bug  #4891 