### PR TITLE
READY: Remove lambda and file

### DIFF
--- a/Tribler/Core/Modules/restapi/downloads_endpoint.py
+++ b/Tribler/Core/Modules/restapi/downloads_endpoint.py
@@ -25,7 +25,6 @@ from Tribler.Core.Utilities.unicode import ensure_unicode, hexlify
 from Tribler.Core.exceptions import InvalidSignatureException
 from Tribler.Core.simpledefs import DLMODE_VOD, DOWNLOAD, UPLOAD, dlstatus_strings
 from Tribler.pyipv8.ipv8.messaging.anonymization.tunnel import CIRCUIT_ID_PORT
-from Tribler.util import cast_to_unicode_utf8
 
 
 def _safe_extended_peer_info(ext_peer_info):
@@ -453,7 +452,7 @@ class DownloadsEndpoint(RESTEndpoint):
             elif state == "recheck":
                 download.force_recheck()
             elif state == "move_storage":
-                dest_dir = cast_to_unicode_utf8(parameters['dest_dir'])
+                dest_dir = parameters['dest_dir']
                 if not os.path.exists(dest_dir):
                     return RESTResponse({"error": "Target directory (%s) does not exist" % dest_dir})
                 download.move_storage(dest_dir)

--- a/Tribler/util.py
+++ b/Tribler/util.py
@@ -1,9 +1,0 @@
-"""
-This file contains various utility methods.
-"""
-import sys
-
-if sys.version_info.major > 2:
-    cast_to_unicode_utf8 = lambda x: "".join([chr(c) for c in x]) if isinstance(x, bytes) else str(x)
-else:
-    cast_to_unicode_utf8 = lambda x: x.decode('utf-8')


### PR DESCRIPTION
~~Before a lambda was assigned to a variable. This made the whole point of lambdas being anonymous functions moot. Instead python 2 support was dropped, and the lambda was refractored to a function.~~

~~In addition instead of checking the type inside the function, single dispatch is used.~~

File held only a single lambda, and said lambda was a one-liner. In addition it was used only in one place. Hence the file the lambda was in was removed and the one-liner copied to the location it was used in.

Fixes #5022 