### PR TITLE
Auto screen scaling for high resolution screens

### DIFF
--- a/TriblerGUI/tribler_window.py
+++ b/TriblerGUI/tribler_window.py
@@ -134,6 +134,8 @@ class TriblerWindow(QMainWindow):
         QCoreApplication.setOrganizationName("TUDelft")
         QCoreApplication.setApplicationName("Tribler")
         QCoreApplication.setAttribute(Qt.AA_UseHighDpiPixmaps)
+        QCoreApplication.setAttribute(Qt.AA_EnableHighDpiScaling)
+        os.environ['QT_AUTO_SCREEN_SCALE_FACTOR'] = "1"
 
         self.gui_settings = QSettings()
         api_port = api_port or int(get_gui_setting(self.gui_settings, "api_port", DEFAULT_API_PORT))


### PR DESCRIPTION
Auto screen scaling factor for high resolution screens set to 1.
Reference: https://doc.qt.io/qt-5/highdpi.html

Fixes partially https://github.com/Tribler/tribler/issues/2748