### PR TITLE
Add requirements-test.txt

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,32 @@
+# Run Tribler
+
+Full instruction: [install requirements](https://github.com/Tribler/tribler#setting-up-your-development-environment)
+
+```
+python3 -m pip install -r requirements.txt
+
+tribler.sh
+```
+
+# Run Tests
+
+Install all necessary dependencies:
+```
+python3 -m pip install -r requirements-test.txt
+```
+Note: `requirements-test.txt` already contains all requirements 
+from` requirements.txt`.
+
+##
+
+Export to PYTHONPATH the following directories:
+
+* tribler-common
+* tribler-core
+* tribler-gui
+
+Execute:
+```
+python3 -m pytest tribler-core
+python3 -m pytest tribler-gui --guitests
+```

--- a/src/requirements-test.txt
+++ b/src/requirements-test.txt
@@ -1,0 +1,11 @@
+-r requirements.txt
+
+pytest
+pytest-asyncio                        
+pytest-cov                            
+pytest-mock
+pytest-randomly                        
+pytest-timeout                         
+pytest-xdist
+
+asynctest


### PR DESCRIPTION
## The problem

We have two environments: 
* Pure Tribler
* Test Tribler

Pure Tribler installs only necessary dependencies, they located in [src/requirements.txt](https://github.com/drew2a/tribler/blob/requirements-dev/src/requirements.txt).

But there is no documentation and no `requirements.txt` for the Test Tribler.

## Solution

I've added [src/requirements-dev.txt](https://github.com/drew2a/tribler/blob/requirements-dev/src/requirements-dev.txt) and [small instruction](https://github.com/drew2a/tribler/blob/requirements-dev/src/README.md) on how to run tests.

Maybe `requirements-dev.txt` is a bad name, and better to use `requirements-test.txt`.

What do you think?