### PR TITLE
WIP: Defensive programming approach for terminating requests Server-Side safely

### DIFF
--- a/Tribler/Core/Modules/restapi/create_torrent_endpoint.py
+++ b/Tribler/Core/Modules/restapi/create_torrent_endpoint.py
@@ -119,7 +119,7 @@ class CreateTorrentEndpoint(resource.Resource):
 
             request.write(json.twisted_dumps({"torrent": base64.b64encode(result['metainfo']).decode('utf-8')}))
             # If the above request.write failed, the request will have already been finished
-            if not request.finished:
+            if not request.finished and not request._disconnected:
                 request.finish()
 
         def _on_create_failure(failure):
@@ -131,7 +131,7 @@ class CreateTorrentEndpoint(resource.Resource):
             self._logger.exception(failure)
             request.write(return_handled_exception(request, failure.value))
             # If the above request.write failed, the request will have already been finished
-            if not request.finished:
+            if not request.finished and not request._disconnected:
                 request.finish()
 
         deferred = self.session.create_torrent_file(file_path_list, recursive_bytes(params))

--- a/Tribler/Core/Modules/restapi/downloads_endpoint.py
+++ b/Tribler/Core/Modules/restapi/downloads_endpoint.py
@@ -432,7 +432,7 @@ class DownloadSpecificEndpoint(DownloadBaseEndpoint):
             self._logger.exception(failure)
             request.write(return_handled_exception(request, failure.value))
             # If the above request.write failed, the request will have already been finished
-            if not request.finished:
+            if not request.finished and not request._disconnected:
                 request.finish()
 
         deferred = self.session.remove_download(download, remove_content=remove_data)
@@ -499,7 +499,7 @@ class DownloadSpecificEndpoint(DownloadBaseEndpoint):
                 self._logger.exception(failure)
                 request.write(return_handled_exception(request, failure.value))
                 # If the above request.write failed, the request will have already been finished
-                if not request.finished:
+                if not request.finished and not request._disconnected:
                     request.finish()
 
             deferred.addCallback(_on_download_readded)

--- a/Tribler/Core/Modules/restapi/metadata_endpoint.py
+++ b/Tribler/Core/Modules/restapi/metadata_endpoint.py
@@ -370,12 +370,10 @@ class TorrentHealthEndpoint(resource.Resource):
             self.finish_request(request)
 
         def on_request_error(failure):
-            if not request.finished:
+            if not request.finished and not request._disconnected:
                 request.setResponseCode(http.BAD_REQUEST)
                 request.write(json.twisted_dumps({"error": failure.getErrorMessage()}))
-            # If the above request.write failed, the request will have already been finished
-            if not request.finished:
-                self.finish_request(request)
+                request.finish()
 
         result_deferred = self.session.check_torrent_health(self.infohash, timeout=timeout, scrape_now=refresh)
         # return immediately. Used by GUI to schedule health updates through the EventsEndpoint

--- a/Tribler/Core/Modules/restapi/torrentinfo_endpoint.py
+++ b/Tribler/Core/Modules/restapi/torrentinfo_endpoint.py
@@ -60,12 +60,10 @@ class TorrentInfoEndpoint(resource.Resource):
 
         def on_got_metainfo(metainfo):
             if not metainfo:
-                if not request.finished:
+                if not request.finished and not request._disconnected:
                     request.setResponseCode(http.INTERNAL_SERVER_ERROR)
                     request.write(json.twisted_dumps({"error": "metainfo error"}))
-                # If the above request.write failed, the request will have already been finished
-                if not request.finished:
-                    self.finish_request(request)
+                    request.finish(request)
                     return
 
             if not isinstance(metainfo, dict) or b'info' not in metainfo:

--- a/Tribler/Test/GUI/FakeTriblerAPI/endpoints/metadata_endpoint.py
+++ b/Tribler/Test/GUI/FakeTriblerAPI/endpoints/metadata_endpoint.py
@@ -250,7 +250,7 @@ class SpecificTorrentHealthEndpoint(resource.Resource):
             return json.twisted_dumps({"error": "the torrent with the specific infohash cannot be found"})
 
         def update_health():
-            if not request.finished:
+            if not request.finished and not request._disconnected:
                 torrent.update_health()
                 request.write(json.twisted_dumps({
                     "health": {


### PR DESCRIPTION
As detailed in issue #4912, Tribler is sometimes susceptible to crashing, when it attempts to close the connection by calling `request.finish()` when the request has actually been unexpectedly terminated in the meantime. This happens even in scenarios where the call to `request.finish()` is guarded by an `if not request.terminated:` clause. As outlined in the aforementioned issue this does not suffice, as the clause needs to be extended to `if not request.terminated and not request_disconnected:` to safely avoid calling `request.finish()` when the situation demands it. The code forwarded in this PR does just this: extends the aforementioned clauses.