### PR TITLE
Fix AddToChannelDialog not showing

### DIFF
--- a/src/tribler-gui/tribler_gui/dialogs/addtopersonalchanneldialog.py
+++ b/src/tribler-gui/tribler_gui/dialogs/addtopersonalchanneldialog.py
@@ -40,6 +40,7 @@ class AddToChannelDialog(DialogContainer):
         self.dialog_widget.channels_tree_wt.itemExpanded.connect(self.on_item_expanded)
 
         self.dialog_widget.channels_tree_wt.setHeaderLabels(['Name'])
+        self.on_main_window_resize()
 
     def on_create_new_channel_clicked(self):
         selected = self.dialog_widget.channels_tree_wt.selectedItems()


### PR DESCRIPTION
This fixes AddToChannelDialog not shown in some cases, due to incorrect size.