### PR TITLE
fix head request to push all streaming content.

### DIFF
--- a/src/tribler-core/tribler_core/modules/libtorrent/restapi/downloads_endpoint.py
+++ b/src/tribler-core/tribler_core/modules/libtorrent/restapi/downloads_endpoint.py
@@ -578,6 +578,9 @@ class DownloadsEndpoint(RESTEndpoint):
         if not 0 <= file_index < len(download.get_def().get_files()):
             return RESTResponse('Selected file out of range', status=HTTP_NOT_FOUND)
 
+        if request.method == "HEAD":
+            return RESTResponse(status=200)
+        
         stream = self.streams.get(infohash)
         if stream and stream.file_index != file_index:
             stream.close()


### PR DESCRIPTION
Kodi Player does bunch of head request before playing a web stream.

Currently rest server iterates the stream object and then handles the HEAD & GET request on the same handler.

This causes stuttering on first launch of the stream, this small fix handles HEAD requests more efficiently and prevents server to bottleneck and fixes the stuttering problem.

PS:
Also it may be beneficial to provide Content-Length to the HEAD response to initialize the Player Buffering Mechanism more efficiently, but i faced a problem when consequent HEAD requests are made, the 2nd HEAD response was not been sent to client by AOI server when content length is provided in HEAD response. This may be another bug.