### PR TITLE
State directory update for rollback support

### DIFF
--- a/Tribler/Core/Config/tribler_config.py
+++ b/Tribler/Core/Config/tribler_config.py
@@ -18,6 +18,7 @@ from Tribler.Core.Utilities.network_utils import get_random_port
 from Tribler.Core.Utilities.unicode import ensure_unicode
 from Tribler.Core.exceptions import InvalidConfigException
 from Tribler.Core.osutils import get_appstate_dir
+from Tribler.Core.version import version_id
 
 CONFIG_FILENAME = 'triblerd.conf'
 SPEC_FILENAME = 'tribler_config.spec'
@@ -41,6 +42,9 @@ class TriblerConfig(object):
         """
         self._logger = logging.getLogger(self.__class__.__name__)
         self._state_dir = self.get_default_state_dir()
+        # If specific version state directory is available, use that version otherwise use default address
+        if not os.path.exists(self._state_dir):
+            self._state_dir = self.get_default_base_state_dir()
 
         if config is None:
             config_file = os.path.join(self._state_dir, CONFIG_FILENAME)
@@ -103,17 +107,31 @@ class TriblerConfig(object):
         """
         if not os.path.exists(self.get_state_dir()):
             os.makedirs(self.get_state_dir())
+        self.update_version()
         self.config.filename = os.path.join(self.get_state_dir(), CONFIG_FILENAME)
         self.config.write()
 
     @staticmethod
-    def get_default_state_dir(home_dir_postfix=u'.Tribler'):
+    def get_default_state_dir(home_dir_postfix=u'.Tribler', version=version_id):
+        """Get the default application state directory."""
+        state_dir = TriblerConfig.get_default_base_state_dir(home_dir_postfix=home_dir_postfix)
+        return TriblerConfig.get_versioned_state_dir(state_dir, version)
+
+    @staticmethod
+    def get_default_base_state_dir(home_dir_postfix=u'.Tribler'):
         """Get the default application state directory."""
         if 'TSTATEDIR' in os.environ:
             path = os.environ['TSTATEDIR']
             return path if os.path.isabs(path) else os.path.join(os.getcwd(), path)
 
         return os.path.join(get_appstate_dir(), home_dir_postfix)
+
+    @staticmethod
+    def get_versioned_state_dir(state_dir, version):
+        dash_index = version.find('-')
+        if dash_index < 0:
+            return ensure_unicode(os.path.join(state_dir, version), 'utf-8')
+        return ensure_unicode(os.path.join(state_dir, version[:dash_index], version[dash_index+1:]), 'utf-8')
 
     def _obtain_port(self, section, option):
         """
@@ -135,6 +153,22 @@ class TriblerConfig(object):
             self._logger.debug(u"Get random port %d for [%s]", self.selected_ports[path], path)
         return self.selected_ports[path]
 
+    # Version and backup
+    def set_version(self, version):
+        self.config['general']['version'] = version
+
+    def get_version(self):
+        return self.config['general']['version']
+
+    def update_version(self):
+        self.config['general']['version'] = version_id
+
+    def set_version_backup_enabled(self, backup_enabled):
+        self.config['general']['version_backup_enabled'] = backup_enabled
+
+    def get_version_backup_enabled(self):
+        return self.config['general']['version_backup_enabled']
+
     # Chant
     def set_chant_enabled(self, value):
         self.config['chant']['enabled'] = bool(value)
@@ -151,8 +185,9 @@ class TriblerConfig(object):
     def set_state_dir(self, state_dir):
         self._state_dir = state_dir
 
-    def get_state_dir(self):
-        return ensure_unicode(self._state_dir, 'utf-8')
+    def get_state_dir(self, version=None):
+        return TriblerConfig.get_versioned_state_dir(self._state_dir, version) if version \
+            else ensure_unicode(self._state_dir, 'utf-8')
 
     def set_trustchain_keypair_filename(self, keypairfilename):
         self.config['trustchain']['ec_keypair_filename'] = self.norm_path(keypairfilename)

--- a/Tribler/Core/Config/tribler_config.spec
+++ b/Tribler/Core/Config/tribler_config.spec
@@ -1,4 +1,6 @@
 [general]
+version = string(default='')
+version_backup_enabled = boolean(default=True)
 log_dir = string(default='logs')
 testnet = boolean(default=False)
 version_checker_enabled = boolean(default=True)

--- a/Tribler/Core/Upgrade/upgrade.py
+++ b/Tribler/Core/Upgrade/upgrade.py
@@ -16,7 +16,10 @@ from Tribler.Core.Modules.MetadataStore.store import MetadataStore
 from Tribler.Core.Upgrade.config_converter import convert_config_to_tribler71, convert_config_to_tribler74
 from Tribler.Core.Upgrade.db72_to_pony import DispersyToPonyMigration, cleanup_pony_experimental_db, should_upgrade
 from Tribler.Core.Utilities.configparser import CallbackConfigParser
-from Tribler.Core.simpledefs import NTFY_FINISHED, NTFY_STARTED, NTFY_UPGRADER, NTFY_UPGRADER_TICK
+from Tribler.Core.osutils import dir_copy
+from Tribler.Core.simpledefs import NTFY_FINISHED, NTFY_STARTED, NTFY_UPGRADER, NTFY_UPGRADER_TICK, \
+    STATEDIR_CHANNELS_DIR, STATEDIR_CHECKPOINT_DIR, STATEDIR_DB_DIR, STATEDIR_WALLET_DIR
+from Tribler.Core.version import version_id
 
 
 def cleanup_noncompliant_channel_torrents(state_dir):
@@ -88,6 +91,7 @@ class TriblerUpgrader(object):
         d = self.upgrade_72_to_pony()
         d.addCallback(self.upgrade_pony_db_6to7)
         self.upgrade_config_to_74()
+        self.backup_state_directory()
         return d
 
     def upgrade_pony_db_6to7(self, _):
@@ -173,6 +177,34 @@ class TriblerUpgrader(object):
         """
         self.session.config = convert_config_to_tribler71(self.session.config)
         self.session.config.write()
+
+    def backup_state_directory(self):
+        """
+        Backs up the current state directory if the version in the state directory and in the code is different.
+        """
+        if self.session.config.get_version_backup_enabled() and self.session.config.get_version() \
+                and not self.session.config.get_version() == version_id:
+
+            src_state_dir = self.session.config.get_state_dir()
+            dest_state_dir = self.session.config.get_state_dir(version=self.session.config.get_version())
+
+            # If only there is no tribler config already in the backup directory, then make the current version backup.
+            dest_conf_path = os.path.join(dest_state_dir, 'triblerd.conf')
+            if not os.path.exists(dest_conf_path):
+                # Backup selected directories
+                backup_dirs = [STATEDIR_DB_DIR, STATEDIR_CHECKPOINT_DIR, STATEDIR_WALLET_DIR, STATEDIR_CHANNELS_DIR]
+                src_sub_dirs = os.listdir(src_state_dir)
+                for backup_dir in backup_dirs:
+                    if backup_dir in src_sub_dirs:
+                        dir_copy(os.path.join(src_state_dir, backup_dir), os.path.join(dest_state_dir, backup_dir))
+                    else:
+                        os.makedirs(os.path.join(dest_state_dir, backup_dir))
+
+                # Backup keys and config files
+                backup_files = ['ec_multichain.pem', 'ecpub_multichain.pem', 'ec_trustchain_testnet.pem',
+                                'ecpub_trustchain_testnet.pem', 'triblerd.conf']
+                for backup_file in backup_files:
+                    dir_copy(os.path.join(src_state_dir, backup_file), os.path.join(dest_state_dir, backup_file))
 
     def notify_starting(self):
         """

--- a/Tribler/Core/osutils.py
+++ b/Tribler/Core/osutils.py
@@ -8,8 +8,10 @@ Author(s): Arno Bakker
 
 from __future__ import absolute_import
 
+import errno
 import logging
 import os
+import shutil
 import subprocess
 import sys
 
@@ -247,3 +249,14 @@ def startfile(filepath):
         subprocess.call(('xdg-open', filepath))
     elif hasattr(os, "startfile"):
         os.startfile(filepath)
+
+
+def dir_copy(src_dir, dest_dir):
+    try:
+        shutil.copytree(src_dir, dest_dir)
+    except OSError as e:
+        # If the error was caused because the source wasn't a directory
+        if e.errno == errno.ENOTDIR:
+            shutil.copy(src_dir, dest_dir)
+        else:
+            logging.error("Directory %s could not be imported", src_dir)

--- a/Tribler/Test/Core/Config/test_tribler_config.py
+++ b/Tribler/Test/Core/Config/test_tribler_config.py
@@ -140,6 +140,13 @@ class TestTriblerConfig(TriblerCoreTest):
         self.tribler_config.set_state_dir("TEST")
         self.assertEqual(self.tribler_config.get_state_dir(), "TEST")
 
+        self.tribler_config.set_version('7.0.0-GIT')
+        self.assertLessEqual(self.tribler_config.get_version(), '7.0.0-GIT')
+
+        self.assertEqual(self.tribler_config.get_version_backup_enabled(), True)
+        self.tribler_config.set_version_backup_enabled(False)
+        self.assertEqual(self.tribler_config.get_version_backup_enabled(), False)
+
         self.assertEqual(self.tribler_config.get_trustchain_testnet_keypair_filename(),
                          os.path.join("TEST", "ec_trustchain_testnet.pem"))
         self.tribler_config.set_trustchain_testnet_keypair_filename("bla2")

--- a/Tribler/Test/Core/test_osutils.py
+++ b/Tribler/Test/Core/test_osutils.py
@@ -1,7 +1,9 @@
 from __future__ import absolute_import
 
 import os
+import shutil
 import sys
+import tempfile
 
 import six
 
@@ -11,8 +13,8 @@ if os.path.exists('test_osutils.py'):
 elif os.path.exists('LICENSE'):
     BASE_DIR = '.'
 
-from Tribler.Core.osutils import (fix_filebasename, is_android, get_home_dir, get_appstate_dir, get_picture_dir,
-                                  get_desktop_dir)
+from Tribler.Core.osutils import (dir_copy, fix_filebasename, get_appstate_dir, get_desktop_dir, get_home_dir,
+                                  get_picture_dir, is_android)
 from Tribler.Test.test_as_server import BaseTestCase
 
 
@@ -90,3 +92,23 @@ class Test_OsUtils(BaseTestCase):
         desktop_dir = get_desktop_dir()
         self.assertIsInstance(desktop_dir, six.text_type)
         self.assertTrue(os.path.isdir(desktop_dir))
+
+    def test_dir_copy(self):
+        """
+        Tests copying a source directory to destination directory.
+        """
+        temp_dir = tempfile.mkdtemp()
+        src_dir = os.path.join(temp_dir, 'src')
+        dest_dir = os.path.join(temp_dir, 'dest')
+
+        src_sub_dirs = ['dir1', 'dir2', 'dir3']
+        os.makedirs(src_dir)
+        for sub_dir in src_sub_dirs:
+            os.makedirs(os.path.join(src_dir, sub_dir))
+        self.assertGreater(len(os.listdir(src_dir)), 1)
+
+        dir_copy(src_dir, dest_dir)
+
+        self.assertEqual(len(os.listdir(dest_dir)), len(os.listdir(src_dir)))
+
+        shutil.rmtree(temp_dir, ignore_errors=True)


### PR DESCRIPTION
Whenever the code version (present in `version.py`) and config version (present in `triblerd.conf`) are different, state directory is backed up. This is done by copying the current `.Tribler` directory under the version name present in `triblerd.conf`, also inside the `.Tribler` directory. Since only the copy of the state directory is done, the state directory remains always forward compatible. When Tribler starts it tries to load the state directory from the versioned path. If it cannot find the version path then it falls back to `.Tribler`. 

The directory structure for backing up the state directory looks like the following:
*For stable release, eg. 7.4.0*
```
/home/<user>/.Tribler/7.4.0
```
*For pre-release, eg. 7.4.0-exp1*
```
/home/<user>/.Tribler/7.4.0/exp1
```
