### PR TITLE
Marked a few tests as flaky

### DIFF
--- a/src/tribler-core/tribler_core/modules/metadata_store/tests/test_store.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/tests/test_store.py
@@ -81,6 +81,7 @@ def test_process_channel_dir_file(tmpdir, metadata_store):
 
 
 @db_session
+@pytest.mark.flaky
 def test_squash_mdblobs(metadata_store):
     chunk_size = metadata_store.ChannelMetadata._CHUNK_SIZE_LIMIT
     md_list = [
@@ -102,6 +103,7 @@ def test_squash_mdblobs(metadata_store):
 
 
 @db_session
+@pytest.mark.flaky
 def test_squash_mdblobs_multiple_chunks(metadata_store):
     md_list = [
         metadata_store.TorrentMetadata(

--- a/src/tribler-core/tribler_core/modules/tunnel/test_full_session/test_tunnel_community.py
+++ b/src/tribler-core/tribler_core/modules/tunnel/test_full_session/test_tunnel_community.py
@@ -196,6 +196,7 @@ async def create_nodes(proxy_factory, num_relays=1, num_exitnodes=1):
 
 @pytest.mark.asyncio
 @pytest.mark.timeout(20)
+@pytest.mark.flaky
 async def test_anon_download(enable_ipv8, proxy_factory, session, video_seeder_session, video_tdef):
     """
     Testing whether an anonymous download over our tunnels works
@@ -217,6 +218,7 @@ async def test_anon_download(enable_ipv8, proxy_factory, session, video_seeder_s
 
 @pytest.mark.asyncio
 @pytest.mark.timeout(30)
+@pytest.mark.flaky
 async def test_hidden_services(enable_ipv8, proxy_factory, session, hidden_seeder_session, video_tdef):
     """
     Test the hidden services overlay by constructing an end-to-end circuit and downloading a torrent over it


### PR DESCRIPTION
In this PR, I'm using the `flaky` library to mark a few tests as flaky. A test that is marked as flaky is automatically executed again, and won't fail the entire run if it succeeds on the second try. I marked the following tests in particular:
- The tunnel tests. At this point, we had so much trouble with these tests that I decided to mark them as flaky. Making these tests non-flaky seems close to impossible with so many moving parts and Tribler sessions.
 -The mdblob squash tests. However, I still believe we should address #5392 and make this test non-flaky.