### PR TITLE
Builder script update - Windows

### DIFF
--- a/Tribler/Main/Build/Win/tribler.nsi
+++ b/Tribler/Main/Build/Win/tribler.nsi
@@ -123,8 +123,10 @@ Section "!Main EXE" SecMain
     SetOutPath "$INSTDIR"
 
     ; Libraries dependant on 2012 are: LibTorrent
-    File vc_redist_110.exe
-    ExecWait "$INSTDIR\vc_redist_110.exe /q /norestart"
+    ; 2019-10-24: Latest version is compiled against 2015 so we don't need this dependency here. Remove it completely
+    ; When python2 dependency is removed.
+    ; File vc_redist_110.exe
+    ; ExecWait "$INSTDIR\vc_redist_110.exe /q /norestart"
 
     ; Libraries dependant on 2015 are: Python, Qt5
     File vc_redist_140.exe

--- a/win/makedist_win.bat
+++ b/win/makedist_win.bat
@@ -71,12 +71,14 @@ mkdir dist\tribler\tools
 copy win\tools\reset*.bat dist\tribler\tools
 
 REM Laurens, 2016-04-20: Copy the redistributables of 2008, 2012 and 2015 and the VLC installer to the install dir
-copy C:\build\vc_redist_110.exe dist\tribler
+REM Sandip, 2019-10-24: redistributables 2008, 2012 are not necessary anymore
+REM copy C:\build\vc_redist_110.exe dist\tribler
 copy C:\build\vc_redist_140.exe dist\tribler
 
 REM Copy various libraries required on runtime (libsodium and openssl)
 copy C:\build\libsodium.dll dist\tribler
-copy C:\build\openssl\*.dll dist\tribler
+REM Sandip, 2019-10-24: No need to copy openssl dlls separately
+REM copy C:\build\openssl\*.dll dist\tribler
 
 REM Copy missing dll files
 copy C:\build\missing_dlls\*.dll dist\tribler


### PR DESCRIPTION
Builder script update - Windows
- removed old vc redistributables
- removed separate copying of openssl dlls, not necessary anymore