### PR TITLE
Shutting down Bootstrap before IPv8

### DIFF
--- a/src/tribler-core/tribler_core/session.py
+++ b/src/tribler-core/tribler_core/session.py
@@ -532,6 +532,11 @@ class Session(TaskManager):
             await self.resource_monitor.stop()
         self.resource_monitor = None
 
+        if self.bootstrap:
+            # We shutdown the bootstrap module before IPv8 since it uses the DHTCommunity.
+            await self.bootstrap.shutdown()
+        self.bootstrap = None
+
         self.tracker_manager = None
 
         if self.tunnel_community and self.trustchain_community:
@@ -561,10 +566,6 @@ class Session(TaskManager):
 
         self.notify_shutdown_state("Saving configuration...")
         self.config.write()
-
-        if self.bootstrap:
-            await self.bootstrap.shutdown()
-        self.bootstrap = None
 
         if self.dlmgr:
             await self.dlmgr.shutdown()


### PR DESCRIPTION
Since the Bootstrap module is relying on the DHTCommunity, we have to shut it down before IPv8.