### PR TITLE
Load metainfo directly when unchecking 'anonymous' checkbox

### DIFF
--- a/src/tribler-core/tribler_core/modules/libtorrent/download_manager.py
+++ b/src/tribler-core/tribler_core/modules/libtorrent/download_manager.py
@@ -371,6 +371,7 @@ class DownloadManager(TaskManager):
         to a few peers, and downloading the metadata for the torrent.
         :param infohash: The (binary) infohash to lookup metainfo for.
         :param timeout: A timeout in seconds.
+        :param hops: the number of tunnel hops to use for this lookup. If None, use config default.
         :return: The metainfo
         """
         infohash_hex = hexlify(infohash)

--- a/src/tribler-core/tribler_core/modules/libtorrent/restapi/torrentinfo_endpoint.py
+++ b/src/tribler-core/tribler_core/modules/libtorrent/restapi/torrentinfo_endpoint.py
@@ -45,6 +45,15 @@ class TorrentInfoEndpoint(RESTEndpoint):
         """
 
         args = request.query
+
+        hops = None
+        if 'hops' in args:
+            try:
+                hops = int(args['hops'])
+            except ValueError:
+                return RESTResponse({"error": f"wrong value of 'hops' parameter: {repr(args['hops'])}"},
+                                    status=HTTP_BAD_REQUEST)
+
         if 'uri' not in args or not args['uri']:
             return RESTResponse({"error": "uri parameter missing"}, status=HTTP_BAD_REQUEST)
 
@@ -67,14 +76,14 @@ class TorrentInfoEndpoint(RESTEndpoint):
             if response.startswith(b'magnet'):
                 _, infohash, _ = parse_magnetlink(response)
                 if infohash:
-                    metainfo = await self.session.dlmgr.get_metainfo(infohash, timeout=60)
+                    metainfo = await self.session.dlmgr.get_metainfo(infohash, timeout=60, hops=hops)
             else:
                 metainfo = bdecode_compat(response)
         elif uri.startswith('magnet'):
             infohash = parse_magnetlink(uri)[1]
             if infohash is None:
                 return RESTResponse({"error": "missing infohash"}, status=HTTP_BAD_REQUEST)
-            metainfo = await self.session.dlmgr.get_metainfo(infohash, timeout=60)
+            metainfo = await self.session.dlmgr.get_metainfo(infohash, timeout=60, hops=hops)
         else:
             return RESTResponse({"error": "invalid uri"}, status=HTTP_BAD_REQUEST)
 


### PR DESCRIPTION
When unchecking :ballot_box_with_check:  "Download anonymously", trigger direct metainfo fetch, and vice-versa. Modify status label text accordingly to indicate in what mode the metainfo is being fetched currently.

Partially solves #4854 