### PR TITLE
Updated IPv8 pointer

### DIFF
--- a/src/tribler-core/tribler_core/session.py
+++ b/src/tribler-core/tribler_core/session.py
@@ -424,6 +424,7 @@ class Session(TaskManager):
             ipv8_config['address'] = self.config.get_ipv8_address()
             ipv8_config['overlays'] = []
             ipv8_config['keys'] = []  # We load the keys ourselves
+            ipv8_config['working_directory'] = str(self.config.get_state_dir())
 
             if self.config.get_ipv8_bootstrap_override():
                 import ipv8.community as community_file


### PR DESCRIPTION
Related to #5450

This PR:
 - Updates the IPv8 pointer, resolving #5450.
 - Explicitly sets `working_directory` of the IPv8 configuration.