### PR TITLE
Query for channels on RemoteQueryCommunity introductions

### DIFF
--- a/src/tribler-core/tribler_core/modules/metadata_store/community/sync_strategy.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/community/sync_strategy.py
@@ -10,14 +10,10 @@ class SyncChannels(DiscoveryStrategy):
     On each tick we send a random peer some of our random subscribed channels.
     """
 
-    def __init__(self, *args, **kwargs):
-        super(SyncChannels, self).__init__(*args, **kwargs)
-
     def take_step(self):
         with self.walk_lock:
             # Share my random channels
             peers = self.overlay.get_peers()
-
             if peers:
                 peer = choice(peers)
                 self.overlay.send_random_to(peer)

--- a/src/tribler-core/tribler_core/modules/metadata_store/community/sync_strategy.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/community/sync_strategy.py
@@ -10,10 +10,14 @@ class SyncChannels(DiscoveryStrategy):
     On each tick we send a random peer some of our random subscribed channels.
     """
 
+    def __init__(self, *args, **kwargs):
+        super(SyncChannels, self).__init__(*args, **kwargs)
+
     def take_step(self):
         with self.walk_lock:
             # Share my random channels
             peers = self.overlay.get_peers()
+
             if peers:
                 peer = choice(peers)
                 self.overlay.send_random_to(peer)

--- a/src/tribler-core/tribler_core/modules/metadata_store/community/tests/test_remote_query_community.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/community/tests/test_remote_query_community.py
@@ -134,7 +134,7 @@ class TestRemoteQueryCommunity(TestBase):
         kwargs_dict = {"metadata_type": [CHANNEL_TORRENT]}
         self.nodes[1].overlay.send_remote_select(peer, **kwargs_dict)
         # There should be an outstanding request in the list
-        self.assertTrue(self.nodes[1].overlay.outstanding_requests)
+        self.assertTrue(self.nodes[1].overlay.request_cache._identifiers)
 
         await self.deliver_messages(timeout=0.5)
 
@@ -144,7 +144,7 @@ class TestRemoteQueryCommunity(TestBase):
             self.assertTrue(40 < received_channels.count() < 60)
 
             # The list of outstanding requests should be empty
-            self.assertFalse(self.nodes[1].overlay.outstanding_requests)
+            self.assertFalse(self.nodes[1].overlay.request_cache._identifiers)
 
     def test_query_on_introduction(self):
         """

--- a/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/channel_metadata.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/channel_metadata.py
@@ -384,7 +384,6 @@ def define_binding(db):
                 return "Downloading"
             return "Preview"
 
-        @db_session
         def to_simple_dict(self, **kwargs):
             """
             Return a basic dictionary with information about the channel.

--- a/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/collection_node.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/collection_node.py
@@ -51,16 +51,10 @@ def define_binding(db):
                 return "Personal"
             return "Preview"
 
-        @db_session
         def to_simple_dict(self):
             result = super(CollectionNode, self).to_simple_dict()
             result.update(
-                {
-                    "torrents": self.num_entries,
-                    "state": self.state,
-                    "total": self.contents_len,
-                    "dirty": self.dirty if self.is_personal else False,
-                }
+                {"torrents": self.num_entries, "state": self.state, "dirty": self.dirty if self.is_personal else False}
             )
             return result
 

--- a/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/metadata_node.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/metadata_node.py
@@ -188,7 +188,6 @@ def define_binding(db):
                     all_terms.add(term)
             return list(all_terms)
 
-        @db_session
         def to_simple_dict(self):
             """
             Return a basic dictionary with information about the channel.

--- a/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/torrent_metadata.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/torrent_metadata.py
@@ -131,7 +131,6 @@ def define_binding(db):
                 lambda g: g.metadata_type == REGULAR_TORRENT and g.status != LEGACY_ENTRY
             ).random(limit)
 
-        @db_session
         def to_simple_dict(self, include_trackers=False):
             """
             Return a basic dictionary with information about the channel.
@@ -149,8 +148,9 @@ def define_binding(db):
                 }
             )
 
-            if include_trackers:
-                simple_dict['trackers'] = [tracker.url for tracker in self.health.trackers]
+            with db_session:
+                if include_trackers:
+                    simple_dict['trackers'] = [tracker.url for tracker in self.health.trackers]
 
             return simple_dict
 

--- a/src/tribler-core/tribler_core/session.py
+++ b/src/tribler-core/tribler_core/session.py
@@ -236,7 +236,8 @@ class Session(TaskManager):
                 import RemoteQueryCommunity, RemoteQueryTestnetCommunity
 
             community_cls = RemoteQueryTestnetCommunity if self.config.get_testnet() else RemoteQueryCommunity
-            self.remote_query_community = community_cls(peer, self.ipv8.endpoint, self.ipv8.network, self.mds)
+            self.remote_query_community = community_cls(peer, self.ipv8.endpoint, self.ipv8.network, self.mds,
+                                                        notifier=self.notifier)
 
             self.ipv8.overlays.append(self.remote_query_community)
             self.ipv8.strategies.append((RandomWalk(self.remote_query_community), 50))

--- a/src/tribler-core/tribler_core/session.py
+++ b/src/tribler-core/tribler_core/session.py
@@ -239,7 +239,7 @@ class Session(TaskManager):
             self.remote_query_community = community_cls(peer, self.ipv8.endpoint, self.ipv8.network, self.mds)
 
             self.ipv8.overlays.append(self.remote_query_community)
-            self.ipv8.strategies.append((RandomWalk(self.remote_query_community), 20))
+            self.ipv8.strategies.append((RandomWalk(self.remote_query_community), 50))
 
     def enable_ipv8_statistics(self):
         if self.config.get_ipv8_statistics():

--- a/src/tribler-gui/tribler_gui/tribler_window.py
+++ b/src/tribler-gui/tribler_gui/tribler_window.py
@@ -581,6 +581,9 @@ class TriblerWindow(QMainWindow):
             self.new_version_dialog = None
 
     def on_search_text_change(self, text):
+        # We do not want to bother the database on petty 1-character queries
+        if len(text) < 2:
+            return
         TriblerNetworkRequest(
             "search/completions", self.on_received_search_completions, url_params={'q': sanitize_for_fts(text)}
         )


### PR DESCRIPTION
This adds a trigger for the introduction of new nodes in RemoteQueryCommunity. The idea is that on every introduction the community will query the remote host for its subscribed channels and update its local database accordingly.
Note that we add remote peers to a "queried" peers set in the community to prevent duplicate queries. The set is cleaned every 1000 entries. In the future, I would prefer a more elegant, Bloom filter-based solution. However, for the moment the auto-clearing set will do the job.
Also, we track the request manually so we only allow up to 10 packets back. This is another protection from spam. Note that there are no limits for query size on the answering side. This is intentional for testing purposes, and should be changed before rolling out a production release.