### PR TITLE
Added more info to OverflowError

### DIFF
--- a/src/tribler-core/tribler_core/modules/libtorrent/download_manager.py
+++ b/src/tribler-core/tribler_core/modules/libtorrent/download_manager.py
@@ -574,10 +574,13 @@ class DownloadManager(TaskManager):
             self.ltsettings[lt_session] = lt_session.get_settings()
         self.ltsettings[lt_session].update(new_settings)
 
-        if hasattr(lt_session, "apply_settings"):
-            lt_session.apply_settings(new_settings)
-        else:
-            lt_session.set_settings(new_settings)
+        try:
+            if hasattr(lt_session, "apply_settings"):
+                lt_session.apply_settings(new_settings)
+            else:
+                lt_session.set_settings(new_settings)
+        except OverflowError:
+            raise OverflowError("Overflow error when setting libtorrent sessions with settings: %s" % new_settings)
 
     def get_session_settings(self, lt_session):
         return deepcopy(self.ltsettings.get(lt_session, {}))

--- a/src/tribler-core/tribler_core/modules/libtorrent/tests/test_download.py
+++ b/src/tribler-core/tribler_core/modules/libtorrent/tests/test_download.py
@@ -199,6 +199,13 @@ class TestDownload(TestAsServer):
         await dl.checkpoint()
         self.assertTrue(filename.is_file())
 
+    @timeout(10)
+    async def test_libtorrent_settings_overflow(self):
+        """
+        Test whether we are catching libtorrent overflow errors.
+        """
+        self.assertRaises(OverflowError, self.session.dlmgr.set_upload_rate_limit, 2 ** 70)
+
 
 class TestDownloadNoSession(TriblerCoreTest):
 


### PR DESCRIPTION
When applying new libtorrent settings. This will help us to debug future OverflowErrors that occur, either because of a bug or a config modified by users.

I consider this enough to fix #5369 for the moment being. First, it only happened once on Windows 32-bit so it's not a severe issue. Second, this is most likely the result of users tampering with their configuration files since we have a built-in check whether the integers added in the settings screen are not overflowing. This PR will now help us to catch this kind of errors in the future, enabling us to make a call whether we should ignore it or fix it.

Fixes #5369