### PR TITLE
READY: Should not eat exception silently

### DIFF
--- a/src/tribler-core/tribler_core/dependencies.py
+++ b/src/tribler-core/tribler_core/dependencies.py
@@ -4,7 +4,7 @@ This file lists the python dependencies for Tribler.
 Note that this file should not depend on any external modules itself other than builtin ones.
 """
 import importlib
-import os
+import platform
 import sys
 
 dependencies = [
@@ -45,15 +45,18 @@ def _show_system_popup(title, text):
     sep = "*" * 80
     print('\n'.join([sep, title, sep, text, sep]), file=sys.stderr)
 
-    if os.name == 'Windows':
+    system = platform.system()
+    if system == 'Windows':
         import win32api
         win32api.MessageBox(0, text, title)
-    elif os.name == 'Linux':
+    elif system == 'Linux':
         import subprocess
         subprocess.Popen(['xmessage', '-center', text])
-    elif os.name == 'Darwin':
+    elif system == 'Darwin':
         import subprocess
         subprocess.Popen(['/usr/bin/osascript', '-e', text])
+    else:
+        print(f'cannot create native pop-up for system {system}')
 
 
 def check_for_missing_dependencies(scope='both'):

--- a/src/tribler-core/tribler_core/dependencies.py
+++ b/src/tribler-core/tribler_core/dependencies.py
@@ -52,10 +52,10 @@ def _show_system_popup(title, text):
         elif os.name == 'Darwin':
             import subprocess
             subprocess.Popen(['/usr/bin/osascript', '-e', text])
-    except Exception as exception:
-        # Use base Exception, because code above is tricky and can raise many
-        # types of exceptions (SubprocessError, ImportError, win32api.error)
-        print(f'Error while showing message box: {exception}')
+    except:
+        print(f'Error while showing message box with text: {text}')
+        raise
+
 
     sep = "*" * 80
     print('\n'.join([sep, title, sep, text, sep]), file=sys.stderr)

--- a/src/tribler-core/tribler_core/dependencies.py
+++ b/src/tribler-core/tribler_core/dependencies.py
@@ -42,23 +42,18 @@ def _show_system_popup(title, text):
     :param title: the pop-up title
     :param text: the pop-up body
     """
-    try:
-        if os.name == 'Windows':
-            import win32api
-            win32api.MessageBox(0, text, title)
-        elif os.name == 'Linux':
-            import subprocess
-            subprocess.Popen(['xmessage', '-center', text])
-        elif os.name == 'Darwin':
-            import subprocess
-            subprocess.Popen(['/usr/bin/osascript', '-e', text])
-    except:
-        print(f'Error while showing message box with text: {text}')
-        raise
-
-
     sep = "*" * 80
     print('\n'.join([sep, title, sep, text, sep]), file=sys.stderr)
+
+    if os.name == 'Windows':
+        import win32api
+        win32api.MessageBox(0, text, title)
+    elif os.name == 'Linux':
+        import subprocess
+        subprocess.Popen(['xmessage', '-center', text])
+    elif os.name == 'Darwin':
+        import subprocess
+        subprocess.Popen(['/usr/bin/osascript', '-e', text])
 
 
 def check_for_missing_dependencies(scope='both'):


### PR DESCRIPTION
It is better to not eat exceptions silently, as it can mask some problems.