### PR TITLE
Iterate iglob result directly

### DIFF
--- a/Tribler/Core/Upgrade/config_converter.py
+++ b/Tribler/Core/Upgrade/config_converter.py
@@ -47,8 +47,7 @@ def convert_config_to_tribler71(current_config, state_dir=None):
 
     # We also have to update all existing downloads, in particular, rename the section 'downloadconfig' to
     # 'download_defaults'.
-    for _, filename in enumerate(iglob(
-            os.path.join(state_dir, STATEDIR_CHECKPOINT_DIR, '*.state'))):
+    for filename in iglob(os.path.join(state_dir, STATEDIR_CHECKPOINT_DIR, '*.state')):
         download_cfg = RawConfigParser()
         try:
             with open(filename) as cfg_file:


### PR DESCRIPTION
The result received from `iglob` has been iterated through `enumerate`. The need for an index has at some point been rendered not needed, and the index variable replaced with an underscore, so there's no need for `enumerate` and the result can be iterated directly. Fixes bug #4897.