### PR TITLE
Minor torrent checker fixes

### DIFF
--- a/src/tribler-core/tribler_core/modules/tests/test_tracker_manager.py
+++ b/src/tribler-core/tribler_core/modules/tests/test_tracker_manager.py
@@ -65,7 +65,7 @@ class TestTrackerManager(TestAsServer):
         self.assertFalse(self.tracker_manager.get_next_tracker_for_auto_check())
 
         self.tracker_manager.add_tracker("http://test1.com:80/announce")
-        self.assertEqual('http://test1.com/announce', self.tracker_manager.get_next_tracker_for_auto_check())
+        self.assertEqual('http://test1.com/announce', self.tracker_manager.get_next_tracker_for_auto_check().url)
 
     def test_get_tracker_for_check_blacklist(self):
         """

--- a/src/tribler-core/tribler_core/modules/torrent_checker/torrent_checker.py
+++ b/src/tribler-core/tribler_core/modules/torrent_checker/torrent_checker.py
@@ -86,40 +86,42 @@ class TorrentChecker(TaskManager):
         """
         Calling this method will fetch a random tracker from the database, select some torrents that have this
         tracker, and perform a request to these trackers.
+        Return whether the check was successful.
         """
-        tracker_url = self.get_valid_next_tracker_for_auto_check()
-        if tracker_url is None:
-            self._logger.warning(u"No tracker to select from, skip")
-            return
+        if self._should_stop:
+            self._logger.warning("Not performing tracker check since we are shutting down")
+            return False
 
-        self._logger.debug(u"Start selecting torrents on tracker %s.", tracker_url)
+        tracker = self.get_valid_next_tracker_for_auto_check()
+        if tracker is None:
+            self._logger.warning(u"No tracker to select from, skip")
+            return False
+
+        self._logger.debug(u"Start selecting torrents on tracker %s.", tracker.url)
 
         # get the torrents that should be checked
         with db_session:
-            tracker = self.tribler_session.mds.TrackerState.get(url=tracker_url)
-            if not tracker:
-                return
             dynamic_interval = TORRENT_CHECK_RETRY_INTERVAL * (2 ** tracker.failures)
             # FIXME: this is a really dumb fix for update_tracker_info not being called in some cases
             if tracker.failures >= MAX_TRACKER_FAILURES:
-                tracker.alive = False
-                return
+                self.update_tracker_info(tracker.url, False)
+                return False
             torrents = select(ts for ts in tracker.torrents if ts.last_check + dynamic_interval < int(time.time()))
             infohashes = [t.infohash for t in torrents[:MAX_TORRENTS_CHECKED_PER_SESSION]]
 
         if len(infohashes) == 0:
             # We have no torrent to recheck for this tracker. Still update the last_check for this tracker.
-            self._logger.info("No torrent to check for tracker %s", tracker_url)
-            self.update_tracker_info(tracker_url, True)
-            return
+            self._logger.info("No torrent to check for tracker %s", tracker.url)
+            self.update_tracker_info(tracker.url, True)
+            return False
 
         try:
-            session = self._create_session_for_request(tracker_url, timeout=30)
+            session = self._create_session_for_request(tracker.url, timeout=30)
         except MalformedTrackerURLException as e:
             # Remove the tracker from the database
-            self.remove_tracker(tracker_url)
+            self.remove_tracker(tracker.url)
             self._logger.error(e)
-            return
+            return False
 
         # We shuffle the list so that different infohashes are checked on subsequent scrape requests if the total
         # number of infohashes exceeds the maximum number of infohashes we check.
@@ -127,11 +129,12 @@ class TorrentChecker(TaskManager):
         for infohash in infohashes:
             session.add_infohash(infohash)
 
-        self._logger.info(u"Selected %d new torrents to check on tracker: %s", len(infohashes), tracker_url)
+        self._logger.info(u"Selected %d new torrents to check on tracker: %s", len(infohashes), tracker.url)
         try:
             await self.connect_to_tracker(session)
+            return True
         except:
-            pass
+            return False
 
     async def connect_to_tracker(self, session):
         try:
@@ -174,11 +177,11 @@ class TorrentChecker(TaskManager):
         return [bytes(random_torrent.infohash)]
 
     def get_valid_next_tracker_for_auto_check(self):
-        tracker_url = self.get_next_tracker_for_auto_check()
-        while tracker_url and not is_valid_url(tracker_url):
-            self.remove_tracker(tracker_url)
-            tracker_url = self.get_next_tracker_for_auto_check()
-        return tracker_url
+        tracker = self.get_next_tracker_for_auto_check()
+        while tracker and not is_valid_url(tracker.url):
+            self.remove_tracker(tracker.url)
+            tracker = self.get_next_tracker_for_auto_check()
+        return tracker
 
     def get_next_tracker_for_auto_check(self):
         return self.tribler_session.tracker_manager.get_next_tracker_for_auto_check()
@@ -186,8 +189,8 @@ class TorrentChecker(TaskManager):
     def remove_tracker(self, tracker_url):
         self.tribler_session.tracker_manager.remove_tracker(tracker_url)
 
-    def update_tracker_info(self, tracker_url, value):
-        self.tribler_session.tracker_manager.update_tracker_info(tracker_url, value)
+    def update_tracker_info(self, tracker_url, is_successful):
+        self.tribler_session.tracker_manager.update_tracker_info(tracker_url, is_successful)
 
     def is_blacklisted_tracker(self, tracker_url):
         return tracker_url in self.tribler_session.tracker_manager.blacklist

--- a/src/tribler-core/tribler_core/modules/tracker_manager.py
+++ b/src/tribler-core/tribler_core/modules/tracker_manager.py
@@ -134,4 +134,4 @@ class TrackerManager(object):
 
         if not tracker:
             return None
-        return tracker[0].url
+        return tracker[0]


### PR DESCRIPTION
- Fixed a potential tracker check schedule on shutdown, fixes #5418. Also added a test for this.
- Made `check_random_tracker` return a boolean, indicating success or failure of the check. I added this since I noticed that we were not asserting anything in the torrent checker tests.
- Removed a unnecessary database fetch.
- Updated IPv8 pointer.