### PR TITLE
Added a venv option when building Tribler

### DIFF
--- a/build/debian/makedist_debian.sh
+++ b/build/debian/makedist_debian.sh
@@ -8,6 +8,11 @@ then
   echo "Please run this script from project root as:\n./build/debian/makedist_debian.sh"
 fi
 
+if [ ! -z "$VENV" ]; then
+  echo "Setting venv to $VENV"
+  source $VENV/bin/activate
+fi
+
 rm -rf build/tribler
 rm -rf dist/tribler
 rm -rf build/debian/tribler/usr/share/tribler


### PR DESCRIPTION
Jenkins by default uses sh to run its scripts. However, sh does not have the source command, which is needed to enter a virtual environment. Therefore, I added a VENV option to the build script (on Linux).