### PR TITLE
Disable VLC library loading

### DIFF
--- a/src/tribler-gui/tribler_gui/tests/test_gui.py
+++ b/src/tribler-gui/tribler_gui/tests/test_gui.py
@@ -5,7 +5,7 @@ import sys
 import threading
 import time
 from asyncio import new_event_loop, set_event_loop
-from unittest import TestCase, skipIf, skipUnless
+from unittest import TestCase, skip, skipIf, skipUnless
 
 from PyQt5.QtCore import QPoint, QTimer, Qt
 from PyQt5.QtGui import QPixmap, QRegion
@@ -406,7 +406,7 @@ class TriblerGUITest(AbstractTriblerGUITest):
         self.wait_for_signal(window.left_menu_playlist.list_loaded, no_args=True)
         self.screenshot(window, name="video_player_left_menu_loaded")
 
-    @skipIf(sys.platform == "darwin", "VLC playback from  nosetests seems to be unreliable on Mac")
+    @skip("This test is currently disabled due to issue #5483")
     def test_video_playback(self):
         """
         Test video playback of a Tribler instance.

--- a/src/tribler-gui/tribler_gui/widgets/videoplayerpage.py
+++ b/src/tribler-gui/tribler_gui/widgets/videoplayerpage.py
@@ -33,12 +33,14 @@ class VideoPlayerPage(QWidget):
         self.freeze = False
 
     def initialize_player(self):
-        vlc_available = True
+        # TODO: We disabled VLC loading for the moment being, due to a crash when parsing media.
+        # Also see issue #5483.
+        vlc_available = False
         vlc = None
-        try:
-            from tribler_gui import vlc
-        except OSError:
-            vlc_available = False
+        # try:
+        #     from tribler_gui import vlc
+        # except OSError:
+        #     vlc_available = False
 
         if vlc and vlc.plugin_path:
             os.environ['VLC_PLUGIN_PATH'] = vlc.plugin_path


### PR DESCRIPTION
We disabled VLC loading for the moment being, due to a crash when parsing media which can cause the Tribler GUI to freeze. See issue #5483 for more information.