### PR TITLE
Log exceptions

### DIFF
--- a/Tribler/Core/Upgrade/db72_to_pony.py
+++ b/Tribler/Core/Upgrade/db72_to_pony.py
@@ -116,7 +116,8 @@ class DispersyToPonyMigration(object):
                 tracker_url_sanitized = get_uniformed_tracker_url(tracker)
                 if not tracker_url_sanitized:
                     continue
-            except:
+            except Exception as e:
+                self._logger.warning("Encountered malformed tracker: %s", e)
                 # Skip malformed trackers
                 continue
             trackers[tracker_url_sanitized] = ({
@@ -211,7 +212,8 @@ class DispersyToPonyMigration(object):
                     "last_check": last_tracker_check
                 } if (last_tracker_check >= 0 and seeders >= 0 and leechers >= 0) else None
                 torrents.append((torrent_dict, health_dict))
-            except:
+            except Exception as e:
+                self._logger.warning("During retrieval of old torrents an exception was raised: %s", e)
                 continue
 
         connection.close()


### PR DESCRIPTION
Added logging to exceptions.

Exceptions are now `except Exception` instead of bare exceptions to prevent catching errors such as `SystemExit`. This prevents unexpected behavior.

Replaces #5011.