### PR TITLE
Added venv build option, fixed installation name of PIL in dependencies

### DIFF
--- a/build/debian/makedist_debian.sh
+++ b/build/debian/makedist_debian.sh
@@ -8,6 +8,11 @@ then
   echo "Please run this script from project root as:\n./build/debian/makedist_debian.sh"
 fi
 
+if [ ! -z "$VENV" ]; then
+  echo "Setting venv to $VENV"
+  source $VENV/bin/activate
+fi
+
 rm -rf build/tribler
 rm -rf dist/tribler
 rm -rf build/debian/tribler/usr/share/tribler

--- a/src/tribler-core/tribler_core/dependencies.py
+++ b/src/tribler-core/tribler_core/dependencies.py
@@ -22,7 +22,7 @@ dependencies = [
     {'module': 'lz4', 'install_type': 'pip3', 'package': 'lz4', 'optional': False, 'scope': 'core'},
     {'module': 'netifaces', 'install_type': 'pip3', 'package': 'netifaces', 'optional': False, 'scope': 'core'},
     {'module': 'networkx', 'install_type': 'pip3', 'package': 'networkx', 'optional': False, 'scope': 'both'},
-    {'module': 'PIL', 'install_type': 'pip3', 'package': 'PIL', 'optional': False, 'scope': 'gui'},
+    {'module': 'PIL', 'install_type': 'pip3', 'package': 'Pillow', 'optional': False, 'scope': 'gui'},
     {'module': 'pony', 'install_type': 'pip3', 'package': 'pony>=0.7.10', 'optional': False, 'scope': 'core'},
     {'module': 'psutil', 'install_type': 'pip3', 'package': 'psutil', 'optional': False, 'scope': 'both'},
     {'module': 'pyasn1', 'install_type': 'pip3', 'package': 'pyasn1', 'optional': False, 'scope': 'core'},


### PR DESCRIPTION
These commits are on `devel` already, but not in the `release-7.5` branch. The `VENV` option is required to build Tribler on our Ubuntu 18.04 machine and to fix #5533.