### PR TITLE
Set PYQTGRAPH_QT_LIB="PyQt5"

### DIFF
--- a/src/tribler.sh
+++ b/src/tribler.sh
@@ -15,6 +15,9 @@ export PYTHONPATH
 
 TRIBLER_SCRIPT=$SRC_DIR/run_tribler.py
 
+PYQTGRAPH_QT_LIB="PyQt5"
+export PYQTGRAPH_QT_LIB
+
 if [ "$UNAME" = "Linux" ]; then
     # Find the Tribler dir
     TRIBLER_DIR="$(dirname "$(readlink -f "$0")")"


### PR DESCRIPTION
PyQtGraph [prefers PyQt4](https://github.com/pyqtgraph/pyqtgraph/blob/0a8ad6b1aae733a2dbd5026b6b1011238aa75548/pyqtgraph/Qt.py#L29) when it and PyQt5 are installed side-by-side.
[This variable overrides](https://github.com/pyqtgraph/pyqtgraph/blob/0a8ad6b1aae733a2dbd5026b6b1011238aa75548/pyqtgraph/Qt.py#L22) that preference to PyQt5 as required by Tribler.

Resolves issue #5605.