### PR TITLE
Added basic query functionality to bandwidth accounting

### DIFF
--- a/build/systemd/bandwidth-crawler.service
+++ b/build/systemd/bandwidth-crawler.service
@@ -1,0 +1,15 @@
+[Unit]
+Description="Bandwidth crawler"
+After=network-online.target
+
+[Service]
+Type=simple
+User=crawler
+Group=crawler
+Restart=always
+Environment=PYTHONPATH=./src/pyipv8:./src/tribler-common:./src/tribler-core
+WorkingDirectory=/opt/tribler
+ExecStart=/usr/bin/python3 src/tribler-core/run_bandwidth_crawler.py --statedir /var/lib/crawler $EXTRA_CRAWLER_ARGS
+
+[Install]
+WantedBy=multi-user.target

--- a/src/tribler-core/run_bandwidth_crawler.py
+++ b/src/tribler-core/run_bandwidth_crawler.py
@@ -1,0 +1,71 @@
+"""
+This executable script starts a Tribler instance and joins the BandwidthAccountingCommunity.
+"""
+import argparse
+import sys
+from asyncio import ensure_future, get_event_loop
+from pathlib import Path
+
+from ipv8.loader import IPv8CommunityLoader
+
+from tribler_core.config.tribler_config import TriblerConfig
+from tribler_core.modules.bandwidth_accounting.database import BandwidthDatabase
+from tribler_core.modules.bandwidth_accounting.settings import BandwidthAccountingSettings
+from tribler_core.modules.ipv8_module_catalog import BandwidthCommunityLauncher
+from tribler_core.session import Session
+
+
+class PortAction(argparse.Action):
+    def __call__(self, _, namespace, values, option_string=None):
+        if not 0 < values < 2**16:
+            raise argparse.ArgumentError(self, "Invalid port number")
+        setattr(namespace, self.dest, values)
+
+
+class BandwidthCommunityCrawlerLauncher(BandwidthCommunityLauncher):
+
+    def get_kwargs(self, session):
+        settings = BandwidthAccountingSettings()
+        settings.outgoing_query_interval = 5
+        database = BandwidthDatabase(session.config.get_state_dir() / "sqlite" / "bandwidth.db",
+                                     session.trustchain_keypair.pub().key_to_bin(), store_all_transactions=True)
+
+        return {
+            "database": database,
+            "settings": settings,
+            "max_peers": -1
+        }
+
+
+async def start_crawler(tribler_config):
+    session = Session(tribler_config)
+
+    # We use our own community loader
+    loader = IPv8CommunityLoader()
+    session.ipv8_community_loader = loader
+    loader.set_launcher(BandwidthCommunityCrawlerLauncher())
+
+    await session.start()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=('Start a crawler in the bandwidth accounting community'))
+    parser.add_argument('--statedir', '-s', default='bw_crawler', type=str, help='Use an alternate statedir')
+    parser.add_argument('--restapi', '-p', default=8085, type=str, help='Use an alternate port for the REST API',
+                        action=PortAction, metavar='{0..65535}')
+    args = parser.parse_args(sys.argv[1:])
+
+    config = TriblerConfig(args.statedir, config_file=Path(args.statedir) / 'triblerd.conf')
+    config.set_state_dir(Path(args.statedir).absolute())
+    config.set_tunnel_community_enabled(False)
+    config.set_libtorrent_enabled(False)
+    config.set_bootstrap_enabled(False)
+    config.set_chant_enabled(False)
+    config.set_torrent_checking_enabled(False)
+    config.set_api_http_enabled(True)
+    config.set_api_http_port(args.restapi)
+
+    loop = get_event_loop()
+    coro = start_crawler(config)
+    ensure_future(coro)
+    loop.run_forever()

--- a/src/tribler-core/tribler_core/modules/bandwidth_accounting/community.py
+++ b/src/tribler-core/tribler_core/modules/bandwidth_accounting/community.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from asyncio import Future
 from binascii import unhexlify
 from pathlib import Path
+from random import Random
 from typing import Dict
 
 from ipv8.community import Community
@@ -15,7 +16,9 @@ from pony.orm import db_session
 from tribler_core.modules.bandwidth_accounting import EMPTY_SIGNATURE
 from tribler_core.modules.bandwidth_accounting.cache import BandwidthTransactionSignCache
 from tribler_core.modules.bandwidth_accounting.database import BandwidthDatabase
-from tribler_core.modules.bandwidth_accounting.payload import BandwidthTransactionPayload
+from tribler_core.modules.bandwidth_accounting.payload import BandwidthTransactionPayload, \
+    BandwidthTransactionQueryPayload
+from tribler_core.modules.bandwidth_accounting.settings import BandwidthAccountingSettings
 from tribler_core.modules.bandwidth_accounting.transaction import BandwidthTransactionData
 from tribler_core.utilities.unicode import hexlify
 
@@ -34,8 +37,10 @@ class BandwidthAccountingCommunity(Community):
         :param persistence: The database that stores transactions, will be created if not provided.
         :param database_path: The path at which the database will be created. Defaults to the current working directory.
         """
+        self.settings = kwargs.pop('settings', BandwidthAccountingSettings())
         self.database = kwargs.pop('database', None)
         self.database_path = Path(kwargs.pop('database_path', ''))
+        self.random = Random()
 
         super().__init__(*args, **kwargs)
 
@@ -46,6 +51,9 @@ class BandwidthAccountingCommunity(Community):
             self.database = BandwidthDatabase(self.database_path, self.my_pk)
 
         self.add_message_handler(BandwidthTransactionPayload, self.received_transaction)
+        self.add_message_handler(BandwidthTransactionQueryPayload, self.received_query)
+
+        self.register_task("query_peers", self.query_random_peer, interval=self.settings.outgoing_query_interval)
 
         self.logger.info("Started bandwidth accounting community with public key %s", hexlify(self.my_pk))
 
@@ -75,22 +83,22 @@ class BandwidthAccountingCommunity(Community):
         with db_session:
             self.database.BandwidthTransaction.insert(tx)
         cache = self.request_cache.add(BandwidthTransactionSignCache(self, tx))
-        self.send_transaction(tx, peer, cache.number)
+        self.send_transaction(tx, peer.address, cache.number)
 
         return cache.future
 
-    def send_transaction(self, transaction: BandwidthTransactionData, peer: Peer, request_id: int) -> None:
+    def send_transaction(self, transaction: BandwidthTransactionData, address: Address, request_id: int) -> None:
         """
         Send a provided transaction to another party.
         :param transaction: The BandwidthTransaction to send to the other party.
-        :param peer: The peer that will receive the transaction.
+        :param peer: The IP address and port of the peer.
         :param request_id: The identifier of the message, is usually provided by a request cache.
         """
         payload = BandwidthTransactionPayload.from_transaction(transaction, request_id)
         packet = self._ez_pack(self._prefix, 1, [payload], False)
-        self.endpoint.send(peer.address, packet)
+        self.endpoint.send(address, packet)
 
-    async def received_transaction(self, source_address: Address, data: bytes) -> None:
+    def received_transaction(self, source_address: Address, data: bytes) -> None:
         """
         Callback when we receive a transaction from another peer.
         :param source_address: The network address of the peer that has sent us the transaction.
@@ -103,38 +111,73 @@ class BandwidthAccountingCommunity(Community):
             self.logger.info("Transaction %s not valid, ignoring it", tx)
             return
 
-        latest_tx = self.database.get_latest_transaction(tx.public_key_a, tx.public_key_b)
-
-        if payload.public_key_b == self.my_peer.public_key.key_to_bin():
-            from_peer = Peer(payload.public_key_a, source_address)
-            if latest_tx:
-                # Check if the amount in the received transaction is higher than the amount of the latest one
-                # in the database.
-                if payload.amount > latest_tx.amount:
-                    # Sign it, store it, and send it back
+        if payload.public_key_a == self.my_pk or payload.public_key_b == self.my_pk:
+            # This transaction involves this peer.
+            latest_tx = self.database.get_latest_transaction(tx.public_key_a, tx.public_key_b)
+            if payload.public_key_b == self.my_peer.public_key.key_to_bin():
+                from_peer = Peer(payload.public_key_a, source_address)
+                if latest_tx:
+                    # Check if the amount in the received transaction is higher than the amount of the latest one
+                    # in the database.
+                    if payload.amount > latest_tx.amount:
+                        # Sign it, store it, and send it back
+                        tx.sign(self.my_peer.key, as_a=False)
+                        self.database.BandwidthTransaction.insert(tx)
+                        self.send_transaction(tx, from_peer.address, payload.request_id)
+                    else:
+                        self.logger.info("Received older bandwidth transaction - sending back the latest one")
+                        self.send_transaction(latest_tx, from_peer.address, payload.request_id)
+                else:
+                    # This transaction is the first one with party A. Sign it, store it, and send it back.
                     tx.sign(self.my_peer.key, as_a=False)
                     self.database.BandwidthTransaction.insert(tx)
-                    self.send_transaction(tx, from_peer, payload.request_id)
-                else:
-                    self.logger.info("Received older bandwidth transaction - sending back the latest one")
-                    self.send_transaction(latest_tx, from_peer, payload.request_id)
-            else:
-                # This transaction is the first one with party A. Sign it, store it, and send it back.
-                tx.sign(self.my_peer.key, as_a=False)
-                self.database.BandwidthTransaction.insert(tx)
-                from_peer = Peer(payload.public_key_a, source_address)
-                self.send_transaction(tx, from_peer, payload.request_id)
-        elif payload.public_key_a == self.my_peer.public_key.key_to_bin():
-            # It seems that we initiated this transaction. Check if we are waiting for it.
-            cache = self.request_cache.get("bandwidth-tx-sign", payload.request_id)
-            if not cache:
-                self.logger.info("Received bandwidth transaction %s without associated cache entry, ignoring it", tx)
-                return
+                    from_peer = Peer(payload.public_key_a, source_address)
+                    self.send_transaction(tx, from_peer.address, payload.request_id)
+            elif payload.public_key_a == self.my_peer.public_key.key_to_bin():
+                # It seems that we initiated this transaction. Check if we are waiting for it.
+                cache = self.request_cache.get("bandwidth-tx-sign", payload.request_id)
+                if not cache:
+                    self.logger.info("Received bandwidth transaction %s without associated cache entry, ignoring it",
+                                     tx)
+                    return
 
-            if not latest_tx or (latest_tx and latest_tx.amount >= tx.amount):
-                self.database.BandwidthTransaction.insert(tx)
+                if not latest_tx or (latest_tx and latest_tx.amount >= tx.amount):
+                    self.database.BandwidthTransaction.insert(tx)
 
-            cache.future.set_result(tx)
+                cache.future.set_result(tx)
+        else:
+            # This transaction involves two unknown peers. We can add it to our database.
+            self.database.BandwidthTransaction.insert(tx)
+
+    def query_random_peer(self) -> None:
+        """
+        Query a random peer neighbouring peer and ask their bandwidth transactions.
+        """
+        peers = list(self.network.verified_peers)
+        random_peer = self.random.choice(peers)
+        if random_peer:
+            self.query_transactions(random_peer)
+
+    def query_transactions(self, peer: Peer) -> None:
+        """
+        Query the transactions of a specific peer and ask for their bandwidth transactions.
+        :param peer: The peer to send the query to.
+        """
+        self.logger.info("Querying the transactions of peer %s:%d", *peer.address)
+        payload = BandwidthTransactionQueryPayload()
+        packet = self._ez_pack(self._prefix, 2, [payload], False)
+        self.endpoint.send(peer.address, packet)
+
+    def received_query(self, source_address: Address, data: bytes) -> None:
+        """
+        We received a query from another peer.
+        :param source_address: The network address of the peer that has sent us the query.
+        :param data: The serialized, raw data in the packet.
+        """
+        my_txs = self.database.get_my_latest_transactions(limit=self.settings.max_tx_returned_in_query)
+        self.logger.debug("Sending %d bandwidth transaction(s) to peer %s:%d", len(my_txs), *source_address)
+        for tx in my_txs:
+            self.send_transaction(tx, source_address, 0)
 
     def get_statistics(self) -> Dict:
         """

--- a/src/tribler-core/tribler_core/modules/bandwidth_accounting/payload.py
+++ b/src/tribler-core/tribler_core/modules/bandwidth_accounting/payload.py
@@ -25,3 +25,11 @@ class BandwidthTransactionPayload(VariablePayload):
             transaction.timestamp,
             request_id
         )
+
+
+@vp_compile
+class BandwidthTransactionQueryPayload(VariablePayload):
+    """
+    (empty) payload for an outgoing query to fetch transactions by the counterparty.
+    """
+    msg_id = 2

--- a/src/tribler-core/tribler_core/modules/bandwidth_accounting/settings.py
+++ b/src/tribler-core/tribler_core/modules/bandwidth_accounting/settings.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class BandwidthAccountingSettings:
+    """
+    This class contains several settings related to the bandwidth accounting mechanism.
+    """
+    outgoing_query_interval: int = 30   # The interval at which we send out queries to other peers, in seconds.
+    max_tx_returned_in_query: int = 10  # The maximum number of bandwidth transactions to return in response to a query.


### PR DESCRIPTION
This PR extends the bandwidth accounting mechanism with a basic query mechanism. Specifically, this PR:
- Adds a new query message.
- Adds a separate settings object where we can quickly change the different parameters of the mechanism. Right now, we do not know what the preferred values of many parameters are, e.g., the speed at which we send out queries. Deployment results will help us to answer this question but for now, I picked a value that I see reasonable.
- Adds functionality where the transactions of a random peer are periodically queried.
- Added a setting to store _all_ incoming transactions in the database, even when they belong to the same pair of users. This setting is used by our network crawler.
- Added a crawler and an accompanying `systemd` file.

We have verified whether our crawling mechanism works by deploying it on a separate server. So far, it has successfully collected over 700 transactions 👍 

Fixes #5676 