### PR TITLE
Fixed a GUI bug when opening Tribler

### DIFF
--- a/src/tribler-gui/tribler_gui/tribler_window.py
+++ b/src/tribler-gui/tribler_gui/tribler_window.py
@@ -438,7 +438,8 @@ class TriblerWindow(QMainWindow):
             self.discovering_page.is_discovering = True
             self.stackedWidget.setCurrentIndex(PAGE_DISCOVERING)
         else:
-            self.stackedWidget.setCurrentIndex(PAGE_DISCOVERED)
+            self.clicked_menu_button_discovered()
+            self.left_menu_button_discovered.setChecked(True)
 
     def stop_discovering(self):
         if not self.discovering_page.is_discovering:
@@ -446,7 +447,8 @@ class TriblerWindow(QMainWindow):
         self.core_manager.events_manager.discovered_channel.disconnect(self.stop_discovering)
         self.discovering_page.is_discovering = False
         if self.stackedWidget.currentIndex() == PAGE_DISCOVERING:
-            self.stackedWidget.setCurrentIndex(PAGE_DISCOVERED)
+            self.clicked_menu_button_discovered()
+            self.left_menu_button_discovered.setChecked(True)
 
     def initialize_personal_channels_page(self):
         autocommit_enabled = (


### PR DESCRIPTION
When opening Tribler, the discovered menu button was unselected and could be selected again by users. This PR fixes that behaviour. The button is now checked when opening Tribler.

![Schermafbeelding 2020-04-06 om 14 30 09](https://user-images.githubusercontent.com/1707075/78558589-28a78380-7813-11ea-83a4-f28ac3912bd0.png)
