### PR TITLE
Added option to disable the discovery community

### DIFF
--- a/src/tribler-core/tribler_core/config/test_tribler_config.py
+++ b/src/tribler-core/tribler_core/config/test_tribler_config.py
@@ -309,3 +309,12 @@ def test_get_set_default_add_download_to_channel(tribler_config):
     assert not tribler_config.get_default_add_download_to_channel()
     tribler_config.set_default_add_download_to_channel(True)
     assert tribler_config.get_default_add_download_to_channel()
+
+
+def test_get_set_discovery_community_enabled(tribler_config):
+    """
+    Test disabling the discovery community.
+    """
+    assert not tribler_config.get_discovery_community_enabled()
+    tribler_config.set_discovery_community_enabled(True)
+    assert tribler_config.get_discovery_community_enabled()

--- a/src/tribler-core/tribler_core/config/tribler_config.py
+++ b/src/tribler-core/tribler_core/config/tribler_config.py
@@ -579,6 +579,14 @@ class TriblerConfig(object):
     def get_record_transactions(self):
         return self.config['market_community']['record_transactions']
 
+    # Discovery Community
+
+    def set_discovery_community_enabled(self, value: bool) -> None:
+        self.config['discovery_community']['enabled'] = value
+
+    def get_discovery_community_enabled(self) -> bool:
+        return self.config['discovery_community']['enabled']
+
     # DHT
 
     def set_dht_enabled(self, value):

--- a/src/tribler-core/tribler_core/config/tribler_config.spec
+++ b/src/tribler-core/tribler_core/config/tribler_config.spec
@@ -16,6 +16,9 @@ enabled = boolean(default=False)
 matchmaker = boolean(default=True)
 record_transactions = boolean(default=False)
 
+[discovery_community]
+enabled = boolean(default=True)
+
 [dht]
 enabled = boolean(default=True)
 

--- a/src/tribler-core/tribler_core/conftest.py
+++ b/src/tribler-core/tribler_core/conftest.py
@@ -46,6 +46,7 @@ def tribler_config(tribler_state_dir, tribler_download_dir):
     config.set_default_destination_dir(tribler_download_dir)
     config.set_torrent_checking_enabled(False)
     config.set_ipv8_enabled(False)
+    config.set_discovery_community_enabled(False)
     config.set_ipv8_walk_scaling_enabled(False)
     config.set_libtorrent_enabled(False)
     config.set_libtorrent_dht_readiness_timeout(0)

--- a/src/tribler-core/tribler_core/modules/ipv8_module_catalog.py
+++ b/src/tribler-core/tribler_core/modules/ipv8_module_catalog.py
@@ -23,7 +23,7 @@ class IPv8DiscoveryCommunityLauncher(IPv8CommunityLauncher):
         return DiscoveryCommunity
 
     def should_launch(self, session):
-        return True
+        return session.config.get_discovery_community_enabled()
 
     def get_kwargs(self, session):
         return {}

--- a/src/tribler-core/tribler_core/tests/test_session.py
+++ b/src/tribler-core/tribler_core/tests/test_session.py
@@ -119,7 +119,6 @@ async def test_load_ipv8_overlays(mocked_endpoints, enable_ipv8, session):
     await session.start()
 
     loaded_launchers = [overlay.__class__.__name__ for overlay in session.ipv8.overlays]
-    assert "DiscoveryCommunity" in loaded_launchers
     assert "TrustChainCommunity" in loaded_launchers
     assert "TrustChainTestnetCommunity" not in loaded_launchers
     assert "DHTDiscoveryCommunity" in loaded_launchers
@@ -152,7 +151,6 @@ async def test_load_ipv8_overlays_testnet(mocked_endpoints, enable_ipv8, session
     await session.start()
 
     loaded_launchers = [overlay.__class__.__name__ for overlay in session.ipv8.overlays]
-    assert "DiscoveryCommunity" in loaded_launchers
     assert "TrustChainCommunity" not in loaded_launchers
     assert "TrustChainTestnetCommunity" in loaded_launchers
     assert "DHTDiscoveryCommunity" in loaded_launchers


### PR DESCRIPTION
By default, the launch of the DiscoveryCommunity is now disabled in the tests. Furthermore, this enables Gumby to also disable the DiscoveryCommunity, since Gumby usually starts isolated communities.

Fixes #5634