### PR TITLE
Use new CommunityLauncher decorators

### DIFF
--- a/src/tribler-core/tribler_core/modules/ipv8_module_catalog.py
+++ b/src/tribler-core/tribler_core/modules/ipv8_module_catalog.py
@@ -1,282 +1,164 @@
-from abc import ABC
-
-from ipv8.loader import CommunityLauncher
+from ipv8.loader import CommunityLauncher, after, kwargs, overlay, precondition, set_in_session, walk_strategy
 from ipv8.peer import Peer
-from ipv8.peerdiscovery.discovery import EdgeWalk, RandomWalk
 
 
-# The lazy-loading of Community-specific files triggers Pylint, this is expected:
-# pylint: disable=C0415
-
-
-class IPv8CommunityLauncher(CommunityLauncher, ABC):
+class IPv8CommunityLauncher(CommunityLauncher):
 
     def get_my_peer(self, ipv8, session):
         return (Peer(session.trustchain_testnet_keypair) if session.config.get_trustchain_testnet()
                 else Peer(session.trustchain_keypair))
 
 
-class IPv8DiscoveryCommunityLauncher(IPv8CommunityLauncher):
-
-    def get_overlay_class(self):
-        from ipv8.peerdiscovery.community import DiscoveryCommunity
-        return DiscoveryCommunity
+class TestnetMixIn:
 
     def should_launch(self, session):
-        return session.config.get_discovery_community_enabled()
+        return True
 
-    def get_kwargs(self, session):
-        return {}
 
-    def get_walk_strategies(self):
-        from ipv8.peerdiscovery.churn import RandomChurn
-        from ipv8.peerdiscovery.community import PeriodicSimilarity
-        return [(RandomChurn, {}, -1), (PeriodicSimilarity, {}, -1), (RandomWalk, {}, 20)]
+@overlay('ipv8.peerdiscovery.community', 'DiscoveryCommunity')
+@precondition('session.config.get_discovery_community_enabled()')
+@walk_strategy('ipv8.peerdiscovery.churn', 'RandomChurn', target_peers=-1)
+@walk_strategy('ipv8.peerdiscovery.discovery', 'RandomWalk')
+@walk_strategy('ipv8.peerdiscovery.community', 'PeriodicSimilarity', target_peers=-1)
+class IPv8DiscoveryCommunityLauncher(IPv8CommunityLauncher):
 
     def finalize(self, ipv8, session, community):
         community.resolve_dns_bootstrap_addresses()
         return super()
 
 
+@overlay('ipv8.attestation.trustchain.community', 'TrustChainCommunity')
+@precondition('session.config.get_trustchain_enabled()')
+@precondition('not session.config.get_trustchain_testnet()')
+@kwargs(working_directory='session.config.get_state_dir()')
+@walk_strategy('ipv8.peerdiscovery.discovery', 'EdgeWalk')
+@set_in_session('trustchain_community')
 class TrustChainCommunityLauncher(IPv8CommunityLauncher):
 
-    def should_launch(self, session):
-        return session.config.get_trustchain_enabled() and not session.config.get_trustchain_testnet()
-
-    def get_overlay_class(self):
-        from ipv8.attestation.trustchain.community import TrustChainCommunity
-        return TrustChainCommunity
-
-    def get_kwargs(self, session):
-        return {'working_directory': session.config.get_state_dir()}
-
-    def get_walk_strategies(self):
-        return [(EdgeWalk, {}, 20)]
-
     def finalize(self, ipv8, session, community):
-        session.trustchain_community = community
-
         from anydex.wallet.tc_wallet import TrustchainWallet
 
         tc_wallet = TrustchainWallet(community)
         session.wallets[tc_wallet.get_identifier()] = tc_wallet
+
         return super()
 
 
-class TrustChainTestnetCommunityLauncher(TrustChainCommunityLauncher):
-
-    def should_launch(self, session):
-        return session.config.get_trustchain_enabled() and session.config.get_trustchain_testnet()
-
-    def get_overlay_class(self):
-        from ipv8.attestation.trustchain.community import TrustChainTestnetCommunity
-        return TrustChainTestnetCommunity
+@overlay('ipv8.attestation.trustchain.community', 'TrustChainTestnetCommunity')
+@precondition('session.config.get_trustchain_enabled()')
+@precondition('session.config.get_trustchain_testnet()')
+class TrustChainTestnetCommunityLauncher(TestnetMixIn, TrustChainCommunityLauncher):
+    pass
 
 
+@overlay('ipv8.dht.discovery', 'DHTDiscoveryCommunity')
+@precondition('session.config.get_dht_enabled()')
+@walk_strategy('ipv8.dht.churn', 'PingChurn', target_peers=-1)
+@walk_strategy('ipv8.peerdiscovery.discovery', 'RandomWalk')
+@set_in_session('dht_community')
 class DHTCommunityLauncher(IPv8CommunityLauncher):
-
-    def should_launch(self, session):
-        return session.config.get_dht_enabled()
-
-    def get_overlay_class(self):
-        from ipv8.dht.discovery import DHTDiscoveryCommunity
-        return DHTDiscoveryCommunity
-
-    def get_kwargs(self, session):
-        return {}
-
-    def get_walk_strategies(self):
-        from ipv8.dht.churn import PingChurn
-        return [(RandomWalk, {}, 20), (PingChurn, {}, -1)]
-
-    def finalize(self, ipv8, session, community):
-        session.dht_community = community
-        return super()
+    pass
 
 
+@after('DHTDiscoveryCommunity', 'TrustChainCommunity', 'TrustChainTestnetCommunity')
+@overlay('tribler_core.modules.tunnel.community.triblertunnel_community', 'TriblerTunnelCommunity')
+@precondition('session.config.get_tunnel_community_enabled()')
+@precondition('not session.config.get_tunnel_testnet()')
+@kwargs(bandwidth_wallet='session.wallets["MB"]',
+        competing_slots='session.config.get_tunnel_community_competing_slots()',
+        ipv8='session.ipv8',
+        random_slots='session.config.get_tunnel_community_random_slots()',
+        tribler_session='session')
+@walk_strategy('ipv8.peerdiscovery.discovery', 'RandomWalk')
+@walk_strategy('tribler_core.modules.tunnel.community.discovery', 'GoldenRatioStrategy', target_peers=-1)
+@set_in_session('tunnel_community')
 class TriblerTunnelCommunityLauncher(IPv8CommunityLauncher):
-
-    def not_before(self):
-        return ['DHTDiscoveryCommunity', 'TrustChainCommunity', 'TrustChainTestnetCommunity']
-
-    def should_launch(self, session):
-        return session.config.get_tunnel_community_enabled() and not session.config.get_tunnel_testnet()
-
-    def get_overlay_class(self):
-        from tribler_core.modules.tunnel.community.triblertunnel_community import TriblerTunnelCommunity
-        return TriblerTunnelCommunity
 
     def get_kwargs(self, session):
         from ipv8.dht.provider import DHTCommunityProvider
         from ipv8.messaging.anonymization.community import TunnelSettings
-
-        random_slots = session.config.get_tunnel_community_random_slots()
-        competing_slots = session.config.get_tunnel_community_competing_slots()
 
         dht_provider = DHTCommunityProvider(session.dht_community, session.config.get_ipv8_port())
         settings = TunnelSettings()
         settings.min_circuits = 3
         settings.max_circuits = 10
 
-        return {
-            'tribler_session': session,
-            'dht_provider': dht_provider,
-            'ipv8': session.ipv8,
-            'bandwidth_wallet': session.wallets["MB"],
-            'random_slots': random_slots,
-            'competing_slots': competing_slots,
-            'settings': settings
-        }
-
-    def get_walk_strategies(self):
-        from tribler_core.modules.tunnel.community.discovery import GoldenRatioStrategy
-        return [(RandomWalk, {}, 20), (GoldenRatioStrategy, {}, -1)]
-
-    def finalize(self, ipv8, session, community):
-        session.tunnel_community = community
-        return super()
+        return {'dht_provider': dht_provider, 'settings': settings}
 
 
-class TriblerTunnelTestnetCommunityLauncher(TriblerTunnelCommunityLauncher):
-
-    def should_launch(self, session):
-        return session.config.get_tunnel_community_enabled() and session.config.get_tunnel_testnet()
-
-    def get_overlay_class(self):
-        from tribler_core.modules.tunnel.community.triblertunnel_community import TriblerTunnelTestnetCommunity
-        return TriblerTunnelTestnetCommunity
+@overlay('tribler_core.modules.tunnel.community.triblertunnel_community', 'TriblerTunnelTestnetCommunity')
+@precondition('session.config.get_tunnel_community_enabled()')
+@precondition('session.config.get_tunnel_testnet()')
+class TriblerTunnelTestnetCommunityLauncher(TestnetMixIn, TriblerTunnelCommunityLauncher):
+    pass
 
 
+@after('DHTDiscoveryCommunity', 'TrustChainCommunity', 'TrustChainTestnetCommunity')
+@overlay('anydex.core.community', 'MarketCommunity')
+@precondition('session.config.get_market_community_enabled()')
+@precondition('not session.config.get_trustchain_testnet()')
+@kwargs(trustchain='session.trustchain_community',
+        dht='session.dht_community',
+        wallets='session.wallets',
+        working_directory='session.config.get_state_dir()',
+        record_transactions='session.config.get_record_transactions()')
+@walk_strategy('ipv8.peerdiscovery.discovery', 'RandomWalk')
+@set_in_session('market_community')
 class MarketCommunityLauncher(IPv8CommunityLauncher):
-
-    def not_before(self):
-        return ['DHTDiscoveryCommunity', 'TrustChainCommunity', 'TrustChainTestnetCommunity']
-
-    def should_launch(self, session):
-        return session.config.get_market_community_enabled() and not session.config.get_trustchain_testnet()
-
-    def get_overlay_class(self):
-        from anydex.core.community import MarketCommunity
-        return MarketCommunity
-
-    def get_kwargs(self, session):
-        return {
-            'trustchain': session.trustchain_community,
-            'dht': session.dht_community,
-            'wallets': session.wallets,
-            'working_directory': session.config.get_state_dir(),
-            'record_transactions': session.config.get_record_transactions()
-        }
-
-    def get_walk_strategies(self):
-        return [(RandomWalk, {}, 20)]
-
-    def finalize(self, ipv8, session, community):
-        session.market_community = community
-        return super()
+    pass
 
 
-class MarketTestnetCommunityLauncher(MarketCommunityLauncher):
-
-    def should_launch(self, session):
-        return session.config.get_market_community_enabled() and session.config.get_trustchain_testnet()
-
-    def get_overlay_class(self):
-        from anydex.core.community import MarketTestnetCommunity
-        return MarketTestnetCommunity
+@overlay('anydex.core.community', 'MarketTestnetCommunity')
+@precondition('session.config.get_market_community_enabled()')
+@precondition('session.config.get_trustchain_testnet()')
+class MarketTestnetCommunityLauncher(TestnetMixIn, MarketCommunityLauncher):
+    pass
 
 
+@overlay('tribler_core.modules.popularity.popularity_community', 'PopularityCommunity')
+@precondition('session.config.get_popularity_community_enabled()')
+@kwargs(metadata_store='session.mds', torrent_checker='session.torrent_checker')
+@walk_strategy('ipv8.peerdiscovery.discovery', 'RandomWalk')
+@set_in_session('popularity_community')
 class PopularityCommunityLauncher(IPv8CommunityLauncher):
-
-    def should_launch(self, session):
-        return session.config.get_popularity_community_enabled()
-
-    def get_overlay_class(self):
-        from tribler_core.modules.popularity.popularity_community import PopularityCommunity
-        return PopularityCommunity
-
-    def get_kwargs(self, session):
-        return {'metadata_store': session.mds, 'torrent_checker': session.torrent_checker}
-
-    def get_walk_strategies(self):
-        return [(RandomWalk, {}, 20)]
-
-    def finalize(self, ipv8, session, community):
-        session.popularity_community = community
-        return super()
+    pass
 
 
+@after('TrustChainCommunity', 'TrustChainTestnetCommunity')
+@overlay('tribler_core.modules.metadata_store.community.gigachannel_community', 'GigaChannelCommunity')
+@precondition('session.config.get_chant_enabled()')
+@precondition('not session.config.get_chant_testnet()')
+@kwargs(metadata_store='session.mds', notifier='session.notifier')
+@walk_strategy('ipv8.peerdiscovery.discovery', 'RandomWalk')
+@walk_strategy('tribler_core.modules.metadata_store.community.sync_strategy', 'SyncChannels')
+@set_in_session('gigachannel_community')
 class GigaChannelCommunityLauncher(IPv8CommunityLauncher):
-
-    def not_before(self):
-        return ['TrustChainCommunity', 'TrustChainTestnetCommunity']
-
-    def should_launch(self, session):
-        return session.config.get_chant_enabled() and not session.config.get_chant_testnet()
-
-    def get_overlay_class(self):
-        from tribler_core.modules.metadata_store.community.gigachannel_community import GigaChannelCommunity
-        return GigaChannelCommunity
-
-    def get_args(self, session):
-        return [session.mds]
-
-    def get_kwargs(self, session):
-        return {'notifier': session.notifier}
-
-    def get_walk_strategies(self):
-        from tribler_core.modules.metadata_store.community.sync_strategy import SyncChannels
-        return [(RandomWalk, {}, 20), (SyncChannels, {}, 20)]
-
-    def finalize(self, ipv8, session, community):
-        session.gigachannel_community = community
-        return super()
+    pass
 
 
-class GigaChannelTestnetCommunityLauncher(GigaChannelCommunityLauncher):
-
-    def should_launch(self, session):
-        return session.config.get_chant_enabled() and session.config.get_chant_testnet()
-
-    def get_overlay_class(self):
-        from tribler_core.modules.metadata_store.community.gigachannel_community import GigaChannelTestnetCommunity
-        return GigaChannelTestnetCommunity
+@overlay('tribler_core.modules.metadata_store.community.gigachannel_community', 'GigaChannelTestnetCommunity')
+@precondition('session.config.get_chant_enabled()')
+@precondition('session.config.get_chant_testnet()')
+class GigaChannelTestnetCommunityLauncher(TestnetMixIn, GigaChannelCommunityLauncher):
+    pass
 
 
+@after('GigaChannelCommunity', 'GigaChannelTestnetCommunity')
+@overlay('tribler_core.modules.metadata_store.community.remote_query_community', 'RemoteQueryCommunity')
+@precondition('session.config.get_chant_enabled()')
+@precondition('not session.config.get_chant_testnet()')
+@kwargs(metadata_store='session.mds', notifier='session.notifier')
+@walk_strategy('ipv8.peerdiscovery.discovery', 'RandomWalk', target_peers=50)
+@set_in_session('remote_query_community')
 class RemoteQueryCommunityLauncher(IPv8CommunityLauncher):
-
-    def not_before(self):
-        return ['GigaChannelCommunity', 'GigaChannelTestnetCommunity']
-
-    def should_launch(self, session):
-        return session.config.get_chant_enabled() and not session.config.get_chant_testnet()
-
-    def get_overlay_class(self):
-        from tribler_core.modules.metadata_store.community.remote_query_community import RemoteQueryCommunity
-        return RemoteQueryCommunity
-
-    def get_args(self, session):
-        return [session.mds]
-
-    def get_kwargs(self, session):
-        return {'notifier': session.notifier}
-
-    def get_walk_strategies(self):
-        return [(RandomWalk, {}, 50)]
-
-    def finalize(self, ipv8, session, community):
-        session.remote_query_community = community
-        return super()
+    pass
 
 
-class RemoteQueryTestnetCommunityLauncher(RemoteQueryCommunityLauncher):
-
-    def should_launch(self, session):
-        return session.config.get_chant_enabled() and session.config.get_chant_testnet()
-
-    def get_overlay_class(self):
-        from tribler_core.modules.metadata_store.community.remote_query_community import RemoteQueryTestnetCommunity
-        return RemoteQueryTestnetCommunity
+@overlay('tribler_core.modules.metadata_store.community.remote_query_community', 'RemoteQueryTestnetCommunity')
+@precondition('session.config.get_chant_enabled()')
+@precondition('session.config.get_chant_testnet()')
+class RemoteQueryTestnetCommunityLauncher(TestnetMixIn, RemoteQueryCommunityLauncher):
+    pass
 
 
 def register_default_launchers(loader):


### PR DESCRIPTION
This PR converts the `tribler_core/modules/ipv8_module_catalog.py` to the new `CommunityLauncher` decorator format, getting rid of 37% of the lines in the file.

Even the `RandomWalk` and `EdgeWalk` strategies are now lazy-loaded.

I recommend clicking [`View File`](https://github.com/Tribler/tribler/blob/ed42b5d469ea6e34243c03988d253f83b9c85823/src/tribler-core/tribler_core/modules/ipv8_module_catalog.py) to check out the finished product. The diff is slightly annoying to read.