### PR TITLE
Revert flaky mark

### DIFF
--- a/src/tribler-core/tribler_core/modules/metadata_store/tests/test_store.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/tests/test_store.py
@@ -81,7 +81,6 @@ def test_process_channel_dir_file(tmpdir, metadata_store):
 
 
 @db_session
-@pytest.mark.flaky
 def test_squash_mdblobs(metadata_store):
     chunk_size = metadata_store.ChannelMetadata._CHUNK_SIZE_LIMIT
     md_list = [
@@ -103,7 +102,6 @@ def test_squash_mdblobs(metadata_store):
 
 
 @db_session
-@pytest.mark.flaky
 def test_squash_mdblobs_multiple_chunks(metadata_store):
     md_list = [
         metadata_store.TorrentMetadata(

--- a/src/tribler-core/tribler_core/modules/tunnel/test_full_session/test_tunnel_community.py
+++ b/src/tribler-core/tribler_core/modules/tunnel/test_full_session/test_tunnel_community.py
@@ -196,7 +196,6 @@ async def create_nodes(proxy_factory, num_relays=1, num_exitnodes=1):
 
 @pytest.mark.asyncio
 @pytest.mark.timeout(20)
-@pytest.mark.flaky
 async def test_anon_download(enable_ipv8, proxy_factory, session, video_seeder_session, video_tdef):
     """
     Testing whether an anonymous download over our tunnels works
@@ -218,7 +217,6 @@ async def test_anon_download(enable_ipv8, proxy_factory, session, video_seeder_s
 
 @pytest.mark.asyncio
 @pytest.mark.timeout(30)
-@pytest.mark.flaky
 async def test_hidden_services(enable_ipv8, proxy_factory, session, hidden_seeder_session, video_tdef):
     """
     Test the hidden services overlay by constructing an end-to-end circuit and downloading a torrent over it


### PR DESCRIPTION
[Due to a critical bug](https://github.com/box/flaky/issues/166), the flaky tool is not working with `pytest-asyncio`. Therefore, I'm removing the flaky marks again.