### PR TITLE
Fix channel corruption by delete entries

### DIFF
--- a/src/tribler-core/tribler_core/logger.yaml
+++ b/src/tribler-core/tribler_core/logger.yaml
@@ -173,3 +173,8 @@ loggers:
         level: INFO
         handlers: [console, error_console, info_memory_handler, error_memory_handler]
         propagate: no
+
+    GigaChannelManager:
+        level: INFO
+        handlers: [console, error_console, info_memory_handler, error_memory_handler]
+        propagate: no

--- a/src/tribler-core/tribler_core/modules/libtorrent/download_manager.py
+++ b/src/tribler-core/tribler_core/modules/libtorrent/download_manager.py
@@ -815,3 +815,7 @@ class DownloadManager(TaskManager):
         """
         return await asyncio.get_event_loop().run_in_executor(None, torrent_utils.create_torrent_file,
                                                               file_path_list, params or {})
+
+    def get_downloads_by_name(self, torrent_name, channels_only=False):
+        downloads = (self.get_channel_downloads() if channels_only else self.get_downloads())
+        return [d for d in downloads if d.get_def().get_name_utf8() == torrent_name]

--- a/src/tribler-core/tribler_core/modules/libtorrent/tests/test_download_manager.py
+++ b/src/tribler-core/tribler_core/modules/libtorrent/tests/test_download_manager.py
@@ -10,7 +10,7 @@ from tribler_core.modules.libtorrent.download_manager import DownloadManager
 from tribler_core.modules.libtorrent.torrentdef import TorrentDef, TorrentDefNoMetainfo
 from tribler_core.notifier import Notifier
 from tribler_core.tests.tools.base_test import MockObject
-from tribler_core.tests.tools.common import TESTS_DATA_DIR
+from tribler_core.tests.tools.common import TESTS_DATA_DIR, TORRENT_UBUNTU_FILE
 from tribler_core.tests.tools.test_as_server import AbstractServer
 from tribler_core.tests.tools.tools import timeout
 from tribler_core.utilities.path_util import mkdtemp
@@ -492,6 +492,15 @@ class TestDownloadManager(AbstractServer):
         await self.dlmgr.sesscb_states_callback([fake_error_state])
 
         return error_stop_future
+
+    def test_get_downloads_by_name(self):
+        dl = self.dlmgr.start_download(torrent_file=TORRENT_UBUNTU_FILE, checkpoint_disabled=True)
+        self.assertTrue(self.dlmgr.get_downloads_by_name("ubuntu-15.04-desktop-amd64.iso"))
+        self.assertFalse(self.dlmgr.get_downloads_by_name("ubuntu-15.04-desktop-amd64.iso", channels_only=True))
+        self.assertFalse(self.dlmgr.get_downloads_by_name("bla"))
+
+        dl.config.set_channel_download(True)
+        self.assertTrue(self.dlmgr.get_downloads_by_name("ubuntu-15.04-desktop-amd64.iso", channels_only=True))
 
     @timeout(20)
     async def test_checkpoint_after_metainfo_cancel(self):

--- a/src/tribler-core/tribler_core/modules/metadata_store/gigachannel_manager.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/gigachannel_manager.py
@@ -156,7 +156,7 @@ class GigaChannelManager(TaskManager):
                 elif not self.session.dlmgr.download_exists(bytes(channel.infohash)):
                     self._logger.info(
                         "Downloading new channel version %s ver %i->%i",
-                        hexlify(channel.public_key),
+                        channel.dirname,
                         channel.local_version,
                         channel.timestamp,
                     )
@@ -167,7 +167,7 @@ class GigaChannelManager(TaskManager):
                 ):
                     self._logger.info(
                         "Processing previously downloaded, but unprocessed channel torrent %s ver %i->%i",
-                        hexlify(channel.public_key),
+                        channel.dirname,
                         channel.local_version,
                         channel.timestamp,
                     )

--- a/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/channel_metadata.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/channel_metadata.py
@@ -54,6 +54,15 @@ def create_torrent_from_dir(directory, torrent_filename):
     return torrent, infohash
 
 
+def get_mdblob_sequence_number(filename):
+    filepath = Path(filename)
+    if filepath.suffixes == [BLOB_EXTENSION]:
+        return int(filename.stem)
+    elif filepath.suffixes == [BLOB_EXTENSION, '.lz4']:
+        return int(Path(filepath.stem).stem)
+    return None
+
+
 def entries_to_chunk(metadata_list, chunk_size, start_index=0):
     """
     For efficiency reasons, this is deliberately written in C style
@@ -198,29 +207,50 @@ def define_binding(db):
 
             return self.commit_channel_torrent(new_start_timestamp=start_timestamp)
 
-        def update_channel_torrent(self, metadata_list, final_timestamp):
+        def update_channel_torrent(self, metadata_list):
             """
             Channel torrents are append-only to support seeding the old versions
             from the same dir and avoid updating already downloaded blobs.
-            :param metadata_list: The list of metadata entries to add to the torrent dir
-            :param final_timestamp: The timestamp that will be used as the filename of the last mdblob in the update
-            :return The new infohash, should be used to update the downloads
+            :param metadata_list: The list of metadata entries to add to the torrent dir. TODELETE entries should be sorted to be at the end!
+            :param start_timestamp: the starting timestamp for the channel
+            :return The newly create channel torrent infohash, final timestamp for the channel and torrent date
             """
-            # Create dir for metadata files
+            # As a workaround for delete entries not having a timestamp in the DB, delete entries should
+            # be placed after create/modify entries:
+            # | create/modify entries | delete entries | <- final timestamp
+
+            # Create dir for the metadata files
             channel_dir = path_util.abspath(self._channels_dir / self.dirname)
             if not channel_dir.is_dir():
                 os.makedirs(str_path(channel_dir))
+
+            existing_contents = sorted(channel_dir.iterdir())
+            last_existing_blob_number = get_mdblob_sequence_number(existing_contents[-1]) if existing_contents else None
 
             index = 0
             while index < len(metadata_list):
                 # Squash several serialized and signed metadata entries into a single file
                 data, index = entries_to_chunk(metadata_list, self._CHUNK_SIZE_LIMIT, start_index=index)
-                # The final file in the sequence should get the same (new) timestamp as the channel entry itself.
+                # Blobs ending with TODELETE entries increase the final timestamp as a workaround for delete commands
+                # possessing no timestamp.
+                if metadata_list[index - 1].status == TODELETE:
+                    blob_timestamp = clock.tick()
+                else:
+                    blob_timestamp = metadata_list[index - 1].timestamp
+
+                # The final file in the sequence should get a timestamp that is higher than the timestamp of
+                # the last channel contents entry. This final timestamp then should be returned to the calling function
+                # to be assigned to the corresponding channel entry.
                 # Otherwise, the local channel version will never become equal to its timestamp.
-                blob_timestamp = metadata_list[index - 1].timestamp if index < len(metadata_list) else final_timestamp
-                blob_filename = str_path(Path(channel_dir, str(blob_timestamp).zfill(12) + BLOB_EXTENSION + '.lz4'))
-                with open(blob_filename, 'wb') as f:
-                    f.write(data)
+                if index >= len(metadata_list):
+                    blob_timestamp = clock.tick()
+                # Check that the mdblob we're going to create has a greater timestamp than the existing ones
+                assert last_existing_blob_number is None or (blob_timestamp > last_existing_blob_number)
+
+                blob_filename = Path(channel_dir, str(blob_timestamp).zfill(12) + BLOB_EXTENSION + '.lz4')
+                assert not blob_filename.exists()  # Never ever write over existing files.
+                blob_filename.write_bytes(data)
+                last_existing_blob_number = blob_timestamp
 
             # TODO: add error-handling routines to make sure the timestamp is not messed up in case of an error
 
@@ -228,13 +258,13 @@ def define_binding(db):
             torrent, infohash = create_torrent_from_dir(channel_dir, self._channels_dir / (self.dirname + ".torrent"))
             torrent_date = datetime.utcfromtimestamp(torrent[b'creation date'])
 
-            return {"infohash": infohash, "timestamp": final_timestamp, "torrent_date": torrent_date}, torrent
+            return {"infohash": infohash, "timestamp": last_existing_blob_number, "torrent_date": torrent_date}, torrent
 
         def commit_channel_torrent(self, new_start_timestamp=None, commit_list=None):
             """
             Collect new/uncommitted and marked for deletion metadata entries, commit them to a channel torrent and
             remove the obsolete entries if the commit succeeds.
-            :param new_start_timestamp: change the start_timestamp of the commited channel entry to this value
+            :param new_start_timestamp: change the start_timestamp of the committed channel entry to this value
             :param commit_list: the list of ORM objects to commit into this channel torrent
             :return The new infohash, should be used to update the downloads
             """
@@ -243,9 +273,8 @@ def define_binding(db):
             if not md_list:
                 return None
 
-            final_timestamp = clock.tick()
             try:
-                update_dict, torrent = self.update_channel_torrent(md_list, final_timestamp)
+                update_dict, torrent = self.update_channel_torrent(md_list)
             except IOError:
                 self._logger.error(
                     "Error during channel torrent commit, not going to garbage collect the channel. Channel %s",

--- a/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/channel_metadata.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/channel_metadata.py
@@ -58,7 +58,7 @@ def get_mdblob_sequence_number(filename):
     filepath = Path(filename)
     if filepath.suffixes == [BLOB_EXTENSION]:
         return int(filename.stem)
-    elif filepath.suffixes == [BLOB_EXTENSION, '.lz4']:
+    if filepath.suffixes == [BLOB_EXTENSION, '.lz4']:
         return int(Path(filepath.stem).stem)
     return None
 
@@ -211,8 +211,8 @@ def define_binding(db):
             """
             Channel torrents are append-only to support seeding the old versions
             from the same dir and avoid updating already downloaded blobs.
-            :param metadata_list: The list of metadata entries to add to the torrent dir. TODELETE entries should be sorted to be at the end!
-            :param start_timestamp: the starting timestamp for the channel
+            :param metadata_list: The list of metadata entries to add to the torrent dir.
+            ACHTUNG: TODELETE entries _MUST_ be sorted to the end of the list to prevent channel corruption!
             :return The newly create channel torrent infohash, final timestamp for the channel and torrent date
             """
             # As a workaround for delete entries not having a timestamp in the DB, delete entries should
@@ -284,6 +284,7 @@ def define_binding(db):
 
             if new_start_timestamp:
                 update_dict['start_timestamp'] = new_start_timestamp
+            # Update channel infohash, etc
             for attr, val in update_dict.items():
                 setattr(self, attr, val)
             self.local_version = self.timestamp

--- a/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/collection_node.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/collection_node.py
@@ -339,7 +339,9 @@ def define_binding(db):
                     ).sum()
                     node.timestamp = clock.tick()
                     node.sign()
-            return sorted(commit_queue, key=lambda x: x.timestamp)[:-1]
+            # This perverted comparator lambda is necessary to ensure that delete entries are always
+            # sorted to the end of the list, as required by the channel serialization routine.
+            return sorted(commit_queue[:-1], key=lambda x: int(x.status == TODELETE) - 1 / x.timestamp)
 
         def delete(self, *args, **kwargs):
             # Recursively delete contents

--- a/src/tribler-core/tribler_core/modules/metadata_store/store.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/store.py
@@ -26,7 +26,7 @@ from tribler_core.modules.metadata_store.orm_bindings import (
     tracker_state,
     vsids,
 )
-from tribler_core.modules.metadata_store.orm_bindings.channel_metadata import BLOB_EXTENSION
+from tribler_core.modules.metadata_store.orm_bindings.channel_metadata import get_mdblob_sequence_number
 from tribler_core.modules.metadata_store.serialization import (
     CHANNEL_TORRENT,
     COLLECTION_NODE,
@@ -204,13 +204,7 @@ class MetadataStore(object):
             )
 
         for full_filename in sorted(dirname.iterdir()):
-            filename = full_filename.name
-
-            blob_sequence_number = None
-            if filename.endswith(BLOB_EXTENSION):
-                blob_sequence_number = int(filename[: -len(BLOB_EXTENSION)])
-            elif filename.endswith(BLOB_EXTENSION + '.lz4'):
-                blob_sequence_number = int(filename[: -len(BLOB_EXTENSION + '.lz4')])
+            blob_sequence_number = get_mdblob_sequence_number(full_filename.name)
 
             if blob_sequence_number is not None:
                 # Skip blobs containing data we already have and those that are


### PR DESCRIPTION
fixes #5295 by:
 * fixing the root cause of the corruption as described in #5295 by moving delete entries to the last mdblobs in the committing sequence and assigning them necessary timestamps;
 * enabling checks for personal channels torrents consistency, re-committing the damaged channels completely. Note that this happens some 10 seconds after the GUI starts and is not reflected in the GUI in any way. For owners of *really BIG* channels, Tribler could appear to become frozen. We will indicate this condition in the Readme (which is definitely read by owners of BIG channels).