### PR TITLE
Streaming Improvements

### DIFF
--- a/src/tribler-core/tribler_core/modules/libtorrent/__init__.py
+++ b/src/tribler-core/tribler_core/modules/libtorrent/__init__.py
@@ -38,3 +38,16 @@ def require_handle(func):
         handle_future.add_done_callback(done_cb)
         return result_future
     return invoke_func
+
+
+def check_vod(default=None):
+    """
+    Check if torrent is vod mode, else return default
+    """
+    def wrap(f):
+        def invoke_func(self, *args, **kwargs):
+            if self.enabled:
+                return f(self, *args, **kwargs)
+            return default
+        return invoke_func
+    return wrap

--- a/src/tribler-core/tribler_core/modules/libtorrent/download_manager.py
+++ b/src/tribler-core/tribler_core/modules/libtorrent/download_manager.py
@@ -7,7 +7,7 @@ import asyncio
 import logging
 import os
 import time as timemod
-from asyncio import CancelledError, TimeoutError, gather, iscoroutine, shield, sleep, wait_for
+from asyncio import CancelledError, gather, iscoroutine, shield, sleep, wait_for
 from binascii import unhexlify
 from copy import deepcopy
 from distutils.version import LooseVersion
@@ -598,6 +598,7 @@ class DownloadManager(TaskManager):
         # the removal having finished.
         if handle:
             if handle.is_valid():
+                download.stream.disable()
                 self._logger.debug("Removing handle %s", hexlify(infohash))
                 ltsession = self.get_session(download.config.get_hops())
                 ltsession.remove_torrent(handle, int(remove_content))

--- a/src/tribler-core/tribler_core/modules/libtorrent/stream.py
+++ b/src/tribler-core/tribler_core/modules/libtorrent/stream.py
@@ -1,182 +1,583 @@
+"""
+There are 2 types of prioritisation implemented:
+1-STATIC PRIORITISATION: Header + Footer + Prebuffer Prioritisation:
+When a file in torrent is set to stream, predefined size of heeder + footer + prebuffer is
+set to prio:7 deadline:0 and rest of the files and pieces are set to prio:0 (which means dont download at all)
+to only focus the required pieces to finish before file starts to stream. The client is expected not to start playing
+the file in this state. The state of this static buffering can be observed over the rest api.
+
+2-DYNMAIC PRIORITISATION: When the static prio is finished then the client can start playing the file,
+When a client starts playing the file over http, it will request a chunk, each requested chunk will initiate a
+dynmaic buffer according to the current read position of the file mapped to related piece of the torrent file.
+The undownloaded pieces starting from the current read position with the length of prebuffsize will be prioritised
+with the DEADLINE_PRIO_MAP sequence and will be deadlined with the indexes of the same map.
+Rest of the pieces are to prio: 1 and no deadline. Note that, the prio, deadline and the actual pieces impacted
+will be dynamically updated eachtime more chunks are readed, until EOF.
+Each chunk will have its own prio applied, and there can be multiple concurrent chucks
+for a given fileindex of a torrent
+"""
+
 import logging
 from asyncio import sleep
 
+from tribler_common.simpledefs import DLSTATUS_DOWNLOADING, DLSTATUS_SEEDING
+
+from tribler_core.modules.libtorrent import check_vod
 from tribler_core.utilities.torrent_utils import get_info_from_handle
 
+# Header and footer sizes are necessary for video client to detect file codecs and muxer metadata.
+# Without below pieces are ready, streamer should not start
+HEADER_SIZE = 5 * 1024 * 1024
+FOOTER_SIZE = 1 * 1024 * 1024
+# the percent of the file size to be used as moving or static prebufferng size
+PREBUFF_PERCENT = 0.05
+# Below map defines the priority/deadline sequence for pieces. List index represents the deadline, and
+# actual value in the index represents the priority of the piece sequence in the torrent file.
+# Minimum prio must be 2, because prio 1 is used for not relevant pieces in streaming
+# Max prio is 7 and must have only 1 deadline attached to it, because lt selects prio 7 regardles of picker desicion
+# The narrower this map, better the prioritaztion worse the throughput ie: 7,6,5,3,2,1
+# The wider this map, worse the prioritization, better the throughput: ie: 7,6,6,6,6,6,6,6,6,5,5,5,5,5,5,5,5,5,5...
+# Below logarithmic map is based on 2^n and achieves 3~4MB/s with a moving 4~5MB window prioritization
+# There is no prio 5 in libtorrent priorities
+# https://www.libtorrent.org/manual.html#piece-priority-prioritize-pieces-piece-priorities
+DEADLINE_PRIO_MAP = [7, 6, 6, 4, 4, 4, 4, 3, 3, 3, 3, 3, 3, 3, 3, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2]
+# time to detect if the client is no more requesting stream chunks from rest api
+# basically this means the video is either paused, or seeked to another postion
+# but the player still wants the old tcp session alive,
+# above setting can be reduced as low as 1 sec.
+# lower this value, better the seek responsivenes
+STREAM_PAUSE_TIME = 1
+# never use 0 priority because when streams are paused
+# we still want lt to download the pieces not important for the stream
+MIN_PIECE_PRIO = 1
 
-class Stream:
 
-    def __init__(self, download, file_index=0):
-        self.logger = logging.getLogger(self.__class__.__name__)
+class NotStreamingError(Exception):
+    pass
 
-        self.download = download
-        self.info = get_info_from_handle(self.download.handle)
-        self.file = None
-        self.file_size = self.info.file_at(file_index).size
-        self.file_index = file_index
 
-        self.prebuffsize = 5 * 1024 * 1024
-        self.endbuffsize = 0
-        self.max_prebuffsize = 5 * 1024 * 1024
-        self.seekpos = 0
+class NoAvailableStreamError(Exception):
+    pass
 
-        self.file_priorities = []
+
+class Stream: # pylint: disable=too-many-instance-attributes
+    """
+    Holds the streaming status of a specific download
+    """
+
+    def __init__(self, download):
+        self._logger = logging.getLogger(self.__class__.__name__)
+        self.infohash = None
+        self.filename = None
+        self.filesize = None
+        self.enabledfiles = None
+        self.firstpiece = None
+        self.lastpiece = None
+        self.prebuffsize = None
+        self.destdir = None
+        self.piecelen = None
+        self.files = None
+        self.mapfile = None
+        self.prebuffpieces = []
+        self.headerpieces = []
+        self.footerpieces = []
+        # cursorpiecemap represents the pieces maintained by all available chunks.
+        # Each chunk is identified by its startbyte
+        # structure for cursorpieces is
+        #                                 <-------------------- dynamic buffer pieces -------------------->
+        # {int:startbyte: [bool:ispaused, list:piecestobuffer 'according to the cursor of the related chunk']
+        self.cursorpiecemap = {}
+        self.fileindex = None
+        # when first initiate this instance does not have related callback ready,
+        # this coro will be awaited when the stream is enabled. If never enabled,
+        # this coro will be closed.
+        self.__prepare_coro = self.__prepare(download)
+
+    async def __prepare(self, download):
+        # wait for an handle first
+        await download.get_handle()
+        self.destdir = download.get_content_dest()
+        metainfo = None
+        while not metainfo:
+            # Wait for an actual tdef with an actual metadata is available
+            metainfo = download.get_def().get_metainfo()
+            if not metainfo:
+                await sleep(1)
+        tdef = download.get_def()
+        self.piecelen = tdef.get_piece_length()
+        self.files = tdef.get_files_with_length()
+        # we use self.infohash also like a flag to detect that stream class is prepared
+        self.infohash = tdef.get_infohash()
+
+        info = get_info_from_handle(download.handle)
+        self.mapfile = info.map_file
+
+        # required callbacks used in this class but defined in download class.
+        # an other approach would be using self.__download = download but
+        # below method looks cleaner
+        self.__lt_state = download.get_state
+        self.__getpieceprios = download.get_piece_priorities
+        self.__setpieceprios = download.set_piece_priorities
+        self.__getfileprios = download.get_file_priorities
+        self.__setselectedfiles = download.set_selected_files
+        self.__setdeadline = download.set_piece_deadline
+        self.__resetdeadline = download.reset_piece_deadline
+        self.__resumedownload = download.resume
+
+    async def enable(self, fileindex=0, prebufpos=None):
+        """
+        Enable streaming mode for a given fileindex.
+        """
+        # if not prepared, prepare the callbacks
+        if not self.infohash:
+            await self.__prepare_coro
+
+        # if fileindex not available for torrent raise exception
+        if fileindex >= len(self.files):
+            raise NoAvailableStreamError()
+
+        # if downlaod is stopped for some reason, resume it.
+        self.__resumedownload()
+
+        # wait until dlstate is downloading or seeding
+        while True:
+            status = self.__lt_state().get_status()
+            if status in [DLSTATUS_DOWNLOADING, DLSTATUS_SEEDING]:
+                break
+            await sleep(1)
+
+        # the streaming status is tracked based on the infohash, if there is already no streaming
+        # or there is already a streaming for a fileindex but we need a new one, reinitialize the
+        # status map. When there is a state for a given infohash, the stream is accepted as streaming,
+        # which means after below line, stream.enaled = True
+        if fileindex != self.fileindex:
+            self.fileindex = fileindex
+        elif self.enabled:
+            # if already there is a state with the same file index do nothing
+            if prebufpos is not None:
+                # if the prebuffposiiton is updated, update the static prebuff pieces
+                currrent_prebuf = list(self.prebuffpieces)
+                currrent_prebuf.extend(self.bytestopieces(prebufpos, self.prebuffsize))
+                self.prebuffpieces = sorted(list(set(currrent_prebuf)))
+            return
+
+        # update the file name and size with the file index
+        filename, self.filesize = self.files[fileindex]
+        if len(self.files) > 1:
+            self.filename = self.destdir / filename
+        else:
+            self.filename = self.destdir
+        # Backup file prios, and set the the streaming file max prio
+        if not self.enabledfiles:
+            self.enabledfiles = [x[0] for x in enumerate(self.__getfileprios()) if x[1]]
+        self.__setselectedfiles([fileindex], 7, True)
+        # Get the piece map of the file
+        self.firstpiece = self.bytetopiece(0)  # inclusive
+        self.lastpiece = min(self.bytetopiece(self.filesize), len(self.pieceshave) - 1)  # inclusive
+        # prebuffer size PREBUFF_PERCENT of the file size
+        self.prebuffsize = int(self.filesize * PREBUFF_PERCENT)
+        # calculate static buffer pieces
+        self.headerpieces = self.bytestopieces(0, HEADER_SIZE)
+        self.footerpieces = self.bytestopieces(-FOOTER_SIZE, 0)
+        self.prebuffpieces = [] if prebufpos is None else self.bytestopieces(prebufpos, self.prebuffsize)
 
     @property
-    def filename(self):
-        if self.download.get_def().is_multifile_torrent():
-            return self.download.get_content_dest() / self.download.get_def().get_files()[self.file_index]
-        return self.download.get_content_dest()
+    def enabled(self):
+        """
+        Check if stream is enabled
+        """
+        return self.infohash is not None and self.fileindex is not None
 
-    async def open(self):
-        self.download.set_selected_files([self.file_index])
-        self.set_vod_mode(True)
-        filename = self.filename
-        while not filename.exists():
-            await sleep(1)
-        self.file = open(filename, 'rb')
+    @property
+    @check_vod(0)
+    def headerprogress(self):
+        """
+        Get current progress of downloaded header pieces of the enabled stream, if not enabled returns 0
+        """
+        return self.calculateprogress(self.headerpieces, False)
+
+    @property
+    @check_vod(0)
+    def footerprogress(self):
+        """
+        Get current progress of downloaded footer pieces of the enabled stream, if not enabled returns 0
+        """
+        return self.calculateprogress(self.footerpieces, False)
+
+    @property
+    @check_vod(0)
+    def prebuffprogress(self):
+        """
+        Get current progress of downloaded prebuff pieces of the enabled stream, if not enabled returns 0
+        """
+        return self.calculateprogress(self.prebuffpieces, False)
+
+    @property
+    @check_vod(0)
+    def prebuffprogress_consec(self):
+        """
+        Get current progress of cosequently downloaded prebuff pieces of the enabled stream, if not enabled returns 0
+        """
+        return self.calculateprogress(self.prebuffpieces, True)
+
+    @property
+    @check_vod([])
+    def pieceshave(self):
+        """
+        Get a list of Booleans indicating that individual pieces of the selected fileindex has been downloaded or not
+        """
+        return self.__lt_state().get_pieces_complete()
+
+    @check_vod(True)
+    def disable(self):
+        """
+        Stop Streaming
+        """
+        self.fileindex = None
+        self.headerpieces = []
+        self.footerpieces = []
+        self.prebuffpieces = []
+        self.cursorpiecemap = {}
+        self.resetprios()
+        self.__setselectedfiles(self.enabledfiles)
 
     def close(self):
-        self.set_vod_mode(False)
-        if self.file:
-            self.file.close()
+        """
+        Close this class gracefully
+        """
+        if not self.infohash:
+            # if the prepare coro has never been awaited (stream never enabled), close the coro
+            self.__prepare_coro.close()
+        self.disable()
 
-    @property
-    def closed(self):
-        return self.file.closed if self.file else False
+    @check_vod([])
+    def bytestopieces(self, bytes_begin, bytes_end):
+        """
+        Returns the pieces that represents the given byte range
+        """
 
-    async def read(self, size):
-        if not self.file:
-            await self.open()
+        bytes_begin = min(self.filesize, bytes_begin) if bytes_begin >= 0 else self.filesize + bytes_begin
+        bytes_end = min(self.filesize, bytes_end) if bytes_end > 0 else self.filesize + bytes_end
 
-        oldpos = self.file.tell()
-        newpos = oldpos + size
-        self.logger.debug('Get bytes %s-%s', oldpos, newpos)
-        while not self.file.closed and self.get_byte_progress([(self.file_index, oldpos, newpos)]) < 1:
-            await sleep(1)
+        startpiece = self.bytetopiece(bytes_begin)
+        endpiece = self.bytetopiece(bytes_end)
+        startpiece = max(startpiece, self.firstpiece)
+        endpiece = min(endpiece, self.lastpiece)
+        return list(range(startpiece, endpiece + 1))
 
-        if self.file.closed:
-            self.logger.debug('Got no bytes, file is closed')
-            return b''
+    @check_vod(-1)
+    def bytetopiece(self, byte_begin):
+        """
+        Finds the piece position that begin_bytes is mapped to
+        """
+        piece = self.mapfile(self.fileindex, byte_begin, 0).piece
+        return piece
 
-        result = self.file.read(size)
-        self.logger.debug('Got bytes %s-%s', oldpos, newpos)
-
-        if self.seekpos == oldpos:
-            self.seekpos = newpos
-
-        return result
-
-    async def seek(self, offset):
-        if not self.file:
-            await self.open()
-
-        self.file.seek(offset)
-        newpos = self.file.tell()
-        self.logger.debug('Seek %s', newpos)
-
-        self.set_byte_priority([(self.file_index, 0, newpos)], 0)
-        self.set_byte_priority([(self.file_index, newpos, -1)], 1)
-
-        self.logger.debug('Seek, get pieces %s', self.download.get_piece_priorities())
-        self.logger.debug('Seek, got pieces %s', self.download.get_state().get_pieces_complete())
-
-        if abs(newpos - self.seekpos) < 1024 * 1024:
-            self.seekpos = newpos
-
-    def set_vod_mode(self, enable=True):
-        self.logger.debug("Set_vod_mode for %s (enable = %s)", self.download.get_def().get_name(), enable)
-
-        if enable:
-            self.file_priorities = self.download.get_file_priorities()
-
-            self.prebuffsize = max(int(self.file_size * 0.05), self.max_prebuffsize)
-            self.endbuffsize = 1 * 1024 * 1024
-            self.seekpos = 0
-
-            self.download.set_sequential_download(True)
-            self.set_byte_priority([(self.file_index, self.prebuffsize, -self.endbuffsize)], 0)
-            self.set_byte_priority([(self.file_index, 0, self.prebuffsize)], 1)
-            self.set_byte_priority([(self.file_index, -self.endbuffsize, -1)], 1)
-
-            self.logger.debug("Going into VOD mode with index %d", self.file_index)
-        else:
-            self.download.set_sequential_download(False)
-            self.download.set_file_priorities(self.file_priorities)
-
-    def get_byte_progress(self, byteranges, consec=False):
-        pieces = self.bytes_to_pieces(byteranges)
-        return self.get_piece_progress(pieces, consec)
-
-    def get_piece_progress(self, pieces, consec=False):
+    @check_vod(0)
+    def calculateprogress(self, pieces, consec):
+        """
+        Claculates the download progress of a given piece list.
+        if consec is True, calcaulation is based only the pieces downloaded sequentially
+        """
         if not pieces:
             return 1.0
-        if consec:
-            pieces.sort()
+        have = 0.0
+        for piece in self.iterpieces(have=True, consec=consec):
+            if have >= len(pieces):
+                break
+            if piece in pieces:
+                have += 1
+        return have / len(pieces) if pieces else 0.0
 
-        bitfield = self.download.get_state().get_pieces_complete()
-        if not bitfield:
-            return 0.0
-
-        pieces_have = 0
-        pieces_all = len(pieces)
-        for index in pieces:
-            if index < len(bitfield) and bitfield[index]:
-                pieces_have += 1
+    @check_vod([])
+    def iterpieces(self, have=None, consec=False, startfrom=None):
+        """
+        Generator function taht yield the pieces for the active fileindex
+        have: None: nofilter, True: only pieces we have, False: only pieces we dont have
+        consec: True: sequentially, False: all pieces
+        startfrom: int: start form index, None: start from first piece
+        """
+        if have is not None:
+            pieces_have = self.pieceshave
+        for piece in range(self.firstpiece, self.lastpiece + 1):
+            if startfrom is not None and piece < startfrom:
+                continue
+            if have is None:
+                yield piece
+            elif have and pieces_have[piece]:
+                yield piece
+            elif not have and not pieces_have[piece]:
+                yield piece
             elif consec:
                 break
-        return pieces_have / pieces_all
 
-    def set_byte_priority(self, byteranges, priority):
-        pieces = self.bytes_to_pieces(byteranges)
-        if pieces:
-            pieces = list(set(pieces))
-            self.set_piece_priority(pieces, priority)
+    async def updateprios(self):  # pylint: disable=too-many-branches
+        """
+        This async function controls how the individual piece priority and deadline is configured.
+        This method is called when a stream in enabled, and when a chunk reads the stream each time.
+        The performance of this method is crucical since it gets called quite frequently
+        """
+        if not self.enabled:
+            return
 
-    def set_piece_priority(self, pieces_need, priority):
-        do_prio = False
-        pieces_have = self.download.get_state().get_pieces_complete()
-        piecepriorities = self.download.get_piece_priorities()
-        for piece in pieces_need:
-            if piece < len(piecepriorities):
-                if piecepriorities[piece] != priority and not pieces_have[piece]:
-                    piecepriorities[piece] = priority
-                    do_prio = True
+        def _updateprio(piece, prio, deadline=None):
+            """
+            Utility function to update piece priorities
+            """
+            if not curr_prio == prio:
+                piecepriorities[piece] = prio
+                if deadline is not None:
+                    # it is cool to step deadlines with 10ms interval but in realty there is no need.
+                    self.__setdeadline(piece, deadline * 10)
+                    diffmap[piece] = "%s:%s:%s->%s" % (piece, deadline * 10, curr_prio, prio)
+                else:
+                    self.__resetdeadline(piece)
+                    diffmap[piece] = "%s:-:%s->%s" % (piece, curr_prio, prio)
+
+        def _find_deadline(piece):
+            """
+            Find the cursor which has this piece closest to its start
+            Returns the deadline for the piece and the cursor startbyte
+            """
+            # if piece is not in piecemaps, then there is no deadline
+            # if piece in piecemaps, then the deadline is the index of the related piecemap
+            deadline = None
+            cursor = None
+            for startbyte in self.cursorpiecemap:
+                paused, cursorpieces = self.cursorpiecemap[startbyte]
+                if not paused and piece in cursorpieces and \
+                        (deadline is None or cursorpieces.index(piece) < deadline):
+                    deadline = cursorpieces.index(piece)
+                    cursor = startbyte
+            return deadline, cursor
+
+        # current priorities
+        piecepriorities = self.__getpieceprios()
+        if not piecepriorities:
+            # this case might happen when hop count is changing.
+            return
+        # a map holds the changes, used only for logging purposes
+        diffmap = {}
+        # flag that holds if we are in static buffering phase of dynamic buffering
+        staticbuff = False
+        for piece in self.iterpieces(have=False):
+            # current piece prio
+            curr_prio = piecepriorities[piece]
+            if piece in self.footerpieces:
+                _updateprio(piece, 7, 0)
+                staticbuff = True
+            elif piece in self.headerpieces:
+                _updateprio(piece, 7, 1)
+                staticbuff = True
+            elif piece in self.prebuffpieces:
+                _updateprio(piece, 7, 2)
+                staticbuff = True
             else:
-                self.logger.info("Could not set priority for non-existing piece %d / %d", piece, len(piecepriorities))
-        if do_prio:
-            self.download.set_piece_priorities(piecepriorities)
-        else:
-            self.logger.info("Skipping set_piece_priority")
+                if staticbuff:
+                    _updateprio(piece, 0)
+                else:
+                    # dynamic buffering
+                    deadline, cursor = _find_deadline(piece)
+                    if cursor is not None:
+                        if deadline < len(DEADLINE_PRIO_MAP):
+                            # get prio according to deadline
+                            _updateprio(piece, DEADLINE_PRIO_MAP[deadline], deadline)
+                        else:
+                            # the deadline is outside of map, set piece prio 1 with the deadline
+                            # buffer size is bigger then prio_map
+                            _updateprio(piece, 1, deadline)
+                    else:
+                        # the piece is not in buffer zone, set to min prio without deadline
+                        _updateprio(piece, MIN_PIECE_PRIO)
+        if diffmap:
+            # log stuff
+            self._logger.info("Piece Piority changed: %s", repr(diffmap))
+            self._logger.debug("Header Pieces: %s", repr(self.headerpieces))
+            self._logger.debug("Footer Pieces: %s", repr(self.footerpieces))
+            self._logger.debug("Prebuff Pieces: %s", repr(self.prebuffpieces))
+            for startbyte in self.cursorpiecemap:
+                self._logger.debug("Cursor '%s' Pieces: %s", startbyte, repr(self.cursorpiecemap[startbyte]))
+            # BELOW LINE WILL BE REMOVED, Most of the above are for debugging to be cleaned
+            self._logger.debug("Current Prios: %s", [(x, piecepriorities[x]) for x in self.iterpieces(have=False)])
+            self.__setpieceprios(piecepriorities)
 
-    def bytes_to_pieces(self, byteranges):
-        if not self.info:
-            self.logger.info("Could not get info from download handle")
+    def resetprios(self, pieces=None, prio=None):
+        """
+        Resets the prios and deadline of the pieces of the active fileindex,
+        If no pieces are provided, resets every piece for the fileindex
+        """
+        prio = prio if prio is not None else 4
+        piecepriorities = self.__getpieceprios()
+        if pieces is None:
+            pieces = list(range(len(piecepriorities)))
+        for piece in pieces:
+            self.__resetdeadline(piece)
+        self.__setpieceprios([prio] * len(pieces))
 
+
+class StreamChunk:
+    """
+    This class reprsents the chunk to be read for the torrent file, and controls the dynamic buffer of the
+    stream instance accroding to read positon
+    """
+
+    def __init__(self, stream, startpos=0):
+        """
+        Stream: the stream to be read
+        startpos: the position offset the the chunk should read from.
+        """
+        self._logger = logging.getLogger(self.__class__.__name__)
+        if not stream.enabled:
+            raise NotStreamingError()
+        self.stream = stream
+        self.file = None
+        self.startpos = startpos
+        self.__seekpos = self.startpos
+
+    @property
+    def seekpos(self):
+        """
+        Current seek position of the actual file on the filesystem
+        """
+        return self.__seekpos
+
+    async def __aenter__(self):
+        await self.open()
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback):  # pylint: disable=unused-variable
+        self._logger.info("Stream %s closed due to %s", self.startpos, exc_type)
+        self.close()
+
+    async def open(self):
+        """
+        Opens the file in the filesystem until its ready and seeks to the seekpos position
+        """
+        while not self.stream.filename.exists():
+            await sleep(1)
+        self.file = open(self.stream.filename, 'rb')
+        self.file.seek(self.seekpos)
+
+    @property
+    def isclosed(self):
+        return self.file is None or self.file.closed
+
+
+    @property
+    def isstarted(self):
+        """
+        Checks if the this chunk has already registered itself to stream instance
+        """
+        return self.startpos in self.stream.cursorpiecemap
+
+    @property
+    def ispaused(self):
+        """
+        Checks if the chunk is in paused state
+        """
+        if self.isstarted and self.stream.cursorpiecemap[self.startpos][0]:
+            return True
+        return False
+
+    @property
+    def shouldpause(self):
+        """
+        Checks if this chunk should pause, based on the desicion that
+        any other chunks also is streaming the same torrent or not
+        """
+        for spos in self.stream.cursorpiecemap:
+            if spos == self.startpos:
+                continue
+            paused, pieces = self.stream.cursorpiecemap[spos]
+            if not paused and pieces:
+                return True
+        return False
+
+    def pause(self, force=False):
+        """
+        Sets the chunk pieces to pause, if not forced, chunk is only paused if other chunks are not paused
+        """
+        if not self.ispaused and (self.shouldpause or force):
+            self.stream.cursorpiecemap[self.startpos][0] = True
+            return True
+        return False
+
+    def resume(self, force=False):
+        """
+        Sets the chunk pieces to resume, if not forced, chunk is only resume if other chunks are paused
+        """
+        if self.ispaused and (not self.shouldpause or force):
+            self.stream.cursorpiecemap[self.startpos][0] = False
+            return True
+        return False
+
+    async def seek(self, positionbyte):
+        """
+        Seeks the stream to the related picece that represents the position byte
+        Also updates the dynamic buffer accordingly
+        """
+        buffersize = 0
+        pospiece = self.stream.bytetopiece(positionbyte)
         pieces = []
-        for file_index, bytes_begin, bytes_end in byteranges:
-            if file_index >= 0 and self.info:
-                # Ensure the we remain within the file's boundaries
-                file_size = self.info.file_at(file_index).size
-                bytes_begin = min(file_size, bytes_begin) if bytes_begin >= 0 else file_size + (bytes_begin + 1)
-                bytes_end = min(file_size, bytes_end) if bytes_end >= 0 else file_size + (bytes_end + 1)
-
-                startpiece = self.info.map_file(file_index, bytes_begin, 0).piece
-                endpiece = self.info.map_file(file_index, bytes_end, 0).piece + 1
-                startpiece = max(startpiece, 0)
-                endpiece = min(endpiece, self.info.num_pieces())
-
-                pieces += list(range(startpiece, endpiece))
+        # note that piece buffer is based the undownloaded piece up the size of prebuffsize
+        for piece in self.stream.iterpieces(have=False, startfrom=pospiece):
+            if buffersize < self.stream.prebuffsize:
+                pieces.append(piece)
+                buffersize += self.stream.piecelen
             else:
-                self.logger.info("Could not get progress for incorrect fileindex")
-        return list(set(pieces))
+                break
+        # update cursor piece that represents this chunk
+        self.stream.cursorpiecemap[self.startpos] = [self.ispaused, pieces]
+        # update the torrent prios
+        await self.stream.updateprios()
+        # update the file cursor also
+        if self.file:
+            self.__seekpos = positionbyte
+        return pieces
 
-    def calc_prebuf_frac(self, consec=False):
-        if self.endbuffsize:
-            return self.get_byte_progress([(self.file_index, self.seekpos, self.seekpos + self.prebuffsize),
-                                           (self.file_index, -self.endbuffsize - 1, -1)], consec=consec)
-        return self.get_byte_progress([(self.file_index, self.seekpos, self.seekpos + self.prebuffsize)], consec=consec)
+    def close(self):
+        """
+        Closes the chunk grecefully, also unregisters the cursor pieces from the stream instance
+        and resets the releavent piece prios.
+        """
+        if self.file:
+            self.file.close()
+            self.file = None
+        if self.isstarted:
+            pieces = self.stream.cursorpiecemap.pop(self.startpos)
+            self.stream.resetprios(pieces[1], MIN_PIECE_PRIO)
 
-    def get_progress(self):
-        return {'vod_prebuffering_progress': self.calc_prebuf_frac(),
-                'vod_prebuffering_progress_consec': self.calc_prebuf_frac(True)}
+    async def read(self):
+        """
+        Reads 1 piece that contains the seekpos.
+        """
+        if not self.file and self.isstarted:
+            await self.open()
+
+        await self.seek(self.seekpos)
+        piece = self.stream.bytetopiece(self.seekpos)
+        self._logger.debug('Chunk %s: Get piece %s', self.startpos, piece)
+
+        if self.isclosed or piece > self.stream.lastpiece or not self.isstarted:
+            self.close()
+            self._logger.debug('Chunk %s: Got no bytes, file is closed', self.startpos)
+            return b''
+
+        # wait until we download what we want, then read the localfile
+        # experiment a garbage write mechanism here if the torrent read is too slow
+        piece = self.stream.bytetopiece(self.seekpos)
+        while True:
+            pieces_have = self.stream.pieceshave
+            if piece == -1:
+                self.close()
+                return b''
+            if (0 <= piece < len(pieces_have) and pieces_have[piece]) or not self.isstarted:
+                break
+            self._logger.debug('Chunk %s, Waiting piece %s', self.startpos, piece)
+            await sleep(1)
+
+        result = self.file.read(self.stream.piecelen)
+        self._logger.debug('Chunk %s: Got bytes %s-%s, %s bytes, piecelen: %s',
+                          self.startpos, self.seekpos, self.seekpos + len(result), len(result), self.stream.piecelen)
+        self.__seekpos = self.file.tell()
+        return result

--- a/src/tribler-core/tribler_core/modules/libtorrent/tests/test_stream.py
+++ b/src/tribler-core/tribler_core/modules/libtorrent/tests/test_stream.py
@@ -1,66 +1,263 @@
-from unittest.mock import Mock
+import os
+from tempfile import mkstemp
 
-from tribler_core.modules.libtorrent.stream import Stream
-from tribler_core.tests.tools.base_test import TriblerCoreTest
+from tribler_common.simpledefs import DLSTATUS_SEEDING
+
+from tribler_core.modules.libtorrent.download_config import DownloadConfig
+from tribler_core.modules.libtorrent.stream import (FOOTER_SIZE, HEADER_SIZE, NoAvailableStreamError,
+                                                    NotStreamingError, PREBUFF_PERCENT, StreamChunk)
+from tribler_core.modules.libtorrent.torrentdef import TorrentDef
+from tribler_core.restapi.base_api_test import AbstractApiTest
+from tribler_core.tests.tools.tools import timeout
+from tribler_core.utilities.path_util import Path
 
 
-class TestStream(TriblerCoreTest):
+def mockpieceshave(instance, pieces):
     """
-    This class contains tests for the download state.
+    With great hacks, comes great responsibilities
     """
+    class mockery():
+        @classmethod
+        def get_pieces_complete(cls):
+            return cls.pieces
 
-    async def setUp(self):
-        await TriblerCoreTest.setUp(self)
+        @classmethod
+        def setprios(cls, prios):
+            cls.prios = prios
+            cls.pieces = [bool(x < len(prios) and prios[x] > 1) for x in range(len(cls.pieces))]
 
-        download = Mock()
-        download.handle.torrent_file.return_value.file_at.return_value = Mock(size=250)
-        self.stream = Stream(download, 0)
+        @classmethod
+        def getprios(cls):
+            return cls.prios
 
-    def test_get_file_size(self):
+    mockery.pieces = pieces
+    mockery.prios = [1] * len(pieces)
+    instance._Stream__getpieceprios = mockery.getprios #  pylint:disable=protected-access
+    instance._Stream__lt_state = mockery #  pylint:disable=protected-access
+    instance._Stream__setpieceprios = mockery.setprios #  pylint:disable=protected-access
+    return instance
+
+
+class TestStream(AbstractApiTest): # pylint: disable=too-many-ancestors
+    def setUpPreSession(self):
+        super(TestStream, self).setUpPreSession()
+        self.config.set_libtorrent_enabled(True)
+        self.pieces = list(range(100))
+        self.piece_len = 1024 * 1024
+        self.size = self.piece_len * len(self.pieces)
+
+    @timeout(20)
+    async def test_enable_disable_close_stream(self):
         """
-        Testing whether the right file size is returned
+        Tests if the stream mode can be enabled through download instance and the stream state is valid,
+        with various fileindex options
         """
-        self.assertEqual(self.stream.file_size, 250)
+        await self.add_torrent()
+        await self.download.stream.enable(0)
+        self.assertEqual(self.download.stream.enabled, True)
+        await self.download.stream.enable(0)
+        self.assertEqual(self.download.stream.enabled, True)
+        self.download.stream.disable()
+        self.assertEqual(self.download.stream.enabled, False)
+        self.download.stream.disable()
+        self.assertEqual(self.download.stream.enabled, False)
+        with self.assertRaises(NoAvailableStreamError):
+            await self.download.stream.enable(1)
+        self.download.stream.close()
+        self.assertEqual(self.download.stream.fileindex, None)
 
-    def test_get_piece_progress(self):
+    @timeout(20)
+    async def test_stream_attrs(self):
         """
-        Testing whether the right piece progress is returned
+        Tests if the attributes received / calculated from the download instance is correct
         """
-        self.assertEqual(self.stream.get_piece_progress(None), 1.0)
+        await self.add_torrent()
+        await self.download.stream.enable(0)
+        self.assertEqual(self.download.stream.fileindex, 0)
+        self.assertEqual(self.download.stream.infohash, self.infohash)
+        self.assertEqual(self.download.stream.filesize, self.size)
+        self.assertEqual(self.download.stream.firstpiece, 0)
+        self.assertEqual(self.download.stream.lastpiece, self.pieces[-1])
+        self.assertEqual(self.download.stream.piecelen, self.piece_len)
+        self.assertEqual(self.download.stream.prebuffsize, int(self.size * PREBUFF_PERCENT))
 
-        self.stream.download.get_state.return_value.get_pieces_complete.return_value = [True, False]
-        self.assertEqual(self.stream.get_piece_progress([0, 1], True), 0.5)
-
-        self.stream.download.get_state.return_value.get_pieces_complete.return_value = []
-        self.assertEqual(self.stream.get_piece_progress([3, 1]), 0.0)
-
-    def test_get_byte_progress(self):
+    @timeout(20)
+    async def test_iter_pieces(self):
         """
-        Testing whether the right byte progress is returned
+        Tests if the iterated pieces are correct for the streamng file.
         """
-        self.assertEqual(self.stream.get_byte_progress([(-1, 0, 0)], False), 1.0)
+        await self.add_torrent()
+        await self.download.stream.enable(0)
+        self.assertEqual(list(self.download.stream.iterpieces()), self.pieces)
+        self.assertEqual(list(self.download.stream.iterpieces(have=True)), self.pieces)
+        self.assertEqual(list(self.download.stream.iterpieces(startfrom=50)), self.pieces[50:])
+        mockedpieces = [True] * len(self.pieces)
+        mockedpieces[0] = False
+        mockedpieces[2] = False
+        mockpieceshave(self.download.stream, mockedpieces)
+        self.assertEqual(list(self.download.stream.iterpieces(have=False)), [0, 2])
+        self.assertEqual(list(self.download.stream.iterpieces(have=False, consec=True)), [0])
 
-        # Scenario: we have a file with 4 pieces, 250 bytes in each piece.
-        self.stream.info.map_file = lambda _, start_byte, __: Mock(piece=int(start_byte / 250))
-        self.stream.info.num_pieces.return_value = 4
-        self.stream.info.file_at.return_value = Mock(size=1000)
-        self.stream.download.get_state.return_value.get_pieces_complete.return_value = [True, False, False, False]
-        self.assertEqual(self.stream.get_byte_progress([(0, 10, 270)], True), 0.5)
-
-    def test_priority_reset(self):
+    @timeout(20)
+    async def test_static_buffer_pieces(self):
         """
-        Testing whether the priorities get reset to their original values after stream is completed
+        Tests if static buffering piece mappings are calcuted correctly.
         """
-        self.stream.info.map_file = lambda _, start_byte, __: Mock(piece=int(start_byte / 250))
-        self.stream.info.num_pieces.return_value = 4
-        self.stream.download.get_piece_priorities.return_value = []
-        self.stream.download.get_state.return_value.get_pieces_complete.return_value = []
+        await self.add_torrent()
+        await self.download.stream.enable(0)
+        self.assertEqual(self.download.stream.pieceshave, [True] * len(self.pieces))
+        headerpieces = int((HEADER_SIZE / self.size) * len(self.pieces))
+        footerpieces = int((FOOTER_SIZE / self.size) * len(self.pieces))
+        self.assertEqual(self.download.stream.headerpieces, list(range(headerpieces + 1)))
+        self.assertEqual(self.download.stream.footerpieces,
+                         list(range(len(self.pieces) - footerpieces, len(self.pieces))))
+        self.assertEqual(self.download.stream.prebuffpieces, [])
+        await self.download.stream.enable(0, 0)
+        prebuffpieces = int((self.download.stream.prebuffsize / self.size) * len(self.pieces))
+        self.assertEqual(self.download.stream.prebuffpieces, list(range(prebuffpieces + 1)))
 
-        file_priorities = [1, 1, 0, 1]
-        self.stream.download.get_file_priorities.return_value = file_priorities
+    @timeout(20)
+    async def test_static_buffer_progress(self):
+        """
+        Tests if static buffer progress is reported correctly according to streaming state.
+        """
+        await self.add_torrent()
+        self.assertEqual(self.download.stream.headerprogress, 0)
+        self.assertEqual(self.download.stream.footerprogress, 0)
+        self.assertEqual(self.download.stream.prebuffprogress, 0)
+        self.assertEqual(self.download.stream.prebuffprogress_consec, 0)
+        await self.download.stream.enable(0)
+        self.assertEqual(self.download.stream.headerprogress, 1)
+        self.assertEqual(self.download.stream.footerprogress, 1)
+        self.assertEqual(self.download.stream.prebuffprogress, 1)
+        self.assertEqual(self.download.stream.prebuffprogress_consec, 1)
 
-        self.stream.set_vod_mode(True)
-        self.assertEqual(self.stream.file_priorities, file_priorities)
+    @timeout(20)
+    async def test_udpate_prios(self):
+        """
+        A very brief test for update_prio method, this test can not fully represent the capcbilities
+        since these tests are run in sedding mode
+        """
+        await self.add_torrent()
+        await self.download.stream.updateprios()
+        await self.download.stream.enable(0)
+        await self.download.stream.updateprios()
 
-        self.stream.close()
-        self.stream.download.set_file_priorities.assert_called_once_with(file_priorities)
+    @timeout(20)
+    async def test_chunk_open_close(self):
+        """
+        Tests if the chunks are opened & closed gracefully
+        Checks the startpos and seekpos is as expected
+        """
+        await self.add_torrent()
+        with self.assertRaises(NotStreamingError):
+            StreamChunk(self.download.stream)
+        for startpos in [0, 10]:
+            await self.download.stream.enable(0)
+            chunk = StreamChunk(self.download.stream, startpos)
+            self.assertEqual(chunk.seekpos, startpos)
+            self.assertEqual(chunk.startpos, startpos)
+            await chunk.open()
+            self.assertNotEqual(chunk.file, None)
+            chunk.close()
+            self.assertEqual(chunk.file, None)
+            async with StreamChunk(self.download.stream, 0) as chunk:
+                self.assertNotEqual(chunk.file, None)
+
+    @timeout(20)
+    async def test_chunk_seek_dynamic_buffer(self):
+        """
+        Tests if the seek mehod for a chunk really seeks the Stream instance
+        """
+        await self.add_torrent()
+        await self.download.stream.enable(0)
+        mockpieceshave(self.download.stream, [False] * len(self.pieces))
+        async with StreamChunk(self.download.stream, 10) as chunk1:
+            self.assertEqual(chunk1.stream.cursorpiecemap.get(chunk1.startpos), None)
+            await chunk1.seek(chunk1.startpos + 20)
+            self.assertNotEqual(chunk1.stream.cursorpiecemap.get(chunk1.startpos), None)
+            self.assertEqual(chunk1.seekpos, chunk1.startpos + 20)
+            self.assertEqual(len(chunk1.stream.cursorpiecemap), 1)
+            async with StreamChunk(self.download.stream, 40) as chunk2:
+                await chunk2.seek(chunk2.startpos + 50)
+                self.assertNotEqual(chunk2.stream.cursorpiecemap.get(chunk2.startpos), None)
+                self.assertEqual(len(chunk2.stream.cursorpiecemap), 2)
+                self.assertEqual(chunk2.seekpos, chunk2.startpos + 50)
+                # we cant really test the piece integrity since all pieces are already downloaded
+        self.assertEqual(chunk1.stream.cursorpiecemap.get(chunk1.startpos), None)
+        self.assertEqual(chunk2.stream.cursorpiecemap.get(chunk2.startpos), None)
+
+    @timeout(20)
+    async def test_chunk_read(self):
+        """
+        Reads the torrent file piece by piece with prios setters
+        """
+        await self.add_torrent()
+        await self.download.stream.enable(0)
+        mockpieceshave(self.download.stream, [False] * len(self.pieces))
+        async with StreamChunk(self.download.stream, 10) as chunk1:
+            while not chunk1.isclosed:
+                await chunk1.read()
+        self.assertEqual(await chunk1.read(), b'')
+
+    @timeout(20)
+    async def test_chunk_pause_resume(self):
+        """
+        Tests if the stream pause/resume functions as expected for concurrent chunks
+        """
+        await self.add_torrent()
+        await self.download.stream.enable(0)
+        async with StreamChunk(self.download.stream, 0) as chunk1:
+            await chunk1.read()
+            # HACK: inject some cursor pieces, since test download is already seeding, cursor piece will always be empty
+            self.download.stream.cursorpiecemap[chunk1.startpos][1] = [1, 2, 3]
+            self.assertEqual(chunk1.shouldpause, False)
+            self.assertEqual(chunk1.ispaused, False)
+            async with StreamChunk(self.download.stream, 10) as chunk2:
+                await chunk2.read()
+                self.assertEqual(chunk2.ispaused, False)
+                # Seeding State
+                self.assertEqual(chunk1.shouldpause, False)
+                self.download.stream.cursorpiecemap[chunk2.startpos][1] = [1, 2, 3]  # HACK
+                # Downloading state, both chunks are reading so it is ok 1 to pause
+                self.assertEqual(chunk1.shouldpause, True)
+                self.assertEqual(chunk2.shouldpause, True)
+                chunk1.pause()
+                self.assertEqual(chunk1.ispaused, True)
+                chunk1.pause()
+                self.assertEqual(chunk1.ispaused, True)
+                # chunk2 is the only chunk reading, so there is no need to pause
+                self.assertEqual(chunk2.shouldpause, False)
+                # but we are forcing chunk2
+                chunk2.pause(True)
+                self.assertEqual(chunk2.ispaused, True)
+                chunk2.resume()
+                self.assertEqual(chunk2.ispaused, False)
+                # chunk2 is the only chunk reading again. so chunk 1 should not resume
+                self.assertEqual(chunk1.shouldpause, True)
+                chunk1.resume()
+                self.assertEqual(chunk1.ispaused, True)
+                # but we are forcing chunk 1 to resume
+                chunk1.resume(True)
+                self.assertEqual(chunk1.ispaused, False)
+
+    @timeout(20)
+    async def add_torrent(self):
+        [srchandle, sourcefn] = mkstemp()
+        self.data = b'\xFF' * self.size # pylint: disable=attribute-defined-outside-init
+        os.write(srchandle, self.data)
+        os.close(srchandle)
+
+        tdef = TorrentDef()
+        tdef.add_content(sourcefn)
+        tdef.set_piece_length(self.piece_len)
+        torrentfn = self.session.config.get_state_dir() / "gen.torrent"
+        tdef.save(torrentfn)
+
+        dscfg = DownloadConfig()
+        destdir = Path(sourcefn).parent
+        dscfg.set_dest_dir(destdir)
+
+        self.download = self.session.dlmgr.start_download(tdef=tdef, config=dscfg)  # pylint: disable=attribute-defined-outside-init
+        await self.download.wait_for_status(DLSTATUS_SEEDING)
+        self.infohash = tdef.get_infohash() # pylint: disable=attribute-defined-outside-init

--- a/src/tribler-gui/tribler_gui/qt_resources/mainwindow.ui
+++ b/src/tribler-gui/tribler_gui/qt_resources/mainwindow.ui
@@ -3528,6 +3528,53 @@ QSlider::sub-page:horizontal {
                       </widget>
                      </item>
                      <item>
+                      <spacer name="horizontalSpacer_666">
+                       <property name="orientation">
+                        <enum>Qt::Horizontal</enum>
+                       </property>
+                       <property name="sizeType">
+                        <enum>QSizePolicy::Fixed</enum>
+                       </property>
+                       <property name="sizeHint" stdset="0">
+                        <size>
+                         <width>8</width>
+                         <height>20</height>
+                        </size>
+                       </property>
+                      </spacer>
+                     </item>
+                     <item>
+                      <widget class="QToolButton" name="video_player_stop_button">
+                       <property name="minimumSize">
+                        <size>
+                         <width>24</width>
+                         <height>24</height>
+                        </size>
+                       </property>
+                       <property name="maximumSize">
+                        <size>
+                         <width>24</width>
+                         <height>24</height>
+                        </size>
+                       </property>
+                       <property name="cursor">
+                        <cursorShape>PointingHandCursor</cursorShape>
+                       </property>
+                       <property name="styleSheet">
+                        <string notr="true">border: none;</string>
+                       </property>
+                       <property name="text">
+                        <string/>
+                       </property>
+                       <property name="iconSize">
+                        <size>
+                         <width>20</width>
+                         <height>20</height>
+                        </size>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
                       <spacer name="horizontalSpacer_13">
                        <property name="orientation">
                         <enum>Qt::Horizontal</enum>

--- a/src/tribler-gui/tribler_gui/qt_resources/video_info_popup.ui
+++ b/src/tribler-gui/tribler_gui/qt_resources/video_info_popup.ui
@@ -99,6 +99,56 @@ border-radius: 0px;
     </widget>
    </item>
    <item>
+    <widget class="QLabel" name="headerbuf_label">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>16</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>16</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>Header-buffering progress:</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="footerbuf_label">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>16</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>16</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>Footer-buffering progress:</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QLabel" name="peers_label">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">

--- a/src/tribler-gui/tribler_gui/tribler_window.py
+++ b/src/tribler-gui/tribler_gui/tribler_window.py
@@ -1108,6 +1108,7 @@ class TriblerWindow(QMainWindow):
             self.core_manager.stop()
             self.core_manager.shutting_down = True
             self.downloads_page.stop_loading_downloads()
+            self.video_player_page.reset_player()
             request_manager.clear()
 
             # Stop the token balance timer

--- a/src/tribler-gui/tribler_gui/widgets/videoplayerinfopopup.py
+++ b/src/tribler-gui/tribler_gui/widgets/videoplayerinfopopup.py
@@ -3,7 +3,7 @@ from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QPainter
 from PyQt5.QtWidgets import QStyle, QStyleOption, QWidget
 
-from tribler_gui.utilities import format_speed, get_ui_file_path
+from tribler_gui.utilities import get_ui_file_path
 
 
 class VideoPlayerInfoPopup(QWidget):
@@ -14,13 +14,6 @@ class VideoPlayerInfoPopup(QWidget):
 
         self.setWindowFlags(Qt.Window | Qt.FramelessWindowHint)
         self.setAttribute(Qt.WA_TranslucentBackground)
-
-    def update(self, download_info):
-        self.download_speed_label.setText(
-            "Speed: d %s u %s" % (format_speed(download_info["speed_down"]), format_speed(download_info["speed_up"]))
-        )
-        self.prebuf_label.setText("Pre-buffering progress: %s" % download_info["vod_prebuffering_progress_consec"])
-        self.peers_label.setText("Peers: S%d L%d" % (download_info["num_seeds"], download_info["num_peers"]))
 
     def paintEvent(self, _):
         opt = QStyleOption()


### PR DESCRIPTION
This is the initial working version of new streamer mentioned in 
https://github.com/Tribler/tribler/issues/5249

This is still an early version, there some log spams ui things to handle, but the core functionality should work.

Please igonre any linter, flake, or test cases issues at the moment, i will request a review when the work is finished.

Nevertheless you can still check it out how it works as of, and i have to admit i really liked the results :)

**stream.py** completely rewritten with new advanced methods with support

- A custom piece priority mehanism isntead of handle.set_sequential_download
- Concurrent Streaming
- Seeking (only with an external player, embedded vlc still does not support seeking to keep the existing behaviour)
- Stopping
- Pausing (adaptive buffering when the video is paused buffering is also paused along with the prebuffer size)

**download.py / download_manager.py**
- adapted new stream class as a subset of itself, not download module directly interfaces with stream (it was handled in the endpoint in past)
- aligned start/stop/changehops/close/remove torrent operations with
- fixed several issues with file include/exclude behaviour

**downloads_endpoint.py**
- adopted the endpoint with new stream interface
- now HTTP PATCH requests can also allow enabling/disabling the stream mode before starting to play. This lets the client to oberve the prebuffering status and start playin accordingly
- improved several HEAD issues with kodi player

**gui improvements**
- now player supports stop, when player stops, the download automatically exits from streaming mode
- now the player prebuffers the video before it plays, and info popup is extended with header/footer/pre buffering progresses.