### PR TITLE
Fixed bug when displaying trust statistics

### DIFF
--- a/src/tribler-gui/tribler_gui/widgets/trustpage.py
+++ b/src/tribler-gui/tribler_gui/widgets/trustpage.py
@@ -52,8 +52,8 @@ class TrustPage(QWidget):
             return
 
         statistics = statistics["statistics"]
-        total_up = statistics.get("total_up", 0)
-        total_down = statistics.get("total_down", 0)
+        total_up = statistics.get("total_given", 0)
+        total_down = statistics.get("total_taken", 0)
 
         self.window().trust_contribution_amount_label.setText("%s MBytes" % (total_up // self.byte_scale))
         self.window().trust_consumption_amount_label.setText("%s MBytes" % (total_down // self.byte_scale))


### PR DESCRIPTION
`total_up` and `total_down` have been replaced by `total_given` and `total_taken`, respectively.