### PR TITLE
Delaying video player initialization

### DIFF
--- a/src/tribler-gui/tribler_gui/tribler_window.py
+++ b/src/tribler-gui/tribler_gui/tribler_window.py
@@ -202,8 +202,6 @@ class TriblerWindow(QMainWindow):
             self.left_menu_button_trust_graph,
         ]
 
-        self.video_player_page.initialize_player()
-
         self.search_results_page.initialize_content_page(self.gui_settings)
         self.search_results_page.channel_torrents_filter_input.setHidden(True)
 
@@ -422,6 +420,10 @@ class TriblerWindow(QMainWindow):
 
         self.add_to_channel_dialog.load_channel(0)
         self.discovered_page.reset_view()
+
+        # We have to load the video player (and initialize VLC stuff) after spawning a subprocess to prevent a crash
+        # on Mac in frozen environments. Also see https://github.com/Tribler/tribler/issues/5420.
+        self.video_player_page.initialize_player()
 
         if not self.gui_settings.value("first_discover", False) and not self.core_manager.use_existing_core:
             self.core_manager.events_manager.discovered_channel.connect(self.stop_discovering)


### PR DESCRIPTION
This fixes an obscure bug on Mac, where the Tribler core would crash if VLC is loaded and instantiated before the subprocess is created. It should also speed up the overall Tribler startup since the VLC libs are now only loaded after Tribler has started.

Fixes #5420