### PR TITLE
Fix tunnel tests shutdown

### DIFF
--- a/src/tribler-core/tribler_core/modules/tunnel/test_full_session/test_tunnel_community.py
+++ b/src/tribler-core/tribler_core/modules/tunnel/test_full_session/test_tunnel_community.py
@@ -104,7 +104,6 @@ async def load_tunnel_community_in_session(session, exitnode=False, start_lt=Fal
     session.config.set_tunnel_community_exitnode_enabled(exitnode)
 
     mock_ipv8 = MockIPv8("curve25519", TriblerTunnelCommunity, settings={"max_circuits": 1}, tribler_session=session)
-    mock_ipv8.stop = lambda **_: succeed(None)
     session.ipv8 = mock_ipv8
 
     if exitnode:
@@ -213,7 +212,7 @@ async def test_anon_download(proxy_factory, session, video_seeder_session, video
 @pytest.mark.asyncio
 @pytest.mark.timeout(40)
 @pytest.mark.tunneltest
-async def test_hidden_services(enable_ipv8, proxy_factory, session, hidden_seeder_session, video_tdef, logger):
+async def test_hidden_services(proxy_factory, session, hidden_seeder_session, video_tdef, logger):
     """
     Test the hidden services overlay by constructing an end-to-end circuit and downloading a torrent over it
     """

--- a/src/tribler-core/tribler_core/restapi/tests/test_statistics_endpoint.py
+++ b/src/tribler-core/tribler_core/restapi/tests/test_statistics_endpoint.py
@@ -16,7 +16,7 @@ async def mock_ipv8(session):
     session.config.set_ipv8_enabled(True)
     yield mock_ipv8
     session.ipv8 = None
-    await mock_ipv8.unload()
+    await mock_ipv8.stop()
 
 
 @pytest.mark.asyncio

--- a/src/tribler-core/tribler_core/restapi/tests/test_trustchain_endpoint.py
+++ b/src/tribler-core/tribler_core/restapi/tests/test_trustchain_endpoint.py
@@ -19,7 +19,7 @@ async def mock_ipv8(session):
     session.trustchain_community = mock_ipv8.overlay
     session.wallets['MB'] = TrustchainWallet(session.trustchain_community)
     yield mock_ipv8
-    await mock_ipv8.unload()
+    await mock_ipv8.stop()
 
 
 @pytest.mark.asyncio

--- a/src/tribler-core/tribler_core/restapi/tests/test_trustview_endpoint.py
+++ b/src/tribler-core/tribler_core/restapi/tests/test_trustview_endpoint.py
@@ -33,7 +33,7 @@ async def mock_trustchain(session):
     mock_ipv8 = MockIPv8(u"low", TrustChainCommunity, working_directory=session.config.get_state_dir())
     session.trustchain_community = mock_ipv8.overlay
     yield
-    await mock_ipv8.unload()
+    await mock_ipv8.stop()
 
 
 @pytest.fixture


### PR DESCRIPTION
Modified the tunnel tests to not start a real IPv8 instance (we are starting a `MockIPv8` instance instead).

Fixes #5660 