### PR TITLE
Fixed infohash logging for existing downloads

### DIFF
--- a/Tribler/Core/Libtorrent/LibtorrentMgr.py
+++ b/Tribler/Core/Libtorrent/LibtorrentMgr.py
@@ -14,6 +14,7 @@ from distutils.version import LooseVersion
 from shutil import rmtree
 
 from ipv8.taskmanager import TaskManager
+from ipv8.util import ensure_binary
 
 import libtorrent as lt
 from libtorrent import bdecode, torrent_handle
@@ -331,7 +332,7 @@ class LibtorrentMgr(TaskManager):
             return succeed(existing_handle)
 
         if infohash in self.torrents:
-            self._logger.info("Torrent already exists in the downloads. Infohash:%s", hexlify(infohash))
+            self._logger.info("Torrent already exists in the downloads. Infohash:%s", hexlify(ensure_binary(infohash)))
 
         # Otherwise, add it anew
         ltsession.async_add_torrent(encode_atp(atp))


### PR DESCRIPTION
Fixed infohash logging for existing downloads.
Fixes https://github.com/Tribler/tribler/issues/4961