### PR TITLE
Root state directory and version support

### DIFF
--- a/src/tribler-core/run_market_helper.py
+++ b/src/tribler-core/run_market_helper.py
@@ -54,7 +54,7 @@ class MarketService(object):
         print("Starting Tribler")
 
         if options.statedir:
-            config.set_state_dir(options.statedir)
+            config.set_root_state_dir(options.statedir)
 
         if options.restapi > 0:
             config.set_http_api_enabled(True)

--- a/src/tribler-core/run_tribler_headless.py
+++ b/src/tribler-core/run_tribler_headless.py
@@ -76,7 +76,7 @@ class TriblerService(object):
         print("Starting Tribler")
 
         if options.statedir:
-            config.set_state_dir(options.statedir)
+            config.set_root_state_dir(options.statedir)
 
         if options.restapi > 0:
             config.set_http_api_enabled(True)

--- a/src/tribler-core/run_tunnel_helper.py
+++ b/src/tribler-core/run_tunnel_helper.py
@@ -113,7 +113,7 @@ class TunnelHelperService(TaskManager):
             ipv8_port = base_port + int(os.environ["HELPER_INDEX"]) * 5
 
         config = TriblerConfig()
-        config.set_state_dir(os.path.join(config.get_state_dir(), "tunnel-%d") % ipv8_port)
+        config.set_root_state_dir(os.path.join(config.get_state_dir(), "tunnel-%d") % ipv8_port)
         config.set_tunnel_community_socks5_listen_ports([])
         config.set_tunnel_community_random_slots(options.random_slots)
         config.set_tunnel_community_competing_slots(options.competing_slots)

--- a/src/tribler-core/tribler_core/modules/libtorrent/download_config.py
+++ b/src/tribler-core/tribler_core/modules/libtorrent/download_config.py
@@ -58,7 +58,7 @@ class DownloadConfig:
         @param path A path of a directory.
         """
         # If something is saved inside the Tribler state dir, it should use relative path
-        path = path_util.Path(path)
+        path = Path(path)
         if self.state_dir:
             base_path = self.state_dir
             path = path_util.norm_path(base_path, path)
@@ -76,7 +76,7 @@ class DownloadConfig:
         if not path_util.isabs(dest_dir):
             dest_dir = self.state_dir / dest_dir
 
-        return path_util.Path(dest_dir)
+        return Path(dest_dir)
 
     def set_mode(self, mode):
         """ Sets the mode of this download.

--- a/src/tribler-core/tribler_core/modules/libtorrent/tests/test_downloadconfig.py
+++ b/src/tribler-core/tribler_core/modules/libtorrent/tests/test_downloadconfig.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 
 from configobj import ConfigObjError
 
@@ -8,7 +9,6 @@ from tribler_common.simpledefs import DLMODE_VOD
 from tribler_core.modules.libtorrent.download_config import DownloadConfig, get_default_dest_dir
 from tribler_core.tests.tools.base_test import TriblerCoreTest
 from tribler_core.tests.tools.common import TESTS_DATA_DIR
-from tribler_core.utilities import path_util
 
 
 class TestConfigParser(TriblerCoreTest):
@@ -18,7 +18,7 @@ class TestConfigParser(TriblerCoreTest):
     def test_downloadconfig(self):
         dlcfg = DownloadConfig()
 
-        self.assertIsInstance(dlcfg.get_dest_dir(), path_util.Path)
+        self.assertIsInstance(dlcfg.get_dest_dir(), Path)
         dlcfg.set_dest_dir(self.session_base_dir)
         self.assertEqual(dlcfg.get_dest_dir(), self.session_base_dir)
 
@@ -68,7 +68,7 @@ class TestConfigParser(TriblerCoreTest):
         dlcfg.load(self.CONFIG_FILES_DIR / "corrupt_download_config.conf")
 
     def test_get_default_dest_dir(self):
-        self.assertIsInstance(get_default_dest_dir(), path_util.Path)
+        self.assertIsInstance(get_default_dest_dir(), Path)
 
     def test_default_download_config_load(self):
         with open(self.session_base_dir / "dlconfig.conf", 'wb') as conf_file:

--- a/src/tribler-core/tribler_core/modules/tests/test_process_checker.py
+++ b/src/tribler-core/tribler_core/modules/tests/test_process_checker.py
@@ -23,7 +23,7 @@ class TestProcessChecker(AbstractServer):
         await super(TestProcessChecker, self).setUp()
         self.process = None
         self.stop_flag = Value('b', 0)
-        self.state_dir = self.getStateDir()
+        self.state_dir = self.getRootStateDir()
 
     def create_lock_file_with_pid(self, pid):
         with open(self.state_dir / LOCK_FILE_NAME, 'w') as lock_file:

--- a/src/tribler-core/tribler_core/modules/torrent_checker/test_torrentchecker_session.py
+++ b/src/tribler-core/tribler_core/modules/torrent_checker/test_torrentchecker_session.py
@@ -264,7 +264,7 @@ class TestDHTSession(TriblerCoreTest):
     async def setUp(self):
         await super(TestDHTSession, self).setUp()
 
-        state_dir = self.getStateDir()
+        state_dir = self.getRootStateDir()
         config = TriblerConfig()
         config.get_default_state_dir = lambda _: state_dir
 

--- a/src/tribler-core/tribler_core/modules/tunnel/test_full_session/test_tunnel_base.py
+++ b/src/tribler-core/tribler_core/modules/tunnel/test_full_session/test_tunnel_base.py
@@ -143,7 +143,8 @@ class TestTunnelBase(TestAsServer):
 
         self.setUpPreSession()
         config = self.config.copy()
-        config.set_state_dir(self.getStateDir(index))
+        config.set_libtorrent_enabled(False)
+        config.set_root_state_dir(self.getRootStateDir(index))
         config.set_tunnel_community_socks5_listen_ports(self.get_ports(5))
 
         session = Session(config)
@@ -159,7 +160,7 @@ class TestTunnelBase(TestAsServer):
         from tribler_core.session import Session
 
         self.seed_config = self.config.copy()
-        self.seed_config.set_state_dir(self.getStateDir(2))
+        self.seed_config.set_root_state_dir(self.getRootStateDir(2))
         self.seed_config.set_libtorrent_enabled(hops == 0)
         self.seed_config.set_tunnel_community_socks5_listen_ports(self.get_ports(5))
         if self.session2 is None:

--- a/src/tribler-core/tribler_core/restapi/tests/test_util.py
+++ b/src/tribler-core/tribler_core/restapi/tests/test_util.py
@@ -13,7 +13,7 @@ class TestRestApiUtil(TriblerCoreTest):
         await super(TestRestApiUtil, self).setUp()
 
         config = TriblerConfig()
-        config.set_state_dir(self.getStateDir())
+        config.set_root_state_dir(self.getRootStateDir())
         config.get_dispersy_enabled = lambda: False
         self.session = Session(config)
 

--- a/src/tribler-core/tribler_core/upgrade/config_converter.py
+++ b/src/tribler-core/tribler_core/upgrade/config_converter.py
@@ -28,7 +28,7 @@ def convert_config_to_tribler71(current_config, state_dir=None):
     :param: current_config: the current config in which we merge the old config files.
     :return: the newly edited TriblerConfig object with the old data inserted.
     """
-    state_dir = state_dir or TriblerConfig.get_default_state_dir()
+    state_dir = state_dir or TriblerConfig.get_default_root_state_dir()
     libtribler_file_loc = state_dir / "libtribler.conf"
     if libtribler_file_loc.exists():
         libtribler_cfg = RawConfigParser()
@@ -135,7 +135,7 @@ def add_libtribler_config(new_config, old_config):
 
             temp_config = config.copy()
             if section == "general" and name == "state_dir":
-                temp_config.set_state_dir(value)
+                temp_config.set_root_state_dir(value)
             elif section == "general" and name == "log_dir":
                 temp_config.set_log_dir(value)
             elif section == "tunnel_community" and name == "enabled":
@@ -206,7 +206,7 @@ def convert_config_to_tribler74(state_dir=None):
     from lib2to3.refactor import RefactoringTool, get_fixers_from_package
     refactoring_tool = RefactoringTool(fixer_names=get_fixers_from_package('lib2to3.fixes'))
 
-    state_dir = state_dir or TriblerConfig.get_default_base_state_dir()
+    state_dir = state_dir or TriblerConfig.get_default_root_state_dir()
     for filename in (state_dir / STATEDIR_CHECKPOINT_DIR).glob('*.state'):
         old_config = CallbackConfigParser()
         try:
@@ -247,7 +247,7 @@ def convert_config_to_tribler75(state_dir=None):
     """
     Convert the download config files from Tribler 7.4 to 7.5 format.
     """
-    state_dir = state_dir or TriblerConfig.get_default_base_state_dir()
+    state_dir = state_dir or TriblerConfig.get_default_root_state_dir()
     for filename in (state_dir / STATEDIR_CHECKPOINT_DIR).glob('*.conf'):
         config = DownloadConfig.load(filename)
         metainfo = config.get_metainfo()

--- a/src/tribler-core/tribler_core/upgrade/tests/test_upgrader.py
+++ b/src/tribler-core/tribler_core/upgrade/tests/test_upgrader.py
@@ -4,13 +4,7 @@ from asyncio import Future
 
 from pony.orm import db_session
 
-from tribler_common.simpledefs import (
-    NTFY,
-    STATEDIR_CHANNELS_DIR,
-    STATEDIR_CHECKPOINT_DIR,
-    STATEDIR_DB_DIR,
-    STATEDIR_WALLET_DIR,
-)
+from tribler_common.simpledefs import NTFY
 
 from tribler_core.modules.metadata_store.orm_bindings.channel_metadata import CHANNEL_DIR_NAME_LENGTH
 from tribler_core.modules.metadata_store.store import MetadataStore
@@ -111,21 +105,3 @@ class TestUpgrader(AbstractUpgrader):
         pstate = CallbackConfigParser()
         pstate.read_file(file_path)
         self.assertEqual(CHANNEL_DIR_NAME_LENGTH, len(pstate.get('state', 'metainfo')['info']['name']))
-
-    async def test_backup_state_directory(self):
-        """
-        Test if backup of the state directory is done if the config version and the code version are different.
-        """
-        self.session.config.set_version('7.4.0')
-        self.session.config.set_version_backup_enabled(True)
-
-        await self.upgrader.run()
-
-        # Check versioned state directory exists
-        version_state_dir = self.session.config.get_state_dir(version=self.config.get_version())
-        self.assertTrue(version_state_dir.exists())
-
-        version_state_sub_dirs = os.listdir(version_state_dir)
-        backup_dirs = [STATEDIR_DB_DIR, STATEDIR_CHECKPOINT_DIR, STATEDIR_WALLET_DIR, STATEDIR_CHANNELS_DIR]
-        for backup_dir in backup_dirs:
-            self.assertTrue(backup_dir in version_state_sub_dirs)

--- a/src/tribler-core/tribler_core/upgrade/upgrade_base.py
+++ b/src/tribler-core/tribler_core/upgrade/upgrade_base.py
@@ -18,5 +18,5 @@ class AbstractUpgrader(TriblerCoreTest):
     async def setUp(self):
         await super(AbstractUpgrader, self).setUp()
         self.config = TriblerConfig(ConfigObj(configspec=str(CONFIG_SPEC_PATH)))
-        self.config.set_state_dir(self.getStateDir())
+        self.config.set_root_state_dir(self.getRootStateDir())
         self.session = Session(self.config)


### PR DESCRIPTION
Introducing `.Tribler` as root state directory to support multiple tribler version. Now each new version will have a separate state directory located inside `.Tribler` directory with the same name as the version.