### PR TITLE
Running fake Tribler API in a subprocess

### DIFF
--- a/src/tribler-gui/tribler_gui/tests/fake_tribler_api/endpoints/search_endpoint.py
+++ b/src/tribler-gui/tribler_gui/tests/fake_tribler_api/endpoints/search_endpoint.py
@@ -43,7 +43,7 @@ class SearchEndpoint(RESTEndpoint):
         torrents_json = []
         for index in picked_torrents:
             torrent_json = tribler_utils.tribler_data.torrents[index].get_json()
-            torrent_json['type'] = 'torrent'
+            torrent_json['type'] = 300  # TODO this should be replaced by REGULAR_TORRENT
             torrents_json.append(torrent_json)
 
         if sort_by:
@@ -52,7 +52,7 @@ class SearchEndpoint(RESTEndpoint):
         channels_json = []
         for index in picked_channels:
             channel_json = tribler_utils.tribler_data.channels[index].get_json()
-            channel_json['type'] = 'channel'
+            channel_json['type'] = 400  # TODO this should be replaced by CHANNEL_TORRENT
             channels_json.append(channel_json)
 
         if sort_by and sort_by not in ['category', 'size']:

--- a/src/tribler-gui/tribler_gui/tests/fake_tribler_api/tribler_data.py
+++ b/src/tribler-gui/tribler_gui/tests/fake_tribler_api/tribler_data.py
@@ -85,6 +85,7 @@ class TriblerData(object):
                 "tunnel_community": {"exitnode_enabled": True},
                 "search_community": {"enabled": True},
                 "resource_monitor": {"enabled": True},
+                "market_community": {"enabled": True},
                 "chant": {"enabled": True, "channel_edit": True},
             },
             "ports": {},

--- a/src/tribler-gui/tribler_gui/tests/start_fake_api.py
+++ b/src/tribler-gui/tribler_gui/tests/start_fake_api.py
@@ -1,0 +1,31 @@
+import logging
+import sys
+from asyncio import new_event_loop, set_event_loop
+
+from aiohttp import web
+
+from tribler_gui.tests.fake_tribler_api.endpoints.root_endpoint import RootEndpoint
+from tribler_gui.tests.fake_tribler_api.tribler_data import TriblerData
+import tribler_gui.tests.fake_tribler_api.tribler_utils as tribler_utils
+
+if __name__ == "__main__":
+    logging.basicConfig()
+    logger = logging.getLogger(__file__)
+    logger.setLevel(logging.INFO)
+
+    logger.info("Generating random Tribler data")
+    tribler_utils.tribler_data = TriblerData()
+    tribler_utils.tribler_data.generate()
+
+    root_endpoint = RootEndpoint(None)
+    runner = web.AppRunner(root_endpoint.app)
+
+    loop = new_event_loop()
+    set_event_loop(loop)
+
+    api_port = int(sys.argv[1])
+    loop.run_until_complete(runner.setup())
+    logger.info("Starting fake Tribler API on port %d", api_port)
+    site = web.TCPSite(runner, 'localhost', api_port)
+    loop.run_until_complete(site.start())
+    loop.run_forever()


### PR DESCRIPTION
It seems that Python 3.8 does not like a Qt event loop and an asyncio event loop in the same process. To address this, I now spawn a subprocess that serves HTTP requests. This subprocess is killed when the tests are done.

I also noticed a few code errors which are also addressed in this PR.

Fixes #5494