### PR TITLE
Fix popularity community

### DIFF
--- a/src/tribler-core/tribler_core/modules/torrent_checker/test_torrentchecker.py
+++ b/src/tribler-core/tribler_core/modules/torrent_checker/test_torrentchecker.py
@@ -228,18 +228,19 @@ class TestTorrentChecker(TestAsServer):
             ts = self.session.mds.TorrentState(infohash=infohash_bin)
             previous_check = ts.last_check
             self.torrent_checker.on_torrent_health_check_completed(infohash_bin, result)
+            self.assertEqual(1, len(self.torrent_checker.torrents_checked))
             self.assertEqual(result[2]['DHT'][0]['leechers'], ts.leechers)
             self.assertEqual(result[2]['DHT'][0]['seeders'], ts.seeders)
             self.assertLess(previous_check, ts.last_check)
 
     def test_on_health_check_failed(self):
         """
-        Check whether there is no crash when the torrent health check failed and the response is None
+        Check whether there is no crash when the torrent health check failed and the response is None.
+        No torrent info is added to torrent_checked list.
         """
         infohash_bin = b'\xee' * 20
         self.torrent_checker.on_torrent_health_check_completed(infohash_bin, [None])
-        self.assertEqual(1, len(self.torrent_checker.torrents_checked))
-        self.assertEqual(0, list(self.torrent_checker.torrents_checked)[0][1])
+        self.assertEqual(0, len(self.torrent_checker.torrents_checked))
 
     @db_session
     def test_check_random_torrent(self):

--- a/src/tribler-core/tribler_core/modules/torrent_checker/torrent_checker.py
+++ b/src/tribler-core/tribler_core/modules/torrent_checker/torrent_checker.py
@@ -29,6 +29,7 @@ MIN_TORRENT_CHECK_INTERVAL = 900   # How much time we should wait before checkin
 TORRENT_CHECK_RETRY_INTERVAL = 30  # Interval when the torrent was successfully checked for the last time
 MAX_TORRENTS_CHECKED_PER_SESSION = 50
 
+
 class TorrentChecker(TaskManager):
 
     def __init__(self, session):
@@ -208,7 +209,8 @@ class TorrentChecker(TaskManager):
         """
         new_result_tuple = (new_result['infohash'], new_result['seeders'],
                             new_result['leechers'], new_result['last_check'])
-        self.torrents_checked.add(new_result_tuple)
+        if new_result['seeders'] > 0:
+            self.torrents_checked.add(new_result_tuple)
 
     def on_torrent_health_check_completed(self, infohash, result):
         final_response = {}

--- a/src/tribler-core/tribler_core/session.py
+++ b/src/tribler-core/tribler_core/session.py
@@ -406,6 +406,12 @@ class Session(TaskManager):
 
         self.tracker_manager = TrackerManager(self)
 
+        # Start torrent checker before Popularity community is loaded
+        if self.config.get_torrent_checking_enabled():
+            self.readable_status = STATE_START_TORRENT_CHECKER
+            self.torrent_checker = TorrentChecker(self)
+            await self.torrent_checker.initialize()
+
         # On Mac, we bundle the root certificate for the SSL validation since Twisted is not using the root
         # certificates provided by the system trust store.
         if sys.platform == 'darwin':
@@ -455,11 +461,6 @@ class Session(TaskManager):
             self.readable_status = STATE_LOAD_CHECKPOINTS
             await self.dlmgr.load_checkpoints()
         self.readable_status = STATE_READABLE_STARTED
-
-        if self.config.get_torrent_checking_enabled():
-            self.readable_status = STATE_START_TORRENT_CHECKER
-            self.torrent_checker = TorrentChecker(self)
-            await self.torrent_checker.initialize()
 
         if self.config.get_dummy_wallets_enabled():
             # For debugging purposes, we create dummy wallets


### PR DESCRIPTION
- Fixes a bug on that popularity community was not receiving torrent checker instance because of which no popular torrents are shared in the community.
- Now the popularity community only shares alive torrents