### PR TITLE
Fix torrent checker timeout value is sent from the rest endpoint as string 

### DIFF
--- a/src/tribler-core/tribler_core/modules/metadata_store/restapi/metadata_endpoint.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/restapi/metadata_endpoint.py
@@ -12,6 +12,9 @@ from tribler_core.restapi.rest_endpoint import HTTP_BAD_REQUEST, HTTP_NOT_FOUND,
 from tribler_core.utilities.unicode import hexlify
 
 
+TORRENT_CHECK_TIMEOUT = 20
+
+
 class UpdateEntryMixin(object):
     @db_session
     def update_entry(self, public_key, id_, update_dict):
@@ -147,7 +150,13 @@ class MetadataEndpoint(MetadataEndpointBase, UpdateEntryMixin):
 
             :statuscode 404: if the torrent is not found in the database
         """
-        timeout = request.query.get('timeout', 20)
+        timeout = request.query.get('timeout')
+        if not timeout:
+            timeout = TORRENT_CHECK_TIMEOUT
+        elif timeout.isdigit():
+            timeout = int(timeout)
+        else:
+            return RESTResponse({"error": "Error processing timeout parameter '%s'" % timeout}, status=HTTP_BAD_REQUEST)
         refresh = request.query.get('refresh', '0') == '1'
         nowait = request.query.get('nowait', '0') == '1'
 

--- a/src/tribler-core/tribler_core/tests/tools/tracker/http_tracker.py
+++ b/src/tribler-core/tribler_core/tests/tools/tracker/http_tracker.py
@@ -33,7 +33,8 @@ class HTTPTracker(object):
         """
         Stop the HTTP Tracker, returns a deferred that fires when the server is closed.
         """
-        return await self.site.stop()
+        if self.site:
+            return await self.site.stop()
 
     async def handle_scrape_request(self, request):
         """

--- a/src/tribler-core/tribler_core/tests/tools/tracker/udp_tracker.py
+++ b/src/tribler-core/tribler_core/tests/tools/tracker/udp_tracker.py
@@ -96,4 +96,5 @@ class UDPTracker(object):
         """
         Stop the UDP Tracker, returns a deferred that fires when the server is closed.
         """
-        self.transport.close()
+        if self.transport:
+            self.transport.close()


### PR DESCRIPTION
This commit fixes the bug where torrentchecker endpoint sends a string
type timeout value to the TorrentChecker class,

If this variable is string then a suppressed error accours in each query
with the hidden trace below. This causes all torrenct health checks
requested from the endpoint to fail, since the argument is passed over
querystrings and query string arguments always are string types.

With this change timeout value is used when arguemnt is passed and a
number.

```
File "/home/boogie/src/tribler/src/tribler-core/tribler_core/modules/torrent_checker/torrentchecker_session.py",
line 137, in connect_to_tracker
    async with
self._session.get(url.encode(\'ascii\').decode(\'utf-8\')) as response:
    File "/home/boogie/.local/lib/python3.7/site-packages/aiohttp/client.py",
line 1012, in __aenter__
    self._resp = await self._coro
    File "/home/boogie/.local/lib/python3.7/site-packages/aiohttp/client.py",
line 405, in _request
    handle = tm.start()
    File "/home/boogie/.local/lib/python3.7/site-packages/aiohttp/helpers.py",
line 530, in start
    if self._timeout is not None and self._timeout > 0:

```