### PR TITLE
Encoding stack trace before sending it

### DIFF
--- a/src/tribler-gui/tribler_gui/code_executor.py
+++ b/src/tribler-gui/tribler_gui/code_executor.py
@@ -66,7 +66,7 @@ class CodeExecutor(object):
     def on_crash(self, exception_text):
         self.stack_trace = exception_text
         for socket in self.sockets:
-            socket.write(b"crash %s\n" % b64encode(exception_text))
+            socket.write(b"crash %s\n" % b64encode(exception_text.encode('utf-8')))
 
     def _on_socket_read_ready(self):
         data = bytes(self.sockets[0].readAll())


### PR DESCRIPTION
This error would not send the stack trace back to the application tester.

This PR is critical for the application tester, as it will not reliably report stack traces otherwise.