### PR TITLE
Add release url in the version check manager

### DIFF
--- a/src/tribler-core/tribler_core/modules/tests/test_versioncheck.py
+++ b/src/tribler-core/tribler_core/modules/tests/test_versioncheck.py
@@ -17,7 +17,7 @@ class TestVersionCheck(TestAsServer):
         self.site = None
         self.should_call_new_version_callback = False
         self.new_version_called = False
-        versioncheck_manager.VERSION_CHECK_URL = 'http://localhost:%s' % self.port
+        versioncheck_manager.VERSION_CHECK_URLS = ['http://localhost:%s' % self.port]
         await super(TestVersionCheck, self).setUp()
         self.session.version_check_manager = VersionCheckManager(self.session)
 
@@ -83,7 +83,7 @@ class TestVersionCheck(TestAsServer):
     @timeout(20)
     async def test_connection_error(self):
         await self.setup_version_server(json.dumps({'name': 'v1.0'}))
-        versioncheck_manager.VERSION_CHECK_URL = "http://this.will.not.exist"
+        versioncheck_manager.VERSION_CHECK_URLS = ["http://this.will.not.exist"]
         await self.check_version()
 
     @timeout(20)

--- a/src/tribler-core/tribler_core/modules/versioncheck_manager.py
+++ b/src/tribler-core/tribler_core/modules/versioncheck_manager.py
@@ -9,9 +9,9 @@ from tribler_common.simpledefs import NTFY
 
 from tribler_core.version import version_id
 
-VERSION_CHECK_URLS = ['https://release.tribler.org/releases/latest',  # Main Tribler release page
+VERSION_CHECK_URLS = [f'https://release.tribler.org/releases/latest?current={version_id}',  # Tribler Release API
                       'https://api.github.com/repos/tribler/tribler/releases/latest']  # Fallback GitHub API
-VERSION_CHECK_INTERVAL = 86400  # One day
+VERSION_CHECK_INTERVAL = 6*3600  # Six hours
 
 
 class VersionCheckManager(TaskManager):


### PR DESCRIPTION
With this PR, a new release URL (https://release.tribler.org) is added to the version check manager. Swagger docs for the currently available endpoints are available at /docs.

Fixes https://github.com/Tribler/tribler/issues/5523