### PR TITLE
GigaChannel RemoteQuery Community

### DIFF
--- a/src/tribler-core/tribler_core/modules/metadata_store/community/gigachannel_community.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/community/gigachannel_community.py
@@ -5,7 +5,7 @@ from random import sample
 from ipv8.community import Community
 from ipv8.database import database_blob
 from ipv8.lazy_community import lazy_wrapper
-from ipv8.messaging.lazy_payload import VariablePayload
+from ipv8.messaging.lazy_payload import VariablePayload, vp_compile
 from ipv8.peer import Peer
 from ipv8.requestcache import RequestCache
 
@@ -44,6 +44,7 @@ v1_md_field_to_metadata_type = {
 }
 
 
+@vp_compile
 class RawBlobPayload(VariablePayload):
     format_list = ['raw']
     names = ['raw_blob']

--- a/src/tribler-core/tribler_core/modules/metadata_store/community/remote_query_community.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/community/remote_query_community.py
@@ -1,0 +1,108 @@
+import json
+from binascii import unhexlify
+from random import sample
+
+from ipv8.community import Community
+from ipv8.lazy_community import lazy_wrapper
+from ipv8.messaging.lazy_payload import VariablePayload, vp_compile
+from ipv8.peer import Peer
+
+from pony.orm import CacheIndexError, TransactionIntegrityError, db_session
+
+from tribler_core.modules.metadata_store.orm_bindings.channel_metadata import entries_to_chunk
+
+
+@vp_compile
+class RemoteSelectPayload(VariablePayload):
+    msg_id = 1
+    format_list = ['I', 'varlenH']
+    names = ['id', 'json']
+
+
+@vp_compile
+class SelectResponsePayload(VariablePayload):
+    msg_id = 2
+    format_list = ['I', 'raw']
+    names = ['id', 'raw_blob']
+
+
+class RemoteQueryCommunitySettings:
+    def __init__(self):
+        self.minimal_blob_size = 200
+        self.maximum_payload_size = 1300
+        self.max_entries = self.maximum_payload_size // self.minimal_blob_size
+        self.max_query_peers = 5
+
+
+class RemoteQueryCommunity(Community):
+    """
+    Community for general purpose SELECT-like queries into remote Channels database
+    """
+
+    master_peer = Peer(
+        unhexlify(
+            "4c69624e61434c504b3a667b8dee4645475512c0780990cfaca234ad19c5dabcb065751776"
+            "b75a4b4210c06e2eb4d8bbf4a775ed735eb16bbc3e44193479ad7426d7cd1067807f95b696"
+        )
+    )
+
+    def __init__(self, my_peer, endpoint, network, metadata_store, settings=None):
+        super(RemoteQueryCommunity, self).__init__(my_peer, endpoint, network)
+        self.mds = metadata_store
+        self.add_message_handler(RemoteSelectPayload.msg_id, self.on_remote_select)
+        self.add_message_handler(SelectResponsePayload.msg_id, self.on_remote_select_response)
+        self.settings = settings or RemoteQueryCommunitySettings()
+
+    def _update_db_with_blob(self, raw_blob):
+        result = None
+        try:
+            with db_session:
+                try:
+                    result = self.mds.process_compressed_mdblob(raw_blob)
+                except (TransactionIntegrityError, CacheIndexError) as err:
+                    self._logger.error("DB transaction error when tried to process payload: %s", str(err))
+        # Unfortunately, we have to catch the exception twice, because Pony can raise them both on the exit from
+        # db_session, and on calling the line of code
+        except (TransactionIntegrityError, CacheIndexError) as err:
+            self._logger.error("DB transaction error when tried to process payload: %s", str(err))
+        finally:
+            self.mds.disconnect_thread()
+        return result
+
+    def get_random_peers(self, sample_size=None):
+        # Randomly sample sample_size peers from the complete list of our peers
+        all_peers = super(RemoteQueryCommunity, self).get_peers()
+        if sample_size is not None and sample_size < len(all_peers):
+            return sample(all_peers, sample_size)
+        return all_peers
+
+    def send_remote_select(self, id_, **kwargs):
+        payload = RemoteSelectPayload(id_, json.dumps(kwargs).encode('utf8'))
+        for p in self.get_random_peers(self.settings.max_query_peers):
+            self.endpoint.send(p.address, self.ezr_pack(payload.msg_id, payload))
+
+    @lazy_wrapper(RemoteSelectPayload)
+    async def on_remote_select(self, peer, request):
+        db_results = self.mds.MetadataNode.get_entries(**json.loads(request.json))
+        if not db_results:
+            return
+
+        index = 0
+        while index < len(db_results):
+            data, index = entries_to_chunk(db_results, self.settings.maximum_payload_size, start_index=index)
+            self.endpoint.send(
+                peer.address, self.ezr_pack(SelectResponsePayload.msg_id, SelectResponsePayload(request.id, data))
+            )
+
+    @lazy_wrapper(SelectResponsePayload)
+    def on_remote_select_response(self, peer, response):
+        self._update_db_with_blob(response.raw_blob)
+
+
+class RemoteQueryTestnetCommunity(RemoteQueryCommunity):
+    master_peer = Peer(
+        unhexlify(
+            "4c69624e61434c504b3a7fcf64783215dba08c1623fb14c3c86127b8591f858c56763e2281"
+            "a8e121ef08caae395b2597879f7f4658b608f22df280073661f85174fd7c565cbee3e4328f"
+        )
+    )

--- a/src/tribler-core/tribler_core/modules/metadata_store/community/tests/test_remote_query_community.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/community/tests/test_remote_query_community.py
@@ -1,0 +1,68 @@
+from ipv8.keyvault.crypto import default_eccrypto
+from ipv8.test.base import TestBase
+
+from pony.orm import db_session
+
+from tribler_core.modules.metadata_store.community.remote_query_community import RemoteQueryCommunity
+from tribler_core.modules.metadata_store.orm_bindings.channel_node import NEW
+from tribler_core.modules.metadata_store.serialization import CHANNEL_TORRENT, REGULAR_TORRENT
+from tribler_core.modules.metadata_store.store import MetadataStore
+from tribler_core.utilities.path_util import Path
+from tribler_core.utilities.random_utils import random_infohash
+
+
+def add_random_torrent(metadata_cls, name="test", channel=None):
+    d = {"infohash": random_infohash(), "title": name, "tags": "", "size": 1234, "status": NEW}
+    if channel:
+        d.update({"origin_id": channel.id_})
+    torrent_metadata = metadata_cls.from_dict(d)
+    torrent_metadata.sign()
+
+
+class TestRemoteQueryCommunity(TestBase):
+    """
+    Unit tests for the GigaChannel community which do not need a real Session.
+    """
+
+    def setUp(self):
+        super(TestRemoteQueryCommunity, self).setUp()
+        self.count = 0
+        self.initialize(RemoteQueryCommunity, 2)
+
+    def create_node(self, *args, **kwargs):
+        metadata_store = MetadataStore(
+            Path(self.temporary_directory()) / f"{self.count}.db",
+            Path(self.temporary_directory()),
+            default_eccrypto.generate_key(u"curve25519"),
+            disable_sync=True,
+        )
+        kwargs['metadata_store'] = metadata_store
+        node = super(TestRemoteQueryCommunity, self).create_node(*args, **kwargs)
+        self.count += 1
+        return node
+
+    async def test_remote_select(self):
+        # Fill Node 0 DB with channels and torrents entries
+        with db_session:
+            channel = self.nodes[0].overlay.mds.ChannelMetadata.create_channel("ubuntu", "ubuntu")
+            for i in range(20):
+                add_random_torrent(self.nodes[0].overlay.mds.TorrentMetadata, name="ubuntu %s" % i, channel=channel)
+            channel.commit_channel_torrent()
+
+        await self.introduce_nodes()
+
+        # Node 1 DB is empty. It searches for 'ubuntu'
+        with db_session:
+            torrents = self.nodes[1].overlay.mds.TorrentMetadata.select()[:]
+            self.assertEqual(len(torrents), 0)
+
+        id_ = 123
+        kwargs_dict = {"txt_filter": "ubuntu*", "metadata_type": [CHANNEL_TORRENT, REGULAR_TORRENT]}
+        self.nodes[1].overlay.send_remote_select(id_, **kwargs_dict)
+
+        await self.deliver_messages(timeout=0.5)
+
+        with db_session:
+            torrents0 = self.nodes[0].overlay.mds.TorrentMetadata.get_entries(**kwargs_dict)
+            torrents1 = self.nodes[1].overlay.mds.TorrentMetadata.get_entries(**kwargs_dict)
+            self.assertEqual(len(torrents0), len(torrents1))

--- a/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/metadata_node.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/metadata_node.py
@@ -68,6 +68,7 @@ def define_binding(db):
             sort_desc=True,
             txt_filter=None,
             category=None,
+            attribute_ranges=None,
         ):
             """
             This method implements REST-friendly way to get entries from the database. It is overloaded by the higher
@@ -90,6 +91,15 @@ def define_binding(db):
                 if channel_pk is not None
                 else pony_query
             )
+
+            if attribute_ranges is not None:
+                for attr, left, right in attribute_ranges:
+                    getattr(cls, attr)  # Check against code injection
+                    if left is not None:
+                        pony_query = pony_query.where(f"g.{attr} >= left")
+                    if right is not None:
+                        pony_query = pony_query.where(f"g.{attr} < right")
+
             # origin_id can be zero, for e.g. root channel
             pony_query = pony_query.where(origin_id=origin_id) if origin_id is not None else pony_query
             pony_query = pony_query.where(lambda g: g.tags == category) if category else pony_query

--- a/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/metadata_node.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/metadata_node.py
@@ -150,6 +150,8 @@ def define_binding(db):
         @classmethod
         @db_session
         def get_entries_count(cls, **kwargs):
+            for p in ["first", "last"]:
+                kwargs.pop(p, None)
             return cls.get_entries_query(**kwargs).count()
 
         @classmethod

--- a/src/tribler-core/tribler_core/session.py
+++ b/src/tribler-core/tribler_core/session.py
@@ -135,6 +135,7 @@ class Session(TaskManager):
         self.wallets = {}
         self.popularity_community = None
         self.gigachannel_community = None
+        self.remote_query_community = None
 
         self.credit_mining_manager = None
         self.market_community = None
@@ -244,6 +245,16 @@ class Session(TaskManager):
 
             self.ipv8.strategies.append((RandomWalk(self.gigachannel_community), 20))
             self.ipv8.strategies.append((SyncChannels(self.gigachannel_community), 20))
+
+            # Gigachannel RemoteQuery Community
+            from tribler_core.modules.metadata_store.community.remote_query_community \
+                import RemoteQueryCommunity, RemoteQueryTestnetCommunity
+
+            community_cls = RemoteQueryTestnetCommunity if self.config.get_testnet() else RemoteQueryCommunity
+            self.remote_query_community = community_cls(peer, self.ipv8.endpoint, self.ipv8.network, self.mds)
+
+            self.ipv8.overlays.append(self.remote_query_community)
+            self.ipv8.strategies.append((RandomWalk(self.remote_query_community), 20))
 
     def enable_ipv8_statistics(self):
         if self.config.get_ipv8_statistics():


### PR DESCRIPTION
RemoteQuery Community's purpose is to serve remote DB queries for metadata stored by GigaChannel. The community remotely sends JSON-serialized arguments for get_entries method of MetadataNode ORM class. The receiving side processes the query and sends back the results. Eventually, this community should replace the first-generation GigaChannel Community, as RemoteQuery Communtiy is more general.

Note that this community does no actions on its own now. The plan is to first test it as a part of an experimental release and then add an aggressive walker that will be used to do fast bootstraps of Tribler Channels system as stated in #3615. Also, the current version imposes no limits on query size on the receiving side, which is fine for experiments but unacceptable for the final release.