### PR TITLE
Fix reading config in headless Core runner scripts

### DIFF
--- a/src/tribler-core/run_market_helper.py
+++ b/src/tribler-core/run_market_helper.py
@@ -37,7 +37,8 @@ class MarketService(object):
         signal.signal(signal.SIGINT, lambda sig, _: ensure_future(signal_handler(sig)))
         signal.signal(signal.SIGTERM, lambda sig, _: ensure_future(signal_handler(sig)))
 
-        config = TriblerConfig(options.statedir or Path(get_appstate_dir(), '.Tribler'))
+        statedir = Path(options.statedir or Path(get_appstate_dir(), '.Tribler'))
+        config = TriblerConfig(statedir, config_file=statedir / 'triblerd.conf')
         config.set_torrent_checking_enabled(False)
         config.set_libtorrent_enabled(True)
         config.set_http_api_enabled(True)
@@ -79,7 +80,7 @@ def main(argv):
     parser.add_argument('--help', '-h', action='help', default=argparse.SUPPRESS, help='Show this help message and exit')
     parser.add_argument('--statedir', '-s', default=None, help='Use an alternate statedir')
     parser.add_argument('--restapi', '-p', default=-1, type=int, help='Use an alternate port for REST API')
-    parser.add_argument('--ipv8', '-i', default=8085, type=int, help='Use an alternate port for the IPv8')
+    parser.add_argument('--ipv8', '-i', default=-1, type=int, help='Use an alternate port for the IPv8')
     
     parser.add_argument('--testnet', '-t', action='store_const', default=False, const=True, help='Join the testnet')
 

--- a/src/tribler-core/run_tribler_headless.py
+++ b/src/tribler-core/run_tribler_headless.py
@@ -68,7 +68,8 @@ class TriblerService(object):
         signal.signal(signal.SIGINT, lambda sig, _: ensure_future(signal_handler(sig)))
         signal.signal(signal.SIGTERM, lambda sig, _: ensure_future(signal_handler(sig)))
 
-        config = TriblerConfig(options.statedir or Path(get_appstate_dir(), '.Tribler'))
+        statedir = Path(options.statedir or Path(get_appstate_dir(), '.Tribler'))
+        config = TriblerConfig(statedir, config_file=statedir / 'triblerd.conf')
 
         # Check if we are already running a Tribler instance
         self.process_checker = ProcessChecker()
@@ -113,7 +114,7 @@ def main(argv):
                         help='Show this help message and exit')
     parser.add_argument('--statedir', '-s', default=None, help='Use an alternate statedir')
     parser.add_argument('--restapi', '-p', default=-1, type=int, help='Use an alternate port for REST API')
-    parser.add_argument('--ipv8', '-i', default=8085, type=int, help='Use an alternate port for the IPv8')
+    parser.add_argument('--ipv8', '-i', default=-1, type=int, help='Use an alternate port for the IPv8')
     parser.add_argument('--libtorrent', '-l', default=-1, type=int, help='Use an alternate port for libtorrent')
     parser.add_argument('--ipv8_bootstrap_override', '-b', default=None, type=str,
                         help='Force the usage of specific IPv8 bootstrap server (ip:port)', action=IPPortAction)

--- a/src/tribler-core/run_tunnel_helper.py
+++ b/src/tribler-core/run_tunnel_helper.py
@@ -18,6 +18,7 @@ from tribler_common.simpledefs import NTFY
 from tribler_core.config.tribler_config import TriblerConfig
 from tribler_core.session import Session
 from tribler_core.utilities.osutils import get_root_state_directory
+from tribler_core.utilities.path_util import Path
 
 logger = logging.getLogger(__name__)
 
@@ -113,7 +114,8 @@ class TunnelHelperService(TaskManager):
             base_port = int(os.environ["HELPER_BASE"])
             ipv8_port = base_port + int(os.environ["HELPER_INDEX"]) * 5
 
-        config = TriblerConfig(os.path.join(get_root_state_directory(), "tunnel-%d") % ipv8_port)
+        statedir = Path(os.path.join(get_root_state_directory(), "tunnel-%d") % ipv8_port)
+        config = TriblerConfig(statedir, config_file=statedir / 'triblerd.conf')
         config.set_tunnel_community_socks5_listen_ports([])
         config.set_tunnel_community_random_slots(options.random_slots)
         config.set_tunnel_community_competing_slots(options.competing_slots)


### PR DESCRIPTION
This fixes `run_tribler_headless.py` and other "headless" scripts not reading the config and overwriting it with the default one.