### PR TITLE
Fixed long path issue in tests

### DIFF
--- a/src/tribler-core/tribler_core/modules/libtorrent/download_config.py
+++ b/src/tribler-core/tribler_core/modules/libtorrent/download_config.py
@@ -1,4 +1,5 @@
 import base64
+from pathlib import Path
 
 from configobj import ConfigObj
 
@@ -12,7 +13,7 @@ from tribler_core.exceptions import InvalidConfigException
 from tribler_core.utilities import path_util
 from tribler_core.utilities.install_dir import get_lib_path
 from tribler_core.utilities.osutils import get_home_dir
-from tribler_core.utilities.path_util import Path
+from tribler_core.utilities.path_util import str_path
 from tribler_core.utilities.utilities import bdecode_compat
 
 SPEC_FILENAME = 'download_config.spec'
@@ -42,14 +43,14 @@ class DownloadConfig:
 
     @staticmethod
     def load(config_path=None):
-        return DownloadConfig(ConfigObj(infile=str(config_path), file_error=True,
+        return DownloadConfig(ConfigObj(infile=str_path(config_path), file_error=True,
                                         configspec=str(CONFIG_SPEC_PATH), default_encoding='utf-8'))
 
     def copy(self):
         return DownloadConfig(ConfigObj(self.config, configspec=str(CONFIG_SPEC_PATH), default_encoding='utf-8'))
 
     def write(self, filename):
-        self.config.filename = filename
+        self.config.filename = str_path(filename)
         self.config.write()
 
     def set_dest_dir(self, path):

--- a/src/tribler-core/tribler_core/modules/libtorrent/tests/test_libtorrent_mgr.py
+++ b/src/tribler-core/tribler_core/modules/libtorrent/tests/test_libtorrent_mgr.py
@@ -441,7 +441,7 @@ class TestLibtorrentMgr(AbstractServer):
         Test whether we are resuming downloads after loading checkpoints
         """
         def mocked_load_checkpoint(filename):
-            self.assertTrue(filename.endswith('abcd.conf'))
+            self.assertTrue(str(filename).endswith('abcd.conf'))
             mocked_load_checkpoint.called = True
 
         mocked_load_checkpoint.called = False

--- a/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/channel_metadata.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/channel_metadata.py
@@ -1,5 +1,6 @@
 import os
 from datetime import datetime
+from pathlib import Path
 
 from ipv8.database import database_blob
 
@@ -20,6 +21,7 @@ from tribler_core.modules.metadata_store.orm_bindings.channel_node import (
 )
 from tribler_core.modules.metadata_store.serialization import CHANNEL_TORRENT, ChannelMetadataPayload
 from tribler_core.utilities import path_util
+from tribler_core.utilities.path_util import str_path
 from tribler_core.utilities.random_utils import random_infohash
 from tribler_core.utilities.unicode import hexlify
 
@@ -185,7 +187,7 @@ def define_binding(db):
                 file_path = folder / filename
                 # We only remove mdblobs and leave the rest as it is
                 if filename.endswith(BLOB_EXTENSION) or filename.endswith(BLOB_EXTENSION + '.lz4'):
-                    os.unlink(file_path)
+                    os.unlink(str_path(file_path))
 
             # Channel should get a new starting timestamp and its contents should get higher timestamps
             start_timestamp = self._clock.tick()
@@ -214,7 +216,7 @@ def define_binding(db):
             # Create dir for metadata files
             channel_dir = path_util.abspath(self._channels_dir / self.dirname)
             if not channel_dir.is_dir():
-                os.makedirs(channel_dir)
+                os.makedirs(str_path(channel_dir))
 
             index = 0
             while index < len(metadata_list):
@@ -223,8 +225,8 @@ def define_binding(db):
                 # The final file in the sequence should get the same (new) timestamp as the channel entry itself.
                 # Otherwise, the local channel version will never become equal to its timestamp.
                 blob_timestamp = metadata_list[index - 1].timestamp if index < len(metadata_list) else final_timestamp
-                blob_filename = str(blob_timestamp).zfill(12) + BLOB_EXTENSION + '.lz4'
-                with open(channel_dir / blob_filename, 'wb') as f:
+                blob_filename = str_path(Path(channel_dir, str(blob_timestamp).zfill(12) + BLOB_EXTENSION + '.lz4'))
+                with open(blob_filename, 'wb') as f:
                     f.write(data)
 
             # TODO: add error-handling routines to make sure the timestamp is not messed up in case of an error

--- a/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/channel_node.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/channel_node.py
@@ -14,6 +14,7 @@ from tribler_core.modules.metadata_store.serialization import (
     DELETED,
     DeletedMetadataPayload,
 )
+from tribler_core.utilities.path_util import str_path
 from tribler_core.utilities.unicode import hexlify
 
 # Metadata, torrents and channel statuses
@@ -206,11 +207,11 @@ def define_binding(db, logger=None, key=None, clock=None):
             return b''.join(self._serialized_delete())
 
         def to_file(self, filename, key=None):
-            with open(filename, 'wb') as output_file:
+            with open(str_path(filename), 'wb') as output_file:
                 output_file.write(self.serialized(key))
 
         def to_delete_file(self, filename):
-            with open(filename, 'wb') as output_file:
+            with open(str_path(filename), 'wb') as output_file:
                 output_file.write(self.serialized_delete())
 
         def sign(self, key=None):

--- a/src/tribler-core/tribler_core/modules/metadata_store/store.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/store.py
@@ -34,6 +34,7 @@ from tribler_core.modules.metadata_store.serialization import (
     read_payload_with_offset,
     time2int,
 )
+from tribler_core.utilities.path_util import str_path
 from tribler_core.utilities.unicode import hexlify
 
 BETA_DB_VERSIONS = [0, 1, 2, 3, 4, 5]
@@ -118,7 +119,7 @@ class MetadataStore(object):
         self.reference_timedelta = timedelta(milliseconds=100)
         self.sleep_on_external_thread = 0.05  # sleep this amount of seconds between batches executed on external thread
 
-        create_db = db_filename == ":memory:" or not self.db_filename.is_file()
+        create_db = str(db_filename) == ":memory:" or not self.db_filename.is_file()
 
         # We have to dynamically define/init ORM-managed entities here to be able to support
         # multiple sessions in Tribler. ORM-managed classes are bound to the database instance
@@ -295,10 +296,10 @@ class MetadataStore(object):
             to possibly pace down the upload process
         :return ChannelNode objects list if we can correctly load the metadata
         """
-        with open(filepath, 'rb') as f:
+        with open(str_path(filepath), 'rb') as f:
             serialized_data = f.read()
 
-        if filepath.endswith('.lz4'):
+        if str(filepath).endswith('.lz4'):
             return self.process_compressed_mdblob(serialized_data, skip_personal_metadata_payload, external_thread)
         return self.process_squashed_mdblob(serialized_data, skip_personal_metadata_payload, external_thread)
 

--- a/src/tribler-core/tribler_core/modules/metadata_store/tests/test_store.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/tests/test_store.py
@@ -27,6 +27,7 @@ from tribler_core.modules.metadata_store.store import (
 )
 from tribler_core.tests.tools.base_test import TriblerCoreTest
 from tribler_core.tests.tools.common import TESTS_DATA_DIR
+from tribler_core.utilities.path_util import str_path
 from tribler_core.utilities.random_utils import random_infohash
 
 
@@ -195,7 +196,7 @@ class TestMetadataStore(TriblerCoreTest):
         torrent_md.delete()
 
         channel_dir = self.mds.ChannelMetadata._channels_dir / channel.dirname
-        self.assertTrue(len(os.listdir(channel_dir)) > 0)
+        self.assertTrue(len(os.listdir(str_path(channel_dir))) > 0)
 
         # By default, personal channel torrent metadata processing is skipped so there should be no torrents
         # added to the channel

--- a/src/tribler-core/tribler_core/upgrade/db72_to_pony.py
+++ b/src/tribler-core/tribler_core/upgrade/db72_to_pony.py
@@ -15,6 +15,7 @@ from tribler_core.modules.metadata_store.orm_bindings.channel_node import LEGACY
 from tribler_core.modules.metadata_store.orm_bindings.torrent_metadata import infohash_to_id
 from tribler_core.modules.metadata_store.serialization import REGULAR_TORRENT, int2time, time2int
 from tribler_core.modules.metadata_store.store import BETA_DB_VERSIONS, CURRENT_DB_VERSION
+from tribler_core.utilities.path_util import str_path
 from tribler_core.utilities.tracker_utils import get_uniformed_tracker_url
 
 DISCOVERED_CONVERSION_STARTED = "discovered_conversion_started"
@@ -261,12 +262,12 @@ class DispersyToPonyMigration(object):
 
                 # We check if we need to re-create the channel dir in case it was deleted for some reason
                 if not folder.is_dir():
-                    os.makedirs(folder)
+                    os.makedirs(str_path(folder))
                 for filename in os.listdir(folder):
                     file_path = folder / filename
                     # We only remove mdblobs and leave the rest as it is
                     if filename.endswith(BLOB_EXTENSION) or filename.endswith(BLOB_EXTENSION + '.lz4'):
-                        os.unlink(file_path)
+                        os.unlink(str_path(file_path))
                 my_channel.commit_channel_torrent()
 
         with db_session:

--- a/src/tribler-core/tribler_core/upgrade/tests/test_upgrader.py
+++ b/src/tribler-core/tribler_core/upgrade/tests/test_upgrader.py
@@ -19,6 +19,7 @@ from tribler_core.tests.tools.tools import timeout
 from tribler_core.upgrade.upgrade import TriblerUpgrader, cleanup_noncompliant_channel_torrents
 from tribler_core.upgrade.upgrade_base import AbstractUpgrader
 from tribler_core.utilities.configparser import CallbackConfigParser
+from tribler_core.utilities.path_util import str_path
 
 
 class TestUpgrader(AbstractUpgrader):
@@ -93,7 +94,7 @@ class TestUpgrader(AbstractUpgrader):
     def test_delete_noncompliant_state(self):
         STATE_DIR = TESTS_DATA_DIR / 'noncompliant_state_dir'
         tmpdir = self.temporary_directory() / STATE_DIR.name
-        shutil.copytree(STATE_DIR, tmpdir)
+        shutil.copytree(str_path(STATE_DIR), str_path(tmpdir))
         cleanup_noncompliant_channel_torrents(tmpdir)
 
         # Check cleanup of the channels dir

--- a/src/tribler-core/tribler_core/upgrade/upgrade.py
+++ b/src/tribler-core/tribler_core/upgrade/upgrade.py
@@ -41,7 +41,7 @@ def cleanup_noncompliant_channel_torrents(state_dir):
     resume_dir = state_dir / "dlcheckpoints"
     if resume_dir.exists():
         for f in resume_dir.iterdir():
-            if not f.endswith('.state'):
+            if not str(f).endswith('.state'):
                 continue
             file_path = resume_dir / f
             pstate = CallbackConfigParser()

--- a/src/tribler-core/tribler_core/utilities/install_dir.py
+++ b/src/tribler-core/tribler_core/utilities/install_dir.py
@@ -6,7 +6,7 @@ Author(s): Elric Milon
 import sys
 
 import tribler_core
-from tribler_core.utilities.path_util import Path
+from tribler_core.utilities.path_util import Path, str_path
 
 
 def is_frozen():
@@ -28,7 +28,7 @@ def get_base_path():
         base_path = Path(sys._MEIPASS)
     except Exception:
         base_path = Path(tribler_core.__file__).parent
-    return base_path
+    return Path(str_path(base_path))
 
 
 def get_lib_path():

--- a/src/tribler-core/tribler_core/utilities/path_util.py
+++ b/src/tribler-core/tribler_core/utilities/path_util.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import pathlib
+import sys
 import tempfile
 import urllib
 from shutil import rmtree
@@ -83,3 +84,12 @@ def mkdtemp(*args, **kwargs):
 
 def pathname2url(input):
     return urllib.request.pathname2url(str(input))
+
+
+def str_path(path):
+    """"
+    String representation of Path-like object with work around for Windows long filename issue.
+    """
+    if sys.platform == 'win32':
+        return "\\\\?\\" + str(path)
+    return str(path)


### PR DESCRIPTION
This PR basically provides a utility function called `str_path()` that creates path which addresses long path issue in windows by consistently passing the result obtained with `str_path()` instead of simply using Path or string in os/filesystem operations like `makedirs`, `unlink` etc.