### PR TITLE
Add default download path to recently used dirs cache

### DIFF
--- a/src/tribler-core/tribler_core/modules/libtorrent/restapi/downloads_endpoint.py
+++ b/src/tribler-core/tribler_core/modules/libtorrent/restapi/downloads_endpoint.py
@@ -106,16 +106,16 @@ class DownloadsEndpoint(RESTEndpoint):
         if safe_seeding:
             download_config.set_safe_seeding(True)
 
-        if parameters.get('destination'):
-            dest_dir = parameters['destination']
-            download_config.set_dest_dir(dest_dir)
+        if 'destination' in parameters:
+            download_config.set_dest_dir(parameters['destination'])
 
         if 'selected_files' in parameters:
             download_config.set_selected_files(parameters['selected_files'])
 
         return download_config, None
 
-    def get_files_info_json(self, download):
+    @staticmethod
+    def get_files_info_json(download):
         """
         Return file information as JSON from a specified download.
         """

--- a/src/tribler-gui/tribler_gui/dialogs/startdownloaddialog.py
+++ b/src/tribler-gui/tribler_gui/dialogs/startdownloaddialog.py
@@ -239,7 +239,7 @@ class StartDownloadDialog(DialogContainer):
 
     def on_browse_dir_clicked(self):
         chosen_dir = QFileDialog.getExistingDirectory(
-            self.window(), "Please select the destination directory of your " "download", "", QFileDialog.ShowDirsOnly
+            self.window(), "Please select the destination directory of your download", "", QFileDialog.ShowDirsOnly
         )
 
         if len(chosen_dir) != 0:

--- a/src/tribler-gui/tribler_gui/tribler_window.py
+++ b/src/tribler-gui/tribler_gui/tribler_window.py
@@ -494,6 +494,22 @@ class TriblerWindow(QMainWindow):
         if uri.startswith('file') or uri.startswith('magnet'):
             self.start_download_from_uri(uri)
 
+    def update_recent_download_locations(self, destination):
+        # Save the download location to the GUI settings
+        current_settings = get_gui_setting(self.gui_settings, "recent_download_locations", "")
+        recent_locations = current_settings.split(",") if len(current_settings) > 0 else []
+        if isinstance(destination, str):
+            destination = destination.encode('utf-8')
+        encoded_destination = hexlify(destination)
+        if encoded_destination in recent_locations:
+            recent_locations.remove(encoded_destination)
+        recent_locations.insert(0, encoded_destination)
+
+        if len(recent_locations) > 5:
+            recent_locations = recent_locations[:5]
+
+        self.gui_settings.setValue("recent_download_locations", ','.join(recent_locations))
+
     def perform_start_download_request(
         self,
         uri,
@@ -532,20 +548,7 @@ class TriblerWindow(QMainWindow):
             "downloads", callback if callback else self.on_download_added, method='PUT', data=post_data
         )
 
-        # Save the download location to the GUI settings
-        current_settings = get_gui_setting(self.gui_settings, "recent_download_locations", "")
-        recent_locations = current_settings.split(",") if len(current_settings) > 0 else []
-        if isinstance(destination, str):
-            destination = destination.encode('utf-8')
-        encoded_destination = hexlify(destination)
-        if encoded_destination in recent_locations:
-            recent_locations.remove(encoded_destination)
-        recent_locations.insert(0, encoded_destination)
-
-        if len(recent_locations) > 5:
-            recent_locations = recent_locations[:5]
-
-        self.gui_settings.setValue("recent_download_locations", ','.join(recent_locations))
+        self.update_recent_download_locations(destination)
 
         if add_to_channel:
 

--- a/src/tribler-gui/tribler_gui/widgets/settingspage.py
+++ b/src/tribler-gui/tribler_gui/widgets/settingspage.py
@@ -245,8 +245,7 @@ class SettingsPage(QWidget):
     def initialize_with_settings(self, settings):
         if not settings:
             return
-        self.settings = settings
-        settings = settings["settings"]
+        self.settings = settings = settings["settings"]
         gui_settings = self.window().gui_settings
 
         self.window().settings_stacked_widget.show()
@@ -530,6 +529,14 @@ class SettingsPage(QWidget):
         settings_data['ipv8']['statistics'] = self.window().checkbox_enable_network_statistics.isChecked()
 
         self.window().settings_save_button.setEnabled(False)
+
+        # TODO: do it in RESTful style, on the REST return JSON instead
+        # In case the default save dir has changed, add it to the top of the list of last download locations.
+        # Otherwise, the user could absentmindedly click through the download dialog and start downloading into
+        # the last used download dir, and not into the newly designated default download dir.
+        if self.settings['download_defaults']['saveas'] != settings_data['download_defaults']['saveas']:
+            self.window().update_recent_download_locations(settings_data['download_defaults']['saveas'])
+        self.settings = settings_data
 
         TriblerNetworkRequest("settings", self.on_settings_saved, method='POST', raw_data=json.dumps(settings_data))
 


### PR DESCRIPTION
fixes #5470 by adding the redefined default download path to the list of the most recently used download dirs.