### PR TITLE
Moved CommunityLauncher registration to Session init

### DIFF
--- a/src/tribler-core/tribler_core/modules/ipv8_module_catalog.py
+++ b/src/tribler-core/tribler_core/modules/ipv8_module_catalog.py
@@ -280,6 +280,14 @@ class RemoteQueryTestnetCommunityLauncher(RemoteQueryCommunityLauncher):
 
 
 def register_default_launchers(loader):
+    """
+    Register the default CommunityLaunchers into the given CommunityLoader.
+    If you define a new default CommunityLauncher, add it here.
+
+    = Warning =
+     Do not perform any state changes in this function. All imports and state changes should be performed within
+     the CommunityLaunchers themselves to be properly scoped and lazy-loaded.
+    """
     loader.set_launcher(IPv8DiscoveryCommunityLauncher())
     loader.set_launcher(TrustChainCommunityLauncher())
     loader.set_launcher(TrustChainTestnetCommunityLauncher())

--- a/src/tribler-core/tribler_core/session.py
+++ b/src/tribler-core/tribler_core/session.py
@@ -118,6 +118,7 @@ class Session(TaskManager):
 
         # modules
         self.ipv8_community_loader = IPv8CommunityLoader()
+        register_default_launchers(self.ipv8_community_loader)
 
         self.api_manager = None
         self.watch_folder = None
@@ -145,7 +146,6 @@ class Session(TaskManager):
         self.core_test_mode = core_test_mode
 
     def load_ipv8_overlays(self):
-        register_default_launchers(self.ipv8_community_loader)
         self.ipv8_community_loader.load(self.ipv8, self)
 
     def enable_ipv8_statistics(self):


### PR DESCRIPTION
Fixes #5613

This allows Community loading/overwriting without subclassing the Session (or, god forbid, loading the Session first and then hooking in custom Communities after starting), example from #5613:

```python
session = Session(config)
session.ipv8_community_loader.community_launchers.clear()  # Remove all default launchers.
session.ipv8_community_loader.set_launcher(my_community_launcher)  # Load (or overwrite existing) custom launcher.
await session.start()
```