### PR TITLE
Split testnet settings into multiple ones

### DIFF
--- a/src/tribler-core/tribler_core/config/test_tribler_config.py
+++ b/src/tribler-core/tribler_core/config/test_tribler_config.py
@@ -117,9 +117,10 @@ class TestTriblerConfig(TriblerCoreTest):
         self.tribler_config.set_trustchain_testnet_keypair_filename("bla2")
         self.assertEqual(self.tribler_config.get_trustchain_testnet_keypair_filename(),
                          self.tribler_config.get_state_dir() / "bla2")
-
-        self.tribler_config.set_testnet(True)
-        self.assertTrue(self.tribler_config.get_testnet())
+        self.tribler_config.set_trustchain_testnet(True)
+        self.assertTrue(self.tribler_config.get_trustchain_testnet())
+        self.tribler_config.set_log_dir(self.tribler_config.get_state_dir() / "bla3")
+        self.assertEqual(self.tribler_config.get_log_dir(), self.tribler_config.get_state_dir() / "bla3")
 
     def test_get_set_methods_version_checker(self):
         """
@@ -219,6 +220,8 @@ class TestTriblerConfig(TriblerCoreTest):
         self.assertEqual(self.tribler_config.get_tunnel_community_random_slots(), 10)
         self.tribler_config.set_tunnel_community_competing_slots(20)
         self.assertEqual(self.tribler_config.get_tunnel_community_competing_slots(), 20)
+        self.tribler_config.set_tunnel_testnet(True)
+        self.assertTrue(self.tribler_config.get_tunnel_testnet())
 
     def test_get_set_methods_wallets(self):
         """
@@ -238,6 +241,8 @@ class TestTriblerConfig(TriblerCoreTest):
         self.tribler_config.set_chant_channels_dir('test')
         self.assertEqual(self.tribler_config.get_chant_channels_dir(),
                          self.tribler_config.get_state_dir() / 'test')
+        self.tribler_config.set_chant_testnet(True)
+        self.assertTrue(self.tribler_config.get_chant_testnet())
 
     def test_get_set_is_matchmaker(self):
         """

--- a/src/tribler-core/tribler_core/config/tribler_config.py
+++ b/src/tribler-core/tribler_core/config/tribler_config.py
@@ -118,6 +118,18 @@ class TriblerConfig(object):
     def get_version(self):
         return self.config['general']['version']
 
+    def set_log_dir(self, value):
+        self.config['general']['log_dir'] = str(self.norm_path(value))
+
+    def get_log_dir(self):
+        return self.abspath(self.config['general']['log_dir'])
+
+    def set_version_checker_enabled(self, value):
+        self.config['general']['version_checker_enabled'] = value
+
+    def get_version_checker_enabled(self):
+        return self.config['general']['version_checker_enabled']
+
     # Chant
     def set_chant_enabled(self, value):
         self.config['chant']['enabled'] = bool(value)
@@ -137,8 +149,16 @@ class TriblerConfig(object):
     def get_chant_channels_dir(self):
         return self.abspath(self.config['chant']['channels_dir'])
 
+    def set_chant_testnet(self, value):
+        self.config['chant']['testnet'] = value
+
+    def get_chant_testnet(self):
+        return 'TESTNET' in os.environ or 'CHANT_TESTNET' in os.environ or self.config['chant']['testnet']
+
     def get_state_dir(self):
         return self._state_dir
+
+    # TrustChain
 
     def set_trustchain_keypair_filename(self, keypairfilename):
         self.config['trustchain']['ec_keypair_filename'] = str(self.norm_path(keypairfilename))
@@ -161,6 +181,14 @@ class TriblerConfig(object):
     def set_trustchain_live_edges_enabled(self, value):
         self.config['trustchain']['live_edges_enabled'] = value
 
+    def get_trustchain_testnet(self):
+        return 'TESTNET' in os.environ or 'TRUSTCHAIN_TESTNET' in os.environ or self.config['trustchain']['testnet']
+
+    def set_trustchain_testnet(self, value):
+        self.config['trustchain']['testnet'] = value
+
+    # Bootstrap
+
     def set_bootstrap_enabled(self, value):
         self.config['bootstrap']['enabled'] = value
 
@@ -181,27 +209,6 @@ class TriblerConfig(object):
 
     def get_trustchain_live_edges_enabled(self):
         return self.config['trustchain']['live_edges_enabled']
-
-    def set_log_dir(self, value):
-        self.config['general']['log_dir'] = str(self.norm_path(value))
-
-    def get_log_dir(self):
-        return self.abspath(self.config['general']['log_dir'])
-
-    def set_testnet(self, value):
-        self.config['general']['testnet'] = value
-
-    def get_testnet(self):
-        return 'TESTNET' in os.environ or self.config['general']['testnet']
-
-    # Version Checker
-    def set_version_checker_enabled(self, value):
-        self.config['general']['version_checker_enabled'] = value
-
-    def get_version_checker_enabled(self):
-        if 'version_checker_enabled' not in self.config['general']:
-            return True
-        return self.config['general']['version_checker_enabled']
 
     # Torrent checking
 
@@ -458,6 +465,12 @@ class TriblerConfig(object):
 
     def get_tunnel_community_competing_slots(self):
         return self.config['tunnel_community']['competing_slots']
+
+    def set_tunnel_testnet(self, value):
+        self.config['tunnel_community']['testnet'] = value
+
+    def get_tunnel_testnet(self):
+        return 'TESTNET' in os.environ or 'TUNNEL_TESTNET' in os.environ or self.config['tunnel_community']['testnet']
 
     def set_default_number_hops(self, value):
         self.config['download_defaults']['number_hops'] = value

--- a/src/tribler-core/tribler_core/config/tribler_config.spec
+++ b/src/tribler-core/tribler_core/config/tribler_config.spec
@@ -1,7 +1,6 @@
 [general]
 version = string(default='')
 log_dir = string(default='logs')
-testnet = boolean(default=False)
 version_checker_enabled = boolean(default=True)
 
 [tunnel_community]
@@ -10,6 +9,7 @@ socks5_listen_ports = string_list(default=list('-1', '-1', '-1', '-1', '-1'))
 exitnode_enabled = boolean(default=False)
 random_slots = integer(default=5)
 competing_slots = integer(default=15)
+testnet = boolean(default=False)
 
 [market_community]
 enabled = boolean(default=False)
@@ -24,6 +24,7 @@ enabled = boolean(default=True)
 ec_keypair_filename = string(default='ec_multichain.pem')
 testnet_keypair_filename = string(default='ec_trustchain_testnet.pem')
 live_edges_enabled = boolean(default=True)
+testnet = boolean(default=False)
 
 [bootstrap]
 enabled = boolean(default=True)
@@ -39,6 +40,7 @@ enabled = boolean(default=True)
 manager_enabled = boolean(default=True)
 channel_edit = boolean(default=False)
 channels_dir = string(default='channels')
+testnet = boolean(default=False)
 
 [torrent_checking]
 enabled = boolean(default=True)

--- a/src/tribler-core/tribler_core/session.py
+++ b/src/tribler-core/tribler_core/session.py
@@ -144,7 +144,7 @@ class Session(TaskManager):
         self.mds = None  # Metadata Store
 
     def load_ipv8_overlays(self):
-        if self.config.get_testnet():
+        if self.config.get_trustchain_testnet():
             peer = Peer(self.trustchain_testnet_keypair)
         else:
             peer = Peer(self.trustchain_keypair)
@@ -160,7 +160,7 @@ class Session(TaskManager):
             from ipv8.attestation.trustchain.community import TrustChainCommunity, \
                 TrustChainTestnetCommunity
 
-            community_cls = TrustChainTestnetCommunity if self.config.get_testnet() else TrustChainCommunity
+            community_cls = TrustChainTestnetCommunity if self.config.get_trustchain_testnet() else TrustChainCommunity
             self.trustchain_community = community_cls(peer, self.ipv8.endpoint,
                                                       self.ipv8.network,
                                                       working_directory=self.config.get_state_dir())
@@ -184,7 +184,7 @@ class Session(TaskManager):
             from tribler_core.modules.tunnel.community.triblertunnel_community import TriblerTunnelCommunity,\
                                                                                TriblerTunnelTestnetCommunity
             from tribler_core.modules.tunnel.community.discovery import GoldenRatioStrategy
-            community_cls = TriblerTunnelTestnetCommunity if self.config.get_testnet() else \
+            community_cls = TriblerTunnelTestnetCommunity if self.config.get_tunnel_testnet() else \
                 TriblerTunnelCommunity
 
             random_slots = self.config.get_tunnel_community_random_slots()
@@ -210,7 +210,7 @@ class Session(TaskManager):
         if self.config.get_market_community_enabled() and self.config.get_dht_enabled():
             from anydex.core.community import MarketCommunity, MarketTestnetCommunity
 
-            community_cls = MarketTestnetCommunity if self.config.get_testnet() else MarketCommunity
+            community_cls = MarketTestnetCommunity if self.config.get_trustchain_testnet() else MarketCommunity
             self.market_community = community_cls(peer, self.ipv8.endpoint, self.ipv8.network,
                                                   trustchain=self.trustchain_community,
                                                   dht=self.dht_community,
@@ -238,7 +238,7 @@ class Session(TaskManager):
             from tribler_core.modules.metadata_store.community.gigachannel_community import GigaChannelCommunity, GigaChannelTestnetCommunity
             from tribler_core.modules.metadata_store.community.sync_strategy import SyncChannels
 
-            community_cls = GigaChannelTestnetCommunity if self.config.get_testnet() else GigaChannelCommunity
+            community_cls = GigaChannelTestnetCommunity if self.config.get_chant_testnet() else GigaChannelCommunity
             self.gigachannel_community = community_cls(peer, self.ipv8.endpoint, self.ipv8.network, self.mds,
                                                        notifier=self.notifier)
 
@@ -251,7 +251,7 @@ class Session(TaskManager):
             from tribler_core.modules.metadata_store.community.remote_query_community \
                 import RemoteQueryCommunity, RemoteQueryTestnetCommunity
 
-            community_cls = RemoteQueryTestnetCommunity if self.config.get_testnet() else RemoteQueryCommunity
+            community_cls = RemoteQueryTestnetCommunity if self.config.get_chant_testnet() else RemoteQueryCommunity
             self.remote_query_community = community_cls(peer, self.ipv8.endpoint, self.ipv8.network, self.mds,
                                                         notifier=self.notifier)
 
@@ -413,7 +413,7 @@ class Session(TaskManager):
 
         if self.config.get_chant_enabled():
             channels_dir = self.config.get_chant_channels_dir()
-            metadata_db_name = 'metadata.db' if not self.config.get_testnet() else 'metadata_testnet.db'
+            metadata_db_name = 'metadata.db' if not self.config.get_chant_testnet() else 'metadata_testnet.db'
             database_path = self.config.get_state_dir() / 'sqlite' / metadata_db_name
             self.mds = MetadataStore(database_path, channels_dir, self.trustchain_keypair)
 

--- a/src/tribler-gui/tribler_gui/tribler_app.py
+++ b/src/tribler-gui/tribler_gui/tribler_app.py
@@ -49,6 +49,12 @@ class TriblerApplication(QtSingleApplication):
 
         if '--testnet' in sys.argv[1:]:
             os.environ['TESTNET'] = "YES"
+        if '--trustchain-testnet' in sys.argv[1:]:
+            os.environ['TRUSTCHAIN_TESTNET'] = "YES"
+        if '--chant-testnet' in sys.argv[1:]:
+            os.environ['CHANT_TESTNET'] = "YES"
+        if '--tunnel-testnet' in sys.argv[1:]:
+            os.environ['TUNNEL_TESTNET'] = "YES"
 
     def event(self, event):
         if event.type() == QEvent.FileOpen and event.file().endswith(".torrent"):


### PR DESCRIPTION
For the application tester I would like to "mix and match" my testnet settings. For example, I want to download using exit nodes on the testnet but use the channels discovered in the chant mainnet. To do so, I split the testnet settings into multiple ones, which can be enabled separately. To fully enable the testnet, you can pass the --testnet flag to Tribler and all communities will automatically load the testnet version.