### PR TITLE
Set safe_seeding default to True

### DIFF
--- a/src/tribler-core/tribler_core/modules/libtorrent/download_config.spec
+++ b/src/tribler-core/tribler_core/modules/libtorrent/download_config.spec
@@ -2,7 +2,7 @@
 hops = integer(default=0)
 selected_files = string_list(default=list())
 selected_file_indexes = int_list(default=list())
-safe_seeding = boolean(default=False)
+safe_seeding = boolean(default=True)
 user_stopped = boolean(default=False)
 share_mode = boolean(default=False)
 upload_mode = boolean(default=False)


### PR DESCRIPTION
Partially resolves issue #5614 by enabling safe seeding by default. This change aligns the default download config with [the core `safeseeding_enabled` option](https://github.com/Tribler/tribler/blob/1900ab766b25166196fe38f469a128a63eb732d7/src/tribler-core/tribler_core/config/tribler_config.py#L530). The new default is a safer choice for people who need the anonymity offered by Tribler.

This doesn’t fix the real issue of this being two different settings for the same thing with only one of them being toggleable in the UI.