### PR TITLE
Various minor GUI fixes

### DIFF
--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -34,7 +34,7 @@ Reporting bugs
 Pull requests
 =============
 
-When creating a new Pull request, please observe the following:
+When creating a new Pull request, please take note of the following:
   * New features always go to ``devel``.
   * If there is an unreleased ``release-X.Y.Z`` branch, fixes go there.
   * Otherwise, fixes go to ``devel``.
@@ -49,6 +49,7 @@ When creating a new Pull request, please observe the following:
     code.
   * If implementing a reasonably big or experimental feature, make it toggleable
     if possible (For instance for a new community, new GUI stuff, etc.).
+  * When you make a change to the user interface, please attach a screenshot of your changes to the pull request. This helps reviewers since it avoids the need for them to manually checkout your code to see what has been changed.
   * Keep a clean and nice git history:
       * Rebase instead of merging back from the base branch.
       * Squash fixup commits together.

--- a/src/tribler-gui/tribler_gui/qt_resources/mainwindow.ui
+++ b/src/tribler-gui/tribler_gui/qt_resources/mainwindow.ui
@@ -1151,7 +1151,7 @@ background-color: #e67300;
       <item>
        <widget class="QStackedWidget" name="stackedWidget">
         <property name="currentIndex">
-         <number>2</number>
+         <number>8</number>
         </property>
         <widget class="ChannelContentsWidget" name="personal_channel_page"/>
         <widget class="ChannelContentsWidget" name="search_results_page"/>
@@ -4691,8 +4691,8 @@ color: white</string>
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>856</width>
-                       <height>387</height>
+                       <width>308</width>
+                       <height>276</height>
                       </rect>
                      </property>
                      <layout class="QFormLayout" name="formLayout_4">
@@ -6762,11 +6762,11 @@ font-weight: bold;</string>
                       <property name="sortingEnabled">
                        <bool>true</bool>
                       </property>
-                      <attribute name="headerMinimumSectionSize">
-                       <number>50</number>
-                      </attribute>
                       <attribute name="headerDefaultSectionSize">
                        <number>120</number>
+                      </attribute>
+                      <attribute name="headerMinimumSectionSize">
+                       <number>50</number>
                       </attribute>
                       <attribute name="headerStretchLastSection">
                        <bool>true</bool>

--- a/src/tribler-gui/tribler_gui/qt_resources/torrents_list.ui
+++ b/src/tribler-gui/tribler_gui/qt_resources/torrents_list.ui
@@ -324,6 +324,31 @@ background-color: transparent;
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
+        <property name="styleSheet">
+         <string notr="true">QComboBox {
+	border: 1px solid #333333;
+	border-radius: 3px;
+	background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #797979, stop:0.48 #696969, stop:0.52 #5e5e5e, stop:1 #4f4f4f);
+	padding: 1px 23px 1px 3px;
+	color: #ffffff;
+}
+QComboBox::drop-down {
+	subcontrol-origin: padding;
+	subcontrol-position: top right;
+	width: 20px;
+	
+	border-top-right-radius: 3px;
+	border-bottom-right-radius: 3px;
+}
+
+QComboBox QAbstractViewItem{
+	background-color: #4f4f4f;
+	color: #999999;
+	
+	selection-background-color: #999999;
+	selection-color: #4f4f4f;
+}</string>
+        </property>
        </widget>
       </item>
       <item>
@@ -385,7 +410,7 @@ color: white;
         </property>
         <property name="sizeHint" stdset="0">
          <size>
-          <width>16</width>
+          <width>10</width>
           <height>20</height>
          </size>
         </property>
@@ -463,22 +488,6 @@ background-color: transparent;
           </widget>
          </item>
          <item>
-          <spacer name="horizontalSpacer_61">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeType">
-            <enum>QSizePolicy::Fixed</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>2</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
           <spacer name="horizontalSpacer_70">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
@@ -488,7 +497,7 @@ background-color: transparent;
            </property>
            <property name="sizeHint" stdset="0">
             <size>
-             <width>5</width>
+             <width>10</width>
              <height>20</height>
             </size>
            </property>
@@ -609,20 +618,39 @@ background-color: transparent;
        <number>0</number>
       </property>
       <item>
-       <spacer name="horizontalSpacer">
+       <spacer name="horizontalSpacer_8">
         <property name="orientation">
          <enum>Qt::Horizontal</enum>
         </property>
-        <property name="sizeType">
-         <enum>QSizePolicy::Fixed</enum>
-        </property>
         <property name="sizeHint" stdset="0">
          <size>
-          <width>10</width>
-          <height>0</height>
+          <width>40</width>
+          <height>20</height>
          </size>
         </property>
        </spacer>
+      </item>
+      <item>
+       <widget class="EllipseButton" name="new_channel_button">
+        <property name="minimumSize">
+         <size>
+          <width>90</width>
+          <height>24</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>90</width>
+          <height>24</height>
+         </size>
+        </property>
+        <property name="cursor">
+         <cursorShape>PointingHandCursor</cursorShape>
+        </property>
+        <property name="text">
+         <string>NEW CHANNEL</string>
+        </property>
+       </widget>
       </item>
       <item>
        <widget class="QToolButton" name="channel_options_button">
@@ -677,42 +705,6 @@ background-color: transparent;
        </widget>
       </item>
       <item>
-       <spacer name="horizontalSpacer_31">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeType">
-         <enum>QSizePolicy::Maximum</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>16</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="QPushButton" name="new_channel_button">
-        <property name="text">
-         <string>New channel</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <spacer name="horizontalSpacer_8">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
        <widget class="QWidget" name="commit_control_bar" native="true">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
@@ -727,6 +719,21 @@ background-color: transparent;
          </size>
         </property>
         <layout class="QHBoxLayout" name="horizontalLayout_11">
+         <property name="spacing">
+          <number>0</number>
+         </property>
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
          <item>
           <widget class="QLabel" name="dirty_channel_status_bar">
            <property name="sizePolicy">

--- a/src/tribler-gui/tribler_gui/qt_resources/torrents_list.ui
+++ b/src/tribler-gui/tribler_gui/qt_resources/torrents_list.ui
@@ -35,6 +35,21 @@
    <string notr="true">background-color: #202020;</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="spacing">
+    <number>0</number>
+   </property>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
    <item>
     <widget class="QFrame" name="channel_details_header">
      <property name="sizePolicy">

--- a/src/tribler-gui/tribler_gui/tribler_window.py
+++ b/src/tribler-gui/tribler_gui/tribler_window.py
@@ -458,7 +458,7 @@ class TriblerWindow(QMainWindow):
         self.personal_channel_page.initialize_root_model(
             self.personal_channel_page.default_channel_model(
                 hide_xxx=False,
-                channel_info={"name": "Personal channels root", "state": "Personal"},
+                channel_info={"name": "My channels", "state": "Personal"},
                 endpoint_url="channels/mychannel/0",
                 exclude_deleted=autocommit_enabled,
             )

--- a/src/tribler-gui/tribler_gui/widgets/channelcontentswidget.py
+++ b/src/tribler-gui/tribler_gui/widgets/channelcontentswidget.py
@@ -345,10 +345,10 @@ class ChannelContentsWidget(widget_form, widget_class):
         if "total" in self.model.channel_info:
             if "torrents" in self.model.channel_info:
                 self.channel_num_torrents_label.setText(
-                    "{}/{} torrents".format(self.model.channel_info["total"], self.model.channel_info["torrents"])
+                    "{}/{} items".format(self.model.channel_info["total"], self.model.channel_info["torrents"])
                 )
             else:
-                self.channel_num_torrents_label.setText("{} results".format(self.model.channel_info["total"]))
+                self.channel_num_torrents_label.setText("{} items".format(self.model.channel_info["total"]))
 
     # ==============================
     # Channel menu related methods.

--- a/src/tribler-gui/tribler_gui/widgets/lazytableview.py
+++ b/src/tribler-gui/tribler_gui/widgets/lazytableview.py
@@ -125,4 +125,4 @@ class TriblerContentTableView(QTableView):
         if self.model() is None:
             return
         for col_num, col in enumerate(self.model().columns):
-            self.setColumnWidth(col_num, self.model().column_width.get(col, lambda _: 100)(self.width()))
+            self.setColumnWidth(col_num, self.model().column_width.get(col, lambda _: 110)(self.width()))

--- a/src/tribler-gui/tribler_gui/widgets/tablecontentmodel.py
+++ b/src/tribler-gui/tribler_gui/widgets/tablecontentmodel.py
@@ -222,7 +222,9 @@ class ChannelContentModel(RemoteTableModel):
         ACTION_BUTTONS: Qt.ItemIsEnabled | Qt.ItemIsSelectable,
     }
 
-    column_width = {u'state': lambda _: 20, u'name': lambda table_width: table_width - 520}
+    column_width = {u'state': lambda _: 20,
+                    u'name': lambda table_width: table_width - 510,
+                    u'action_buttons': lambda _: 70}
 
     column_tooltip_filters = {
         u'state': lambda data: data,
@@ -262,7 +264,7 @@ class ChannelContentModel(RemoteTableModel):
 
         # Current channel attributes. This is intentionally NOT copied, so local changes
         # can propagate to the origin, e.g. parent channel.
-        self.channel_info = channel_info or {"name": "Personal channels root", "status": 123}
+        self.channel_info = channel_info or {"name": "My channels", "status": 123}
 
         self.endpoint_url_override = endpoint_url
 
@@ -415,7 +417,7 @@ class DiscoveredChannelsModel(ChannelContentModel):
     columns = [u'state', u'votes', u'name', u'torrents', u'updated']
     column_headers = [u'', u'Popularity', u'Name', u'Torrents', u'Updated']
 
-    column_width = {u'state': lambda _: 20, u'name': lambda table_width: table_width - 360}
+    column_width = {u'state': lambda _: 20, u'name': lambda table_width: table_width - 350}
 
     default_sort_column = 1
 
@@ -489,6 +491,8 @@ class PersonalChannelsModel(ChannelContentModel):
 class SimplifiedPersonalChannelsModel(PersonalChannelsModel):
     columns = [u'category', u'name', u'size', ACTION_BUTTONS]
     column_headers = [u'Category', u'Name', u'Size', u'']
+
+    column_width = {u'state': lambda _: 20, u'name': lambda table_width: table_width - 330}
 
     def __init__(self, *args, **kwargs):
         kwargs["exclude_deleted"] = kwargs.get("exclude_deleted", True)


### PR DESCRIPTION
In this PR, I made the following changes:
- Made sure that the width of all tables in the GUI match the window width.
- Moved the 'new channel' and 'channel options' button to the right of the screen.
- Renamed 'Personal channel root' to 'My channels'.
- Removed unnecessary margin around the discovered channels table.
- Customized the `QComboBox` dropdown and the 'new channel' buttons.
- Renamed 'results' to 'items' (the label left to the filter).

I also updated the contribution guidelines to include the rule that screenshots have to be attached when making GUI changes.

![Schermafbeelding 2020-04-02 om 12 15 26](https://user-images.githubusercontent.com/1707075/78237532-be71a480-74db-11ea-8909-30af7866f4f2.png)

![Schermafbeelding 2020-04-02 om 12 15 36](https://user-images.githubusercontent.com/1707075/78237543-c0d3fe80-74db-11ea-81a1-969d69e62fb9.png)

![Schermafbeelding 2020-04-02 om 12 15 55](https://user-images.githubusercontent.com/1707075/78237560-c92c3980-74db-11ea-85aa-4c9c92e386e0.png)

![Schermafbeelding 2020-04-02 om 12 17 10](https://user-images.githubusercontent.com/1707075/78237653-e6f99e80-74db-11ea-88d0-feba7508414f.png)
