### PR TITLE
Added anonymization support to TorrentChecker

### DIFF
--- a/src/tribler-core/tribler_core/modules/torrent_checker/test_torrentchecker.py
+++ b/src/tribler-core/tribler_core/modules/torrent_checker/test_torrentchecker.py
@@ -121,7 +121,7 @@ async def test_task_select_tracker(enable_chant, torrent_checker, session):
         tracker = session.mds.TrackerState(url="http://localhost/tracker")
         session.mds.TorrentState(infohash=b'a' * 20, seeders=5, leechers=10, trackers={tracker})
 
-    controlled_session = HttpTrackerSession("127.0.0.1", ("localhost", 8475), "/announce", 5)
+    controlled_session = HttpTrackerSession("127.0.0.1", ("localhost", 8475), "/announce", 5, None)
     controlled_session.connect_to_tracker = lambda: succeed(None)
 
     torrent_checker._create_session_for_request = lambda *args, **kwargs: controlled_session

--- a/src/tribler-core/tribler_core/modules/tunnel/community/dispatcher.py
+++ b/src/tribler-core/tribler_core/modules/tunnel/community/dispatcher.py
@@ -95,6 +95,7 @@ class TunnelDispatcher(TaskManager):
 
         if response:
             tcp_connection.transport.write(response)
+        tcp_connection.transport.close()
 
     def select_circuit(self, connection, request):
         if request.destination[1] == CIRCUIT_ID_PORT:
@@ -118,6 +119,7 @@ class TunnelDispatcher(TaskManager):
                 self._logger.debug("Failed to create circuit for data to %s", request.destination)
                 return None
             self._logger.debug("Creating circuit for data to %s. Retrying later..", request.destination)
+            self.cid_to_con[circuit.circuit_id] = connection
             circuit.ready.add_done_callback(lambda f, c=connection.udp_connection, r=request:
                                             self.on_socks5_udp_data(c, r) if f.result() else None)
             return None

--- a/src/tribler-core/tribler_core/modules/tunnel/community/dispatcher.py
+++ b/src/tribler-core/tribler_core/modules/tunnel/community/dispatcher.py
@@ -1,4 +1,5 @@
-import logging
+import random
+from collections import defaultdict
 
 from ipv8.messaging.anonymization.tunnel import (
     CIRCUIT_ID_PORT,
@@ -17,87 +18,76 @@ class TunnelDispatcher(TaskManager):
     This dispatcher acts as a "secondary" proxy between the SOCKS5 UDP session and the tunnel community.
     """
 
-    def __init__(self, tunnel_community):
-        super(TunnelDispatcher, self).__init__()
-        self.tunnel_community = tunnel_community
+    def __init__(self, tunnels):
+        super().__init__()
+        self.tunnels = tunnels
         self.socks_servers = []
 
         # Map to keep track of the circuits associated with each destination.
-        self.destinations = {}
+        self.con_to_cir = defaultdict(dict)
 
         # Map to keep track of the circuit id to UDP connection.
-        self.circuit_id_to_connection = {}
+        self.cid_to_con = {}
+
+        self.register_task('check_connections', self.check_connections, interval=30)
 
     def set_socks_servers(self, socks_servers):
         self.socks_servers = socks_servers
-        self.destinations = {(ind + 1): {} for ind, _ in enumerate(self.socks_servers)}
 
-    def on_incoming_from_tunnel(self, community, circuit, origin, data, force=False):
+    def on_incoming_from_tunnel(self, community, circuit, origin, data):
         """
         We received some data from the tunnel community. Dispatch it to the right UDP SOCKS5 socket.
         """
         if circuit.ctype in [CIRCUIT_TYPE_RP_DOWNLOADER, CIRCUIT_TYPE_RP_SEEDER]:
             origin = (community.circuit_id_to_ip(circuit.circuit_id), CIRCUIT_ID_PORT)
-        session_hops = circuit.goal_hops if circuit.ctype != CIRCUIT_TYPE_RP_DOWNLOADER else circuit.goal_hops - 1
 
-        if session_hops > len(self.socks_servers):
-            self._logger.error("No socks server found for %d hops", session_hops)
+        try:
+            connection = self.cid_to_con[circuit.circuit_id]
+        except KeyError:
+            session_hops = circuit.goal_hops if circuit.ctype != CIRCUIT_TYPE_RP_DOWNLOADER else circuit.goal_hops - 1
+            if session_hops > len(self.socks_servers) or not self.socks_servers[session_hops - 1].sessions:
+                self._logger.error("No connection found for %d hops", session_hops)
+                return False
+            connection = next((s for s in self.socks_servers[session_hops - 1].sessions
+                               if s.udp_connection and s.udp_connection.remote_udp_address), None)
+
+        if connection is None or connection.udp_connection is None:
+            self._logger.error("Connection has closed or has not gotten an UDP associate")
+            self.connection_dead(connection)
             return False
 
-        sock_server = self.socks_servers[session_hops - 1]
-
-        sent = False
-        destinations = self.destinations[session_hops]
-        if circuit in destinations.values() or force:
-            destinations[origin] = circuit
-
-            sessions = [self.circuit_id_to_connection[circuit.circuit_id]] \
-                if circuit.circuit_id in self.circuit_id_to_connection else sock_server.sessions
-
-            for session in sessions:
-                if session._udp_socket:
-                    socks5_data = conversion.encode_udp_packet(
-                        0, 0, conversion.ADDRESS_TYPE_IPV4, origin[0], origin[1], data)
-                    session._udp_socket.sendDatagram(socks5_data)
-                    sent = True
-
-        return sent
+        packet = conversion.encode_udp_packet(0, 0, conversion.ADDRESS_TYPE_IPV4, *origin, data)
+        connection.udp_connection.send_datagram(packet)
+        return True
 
     def on_socks5_udp_data(self, udp_connection, request):
         """
-        We received some data from the SOCKS5 server (from libtorrent). This methods selects a circuit to
-        send this data over to the final destination.
+        We received some data from the SOCKS5 server (from the SOCKS5 client). This method
+        selects a circuit to send this data over to the final destination.
         """
-        hops = self.socks_servers.index(udp_connection.socksconnection.socksserver) + 1
-
-        destination = request.destination
-        if destination not in self.destinations[hops]:
-            selected_circuit = self.tunnel_community.select_circuit(destination, hops)
-            if not selected_circuit:
+        circuit = None
+        connection = udp_connection.socksconnection
+        try:
+            circuit = self.con_to_cir[connection][request.destination]
+        except KeyError:
+            circuit = circuit or self.select_circuit(connection, request)
+            if circuit is None:
                 return False
 
-            self.destinations[hops][destination] = selected_circuit
-            self._logger.debug("SELECT circuit %d for %s", self.destinations[hops][destination].circuit_id,
-                               destination)
-        circuit = self.destinations[hops][destination]
-
         if circuit.state != CIRCUIT_STATE_READY:
-            self._logger.debug(
-                "Circuit is not ready, dropping %d bytes to %s", len(request.payload), request.destination)
+            self._logger.debug("Circuit not ready, dropping %d bytes to %s", len(request.payload), request.destination)
             return False
 
-        self._logger.debug("Sending data over circuit destined for %r:%r", *request.destination)
-        self.circuit_id_to_connection[circuit.circuit_id] = udp_connection.socksconnection
-        self.tunnel_community.send_data(circuit.peer, circuit.circuit_id, request.destination,
-                                        ('0.0.0.0', 0), request.payload)
+        self._logger.debug("Sending data over circuit %d destined for %r:%r", circuit.circuit_id, *request.destination)
+        self.tunnels.send_data(circuit.peer, circuit.circuit_id, request.destination, ('0.0.0.0', 0), request.payload)
         return True
 
     @task
     async def on_socks5_tcp_data(self, tcp_connection, destination, request):
-        self._logger.debug('Got request for %s: %s', destination, request)
+        self._logger.debug("Got request for %s: %s", destination, request)
         hops = self.socks_servers.index(tcp_connection.socksserver) + 1
         try:
-            response = await self.tunnel_community.perform_http_request(destination, request, hops)
+            response = await self.tunnels.perform_http_request(destination, request, hops)
             self._logger.debug('Got response from %s: %s', destination, response)
         except RuntimeError as e:
             self._logger.info('Failed to get HTTP response using tunnels: %s', e)
@@ -106,26 +96,62 @@ class TunnelDispatcher(TaskManager):
         if response:
             tcp_connection.transport.write(response)
 
+    def select_circuit(self, connection, request):
+        if request.destination[1] == CIRCUIT_ID_PORT:
+            circuit = self.tunnels.circuits.get(self.tunnels.ip_to_circuit_id(request.destination[0]))
+            if circuit and circuit.state == CIRCUIT_STATE_READY and circuit.ctype in [CIRCUIT_TYPE_RP_DOWNLOADER,
+                                                                                      CIRCUIT_TYPE_RP_SEEDER]:
+                return circuit
+
+        hops = self.socks_servers.index(connection.socksserver) + 1
+        options = [c for c in self.tunnels.circuits.values()
+                   if c.goal_hops == hops and c.state == CIRCUIT_STATE_READY
+                   and self.cid_to_con.get(c.circuit_id, connection) == connection]
+        if not options:
+            # We allow each connection to claim at least 1 circuit. If no such circuit exists we'll create one.
+            if connection in self.cid_to_con.values():
+                self._logger.debug("No circuit for sending data to %s", request.destination)
+                return None
+
+            circuit = self.tunnels.create_circuit(goal_hops=hops)
+            if circuit is None:
+                self._logger.debug("Failed to create circuit for data to %s", request.destination)
+                return None
+            self._logger.debug("Creating circuit for data to %s. Retrying later..", request.destination)
+            circuit.ready.add_done_callback(lambda f, c=connection.udp_connection, r=request:
+                                            self.on_socks5_udp_data(c, r) if f.result() else None)
+            return None
+
+        circuit = random.choice(options)
+        self.cid_to_con[circuit.circuit_id] = connection
+        self.con_to_cir[connection][request.destination] = circuit
+        self._logger.debug("Select circuit %d for %s", circuit.circuit_id, request.destination)
+        return circuit
+
     def circuit_dead(self, broken_circuit):
         """
         When a circuit dies, we update the destinations dictionary and remove all peers that are affected.
         """
-        counter = 0
-        affected_destinations = set()
-        for hops, destinations in list(self.destinations.items()):
-            new_affected_destinations = set(destination for destination, tunnel_circuit in list(destinations.items())
-                                            if tunnel_circuit == broken_circuit)
-            for destination in new_affected_destinations:
-                if destination in self.destinations[hops]:
-                    del self.destinations[hops][destination]
-                    counter += 1
+        con = self.cid_to_con.pop(broken_circuit.circuit_id, None)
 
-            affected_destinations.update(new_affected_destinations)
+        destinations = set()
+        destination_to_circuit = self.con_to_cir.get(con, {})
+        for destination, circuit in list(destination_to_circuit.items()):
+            if circuit == broken_circuit:
+                destination_to_circuit.pop(destination, None)
+                destinations.add(destination)
 
-        if counter > 0:
-            self._logger.debug("Deleted %d peers from destination list", counter)
+        self._logger.debug("Deleted %d peers from destination list", len(destinations))
+        return destinations
 
-        if broken_circuit.circuit_id in self.circuit_id_to_connection:
-            self.circuit_id_to_connection.pop(broken_circuit.circuit_id, None)
+    def connection_dead(self, connection):
+        self.con_to_cir.pop(connection, None)
+        for cid, con in list(self.cid_to_con.items()):
+            if con == connection:
+                self.cid_to_con.pop(cid, None)
+        self._logger.error("Detected closed connection")
 
-        return affected_destinations
+    def check_connections(self):
+        for connection in list(self.cid_to_con.values()):
+            if not connection.udp_connection:
+                self.connection_dead(connection)

--- a/src/tribler-core/tribler_core/modules/tunnel/community/triblertunnel_community.py
+++ b/src/tribler-core/tribler_core/modules/tunnel/community/triblertunnel_community.py
@@ -595,7 +595,7 @@ class TriblerTunnelCommunity(HiddenTunnelCommunity):
 
         writer = None
         try:
-            with async_timeout.timeout(3):
+            with async_timeout.timeout(10):
                 self.logger.debug("Opening TCP connection to %s", target_address)
                 reader, writer = await open_connection(*target_address)
                 writer.write(payload.request)
@@ -624,7 +624,7 @@ class TriblerTunnelCommunity(HiddenTunnelCommunity):
         except (IndexError, RuntimeError):
             response_decoded = None
 
-        if response_decoded is None:
+        if response_decoded is None and not response.startswith(b'HTTP/1.1 307'):
             self.logger.warning('Tunnel HTTP request not allowed')
             return
 

--- a/src/tribler-core/tribler_core/modules/tunnel/community/triblertunnel_community.py
+++ b/src/tribler-core/tribler_core/modules/tunnel/community/triblertunnel_community.py
@@ -449,8 +449,7 @@ class TriblerTunnelCommunity(HiddenTunnelCommunity):
             self.readd_bittorrent_peers()
 
     def on_raw_data(self, circuit, origin, data):
-        anon_seed = circuit.ctype == CIRCUIT_TYPE_RP_SEEDER
-        self.dispatcher.on_incoming_from_tunnel(self, circuit, origin, data, anon_seed)
+        self.dispatcher.on_incoming_from_tunnel(self, circuit, origin, data)
 
     def monitor_downloads(self, dslist):
         # Monitor downloads with anonymous flag set, and build rendezvous/introduction points when needed.
@@ -562,8 +561,8 @@ class TriblerTunnelCommunity(HiddenTunnelCommunity):
                 lt_listen_port = self.tribler_session.dlmgr.listen_ports.get(hops)
                 lt_listen_port = lt_listen_port or self.tribler_session.dlmgr.get_session(hops).listen_port()
                 for session in self.socks_servers[hops - 1].sessions:
-                    if session.get_udp_socket() and lt_listen_port:
-                        session.get_udp_socket().remote_udp_address = ("127.0.0.1", lt_listen_port)
+                    if session.udp_connection and lt_listen_port:
+                        session.udp_connection.remote_udp_address = ("127.0.0.1", lt_listen_port)
         await super(TriblerTunnelCommunity, self).create_introduction_point(info_hash, required_ip=required_ip)
 
     async def unload(self):

--- a/src/tribler-core/tribler_core/modules/tunnel/socks5/aiohttp_connector.py
+++ b/src/tribler-core/tribler_core/modules/tunnel/socks5/aiohttp_connector.py
@@ -1,0 +1,42 @@
+import socket
+from asyncio import wait_for
+
+from aiohttp import TCPConnector
+from aiohttp.abc import AbstractResolver
+
+from tribler_core.modules.tunnel.socks5.client import Socks5Client
+
+
+class FakeResolver(AbstractResolver):
+
+    async def resolve(self, host, port=0, family=socket.AF_INET):
+        return [{'hostname': host,
+                 'host': host, 'port': port,
+                 'family': family, 'proto': 0,
+                 'flags': 0}]
+
+    async def close(self):
+        pass
+
+
+class Socks5Connector(TCPConnector):
+    def __init__(self, proxy_addr, **kwargs):
+        kwargs['resolver'] = FakeResolver()
+
+        super().__init__(**kwargs)
+        self.proxy_addr = proxy_addr
+
+    # pylint: disable=W0221
+    async def _wrap_create_connection(self, protocol_factory, host, port, **kwargs):
+        client = Socks5Client(self.proxy_addr, lambda *_: None)
+
+        if 'timeout' in kwargs and hasattr(kwargs['timeout'], 'sock_connect'):
+            await wait_for(client.connect_tcp((host, port)), timeout=kwargs['timeout'].sock_connect)
+        else:
+            await client.connect_tcp((host, port))
+
+        proto = protocol_factory()
+        transport = client.transport
+        transport._protocol = proto  # pylint: disable=W0212
+        proto.transport = transport
+        return transport, proto

--- a/src/tribler-core/tribler_core/modules/tunnel/socks5/client.py
+++ b/src/tribler-core/tribler_core/modules/tunnel/socks5/client.py
@@ -1,0 +1,153 @@
+import logging
+import socket
+from asyncio import DatagramProtocol, Protocol, Queue, get_event_loop
+
+from tribler_core.modules.tunnel.socks5.conversion import (
+    ADDRESS_TYPE_DOMAIN_NAME,
+    ADDRESS_TYPE_IPV4,
+    MethodRequest,
+    REQ_CMD_CONNECT,
+    REQ_CMD_UDP_ASSOCIATE,
+    Request,
+    SOCKS_AUTH_ANON,
+    SOCKS_VERSION,
+    decode_method_selection_message,
+    decode_reply,
+    decode_udp_packet,
+    encode_methods_request,
+    encode_request,
+    encode_udp_packet,
+)
+
+
+class Socks5Error(Exception):
+    pass
+
+
+class Socks5ClientUDPConnection(DatagramProtocol):
+
+    def __init__(self, callback):
+        self.callback = callback
+        self.transport = None
+        self.proxy_udp_addr = None
+
+    def connection_made(self, transport):
+        self.transport = transport
+
+    def datagram_received(self, data, _):
+        request = decode_udp_packet(data)
+        self.callback(request.payload, request.destination)
+
+    def sendto(self, data, target_addr):
+        packet = encode_udp_packet(0, 0, ADDRESS_TYPE_IPV4, *target_addr, data)
+        self.transport.sendto(packet, self.proxy_udp_addr)
+
+
+class Socks5Client(Protocol):
+    """
+    This object represents a minimal Socks5 client. Both TCP and UDP are supported.
+    """
+
+    def __init__(self, proxy_addr, callback):
+        self._logger = logging.getLogger(self.__class__.__name__)
+        self.proxy_addr = proxy_addr
+        self.callback = callback
+        self.transport = None
+        self.connection = None
+        self.connected_to = None
+        self.queue = Queue(maxsize=1)
+
+    def data_received(self, data):
+        if self.connected_to:
+            self.callback(data)
+        elif self.queue.empty():
+            self.queue.put_nowait(data)
+
+    def connection_lost(self, _):
+        self.transport = None
+
+    async def _send(self, data):
+        self.transport.write(data)
+        return await self.queue.get()
+
+    async def _login(self):
+        self.transport, _ = await get_event_loop().create_connection(lambda: self, *self.proxy_addr)
+
+        request = MethodRequest(SOCKS_VERSION, [SOCKS_AUTH_ANON])
+        response = await self._send(encode_methods_request(request))
+        version, auth_method = decode_method_selection_message(response)
+
+        if version != SOCKS_VERSION or auth_method != SOCKS_AUTH_ANON:
+            raise Socks5Error('Unsupported proxy server')
+
+    async def _associate_udp(self, local_addr=None):
+        local_addr = local_addr or ('127.0.0.1', 0)
+        connection = Socks5ClientUDPConnection(self.callback)
+        transport, _ = await get_event_loop().create_datagram_endpoint(lambda: connection, local_addr=local_addr)
+        sock = transport.get_extra_info("socket")
+
+        request = Request(SOCKS_VERSION, REQ_CMD_UDP_ASSOCIATE, 0, ADDRESS_TYPE_IPV4, *sock.getsockname())
+        response = await self._send(encode_request(request))
+        version, reply, _, bind_address, bind_port = decode_reply(response)
+        connection.proxy_udp_addr = (bind_address, bind_port[0])
+
+        if version != SOCKS_VERSION:
+            raise Socks5Error('Unsupported proxy server')
+
+        if reply > 0:
+            raise Socks5Error('UDP associate failed')
+
+        self.connection = connection
+
+    async def _connect_tcp(self, target_addr):
+        try:
+            socket.inet_aton(target_addr[0])
+            address_type = ADDRESS_TYPE_IPV4
+        except (ValueError, OSError):
+            address_type = ADDRESS_TYPE_DOMAIN_NAME
+
+        request = Request(SOCKS_VERSION, REQ_CMD_CONNECT, 0, address_type, *target_addr)
+        response = await self._send(encode_request(request))
+        version, reply, _, _, _ = decode_reply(response)
+
+        if version != SOCKS_VERSION:
+            raise Socks5Error('Unsupported proxy server')
+
+        if reply > 0:
+            raise Socks5Error('TCP connect failed')
+
+        self.connected_to = target_addr
+
+    @property
+    def connected(self):
+        return self.transport is not None and self.connected_to is not None
+
+    @property
+    def associated(self):
+        return self.transport is not None and self.connection is not None
+
+    async def associate_udp(self):
+        if self.connected:
+            raise Socks5Error(f'Client already used for connecting to {self.connected_to[0]}:{self.connected_to[1]}')
+
+        if not self.associated:
+            await self._login()
+            await self._associate_udp()
+
+    def sendto(self, data, target_addr):
+        if not self.associated:
+            raise Socks5Error('Not associated yet. First call associate_udp.')
+        self.connection.sendto(data, target_addr)
+
+    async def connect_tcp(self, target_addr):
+        if self.associated:
+            raise Socks5Error('Client already used for UDP communication')
+
+        if not self.connected:
+            await self._login()
+            await self._connect_tcp(target_addr)
+
+    def write(self, data):
+        if not self.connected:
+            raise Socks5Error('Not connected yet. First call connect_tcp.')
+        return self.transport.write(data)

--- a/src/tribler-core/tribler_core/modules/tunnel/socks5/tests/test_connection.py
+++ b/src/tribler-core/tribler_core/modules/tunnel/socks5/tests/test_connection.py
@@ -41,8 +41,8 @@ def connection():
     connection = Socks5Connection(None)
     connection.transport = MockTransport()
     yield connection
-    if connection._udp_socket:  # Close opened UDP sockets
-        connection._udp_socket.close()
+    if connection.udp_connection:  # Close opened UDP sockets
+        connection.udp_connection.close()
 
 
 def test_invalid_version(connection):

--- a/src/tribler-core/tribler_core/modules/tunnel/socks5/tests/test_conversion.py
+++ b/src/tribler-core/tribler_core/modules/tunnel/socks5/tests/test_conversion.py
@@ -1,85 +1,79 @@
 import struct
 
+from ipv8.messaging.serialization import PackError
+
 import pytest
 
 from tribler_core.modules.tunnel.socks5.conversion import (
     ADDRESS_TYPE_DOMAIN_NAME,
-    InvalidAddressException,
-    decode_request,
-    decode_udp_packet,
-    encode_reply,
-    encode_udp_packet,
+    CommandRequest,
+    CommandResponse,
+    UdpPacket,
+    socks5_serializer,
 )
-
-
-def test_decode_request():
-    """
-    Test the decoding process of a request
-    """
-    assert decode_request(0, struct.pack("!BBBB", 5, 0, 0, 5))[1] is None  # Invalid address type
-    assert decode_request(0, struct.pack("!BBBB", 5, 0, 0, 4))[1] is None  # IPv6
 
 
 def test_encode_decode_udp_packet():
     rsv = 0
     frag = 0
-    address_type = ADDRESS_TYPE_DOMAIN_NAME
-    address = 'tracker1.good-tracker.com'
-    port = 8084
-    payload = b'0x000'
-    encoded = encode_udp_packet(rsv, frag, address_type, address, port, payload)
-    decoded = decode_udp_packet(encoded)
+    address = ('tracker1.good-tracker.com', 8084)
+    data = b'0x000'
+    encoded = socks5_serializer.pack_serializable(UdpPacket(rsv, frag, (ADDRESS_TYPE_DOMAIN_NAME, *address), data))
+    decoded, _ = socks5_serializer.unpack_serializable(UdpPacket, encoded)
 
     assert rsv == decoded.rsv
     assert frag == decoded.frag
-    assert address_type == decoded.address_type
-    assert address == decoded.destination_host
+    assert address == decoded.destination
 
-    address = 'tracker1.unicode-tracker\xc4\xe95\x11$\x00'
-    encoded = encode_udp_packet(rsv, frag, address_type, address, port, payload)
-    decoded = decode_udp_packet(encoded)
+    address = ('tracker1.unicode-tracker\xc4\xe95\x11$\x00', 8084)
+    encoded = socks5_serializer.pack_serializable(UdpPacket(rsv, frag, (ADDRESS_TYPE_DOMAIN_NAME, *address), data))
+    decoded, _ = socks5_serializer.unpack_serializable(UdpPacket, encoded)
 
     assert rsv == decoded.rsv
     assert frag == decoded.frag
-    assert address_type == decoded.address_type
-    assert address == decoded.destination_host
+    assert address == decoded.destination
 
 
-def test_encode_decode_udp_packet_py3():
+def test_decode_udp_packet_fail():
     # try decoding badly encoded udp packet, should raise an exception in Python3
     badly_encoded_packet = b'\x00\x00\x00\x03 tracker1.invalid-tracker\xc4\xe95\x11$\x00\x1f\x940x000'
-    with pytest.raises(InvalidAddressException):
-        decode_udp_packet(badly_encoded_packet)
+    with pytest.raises(PackError):
+        socks5_serializer.unpack_serializable(UdpPacket, badly_encoded_packet)
 
 
-def test_encode_decode_packet():
+def test_encode_decode_command_request():
     rsv = 0
-    address_type = ADDRESS_TYPE_DOMAIN_NAME
-    bind_address = 'tracker1.good-tracker.com'
-    bind_port = 8084
+    address = ('tracker1.good-tracker.com', 8084)
     rep = 0
     version = 5
 
-    encoded = encode_reply(version, rep, rsv, address_type, bind_address, bind_port)
-    _, decoded = decode_request(0, encoded)
+    encoded = socks5_serializer.pack_serializable(CommandRequest(version, rep, rsv,
+                                                                 (ADDRESS_TYPE_DOMAIN_NAME, *address)))
+    decoded, _ = socks5_serializer.unpack_serializable(CommandRequest, encoded)
 
     assert version == decoded.version
     assert rsv == decoded.rsv
-    assert address_type == decoded.address_type
-    assert bind_address == decoded.destination_host
+    assert address == decoded.destination
 
-    bind_address = 'tracker1.unicode-tracker\xc4\xe95\x11$\x00'
-    encoded = encode_reply(version, rep, rsv, address_type, bind_address, bind_port)
-    _, decoded = decode_request(0, encoded)
+    address = ('tracker1.unicode-tracker\xc4\xe95\x11$\x00', 8084)
+    encoded = socks5_serializer.pack_serializable(CommandResponse(version, rep, rsv,
+                                                                  (ADDRESS_TYPE_DOMAIN_NAME, *address)))
+    decoded, _ = socks5_serializer.unpack_serializable(CommandResponse, encoded)
 
     assert version == decoded.version
     assert rsv == decoded.rsv
-    assert address_type == decoded.address_type
-    assert bind_address == decoded.destination_host
+    assert address == decoded.bind
 
 
-def test_encode_decode_packet_py3():
-    # try decoding badly encoded packet, should return None in Python3
+def test_decode_command_request_fail():
     badly_encoded = b'\x05\x00\x00\x03 tracker1.invalid-tracker\xc4\xe95\x11$\x00\x1f\x94'
-    _, decoded = decode_request(0, badly_encoded)
-    assert decoded is None
+    with pytest.raises(PackError):
+        socks5_serializer.unpack_serializable(CommandRequest, badly_encoded)
+
+    with pytest.raises(PackError):
+        # Invalid address type
+        socks5_serializer.unpack_serializable(CommandRequest, struct.pack("!BBBB", 5, 0, 0, 5))
+
+    with pytest.raises(PackError):
+        # IPv6
+        socks5_serializer.unpack_serializable(CommandRequest, struct.pack("!BBBB", 5, 0, 0, 4))

--- a/src/tribler-core/tribler_core/modules/tunnel/socks5/tests/test_server.py
+++ b/src/tribler-core/tribler_core/modules/tunnel/socks5/tests/test_server.py
@@ -3,8 +3,8 @@ from unittest.mock import Mock
 
 import pytest
 
-from tribler_core.modules.tunnel.socks5 import conversion
 from tribler_core.modules.tunnel.socks5.client import Socks5Client, Socks5Error
+from tribler_core.modules.tunnel.socks5.conversion import UdpPacket, socks5_serializer
 from tribler_core.modules.tunnel.socks5.server import Socks5Server
 
 
@@ -63,10 +63,10 @@ async def test_socks5_sendto_success(socks5_server):
     socks5_server.output_stream.on_socks5_udp_data.assert_called_once()
     connection = socks5_server.output_stream.on_socks5_udp_data.call_args[0][0]
     request = socks5_server.output_stream.on_socks5_udp_data.call_args[0][1]
-    assert request.payload == data
+    assert request.data == data
     assert request.destination == target
 
-    packet = conversion.encode_udp_packet(0, 0, conversion.ADDRESS_TYPE_IPV4, *target, data)
+    packet = socks5_serializer.pack_serializable(UdpPacket(0, 0, target, data))
     client.callback.assert_not_called()
     connection.send_datagram(packet)
     await sleep(0.1)

--- a/src/tribler-core/tribler_core/modules/tunnel/socks5/tests/test_server.py
+++ b/src/tribler-core/tribler_core/modules/tunnel/socks5/tests/test_server.py
@@ -1,11 +1,16 @@
+from asyncio import sleep
+from unittest.mock import Mock
+
 import pytest
 
+from tribler_core.modules.tunnel.socks5 import conversion
+from tribler_core.modules.tunnel.socks5.client import Socks5Client, Socks5Error
 from tribler_core.modules.tunnel.socks5.server import Socks5Server
 
 
-@pytest.fixture
-async def socks5_server(free_port):
-    socks5_server = Socks5Server(free_port, None)
+@pytest.fixture(name='socks5_server')
+async def fixture_socks5_server(free_port):
+    socks5_server = Socks5Server(free_port, Mock())
     yield socks5_server
     await socks5_server.stop()
 
@@ -16,3 +21,53 @@ async def test_start_server(socks5_server):
     Test writing an invalid version to the socks5 server
     """
     await socks5_server.start()
+
+
+@pytest.mark.asyncio
+async def test_socks5_udp_associate(socks5_server):
+    """
+    Test is sending a UDP associate request to the server succeeds.
+    """
+    await socks5_server.start()
+    client = Socks5Client(('127.0.0.1', socks5_server.port), Mock())
+    await client.associate_udp()
+    assert client.transport is not None
+    assert client.connection is not None
+    assert client.connection.transport is not None
+
+
+@pytest.mark.asyncio
+async def test_socks5_sendto_fail(socks5_server):
+    """
+    Test if sending a UDP packet without a successful association fails.
+    """
+    await socks5_server.start()
+    client = Socks5Client(('127.0.0.1', socks5_server.port), Mock())
+    with pytest.raises(Socks5Error):
+        client.sendto(b'\x00', ('127.0.0.1', 123))
+
+
+@pytest.mark.asyncio
+async def test_socks5_sendto_success(socks5_server):
+    """
+    Test if sending/receiving a UDP packet works correctly.
+    """
+    await socks5_server.start()
+    data = b'\x00'
+    target = ('127.0.0.1', 123)
+    client = Socks5Client(('127.0.0.1', socks5_server.port), Mock())
+    await client.associate_udp()
+
+    client.sendto(data, target)
+    await sleep(0.1)
+    socks5_server.output_stream.on_socks5_udp_data.assert_called_once()
+    connection = socks5_server.output_stream.on_socks5_udp_data.call_args[0][0]
+    request = socks5_server.output_stream.on_socks5_udp_data.call_args[0][1]
+    assert request.payload == data
+    assert request.destination == target
+
+    packet = conversion.encode_udp_packet(0, 0, conversion.ADDRESS_TYPE_IPV4, *target, data)
+    client.callback.assert_not_called()
+    connection.send_datagram(packet)
+    await sleep(0.1)
+    client.callback.assert_called_once_with(data, target)

--- a/src/tribler-core/tribler_core/modules/tunnel/socks5/tests/test_udp_connection.py
+++ b/src/tribler-core/tribler_core/modules/tunnel/socks5/tests/test_udp_connection.py
@@ -34,6 +34,6 @@ def test_send_diagram(connection):
     """
     Test sending a diagram over the SOCKS5 UDP connection
     """
-    assert connection.sendDatagram(b'a')
+    assert connection.send_datagram(b'a')
     connection.remote_udp_address = None
-    assert not connection.sendDatagram(b'a')
+    assert not connection.send_datagram(b'a')

--- a/src/tribler-core/tribler_core/modules/tunnel/socks5/udp_connection.py
+++ b/src/tribler-core/tribler_core/modules/tunnel/socks5/udp_connection.py
@@ -1,7 +1,9 @@
 import logging
 from asyncio import DatagramProtocol, get_event_loop
 
-from tribler_core.modules.tunnel.socks5 import conversion
+from ipv8.messaging.serialization import PackError
+
+from tribler_core.modules.tunnel.socks5.conversion import UdpPacket, socks5_serializer
 
 
 class SocksUDPConnection(DatagramProtocol):
@@ -29,27 +31,22 @@ class SocksUDPConnection(DatagramProtocol):
             return False
 
     def datagram_received(self, data, source):
-        # if remote_address was not set before, use first one
+        # If remote_address was not set before, use first one
         if self.remote_udp_address is None:
             self.remote_udp_address = source
 
         if self.remote_udp_address == source:
             try:
-                request = conversion.decode_udp_packet(data)
-            except conversion.IPV6AddrError:
-                self._logger.warning("Received an IPV6 udp datagram, dropping it (Not implemented yet)")
-                return False
-            except conversion.InvalidAddressException as ide:
-                self._logger.warning("Received an invalid host address. %r", ide)
+                request, _ = socks5_serializer.unpack_serializable(UdpPacket, data)
+            except PackError:
+                self._logger.warning("Cannot serialize UDP packet")
                 return False
 
-            if request.frag == 0 and request.destination_host:
+            if request.frag == 0 and request.destination:
                 return self.socksconnection.socksserver.output_stream.on_socks5_udp_data(self, request)
-            else:
-                self._logger.debug("No support for fragmented data or without destination host, dropping")
+            self._logger.debug("No support for fragmented data or without destination host, dropping")
         else:
-            self._logger.debug("Ignoring data from %s:%d, is not %s:%d",
-                               source[0], source[1], self.remote_udp_address[0], self.remote_udp_address[1])
+            self._logger.debug("Ignoring data from %s:%d, is not %s:%d", *source, *self.remote_udp_address)
 
         return False
 

--- a/src/tribler-core/tribler_core/modules/tunnel/socks5/udp_connection.py
+++ b/src/tribler-core/tribler_core/modules/tunnel/socks5/udp_connection.py
@@ -10,11 +10,7 @@ class SocksUDPConnection(DatagramProtocol):
         self._logger = logging.getLogger(self.__class__.__name__)
         self.socksconnection = socksconnection
         self.transport = None
-
-        if remote_udp_address != ("0.0.0.0", 0):
-            self.remote_udp_address = remote_udp_address
-        else:
-            self.remote_udp_address = None
+        self.remote_udp_address = remote_udp_address if remote_udp_address != ("0.0.0.0", 0) else None
 
     async def open(self):
         self.transport, _ = await get_event_loop().create_datagram_endpoint(lambda: self,
@@ -24,7 +20,7 @@ class SocksUDPConnection(DatagramProtocol):
         _, port = self.transport.get_extra_info('sockname')
         return port
 
-    def sendDatagram(self, data):
+    def send_datagram(self, data):
         if self.remote_udp_address:
             self.transport.sendto(data, self.remote_udp_address)
             return True

--- a/src/tribler-core/tribler_core/modules/tunnel/tests/test_dispatcher.py
+++ b/src/tribler-core/tribler_core/modules/tunnel/tests/test_dispatcher.py
@@ -8,21 +8,21 @@ import pytest
 from tribler_core.modules.tunnel.community.dispatcher import TunnelDispatcher
 
 
-@pytest.fixture
-async def dispatcher():
+@pytest.fixture(name='dispatcher')
+async def fixture_dispatcher():
     mock_tunnel_community = Mock()
-    mock_tunnel_community.select_circuit = lambda *_: None
     mock_tunnel_community.send_data = lambda *_: None
     dispatcher = TunnelDispatcher(mock_tunnel_community)
     yield dispatcher
     await dispatcher.shutdown_task_manager()
 
 
-@pytest.fixture
-def mock_circuit():
+@pytest.fixture(name='mock_circuit')
+def fixture_mock_circuit():
     mock_circuit = Mock()
     mock_circuit.state = CIRCUIT_STATE_EXTENDING
     mock_circuit.circuit_id = 3
+    mock_circuit.goal_hops = 1
     mock_circuit.peer.address = ("1.1.1.1", 1234)
     mock_circuit.tunnel_data = lambda *_: None
     return mock_circuit
@@ -32,46 +32,42 @@ def test_on_tunnel_in(dispatcher):
     """
     Test whether no data is sent to the SOCKS5 server when we receive data from the tunnels
     """
-    mock_circuit = Mock()
-    mock_circuit.goal_hops = 300
-    mock_circuit.circuit_id = b'a'
-    mock_circuit.ctype = CIRCUIT_TYPE_DATA
     origin = ("0.0.0.0", 1024)
-    assert not dispatcher.on_incoming_from_tunnel(dispatcher.tunnel_community, mock_circuit, origin, b'a')
+
+    mock_circuit = Mock(goal_hops=300, circuit_id=123, ctype=CIRCUIT_TYPE_DATA)
+    assert not dispatcher.on_incoming_from_tunnel(dispatcher.tunnels, mock_circuit, origin, b'a')
 
     mock_circuit.goal_hops = 1
-    mock_sock_server = Mock()
-    mock_session = Mock()
-    mock_session._udp_socket = None
-    mock_sock_server.sessions = [mock_session]
+    mock_sock_server = Mock(sessions=[])
     dispatcher.set_socks_servers([mock_sock_server])
-    dispatcher.destinations[1] = {b'a': mock_circuit}
-    assert not dispatcher.on_incoming_from_tunnel(dispatcher.tunnel_community, mock_circuit, origin, b'a')
+    assert not dispatcher.on_incoming_from_tunnel(dispatcher.tunnels, mock_circuit, origin, b'a')
 
-    mock_session._udp_socket = Mock()
-    mock_session._udp_socket.sendDatagram = lambda _: True
-    assert dispatcher.on_incoming_from_tunnel(dispatcher.tunnel_community, mock_circuit, origin, b'a')
+    mock_session = Mock(udp_connection=None)
+    mock_sock_server.sessions = [mock_session]
+    assert not dispatcher.on_incoming_from_tunnel(dispatcher.tunnels, mock_circuit, origin, b'a')
+
+    dispatcher.cid_to_con[b'a'] = mock_session
+    assert not dispatcher.on_incoming_from_tunnel(dispatcher.tunnels, mock_circuit, origin, b'a')
+
+    mock_session.udp_connection = Mock()
+    mock_session.udp_connection.send_datagram = lambda _: True
+    assert dispatcher.on_incoming_from_tunnel(dispatcher.tunnels, mock_circuit, origin, b'a')
 
 
 def test_on_socks_in_udp(dispatcher, mock_circuit):
     """
     Test whether data is correctly dispatched to a circuit
     """
-    mock_socks_server = Mock()
-    dispatcher.set_socks_servers([mock_socks_server])
-
+    mock_request = Mock(destination=("0.0.0.0", 1024), payload=b'a')
     mock_udp_connection = Mock()
-    mock_udp_connection.socksconnection = Mock()
-    mock_udp_connection.socksconnection.socksserver = mock_socks_server
-
-    mock_request = Mock()
-    mock_request.destination = ("0.0.0.0", 1024)
-    mock_request.payload = 'a'
+    dispatcher.set_socks_servers([mock_udp_connection.socksconnection.socksserver])
+    dispatcher.tunnels.create_circuit = lambda **_: None
+    dispatcher.tunnels.circuits = {}
 
     # No circuit is selected
     assert not dispatcher.on_socks5_udp_data(mock_udp_connection, mock_request)
 
-    dispatcher.tunnel_community.select_circuit = lambda *_: mock_circuit
+    dispatcher.tunnels.circuits = {mock_circuit.circuit_id: mock_circuit}
 
     # Circuit is not ready
     assert not dispatcher.on_socks5_udp_data(mock_udp_connection, mock_request)
@@ -90,11 +86,11 @@ async def test_on_socks_in_tcp(dispatcher):
     tcp_connection = Mock()
     dispatcher.set_socks_servers([tcp_connection.socksserver])
 
-    dispatcher.tunnel_community.perform_http_request = Mock(return_value=succeed(None))
+    dispatcher.tunnels.perform_http_request = Mock(return_value=succeed(None))
     await dispatcher.on_socks5_tcp_data(tcp_connection, ("0.0.0.0", 1024), b'')
     tcp_connection.transport.write.assert_not_called()
 
-    dispatcher.tunnel_community.perform_http_request = Mock(return_value=succeed(b'test'))
+    dispatcher.tunnels.perform_http_request = Mock(return_value=succeed(b'test'))
     await dispatcher.on_socks5_tcp_data(tcp_connection, ("0.0.0.0", 1024), b'')
     tcp_connection.transport.write.assert_called_once_with(b'test')
 
@@ -103,8 +99,32 @@ def test_circuit_dead(dispatcher, mock_circuit):
     """
     Test whether the correct peers are removed when a circuit breaks
     """
-    dispatcher.destinations = {1: {'a': mock_circuit, 'b': mock_circuit},
-                               2: {'c': mock_circuit, 'a': mock_circuit}}
+    connection = Mock()
+
+    dispatcher.con_to_cir = {connection: {1: mock_circuit,
+                                          2: mock_circuit,
+                                          3: mock_circuit}}
+    dispatcher.cid_to_con = {mock_circuit.circuit_id: connection}
+
     res = dispatcher.circuit_dead(mock_circuit)
     assert res
     assert len(res) == 3
+    assert len(dispatcher.con_to_cir[connection]) == 0
+    assert mock_circuit.circuit_id not in dispatcher.cid_to_con
+
+
+def test_check_connections(dispatcher, mock_circuit):
+    """
+    Test whether closed connections are cleaned up properly
+    """
+    connection = Mock(udp_connection=None)
+
+    dispatcher.con_to_cir = {connection: {1: mock_circuit,
+                                          2: mock_circuit,
+                                          3: mock_circuit}}
+    dispatcher.cid_to_con = {mock_circuit.circuit_id: connection, 2: Mock()}
+
+    dispatcher.check_connections()
+    assert connection not in dispatcher.con_to_cir
+    assert mock_circuit.circuit_id not in dispatcher.cid_to_con
+    assert 2 in dispatcher.cid_to_con

--- a/src/tribler-core/tribler_core/modules/tunnel/tests/test_dispatcher.py
+++ b/src/tribler-core/tribler_core/modules/tunnel/tests/test_dispatcher.py
@@ -58,7 +58,7 @@ def test_on_socks_in_udp(dispatcher, mock_circuit):
     """
     Test whether data is correctly dispatched to a circuit
     """
-    mock_request = Mock(destination=("0.0.0.0", 1024), payload=b'a')
+    mock_request = Mock(destination=("0.0.0.0", 1024), data=b'a')
     mock_udp_connection = Mock()
     dispatcher.set_socks_servers([mock_udp_connection.socksconnection.socksserver])
     dispatcher.tunnels.create_circuit = lambda **_: None

--- a/src/tribler-core/tribler_core/utilities/tracker_utils.py
+++ b/src/tribler-core/tribler_core/utilities/tracker_utils.py
@@ -112,6 +112,9 @@ def parse_tracker_url(tracker_url):
     :returns: a tuple of size 3 containing the scheme, a tuple of hostname and port,
         and path of the url
     """
+    if tracker_url.lower().startswith('http://') and ':80/' in tracker_url:
+        tracker_url = tracker_url.replace(':80/', '/', 1)
+
     if tracker_url != get_uniformed_tracker_url(tracker_url):
         raise MalformedTrackerURLException(u'Could not sanitize url (%s).' % tracker_url)
 


### PR DESCRIPTION
Fixes https://github.com/Tribler/tribler/issues/5262.

This PR:
* Updates `Dispatcher` to allow multiple simultaneous connections to the tunnel SOCKS server. To achieve this, circuits are reserved for a particular SOCKS session.
* Adds `Socks5Client` that can be used for connecting to our `Socks5Server`. Both TCP and UDP are supported.
* Adds `Socks5Connector` that allows anonymous HTTP connections to be established using `aiohttp`.
* Adds anonymization support to `TorrentChecker`. The `TorrentChecker` now uses the default hop count for all traffic.
* Updates SOCKS5 client/server to use the IPv8 serializer.