### PR TITLE
Make VSIDS decay offline

### DIFF
--- a/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/vsids.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/vsids.py
@@ -41,7 +41,7 @@ def define_binding(db):
         total_activity = orm.Required(float)
         last_bump = orm.Required(datetime)
         rescale_threshold = orm.Optional(float, default=10.0 ** 100)
-        exp_period = orm.Optional(float, default=24.0 * 60 * 60)  # decay e times over this period
+        exp_period = orm.Optional(float, default=24.0 * 60 * 60 * 3)  # decay e times over this period of seconds
         max_val = orm.Optional(float, default=1.0)
 
         @db_session

--- a/src/tribler-core/tribler_core/modules/metadata_store/store.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/store.py
@@ -147,8 +147,6 @@ class MetadataStore(object):
             if not default_vsids:
                 default_vsids = self.Vsids.create_default_vsids()
             self.ChannelMetadata.votes_scaling = default_vsids.max_val
-            # Decay only happens while Tribler is running
-            default_vsids.last_bump = datetime.utcnow()
 
     @db_session
     def upsert_vote(self, channel, peer_pk):


### PR DESCRIPTION
fixes #4927 

Channels ratings will now decay even when Tribler is offline, but this will happen (decay period is 3 days now instead of 1 day).