### PR TITLE
Added ipv8 walk_interval scaling

### DIFF
--- a/src/tribler-core/tribler_core/config/test_tribler_config.py
+++ b/src/tribler-core/tribler_core/config/test_tribler_config.py
@@ -155,6 +155,12 @@ def test_get_set_methods_ipv8(tribler_config):
     assert tribler_config.get_ipv8_bootstrap_override() == ("127.0.0.1", 12345)
     tribler_config.set_ipv8_statistics(True)
     assert tribler_config.get_ipv8_statistics()
+    tribler_config.set_ipv8_walk_interval(0.77)
+    assert tribler_config.get_ipv8_walk_interval() == 0.77
+    tribler_config.set_ipv8_walk_scaling_enabled(False)
+    assert not tribler_config.get_ipv8_walk_scaling_enabled()
+    tribler_config.set_ipv8_walk_scaling_upper_limit(9.6)
+    assert tribler_config.get_ipv8_walk_scaling_upper_limit() == 9.6
 
 
 def test_get_set_methods_libtorrent(tribler_config):

--- a/src/tribler-core/tribler_core/config/tribler_config.py
+++ b/src/tribler-core/tribler_core/config/tribler_config.py
@@ -301,6 +301,24 @@ class TriblerConfig(object):
     def get_ipv8_statistics(self):
         return self.config['ipv8']['statistics']
 
+    def set_ipv8_walk_interval(self, value: float) -> None:
+        self.config['ipv8']['walk_interval'] = value
+
+    def get_ipv8_walk_interval(self) -> float:
+        return self.config['ipv8']['walk_interval']
+
+    def set_ipv8_walk_scaling_enabled(self, value: bool) -> None:
+        self.config['ipv8']['walk_scaling_enabled'] = value
+
+    def get_ipv8_walk_scaling_enabled(self) -> bool:
+        return self.config['ipv8']['walk_scaling_enabled']
+
+    def set_ipv8_walk_scaling_upper_limit(self, value: float) -> None:
+        self.config['ipv8']['walk_scaling_upper_limit'] = value
+
+    def get_ipv8_walk_scaling_upper_limit(self) -> float:
+        return self.config['ipv8']['walk_scaling_upper_limit']
+
     # Libtorrent
 
     def set_libtorrent_enabled(self, value):

--- a/src/tribler-core/tribler_core/config/tribler_config.spec
+++ b/src/tribler-core/tribler_core/config/tribler_config.spec
@@ -81,6 +81,9 @@ port = integer(min=-1, max=65536, default=7759)
 address = string(default='0.0.0.0')
 bootstrap_override = string(default='')
 statistics = boolean(default=False)
+walk_interval = float(default=0.5)
+walk_scaling_enabled = boolean(default=True)
+walk_scaling_upper_limit = float(default=3.0)
 
 [video_server]
 enabled = boolean(default=True)

--- a/src/tribler-core/tribler_core/modules/ipv8_health_monitor.py
+++ b/src/tribler-core/tribler_core/modules/ipv8_health_monitor.py
@@ -1,0 +1,89 @@
+import logging
+import statistics
+import time
+
+from ipv8.REST.asyncio_endpoint import DriftMeasurementStrategy
+from ipv8.taskmanager import TaskManager
+
+from ipv8_service import IPv8
+
+
+class IPv8Monitor:
+    """
+    Monitor the state of IPv8 and adjust its walk_interval accordingly.
+    """
+
+    def __init__(self,
+                 ipv8_instance: IPv8,
+                 min_update_rate: float,
+                 max_update_rate: float,
+                 choke_limit: float = 0.01) -> None:
+        """
+        Monitor an IPv8 instance and modulate its walk_interval between the minimum and maximum update rates.
+        This uses a hard limit to distinguish choke from noise in the congestion.
+
+        :param ipv8_instance: the IPv8 instance to modulate the walk_interval for.
+        :param min_update_rate: the minimum time between steps (in seconds).
+        :param max_update_rate: the maximum time between steps (in seconds).
+        :param choke_limit: the noise limit for choke detection (in seconds).
+        """
+        super(IPv8Monitor, self).__init__()
+
+        self.ipv8_instance = ipv8_instance
+        self.min_update_rate = min_update_rate
+        self.max_update_rate = max_update_rate
+        self.choke_limit = choke_limit
+
+        self.measurement_strategy = DriftMeasurementStrategy(min_update_rate)
+        self.current_rate = min_update_rate
+        self.last_check = time.time()
+        self.interval = 5.0
+
+        # 5 steps from slowest to fastest (with the default interval of 5 seconds, this takes 25 seconds).
+        self.speedup_step = (self.max_update_rate - self.min_update_rate)/5.0
+
+        self.logger = logging.getLogger(self.__class__.__name__)
+
+    def start(self, task_manager: TaskManager, interval: float = 5.0):
+        """
+        Insert this monitor into the IPv8 strategies and start scaling periodically scaling the walk_interval.
+
+        :param task_manager: The TaskManager to register our periodic check for.
+        :param interval: The time (in seconds) between checking the IPv8 health.
+        """
+        self.interval = interval
+        with self.ipv8_instance.overlay_lock:
+            self.ipv8_instance.strategies.append((self.measurement_strategy, -1))
+        task_manager.register_task("IPv8 auto-scaling", self.auto_scale_ipv8, interval=interval)
+
+    def auto_scale_ipv8(self):
+        """
+        Evaluate the IPv8 choking history and determine whether the walk_interval should be slowed down or sped up.
+        """
+        if self.last_check + self.interval > time.time():
+            # Periodic tasks have a nasty habit of not really caring about the interval.
+            return
+        self.last_check = time.time()
+
+        history = [record[1] for record in self.measurement_strategy.history
+                   if record[0] > self.last_check - self.interval]
+        median_time_taken = statistics.median(history) if history else 0.0
+
+        self.logger.debug("Mean drift: %f, choke detected: %s.",
+                          median_time_taken,
+                          str(median_time_taken > self.choke_limit))
+
+        # TCP-like AIMD (inverted)
+        if median_time_taken > self.choke_limit:
+            self.current_rate = min(self.max_update_rate, self.current_rate * 1.5)
+        else:
+            self.current_rate = max(self.min_update_rate, self.current_rate - self.speedup_step)
+
+        self.logger.debug("Current walk_interval: %f.", self.current_rate)
+
+        self.ipv8_instance.walk_interval = self.current_rate
+
+        with self.ipv8_instance.overlay_lock:
+            for strategy, _ in self.ipv8_instance.strategies:
+                if isinstance(strategy, DriftMeasurementStrategy):
+                    strategy.core_update_rate = self.current_rate

--- a/src/tribler-core/tribler_core/modules/tests/test_ipv8_health_manager.py
+++ b/src/tribler-core/tribler_core/modules/tests/test_ipv8_health_manager.py
@@ -1,0 +1,123 @@
+"""
+Tests for the IPv8Monitor.
+By design, these tests only test if the IPv8 walk_interval is appropriately scaled.
+These tests do not test how much the walk_interval is scaled.
+"""
+import threading
+import time
+
+import pytest
+
+from ipv8.taskmanager import TaskManager
+
+from tribler_core.modules.ipv8_health_monitor import IPv8Monitor
+
+
+DEFAULT_WALK_INTERVAL = 0.5
+
+
+@pytest.fixture(name="ipv8")
+def fixture_ipv8():
+    return type("IPv8", (object, ), {
+        "strategies": [],
+        "overlay_lock": threading.RLock(),
+        "walk_interval": DEFAULT_WALK_INTERVAL
+    })
+
+
+@pytest.fixture(name="task_manager")
+async def fixture_task_manager():
+    task_manager = TaskManager()
+    yield task_manager
+    await task_manager.shutdown_task_manager()
+
+
+@pytest.fixture(name="ipv8_health_monitor")
+def fixture_ipv8_health_monitor(ipv8):
+    return IPv8Monitor(ipv8, DEFAULT_WALK_INTERVAL, 3.0, 0.01)
+
+
+@pytest.mark.asyncio
+async def test_start(task_manager, ipv8_health_monitor):
+    mock_interval = 7.7
+
+    ipv8_health_monitor.start(task_manager, mock_interval)
+
+    assert len(task_manager.get_tasks()) == 1
+    assert ipv8_health_monitor.interval == mock_interval
+
+
+def test_choke_exceed(ipv8_health_monitor):
+    """
+    We should slow down, if choke is detected.
+    """
+    ipv8_health_monitor.measurement_strategy.history = [(time.time(), 2 * ipv8_health_monitor.choke_limit)]
+    ipv8_health_monitor.last_check = 0
+
+    ipv8_health_monitor.auto_scale_ipv8()
+
+    assert ipv8_health_monitor.ipv8_instance.walk_interval > DEFAULT_WALK_INTERVAL
+
+
+def test_choke_exceed_maximum(ipv8_health_monitor):
+    """
+    We should not change, if choke is detected and we are already at the slowest speed.
+    """
+    ipv8_health_monitor.measurement_strategy.history = [(time.time(), 2 * ipv8_health_monitor.choke_limit)]
+    ipv8_health_monitor.last_check = 0
+    ipv8_health_monitor.current_rate = ipv8_health_monitor.max_update_rate
+
+    ipv8_health_monitor.auto_scale_ipv8()
+
+    assert ipv8_health_monitor.ipv8_instance.walk_interval == ipv8_health_monitor.max_update_rate
+
+
+def test_no_choke(ipv8_health_monitor):
+    """
+    We should speed up our walk_interval if we're not choked.
+    """
+    ipv8_health_monitor.measurement_strategy.history = [(time.time(), ipv8_health_monitor.choke_limit)]
+    ipv8_health_monitor.last_check = 0
+    ipv8_health_monitor.current_rate = ipv8_health_monitor.max_update_rate
+
+    ipv8_health_monitor.auto_scale_ipv8()
+
+    assert ipv8_health_monitor.ipv8_instance.walk_interval < ipv8_health_monitor.max_update_rate
+
+
+def test_no_choke_minimum(ipv8_health_monitor):
+    """
+    We should not change our walk_interval if we're already at the minimum.
+    """
+    ipv8_health_monitor.measurement_strategy.history = [(time.time(), ipv8_health_monitor.choke_limit)]
+    ipv8_health_monitor.last_check = 0
+    ipv8_health_monitor.current_rate = ipv8_health_monitor.min_update_rate
+
+    ipv8_health_monitor.auto_scale_ipv8()
+
+    assert ipv8_health_monitor.ipv8_instance.walk_interval == DEFAULT_WALK_INTERVAL
+
+
+def test_intialize_minimum(ipv8_health_monitor):
+    """
+    We should not deviate from the minimum update rate if we don't have a history.
+    """
+    ipv8_health_monitor.measurement_strategy.history = []
+    ipv8_health_monitor.last_check = 0
+
+    ipv8_health_monitor.auto_scale_ipv8()
+
+    assert ipv8_health_monitor.ipv8_instance.walk_interval == DEFAULT_WALK_INTERVAL
+
+
+def test_update_rate(ipv8_health_monitor):
+    """
+    We should not update our rate when the last check was within the interval.
+    """
+    ipv8_health_monitor.measurement_strategy.history = [(time.time(), ipv8_health_monitor.choke_limit)]
+    ipv8_health_monitor.current_rate = ipv8_health_monitor.max_update_rate
+    ipv8_health_monitor.ipv8_instance.walk_interval = ipv8_health_monitor.max_update_rate
+
+    ipv8_health_monitor.auto_scale_ipv8()
+
+    assert ipv8_health_monitor.ipv8_instance.walk_interval == ipv8_health_monitor.max_update_rate

--- a/src/tribler-gui/tribler_gui/widgets/ipv8health.py
+++ b/src/tribler-gui/tribler_gui/widgets/ipv8health.py
@@ -29,8 +29,9 @@ class MonitorWidget(QWidget):
 
         self.update_lock = threading.Lock()
         self.draw_times = []
-        self.median_drift = "-"
-        self.mean_drift = "-"
+        self.median_drift = "?"
+        self.mean_drift = "?"
+        self.walk_interval_target = "?"
 
         self.timer = QTimer()
         self.timer.timeout.connect(self.repaint)
@@ -60,9 +61,16 @@ class MonitorWidget(QWidget):
                 drifts = [entry[1] for entry in self.draw_times]
                 self.median_drift = round(statistics.median(drifts), 5)
                 self.mean_drift = round(statistics.mean(drifts), 5)
+                if len(drifts) > 1:
+                    self.walk_interval_target = round(self.draw_times[-1][0]
+                                                      - self.draw_times[-2][0]
+                                                      - self.draw_times[-1][1], 4)
+                else:
+                    self.walk_interval_target = "?"
             else:
-                self.median_drift = "-"
-                self.mean_drift = "-"
+                self.median_drift = "?"
+                self.mean_drift = "?"
+                self.walk_interval_target = "?"
 
     def paintEvent(self, e):
         painter = QPainter()
@@ -85,8 +93,9 @@ class MonitorWidget(QWidget):
 
         # Draw the statistics
         painter.setPen(Qt.white)
-        painter.drawText(0, 20, f" Mean:\t{self.mean_drift}")
-        painter.drawText(0, 40, f" Median:\t{self.median_drift}")
+        painter.drawText(0, 20, f" Target:\t{self.walk_interval_target}")
+        painter.drawText(0, 40, f" Mean:\t+{self.mean_drift}")
+        painter.drawText(0, 60, f" Median:\t+{self.median_drift}")
 
         # Draw the baseline frequency bands (a perfect score of 0.0 drift).
         midy = (size.height() - 1) // 2


### PR DESCRIPTION
Fixes #5384 

This PR addresses scaling back IPv8's bandwidth and CPU use while the main thread is congested. Concretely, this PR makes the following changes:

 - Adds a configuration option for enabling IPv8 auto scaling (enabled by default).
 - Adds a configuration option for the IPv8 `walk_interval`.
 - Adds a configuration option for the upper limit the `walk_interval` may grow to, if scaling is enabled.
 - Adds the `IPv8Monitor` class (and tests), to measure the main thread choking and scale the `walk_interval` accordingly.
 - Adds the `IPv8Monitor` to the `Session` IPv8 initialization.
 - Updates the IPv8 initialization in `Session` to use the new `ConfigBuilder`.
 - Updates the IPv8 health debug screen to show the current target `walk_interval`.
 - Updates the IPv8 pointer (fixes a bug where inspecting the debug IPv8 health interferes with this code).