### PR TITLE
Workaround for latest SetupTools issue with PyInstaller

### DIFF
--- a/tribler.spec
+++ b/tribler.spec
@@ -80,9 +80,10 @@ hiddenimports = [
     'pyaes',
     'scrypt', '_scrypt',
     'sqlalchemy', 'sqlalchemy.ext.baked', 'sqlalchemy.ext.declarative',
+    'pkg_resources', 'pkg_resources.py2_warn', # Workaround PyInstaller & SetupTools, https://github.com/pypa/setuptools/issues/1963
     'requests',
     'PyQt5.QtTest',
-    'pyqtgraph'] + widget_files + pony_deps,
+    'pyqtgraph'] + widget_files + pony_deps
 
 
 sys.modules['FixTk'] = None
@@ -90,7 +91,7 @@ a = Analysis(['src/run_tribler.py'],
              pathex=[''],
              binaries=None,
              datas=data_to_copy,
-             hiddenimports=['csv', 'ecdsa', 'pyaes', 'scrypt', '_scrypt', 'sqlalchemy', 'sqlalchemy.ext.baked', 'sqlalchemy.ext.declarative', 'requests', 'PyQt5.QtTest', 'pyqtgraph'] + widget_files + pony_deps,
+             hiddenimports=hiddenimports,
              hookspath=[],
              runtime_hooks=[],
              excludes=excluded_libs,


### PR DESCRIPTION
Workaround PyInstaller & SetupTools, 
https://github.com/pypa/setuptools/issues/1963

The current build is probably working because SetupTools is of version 44.0 or less. Incase this PR is merged, the builder will need to be updated and tested. I have tested locally building the deb package and running on Ubuntu 20.04 and it is working fine.