### PR TITLE
Fixed status code in debug pane

### DIFF
--- a/src/tribler-gui/tribler_gui/debug_window.py
+++ b/src/tribler-gui/tribler_gui/debug_window.py
@@ -247,7 +247,12 @@ class DebugWindow(QMainWindow):
 
     def load_requests_tab(self):
         self.window().requests_tree_widget.clear()
-        for endpoint, method, data, timestamp, status_code in sorted(tribler_performed_requests, key=lambda x: x[3]):
+        for request, status_code in sorted(tribler_performed_requests, key=lambda rq: rq[0].time):
+            endpoint = request.url
+            method = request.method
+            data = request.raw_data
+            timestamp = request.time
+
             item = QTreeWidgetItem(self.window().requests_tree_widget)
             item.setText(0, "%s %s %s" % (method, repr(endpoint), repr(data)))
             item.setText(1, ("%d" % status_code) if status_code else "unknown")

--- a/src/tribler-gui/tribler_gui/dialogs/feedbackdialog.py
+++ b/src/tribler-gui/tribler_gui/dialogs/feedbackdialog.py
@@ -64,12 +64,11 @@ class FeedbackDialog(QDialog):
 
         # Add recent requests to feedback dialog
         request_ind = 1
-        for endpoint, method, data, timestamp, status_code in sorted(tribler_performed_requests, key=lambda x: x[3])[
-            -30:
-        ]:
+        for request, status_code in sorted(tribler_performed_requests, key=lambda rq: rq[0].time)[-30:]:
             add_item_to_info_widget(
                 'request_%d' % request_ind,
-                '%s %s %s (time: %s, code: %s)' % (endpoint, method, data, timestamp, status_code),
+                '%s %s %s (time: %s, code: %s)' % (request.url, request.method,
+                                                   request.raw_data, request.time, status_code),
             )
             request_ind += 1
 


### PR DESCRIPTION
We did never set the status code after a request has been completed. Unfortunately, I cannot reuse the QNetworkRequest.reply attribute since that seems to be a different object that is not correctly updated after a request has been finished.

Fixes #5269

![Schermafbeelding 2020-04-02 om 14 42 27](https://user-images.githubusercontent.com/1707075/78250674-790ba200-74f0-11ea-8eb9-13ce72ad630c.png)
