### PR TITLE
Fixed a bug during shutdown

### DIFF
--- a/src/tribler-gui/tribler_gui/tribler_window.py
+++ b/src/tribler-gui/tribler_gui/tribler_window.py
@@ -356,6 +356,7 @@ class TriblerWindow(QMainWindow):
         :return:
         """
         self.downloads_page.stop_loading_downloads()
+        self.core_manager.shutting_down = True
         self.core_manager.stop(False)
         close_dialog = ConfirmationDialog(
             self.window(),


### PR DESCRIPTION
We forgot to indicate that the core manager is shutting down if Tribler closes for any reason besides an unhandled exception (e.g., when running low on disk space). This could result in an inconsistent state.