### PR TITLE
Stop videoplayer crash when clicking the slider with no video loaded

### DIFF
--- a/src/tribler-gui/tribler_gui/widgets/videoplayerpage.py
+++ b/src/tribler-gui/tribler_gui/widgets/videoplayerpage.py
@@ -143,6 +143,9 @@ class VideoPlayerPage(QWidget):
         self.freeze = False
 
     def on_should_change_video_time(self, position):
+        if not self.mediaplayer or not self.media:
+            return
+
         self.freeze = True
         self.mediaplayer.stop()
         self.mediaplayer.play()


### PR DESCRIPTION
Fixes https://github.com/Tribler/tribler/issues/5237.