### PR TITLE
Fix channels not downloading on Python3

### DIFF
--- a/Tribler/Core/Modules/gigachannel_manager.py
+++ b/Tribler/Core/Modules/gigachannel_manager.py
@@ -231,7 +231,7 @@ class GigaChannelManager(TaskManager):
             # TODO: count the number of tries we had with the channel, so we can stop trying eventually
             returnValue(None)
         try:
-            if metainfo['info']['name'] != channel.dirname:
+            if metainfo[b'info'][b'name'].decode('utf-8') != channel.dirname:
                 # Malformed channel
                 # TODO: stop trying to download this channel until it is updated with a new infohash
                 returnValue(None)

--- a/Tribler/Test/Core/Modules/MetadataStore/test_channel_download.py
+++ b/Tribler/Test/Core/Modules/MetadataStore/test_channel_download.py
@@ -51,7 +51,7 @@ class TestChannelDownload(TestAsServer):
             channel = self.session.lm.mds.ChannelMetadata.get(signature=payload.signature)
 
         def fake_get_metainfo(infohash, timeout=30):
-            return {'info': {'name': channel.dirname}}
+            return {b'info': {b'name': channel.dirname.encode('utf-8')}}
 
         self.session.lm.ltmgr.get_metainfo = fake_get_metainfo
         # The leecher should be hinted to leech from localhost. Thus, we must extend start_downoload_from_tdef

--- a/Tribler/Test/Core/Modules/RestApi/test_downloads_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_downloads_endpoint.py
@@ -700,7 +700,7 @@ class TestMetadataDownloadEndpoint(AbstractApiTest):
         with db_session:
             channel = self.session.lm.mds.ChannelMetadata.create_channel(test_channel_name, 'bla')
             def fake_get_metainfo(infohash, timeout=30):
-                return {'info': {'name': channel.dirname}}
+                return {b'info': {b'name': channel.dirname.encode('utf-8')}}
             self.session.lm.ltmgr.get_metainfo = fake_get_metainfo
             self.session.lm.gigachannel_manager.download_channel(channel)
 

--- a/Tribler/Test/Core/Modules/test_gigachannel_manager.py
+++ b/Tribler/Test/Core/Modules/test_gigachannel_manager.py
@@ -247,10 +247,10 @@ class TestGigaChannelManager(TriblerCoreTest):
         self.mock_session.lm.ltmgr = MockObject()
 
         def mock_get_metainfo_bad(_, timeout=None):
-            return {'info': {'name': "bla"}}
+            return {b'info': {b'name': b'bla'}}
 
         def mock_get_metainfo_good(_, timeout=None):
-            return {'info': {'name': channel.dirname}}
+            return {b'info': {b'name': channel.dirname.encode('utf-8')}}
 
         self.initiated_download = False
 


### PR DESCRIPTION
Fix mismatch in text types in Python3 in GigaChannel Manager routine that checks channels for correction. Without this fix, all channels would be rejected in Python3 as incorrect.