### PR TITLE
Fixed logger.yaml loading in frozen environments

### DIFF
--- a/src/tribler-core/tribler_core/__init__.py
+++ b/src/tribler-core/tribler_core/__init__.py
@@ -21,5 +21,9 @@ def load_logger_config(log_dir):
     Loads tribler-core module logger configuration. Note that this function should be called explicitly to
     enable Core logs dump to a file in the log directory (default: inside state directory).
     """
-    logger_config = os.path.join("tribler-core", __name__, "logger.yaml")
-    setup_logging(config_path=logger_config, module='tribler-core', log_dir=log_dir)
+    if hasattr(sys, '_MEIPASS'):
+        logger_config_path = os.path.join(getattr(sys, '_MEIPASS'), "tribler_source", "tribler_core", "logger.yaml")
+    else:
+        logger_config_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "logger.yaml")
+
+    setup_logging(config_path=logger_config_path, module='tribler-core', log_dir=log_dir)

--- a/src/tribler-gui/tribler_gui/__init__.py
+++ b/src/tribler-gui/tribler_gui/__init__.py
@@ -2,6 +2,7 @@
 This package contains the code for the GUI, written in pyQt.
 """
 import os
+import sys
 
 from tribler_common.logger import setup_logging
 
@@ -11,5 +12,9 @@ def load_logger_config(log_dir):
     Loads tribler-gui module logger configuration. Note that this function should be called explicitly to
     enable GUI logs dump to a file in the log directory (default: inside state directory).
     """
-    logger_config = os.path.join("tribler-gui", __name__, "logger.yaml")
-    setup_logging(config_path=logger_config, module='tribler-gui', log_dir=log_dir)
+    if hasattr(sys, '_MEIPASS'):
+        logger_config_path = os.path.join(getattr(sys, '_MEIPASS'), "tribler_source", "tribler_gui", "logger.yaml")
+    else:
+        logger_config_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "logger.yaml")
+
+    setup_logging(config_path=logger_config_path, module='tribler-gui', log_dir=log_dir)

--- a/tribler.spec
+++ b/tribler.spec
@@ -37,6 +37,7 @@ data_to_copy = [
     (os.path.join(src_dir, "tribler-gui", "tribler_gui", "qt_resources"), 'qt_resources'),
     (os.path.join(src_dir, "tribler-gui", "tribler_gui", "images"), 'images'),
     (os.path.join(src_dir, "tribler-core", "tribler_core"), 'tribler_source/tribler_core'),
+    (os.path.join(src_dir, "tribler-gui", "tribler_gui"), 'tribler_source/tribler_gui'),
     (os.path.join(root_dir, "build", "win", "resources"), 'tribler_source/resources')
 ]
 


### PR DESCRIPTION
In a frozen environment, the path to `logger.yaml` is different than when running Tribler from source. We should check for this and adjust the path accordingly.

Fixes #5230