### PR TITLE
Fix checkpoint save tests

### DIFF
--- a/src/tribler-core/tribler_core/modules/credit_mining/credit_mining_manager.py
+++ b/src/tribler-core/tribler_core/modules/credit_mining/credit_mining_manager.py
@@ -223,7 +223,7 @@ class CreditMiningManager(TaskManager):
 
         # If a download already exists or already has a checkpoint, skip this torrent
         if self.session.dlmgr.get_download(unhexlify(infohash)) or \
-                (self.session.dlmgr.get_checkpoint_dir() / infohash).with_suffix('.state').exists():
+                (self.session.dlmgr.get_checkpoint_dir() / infohash).with_suffix('.conf').exists():
             self._logger.debug('Skipping torrent %s (download already running or scheduled to run)', infohash)
             return
 

--- a/src/tribler-core/tribler_core/modules/libtorrent/tests/test_download.py
+++ b/src/tribler-core/tribler_core/modules/libtorrent/tests/test_download.py
@@ -180,7 +180,7 @@ class TestDownload(TestAsServer):
 
         # This should not cause a checkpoint
         dl.setup(None, 0, checkpoint_disabled=True)
-        basename = hexlify(tdef.get_infohash()) + '.state'
+        basename = hexlify(tdef.get_infohash()) + '.conf'
         filename = self.session.dlmgr.get_checkpoint_dir() / basename
         self.assertFalse(filename.is_file())
 
@@ -188,6 +188,16 @@ class TestDownload(TestAsServer):
         await dl.checkpoint()
         self.assertFalse(filename.is_file())
         dl.stop()
+
+    @timeout(10)
+    async def test_save_checkpoint(self):
+        tdef = self.create_tdef()
+        dl = Download(self.session, tdef)
+        dl.setup()
+        basename = hexlify(tdef.get_infohash()) + '.conf'
+        filename = self.session.dlmgr.get_checkpoint_dir() / basename
+        await dl.checkpoint()
+        self.assertTrue(filename.is_file())
 
 
 class TestDownloadNoSession(TriblerCoreTest):


### PR DESCRIPTION
This fixes a broken (always positive) test. Also, it adds a complementary check for properly *saving* a checkpoint file.