### PR TITLE
Include full exception context in report

### DIFF
--- a/src/tribler-core/tribler_core/session.py
+++ b/src/tribler-core/tribler_core/session.py
@@ -373,7 +373,8 @@ class Session(TaskManager):
         if exc:
             with StringIO() as buffer:
                 print_exception(type(exc), exc, exc.__traceback__, file=buffer)
-                text_long = buffer.getvalue()
+                text_long = text_long + "\n--LONG TEXT--\n" + buffer.getvalue()
+        text_long = text_long + "\n--CONTEXT--\n" + str(context)
 
         if self.api_manager and len(text_long) > 0:
             self.api_manager.get_endpoint('events').on_tribler_exception(text_long)

--- a/src/tribler-core/tribler_core/tests/test_session.py
+++ b/src/tribler-core/tribler_core/tests/test_session.py
@@ -35,16 +35,18 @@ class TestSessionAsServer(TestAsServer):
         """
         self.mock_endpoints()
 
-        expected_text = ""
 
         def on_tribler_exception(exception_text):
-            self.assertEqual(exception_text, expected_text)
+            self.assertTrue("abcd" in exception_text)
+            self.assertTrue("foobar" in exception_text)
+            on_tribler_exception.called = 1
+
 
         on_tribler_exception.called = 0
         self.session.api_manager.get_endpoint('events').on_tribler_exception = on_tribler_exception
         self.session.api_manager.get_endpoint('state').on_tribler_exception = on_tribler_exception
-        expected_text = "abcd"
-        self.session.unhandled_error_observer(None, {'message': 'abcd'})
+        self.session.unhandled_error_observer(None, {'message': 'abcd', 'context': 'foobar'})
+        self.assertTrue(on_tribler_exception.called)
 
     def test_error_observer_ignored_error(self):
         """


### PR DESCRIPTION
This includes the full `context` in the error report. Debugging complex asynchronous code is basically impossible without this.