### PR TITLE
Add build parameters on snap build script

### DIFF
--- a/build/debian/build-snap.sh
+++ b/build/debian/build-snap.sh
@@ -6,7 +6,8 @@ fi
 # Make sure we have the latest packages
 apt-get update
 
-snapcraft
+BUILD_ARGS=${SNAP_BUILD_ARGS:-''}
+snapcraft $BUILD_ARGS
 
 # Remove intermediate files
 rm -rf parts stage prime


### PR DESCRIPTION
Add build parameters on snap build script so LXD can be used where multipass is not supported