### PR TITLE
Move TriblerRequestManager error callback to a separate slot

### DIFF
--- a/src/tribler-gui/tribler_gui/core_manager.py
+++ b/src/tribler-gui/tribler_gui/core_manager.py
@@ -103,7 +103,7 @@ class CoreManager(QObject):
 
     def check_core_ready(self):
         TriblerNetworkRequest(
-            "state", self.on_received_state, capture_errors=False, priority=QNetworkRequest.HighPriority
+            "state", self.on_received_state, capture_core_errors=False, priority=QNetworkRequest.HighPriority
         )
 
     def on_received_state(self, state):

--- a/src/tribler-gui/tribler_gui/dialogs/startdownloaddialog.py
+++ b/src/tribler-gui/tribler_gui/dialogs/startdownloaddialog.py
@@ -158,7 +158,7 @@ class StartDownloadDialog(DialogContainer):
         request = f"torrentinfo?uri={quote_plus_unicode(self.download_uri)}"
         if direct is True:
             request = request + f"&hops=0"
-        self.rest_request = TriblerNetworkRequest(request, self.on_received_metainfo, capture_errors=False)
+        self.rest_request = TriblerNetworkRequest(request, self.on_received_metainfo, capture_core_errors=False)
 
         if self.metainfo_retries <= METAINFO_MAX_RETRIES:
             fetch_mode = 'directly' if direct else 'anonymously'

--- a/src/tribler-gui/tribler_gui/tribler_window.py
+++ b/src/tribler-gui/tribler_gui/tribler_window.py
@@ -603,7 +603,7 @@ class TriblerWindow(QMainWindow):
         self.search_completion_model.setStringList(completions["completions"])
 
     def fetch_settings(self):
-        TriblerNetworkRequest("settings", self.received_settings, capture_errors=False)
+        TriblerNetworkRequest("settings", self.received_settings, capture_core_errors=False)
 
     def received_settings(self, settings):
         if not settings:
@@ -679,7 +679,7 @@ class TriblerWindow(QMainWindow):
         self.navigation_stack = []
 
     def load_token_balance(self):
-        TriblerNetworkRequest("trustchain/statistics", self.received_trustchain_statistics, capture_errors=False)
+        TriblerNetworkRequest("trustchain/statistics", self.received_trustchain_statistics, capture_core_errors=False)
 
     def received_trustchain_statistics(self, statistics):
         if not statistics or "statistics" not in statistics:

--- a/src/tribler-gui/tribler_gui/widgets/torrentdetailstabwidget.py
+++ b/src/tribler-gui/tribler_gui/widgets/torrentdetailstabwidget.py
@@ -177,7 +177,7 @@ class TorrentDetailsTabWidget(QTabWidget):
             "metadata/torrents/%s/health" % infohash,
             self.on_health_response,
             url_params={"nowait": True, "refresh": True},
-            capture_errors=False,
+            capture_core_errors=False,
             priority=QNetworkRequest.LowPriority,
             on_cancel=on_cancel_health_check,
         )


### PR DESCRIPTION
Beware!
Calls to PyQT signal callbacks **drop unexpected arguments**!

E.g.
```
s = Signal(int, int)

def foo(a):
    print(a)

s.connect(foo)
s.emit(1,2)
```
will perfectly print `1` and just **ignore** the second argument :exploding_head: 

I should probably report it to PyQT list...
