### PR TITLE
Remove content of tribler dir on dpkg uninstall

### DIFF
--- a/build/debian/tribler/DEBIAN/tribler.prerm
+++ b/build/debian/tribler/DEBIAN/tribler.prerm
@@ -1,0 +1,2 @@
+# Remove the content of the /usr/share/tribler directory
+rm -rf /usr/share/tribler

--- a/src/tribler-core/tribler_core/modules/tunnel/test_full_session/test_hidden_services.py
+++ b/src/tribler-core/tribler_core/modules/tunnel/test_full_session/test_hidden_services.py
@@ -19,7 +19,7 @@ class TestHiddenServices(TestTunnelBase):
         Test the hidden services overlay by constructing an end-to-end circuit and downloading a torrent over it
         """
         await self.setup_nodes(num_relays=4, num_exitnodes=2, seed_hops=1)
-        await self.deliver_messages()
+        await self.deliver_messages(timeout=1)
 
         for c in self.tunnel_communities:
             self.assertEqual(7, len(c.get_peers()))


### PR DESCRIPTION
This PR ensures that the content of the `/usr/share/tribler` directory is removed when Tribler is being uninstalled. Removal of this directory should be safe since no user-generated content is saved in `/usr/share/tribler`.

Please test out this PR to see if it does not break anything. I tested it on Ubuntu 18.04 and it seems to surpress the warning.

Fixes #5193 