### PR TITLE
Fixed documentation build issues

### DIFF
--- a/Tribler/Core/Modules/restapi/metadata_endpoint.py
+++ b/Tribler/Core/Modules/restapi/metadata_endpoint.py
@@ -97,7 +97,7 @@ class MetadataPublicKeyEndpoint(resource.Resource):
     Intermediate endpoint for parsing public_key part of the request.
 
     # /<public_key>
-    #              /<id_>
+    #              /<id\_>
     """
 
     def getChild(self, path, request):
@@ -113,7 +113,7 @@ class SpecificMetadataEndpoint(resource.Resource, UpdateEntryMixin):
     """
     The endpoint to modify and get individual metadata entries.
 
-    # /<id_>
+    # /<id\_>
     """
 
     def __init__(self, session, public_key, path):

--- a/doc/restapi/introduction.rst
+++ b/doc/restapi/introduction.rst
@@ -82,7 +82,6 @@ Endpoints
    events
    libtorrent
    metadata
-   mychannel
    search
    settings
    shutdown

--- a/doc/restapi/mychannel.rst
+++ b/doc/restapi/mychannel.rst
@@ -1,6 +1,0 @@
-==========
-My Channel
-==========
-
-.. automodule:: Tribler.Core.Modules.restapi.mychannel_endpoint
-    :members:


### PR DESCRIPTION
Fixed documentation build issues.
- Escaped underscore in docstring variables. Might not be necessary later (https://github.com/sphinx-doc/sphinx/pull/6460)
- Removed references to obsolete `mychannel_endpoint` references