### PR TITLE
Also catching KeyError when loading checkpoint

### DIFF
--- a/src/tribler-core/tribler_core/modules/libtorrent/download_manager.py
+++ b/src/tribler-core/tribler_core/modules/libtorrent/download_manager.py
@@ -758,7 +758,7 @@ class DownloadManager(TaskManager):
             url = url.decode('utf-8') if url else url
             tdef = (TorrentDefNoMetainfo(metainfo[b'infohash'], metainfo[b'name'], url)
                     if b'infohash' in metainfo else TorrentDef.load_from_dict(metainfo))
-        except ValueError as e:
+        except (KeyError, ValueError) as e:
             self._logger.exception("Could not restore tdef from metainfo dict: %s %s ", e, metainfo)
             return
 


### PR DESCRIPTION
It could be that one of the accessed dictionary keys is missing. Tribler should not crash in this scenario.

Fixes #5276 