### PR TITLE
Add years and “Forever” (1c+) ETAs

### DIFF
--- a/src/tribler-gui/tribler_gui/utilities.py
+++ b/src/tribler-gui/tribler_gui/utilities.py
@@ -140,6 +140,8 @@ def pretty_date(time=False):
 
 
 def duration_to_string(seconds):
+    years = int(seconds // (60 * 60 * 24 * 365.249))
+    seconds -= years * (60 * 60 * 24 * 365.249)
     weeks = int(seconds // (60 * 60 * 24 * 7))
     seconds -= weeks * (60 * 60 * 24 * 7)
     days = int(seconds // (60 * 60 * 24))
@@ -150,6 +152,10 @@ def duration_to_string(seconds):
     seconds -= minutes * 60
     seconds = int(seconds)
 
+    if years >= 100:
+        return "Forever"
+    if years > 0:
+        return "{}y {}w".format(years, weeks)
     if weeks > 0:
         return "{}w {}d".format(weeks, days)
     if days > 0:


### PR DESCRIPTION
Added solar year precision to download ETAs, and labelled downloads that will take over a century as “Forever.” 

Users won’t see these labels except under exceptionally poor network conditions, or for stalled transfers. The following screenshot is from a stalled transfer:

![ETA: 51601586521w 5d](https://user-images.githubusercontent.com/1102886/95868790-edaa7d80-0d6a-11eb-910d-110211329175.png)

I didn’t add months (m) to avoid confusion with minutes (m). Although, maybe that’s not a problem when the m is displayed after a y or in front of a w?