### PR TITLE
Experiment 3

### DIFF
--- a/experiment/popularity_community/README.md
+++ b/experiment/popularity_community/README.md
@@ -81,7 +81,8 @@ Where:
 ```
 export PYTHONPATH=${PYTHONPATH}:`echo ../.. ../../src/{pyipv8,tribler-common,tribler-core} | tr " " :`
 
-python3 crawl_torrents.py [-t <timeout_in_sec>] [-f <db_file.sqlite>]
+python3 crawl_torrents.py [-t <timeout_in_sec>] [-f <db_file.sqlite>] [-v]
+                          [--peers_count_csv=<csv_file_with_peers_count>]
 ```
 
 Where:
@@ -89,6 +90,8 @@ Where:
 * `db_file.sqlite` means the path to `sqlite` db file. 
     If file doesn't exists, then new file will be created. 
     If file exists, then crawler will append it.
+* `csv_file_with_peers_count` means the path to `csv` file that contains
+    `(time, active_peers, crawled_peers)` tuples.
  
 
 ### Example
@@ -96,4 +99,88 @@ Where:
 ```
 python3 crawl_torrents.py -t 600
 python3 crawl_torrents.py -t 600 -f torrents.sqlite
+python3 crawl_torrents.py -t 600 -f torrents.sqlite --peers_count_csv="peers.csv"
+python3 crawl_torrents.py -t 600 -f torrents.sqlite --peers_count_csv="peers.csv" -v
+```
+
+## analyze_crawled_data.py
+
+Source: [analyze_crawled_data.py](analyze_crawled_data.py)
+
+### Description
+
+This script analyzes the crawled data.
+
+As an input it takes `sqlite db`, produced by 
+[crawl_torrents.py](crawl_torrents.py).
+
+The result will be stored in a `json` file:
+```
+[
+  {
+    "hash": "3f93ae6aabbba6d07176e778d9cbff088e9fbf1d",
+    "title": "Ubuntu",
+    "count": 224,
+    "ratio": 72
+  },
+  {
+    "hash": "95e8d04147f0d9cb8bf00ec8775c926126a65236",
+    "title": "Fedora",
+    "count": 139,
+    "ratio": 44
+  },
+  {
+    "hash": "ba693a610b43a1aa246d3382299775ebdf0fec34",
+    "title": "Linux Mint",
+    "count": 136,
+    "ratio": 43
+  }
+]
+```
+
+and in `csv` file (in a short form):
+
+```
+position,node_count,torrent_count,ratio
+0,55,39,70
+1,55,34,61
+2,55,30,54
+```
+
+
+`ratio` is a number, calculated as 
+
+![\Large l](https://latex.codecogs.com/svg.latex?ratio_{i}=\frac{100*count_{i}}{node\\_count})
+
+Where:
+ * ![\Large l](https://latex.codecogs.com/svg.latex?ratio_{i})  is a ratio for `i-th torrent`
+ * ![\Large l](https://latex.codecogs.com/svg.latex?count_{i})  how many times `i-th torrent` encountered on crawled nodes
+ * ![\Large l](https://latex.codecogs.com/svg.latex?node\\_count)  is a count of crawled nodes
+
+### Usage
+
+```
+export PYTHONPATH=${PYTHONPATH}:`echo ../.. ../../src/{pyipv8,tribler-common,tribler-core} | tr " " :`
+
+python3 analyze_crawled_data.py [-d <sqlite_db_path>] [-f <json_output_file_path>]
+                                [-l <torrent_limit>] [-v]
+```
+
+Where:
+* `sqlite_db_path` means the path to `sqlite` db file
+* `json_output_file_path` means the path to result `json` file. 
+Note, there is also a `csv` file that will be produced. It will be located 
+on the same path, but with `.csv` extension
+* `torrent_limit` is the maximum size of the result set
+* `-v` means increase verbosity
+
+ 
+
+### Example
+
+```
+python3 analyze_crawled_data.py -d crawled_data.sqlite 
+python3 analyze_crawled_data.py -d crawled_data.sqlite -f result.json
+python3 analyze_crawled_data.py -d crawled_data.sqlite -f result.json -l 100
+python3 analyze_crawled_data.py -d crawled_data.sqlite -f result.json -l 100 -v
 ```

--- a/experiment/popularity_community/analyze_crawled_data.py
+++ b/experiment/popularity_community/analyze_crawled_data.py
@@ -1,0 +1,147 @@
+"""This script analyzes the crawled data.
+
+As an input it takes `sqlite db`, produced by crawl_torrents.py
+
+The result will be stored in a `json` file and in a `csv` file (in a short form):
+```
+[
+  {
+    "hash": "3f93ae6aabbba6d07176e778d9cbff088e9fbf1d",
+    "title": "Ubuntu",
+    "count": 224,
+    "ratio": 72
+  },
+  ...,
+  {
+    ...
+  }
+]
+```
+
+Where:
+    * `ratio = 100 * torrent.count / node_count
+
+### Usage
+
+```
+export PYTHONPATH=${PYTHONPATH}:`echo ../.. ../../src/{pyipv8,tribler-common,tribler-core} | tr " " :`
+
+python3 analyze_crawled_data.py [-d <sqlite_db_path>] [-f <json_output_file_path>]
+                                [-l <torrent_limit>] [-v]
+```
+
+Where:
+    * `sqlite_db_path` means the path to `sqlite` db file
+    * `json_output_file_path` means the path to result `json` file.
+    Note, there is also a `csv` file that will be produced. It will be located
+    on the same path, but with `.csv` extension
+    * `torrent_limit` is the maximum size of the result set
+    * `-v` means increase verbosity
+
+
+
+### Example
+
+```
+python3 analyze_crawled_data.py -d crawled_data.sqlite
+python3 analyze_crawled_data.py -d crawled_data.sqlite -f result.json
+python3 analyze_crawled_data.py -d crawled_data.sqlite -f result.json -l 100
+python3 analyze_crawled_data.py -d crawled_data.sqlite -f result.json -l 100 -v
+```
+"""
+import argparse
+import csv
+import json
+import logging
+import math
+from pathlib import Path
+
+from pony.orm import Database, db_session
+
+db = Database()
+logger = logging.getLogger(__name__)
+
+
+@db_session
+def _get_node_count():
+    query = 'select count(distinct peer_hash) as count from RawData'
+    logger.info(f'Run query: {query}')
+    query_result = db.select(query)
+    return query_result[0]
+
+
+@db_session
+def _get_torrent_hash_distribution(limit):
+    query = 'select results.torrent_hash, titles.torrent_title, count(results.torrent_hash) as count\n' \
+            'from (select distinct torrent_hash, peer_hash from RawData) as results\n' \
+            '         join (select distinct torrent_hash, torrent_title from RawData) as titles\n' \
+            '              on results.torrent_hash = titles.torrent_hash\n' \
+            'group by results.torrent_hash\n' \
+            'order by count desc\n' \
+            f'limit {limit}'
+    logger.info(f'Run query: {query}')
+    return db.select(query)
+
+
+def _save_torrent_hash_distribution(json_file_path, torrent_hash_distribution, node_count):
+    result_list = []
+    print(f'\nNode count: {node_count}')
+    print('ratio')
+    for i, torrent in enumerate(torrent_hash_distribution):
+        ratio = math.trunc(100 * torrent.count / node_count)
+        entity = {
+            'position': i,
+            'hash': torrent.torrent_hash,
+            'title': torrent.torrent_title,
+            'count': torrent.count,
+            'node_count': node_count,
+            'ratio': ratio}
+        logger.debug(f'Processing entity: {entity}')
+        result_list.append(entity)
+        print(f'{i},{node_count},{torrent.count},{ratio}')
+
+    _save_to_json(json_file_path, result_list)
+    _save_to_csv(Path(json_file_path).with_suffix('.csv'), result_list)
+
+
+def _save_to_csv(csv_file_path, result):
+    logger.info(f'Saving only "ration" results into {csv_file_path}')
+    with csv_file_path.open('w') as f:
+        csv_writer = csv.writer(f)
+        csv_writer.writerow(['position', 'node_count', 'torrent_count', 'ratio'])
+        csv_writer.writerows([e['position'], e['node_count'], e['count'], e['ratio']] for e in result)
+
+
+def _save_to_json(json_file_path, result):
+    logger.info(f'Saving full results into {json_file_path}')
+    with open(json_file_path, 'w') as f:
+        json.dump(result, f)
+
+
+def _analyze_results(json_file_path, limit):
+    _node_count = _get_node_count()
+    _torrent_hash_distribution = _get_torrent_hash_distribution(limit)
+    _save_torrent_hash_distribution(json_file_path, _torrent_hash_distribution, _node_count)
+
+
+def _parse_argv():
+    parser = argparse.ArgumentParser(description='Crawl first 100 torrents from random nodes in the network')
+    parser.add_argument('-d', '--db', type=str, help='sqlite db file path', default='torrents.sqlite')
+    parser.add_argument('-f', '--file', type=str, help='result json file path', default='torrents_distribution.json')
+    parser.add_argument('-v', '--verbosity', help='increase output verbosity', action='store_true')
+    parser.add_argument('-l', '--limit', type=int, help='count (limit) of torrents in the output list', default=50)
+
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    _arguments = _parse_argv()
+    print(f"Arguments: {_arguments}")
+
+    logging_level = logging.DEBUG if _arguments.verbosity else logging.CRITICAL
+    logging.basicConfig(level=logging_level)
+
+    db.bind('sqlite', _arguments.db)
+    db.generate_mapping(check_tables=True)
+
+    _analyze_results(_arguments.file, _arguments.limit)

--- a/experiment/popularity_community/crawl_torrents.py
+++ b/experiment/popularity_community/crawl_torrents.py
@@ -112,7 +112,7 @@ class TorrentCrawler(RemoteQueryCommunity):
         time = self.seconds_since_start()
         peers_count = len(self.get_peers())
         peers_crawled = len(self._crawled_peers)
-        print(f"Time: {time}, peers: {peers_count}, crawled: {peers_crawled}")
+        print(f"\nTime: {time}, peers: {peers_count}, crawled: {peers_crawled}")
         self._peers_count_csv_file.write(f"{time},{peers_count},{peers_crawled}\n")
 
     def request_torrents_from_new_peers(self):

--- a/experiment/popularity_community/crawl_torrents.py
+++ b/experiment/popularity_community/crawl_torrents.py
@@ -1,11 +1,10 @@
 """This script crawl first 100 torrens from random nodes in the network.
 
-### Usage
-
 ```
-export PYTHONPATH=${PYTHONPATH}:`echo ../../../src/{pyipv8,tribler-common,tribler-core} | tr " " :`
+export PYTHONPATH=${PYTHONPATH}:`echo ../.. ../../src/{pyipv8,tribler-common,tribler-core} | tr " " :`
 
-python3 crawl_torrents.py [-t <timeout_in_sec>] [-f <db_file.sqlite>]
+python3 crawl_torrents.py [-t <timeout_in_sec>] [-f <db_file.sqlite>] [-v]
+                          [--peers_count_csv=<csv_file_with_peers_count>]
 ```
 
 Where:
@@ -13,12 +12,16 @@ Where:
 * `db_file.sqlite` means the path to `sqlite` db file.
     If file doesn't exists, then new file will be created.
     If file exists, then crawler will append it.
+* `csv_file_with_peers_count` means the path to `csv` file that contains
+    `(time, active_peers, crawled_peers)` tuples.
 
 ### Example
 
 ```
 python3 crawl_torrents.py -t 600
 python3 crawl_torrents.py -t 600 -f torrents.sqlite
+python3 crawl_torrents.py -t 600 -f torrents.sqlite --peers_count_csv="peers.csv"
+python3 crawl_torrents.py -t 600 -f torrents.sqlite --peers_count_csv="peers.csv" -v
 ```
 
 """
@@ -26,8 +29,10 @@ import argparse
 import asyncio
 import json
 import logging
+from collections import defaultdict
 from datetime import datetime
 from pathlib import Path
+from types import SimpleNamespace
 
 from ipv8.lazy_community import lazy_wrapper
 from ipv8.peer import Peer
@@ -51,6 +56,9 @@ IPV8_WALK_INTERVAL = 0.05
 RANDOM_WALK_TIMEOUT_IN_SEC = 5
 RANDOM_WALK_WINDOW_SIZE = 0
 RANDOM_WALK_RESET_CHANCE = 30
+
+CRAWLER_SELECT_REQUEST_INTERVAL_IN_SEC = 20
+CRAWLER_SELECT_COUNT_LIMIT_PER_ONE_REQUEST = 20
 
 CRAWLER_REQUEST_TIMEOUT_IN_SEC = 60
 
@@ -85,14 +93,27 @@ class TorrentCrawler(RemoteQueryCommunity):
         * use RemoteQueryCommunity's ability to select MetadataInfo from remote db
     """
 
-    def __init__(self, my_peer, endpoint, network, metadata_store, db_file_path):
+    def __init__(self, my_peer, endpoint, network, metadata_store, crawler_settings):
         super().__init__(my_peer, endpoint, network, metadata_store)
         self._logger = logging.getLogger(self.__class__.__name__)
+        self._db = TorrentCrawler.create_db(crawler_settings.output_file_path)
+        self._peers_count_csv_file = Path(crawler_settings.peers_count_csv_file_path).open("a")
+        self._limit_per_one_request = CRAWLER_SELECT_COUNT_LIMIT_PER_ONE_REQUEST
+        self._crawled_peers = defaultdict(lambda: 0)  # value is a count of crawled torrents
+
         self.max_peers = UNLIMITED
+        self.start_time = datetime.utcnow()
 
-        self.db = TorrentCrawler.create_db(db_file_path)
+        self.register_task("log_peer_count", self.log_peers_count, interval=60)
+        self.register_task("request_torrents", self.request_torrents_from_new_peers,
+                           interval=CRAWLER_SELECT_REQUEST_INTERVAL_IN_SEC)
 
-        self.register_task("request_torrents", self.request_torrents_from_new_peers, interval=10)
+    def log_peers_count(self):
+        time = self.seconds_since_start()
+        peers_count = len(self.get_peers())
+        peers_crawled = len(self._crawled_peers)
+        print(f"Time: {time}, peers: {peers_count}, crawled: {peers_crawled}")
+        self._peers_count_csv_file.write(f"{time},{peers_count},{peers_crawled}\n")
 
     def request_torrents_from_new_peers(self):
         """Send a request for gathering torrent information
@@ -105,14 +126,26 @@ class TorrentCrawler(RemoteQueryCommunity):
                 increase of code complexity.
         Ref: see RemoteQueryCommunity.sanitize_query(query_dict, cap=100)
         """
-        peers_ready_to_request = self.get_peers()
-        self._logger.info(f"Request torrents from {len(peers_ready_to_request)} peers")
+        print(f'\nTime: {self.seconds_since_start()}, starting select request')
+        requested_select_count = 0
+        for peer in self.get_peers():
+            try:
+                peer_has_already_been_crawled = peer.mid in self._crawled_peers
+                if peer_has_already_been_crawled:
+                    print('·', end='')
+                    continue
 
-        for peer in peers_ready_to_request:
-            self._logger.debug(f"Requesting torrents from {peer}.")
-            self.send_select(peer, metadata_type=[REGULAR_TORRENT], sort_by="HEALTH", first=0, last=100)
-            self._logger.debug(f"Marked as polled: {peer}")
-            self.network.remove_peer(peer)
+                limit_reached = requested_select_count > self._limit_per_one_request
+                if limit_reached:
+                    print('Select limit reached')
+                    break
+
+                print(f"Requesting torrents from {hexlify(peer.mid)}")
+                self.send_select(peer, metadata_type=[REGULAR_TORRENT],
+                                 sort_by="HEALTH", first=0, last=100)
+                requested_select_count += 1
+            finally:
+                self.network.remove_peer(peer)
 
     @lazy_wrapper(SelectResponsePayload)
     async def on_remote_select_response(self, peer, response):
@@ -132,7 +165,8 @@ class TorrentCrawler(RemoteQueryCommunity):
 
     @db_session
     def save_to_db(self, peer, unpacked_data):
-        for index, (metadata, _) in enumerate(unpacked_data):
+        index = self._crawled_peers[peer.mid]
+        for metadata, _ in unpacked_data:
             if not metadata:
                 continue
 
@@ -140,11 +174,13 @@ class TorrentCrawler(RemoteQueryCommunity):
             votes = int(getattr(metadata, 'votes', 0))
             infohash = hexlify(getattr(metadata, 'infohash', ''))
             title = getattr(metadata, 'title', '')
-
             self._logger.debug(f"Collect torrent item for {peer_hash}: {title}")
             RawData(torrent_hash=infohash, torrent_title=title, peer_hash=peer_hash,
                     torrent_votes=votes, date_add=datetime.utcnow(),
                     torrent_position=index)
+            index += 1
+
+        self._crawled_peers[peer.mid] = index
 
     # this method has been overloaded only for changing timeout
     def send_select(self, peer, **kwargs):
@@ -157,12 +193,17 @@ class TorrentCrawler(RemoteQueryCommunity):
         """
         self._logger.debug(f"Peer {peer} wants to introduce {payload.wan_introduction_address}")
 
+    def seconds_since_start(self):
+        return (datetime.utcnow() - self.start_time).seconds
+
 
 class Service(TinyTriblerService):
-    def __init__(self, output_file_path, timeout_in_sec, working_dir, config_path):
+    def __init__(self, output_file_path, peers_count_csv_file_path, timeout_in_sec,
+                 working_dir, config_path):
         super().__init__(Service.create_config(working_dir, config_path),
                          timeout_in_sec, working_dir, config_path)
         self._output_file_path = output_file_path
+        self._peers_count_csv_file_path = peers_count_csv_file_path
 
     @staticmethod
     def create_config(working_dir, config_path):
@@ -179,9 +220,11 @@ class Service(TinyTriblerService):
         session = self.session
         peer = Peer(session.trustchain_keypair)
 
+        crawler_settings = SimpleNamespace(output_file_path=self._output_file_path,
+                                           peers_count_csv_file_path=self._peers_count_csv_file_path)
         session.remote_query_community = TorrentCrawler(peer, session.ipv8.endpoint,
                                                         session.ipv8.network,
-                                                        session.mds, self._output_file_path)
+                                                        session.mds, crawler_settings)
 
         session.ipv8.overlays.append(session.remote_query_community)
         session.ipv8.strategies.append((RandomWalk(session.remote_query_community,
@@ -196,13 +239,15 @@ def _parse_argv():
     parser.add_argument('-t', '--timeout', type=int, help='the time in sec that the experiment will last', default=0)
     parser.add_argument('-f', '--file', type=str, help='sqlite db file path', default='torrents.sqlite')
     parser.add_argument('-v', '--verbosity', help='increase output verbosity', action='store_true')
+    parser.add_argument('--peers_count_csv', type=str, help='csv file that logs peers count in time',
+                        default='peers_count.csv')
 
     return parser.parse_args()
 
 
 def _run_tribler(arguments):
     working_dir = Path('/tmp/tribler/experiment/popularity_community/crawl_torrents/.Tribler')
-    service = Service(arguments.file, arguments.timeout,
+    service = Service(arguments.file, arguments.peers_count_csv, arguments.timeout,
                       working_dir=working_dir,
                       config_path=Path('./tribler.conf'))
 
@@ -219,7 +264,7 @@ if __name__ == "__main__":
     _arguments = _parse_argv()
     print(f"Arguments: {_arguments}")
 
-    logging_level = logging.DEBUG if _arguments.verbosity else logging.INFO
+    logging_level = logging.DEBUG if _arguments.verbosity else logging.CRITICAL
     logging.basicConfig(level=logging_level)
 
     _run_tribler(_arguments)

--- a/experiment/popularity_community/initial_filling.py
+++ b/experiment/popularity_community/initial_filling.py
@@ -53,8 +53,7 @@ class ObservablePopularityCommunity(PopularityCommunity):
         time_since_start = time.time() - self._start_time
         torrents_total, torrents_with_seeders = self.get_torrents_info_tuple()
 
-        self._logger.info(f"Time: {time_since_start:.0f}s, total: {torrents_total}, live: {torrents_with_seeders}")
-
+        print(f"Time: {time_since_start:.0f}s, total: {torrents_total}, live: {torrents_with_seeders}")
         self._csv_writer.writerow([f"{time_since_start:.0f}", torrents_total, torrents_with_seeders])
         self._csv_file.flush()
 
@@ -130,7 +129,7 @@ if __name__ == "__main__":
     _arguments = _parse_argv()
     print(f"Arguments: {_arguments}")
 
-    logging_level = logging.DEBUG if _arguments.verbosity else logging.INFO
+    logging_level = logging.DEBUG if _arguments.verbosity else logging.CRITICAL
     logging.basicConfig(level=logging_level)
 
     _run_tribler(_arguments)


### PR DESCRIPTION
This PR contains:
1. Improvements for `crawl_torrents.py`:
   1. Crawler speed has been improved
   1. Console output informativeness has been increased
   1. Added `select limit per request = 20` for preventing overloading
1. Small improvements for `initial_filling_velocity.py` 
1. `analyze_crawled_data.py`

It solves #5625 

## analyze_crawled_data.py

Source: [analyze_crawled_data.py](https://github.com/drew2a/tribler/blob/experiment3/experiment/popularity_community/analyze_crawled_data.py)

### Description

This script analyzes the crawled data.

As an input, it takes `sqlite db`, produced by [crawl_torrents.py](https://github.com/drew2a/tribler/blob/experiment3/experiment/popularity_community/crawl_torrents.py).

The result will be stored in a `json` file:
```
[
  {
    "hash": "3f93ae6aabbba6d07176e778d9cbff088e9fbf1d",
    "title": "Ubuntu",
    "count": 224,
    "ratio": 72
  },
  {
    "hash": "95e8d04147f0d9cb8bf00ec8775c926126a65236",
    "title": "Fedora",
    "count": 139,
    "ratio": 44
  },
  {
    "hash": "ba693a610b43a1aa246d3382299775ebdf0fec34",
    "title": "Linux Mint",
    "count": 136,
    "ratio": 43
  }
]
```

and in `csv` file (short form):

```
position,node_count,torrent_count,ratio
0,55,39,70
1,55,34,61
2,55,30,54
```

`ratio` is a number, calculated as 

![\Large l](https://latex.codecogs.com/svg.latex?ratio_{i}=\frac{100*count_{i}}{node\\_count})

Where:
 * ![\Large l](https://latex.codecogs.com/svg.latex?ratio_{i})  is a ratio for `i-th torrent`
 * ![\Large l](https://latex.codecogs.com/svg.latex?count_{i})  how many times `i-th torrent` encountered on crawled nodes
* ![\Large l](https://latex.codecogs.com/svg.latex?node\\_count)  is a count of crawled nodes


### Usage

```
export PYTHONPATH=${PYTHONPATH}:`echo ../.. ../../src/{pyipv8,tribler-common,tribler-core} | tr " " :`

python3 analyze_crawled_data.py [-d <sqlite_db_path>] [-f <json_output_file_path>]
                                [-l <torrent_limit>] [-v]
```

Where:
* `sqlite_db_path` means the path to `sqlite` db file
* `json_output_file_path` means the path to result `json` file. 
Note, there is also a `csv` file that will be produced. It will be located on the same path, but with `.csv` extension
* `torrent_limit` is the maximum size of the result set
* `-v` means increase verbosity

 

### Example

```
python3 analyze_crawled_data.py -d crawled_data.sqlite 
python3 analyze_crawled_data.py -d crawled_data.sqlite -f result.json
python3 analyze_crawled_data.py -d crawled_data.sqlite -f result.json -l 100
python3 analyze_crawled_data.py -d crawled_data.sqlite -f result.json -l 100 -v
```

