### PR TITLE
READY: Support querying by id_ and subscribed attributes

### DIFF
--- a/src/tribler-core/tribler_core/modules/metadata_store/community/remote_query_community.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/community/remote_query_community.py
@@ -73,6 +73,7 @@ class RemoteQueryCommunity(Community):
             return
 
         index = 0
+
         while index < len(db_results):
             data, index = entries_to_chunk(db_results, self.settings.maximum_payload_size, start_index=index)
             self.ez_send(peer, SelectResponsePayload(request.id, data))

--- a/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/channel_metadata.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/channel_metadata.py
@@ -364,14 +364,6 @@ def define_binding(db):
                 and g.public_key != database_blob(cls._my_key.pub().key_to_bin()[10:])
             )
 
-        @classmethod
-        @db_session
-        def get_entries_query(cls, subscribed=None, **kwargs):
-            # This method filters channels-related arguments and translates them into Pony query parameters
-            pony_query = super(ChannelMetadata, cls).get_entries_query(**kwargs)
-            pony_query = pony_query.where(subscribed=subscribed) if subscribed is not None else pony_query
-            return pony_query
-
         @property
         @db_session
         def state(self):

--- a/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/metadata_node.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/metadata_node.py
@@ -67,8 +67,10 @@ def define_binding(db):
             sort_by=None,
             sort_desc=True,
             txt_filter=None,
+            subscribed=None,
             category=None,
             attribute_ranges=None,
+            id_=None,
         ):
             """
             This method implements REST-friendly way to get entries from the database. It is overloaded by the higher
@@ -76,7 +78,6 @@ def define_binding(db):
             :return: PonyORM query object corresponding to the given params.
             """
             # Warning! For Pony magic to work, iteration variable name (e.g. 'g') should be the same everywhere!
-            # Filter the results on a keyword or some keywords
 
             pony_query = cls.search_keyword(txt_filter, lim=1000) if txt_filter else select(g for g in cls)
 
@@ -101,7 +102,9 @@ def define_binding(db):
                         pony_query = pony_query.where(f"g.{attr} < right")
 
             # origin_id can be zero, for e.g. root channel
+            pony_query = pony_query.where(id_=id_) if id_ is not None else pony_query
             pony_query = pony_query.where(origin_id=origin_id) if origin_id is not None else pony_query
+            pony_query = pony_query.where(lambda g: g.subscribed) if subscribed is not None else pony_query
             pony_query = pony_query.where(lambda g: g.tags == category) if category else pony_query
             pony_query = pony_query.where(lambda g: g.status != TODELETE) if exclude_deleted else pony_query
             pony_query = pony_query.where(lambda g: g.xxx == 0) if hide_xxx else pony_query

--- a/src/tribler-core/tribler_core/modules/metadata_store/tests/test_torrent_metadata.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/tests/test_torrent_metadata.py
@@ -261,6 +261,13 @@ class TestTorrentMetadata(TriblerCoreTest):
         args = dict(channel_pk=channel_pk, origin_id=0, attribute_ranges=(("timestamp < 3 and g.timestamp", 3, 30),))
         self.assertRaises(AttributeError, self.mds.TorrentMetadata.get_entries, **args)
 
+        # Test getting entry by id_
+        with db_session:
+            entry = self.mds.TorrentMetadata(id_=123, infohash=random_infohash())
+        args = dict(channel_pk=channel_pk, id_=123)
+        torrents = self.mds.TorrentMetadata.get_entries(first=1, last=10, **args)
+        self.assertListEqual(list(torrents), [entry])
+
     @db_session
     def test_metadata_conflicting(self):
         tdict = dict(rnd_torrent(), title="lakes sheep", tags="video", infohash=b'\x00\xff')


### PR DESCRIPTION
This enables RemoteQuery Community to query remotely for e.g. subscribed channels only, or for updates of some certain channel entry.