### PR TITLE
Tunnel helpers now store more TrustChain blocks

### DIFF
--- a/src/tribler-core/run_tunnel_helper.py
+++ b/src/tribler-core/run_tunnel_helper.py
@@ -154,6 +154,9 @@ class TunnelHelperService(TaskManager):
             # We set this after Tribler has started since the tunnel_community won't be available otherwise
             self.session.tunnel_community.reject_callback = self.on_circuit_reject
 
+        # Tunnel helpers store more TrustChain blocks
+        self.session.trustchain_community.settings.max_db_blocks = 5000000
+
         self.tribler_started()
         
     async def stop(self):


### PR DESCRIPTION
Tunnel helpers (relay and exit nodes) are more likely to create new blocks. I found that the current limit of 1 million blocks is somewhat on the lower side. Therefore, I'm increasing it.