### PR TITLE
READY: Isolated RemoteQueryCommunity

### DIFF
--- a/src/tribler-core/tribler_core/modules/metadata_store/community/remote_query_community.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/community/remote_query_community.py
@@ -6,6 +6,7 @@ from ipv8.community import Community
 from ipv8.lazy_community import lazy_wrapper
 from ipv8.messaging.lazy_payload import VariablePayload, vp_compile
 from ipv8.peer import Peer
+from ipv8.peerdiscovery.network import Network
 from ipv8.requestcache import RandomNumberCache, RequestCache
 
 from pony.orm.dbapiprovider import OperationalError
@@ -75,10 +76,9 @@ class RemoteQueryCommunity(Community):
     )
 
     def __init__(self, my_peer, endpoint, network, metadata_store, settings=None, notifier=None):
-        super(RemoteQueryCommunity, self).__init__(my_peer, endpoint, network)
+        super().__init__(my_peer, endpoint, Network())
 
         self.notifier = notifier
-        self.max_peers = 60
 
         self.settings = settings or RemoteQueryCommunitySettings()
 

--- a/src/tribler-core/tribler_core/modules/metadata_store/community/sync_strategy.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/community/sync_strategy.py
@@ -17,3 +17,17 @@ class SyncChannels(DiscoveryStrategy):
             if peers:
                 peer = choice(peers)
                 self.overlay.send_random_to(peer)
+
+
+class RemovePeers(DiscoveryStrategy):
+    """
+    Synchronization strategy for remote query community.
+
+    Remove a random peer, if we have enough peers to walk to.
+    """
+
+    def take_step(self):
+        with self.walk_lock:
+            peers = self.overlay.get_peers()
+            if peers and len(peers) > 20:
+                self.overlay.network.remove_peer(choice(peers))

--- a/src/tribler-core/tribler_core/modules/metadata_store/community/tests/test_sync_strategy.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/community/tests/test_sync_strategy.py
@@ -1,8 +1,9 @@
 from ipv8.keyvault.crypto import default_eccrypto
 from ipv8.peer import Peer
+from ipv8.peerdiscovery.network import Network
 from ipv8.test.base import TestBase
 
-from tribler_core.modules.metadata_store.community.sync_strategy import SyncChannels
+from tribler_core.modules.metadata_store.community.sync_strategy import RemovePeers, SyncChannels
 
 
 class MockCommunity(object):
@@ -10,6 +11,7 @@ class MockCommunity(object):
         self.fetch_next_called = False
         self.send_random_to_called = []
         self.get_peers_return = []
+        self.network = Network()
 
     def send_random_to(self, peer):
         self.send_random_to_called.append(peer)
@@ -59,3 +61,43 @@ class TestSyncChannels(TestBase):
 
         self.assertEqual(1, len(self.community.send_random_to_called))
         self.assertIn(self.community.send_random_to_called[0], self.community.get_peers_return)
+
+
+class TestRemovePeers(TestBase):
+    def setUp(self):
+        self.community = MockCommunity()
+        self.strategy = RemovePeers(self.community)
+        return super().setUp()
+
+    def test_strategy_no_peers(self):
+        """
+        If we have no peers, nothing should happen.
+        """
+        self.strategy.take_step()
+
+        self.assertSetEqual(set(), self.community.network.verified_peers)
+
+    def test_strategy_one_peer(self):
+        """
+        If we have one peer, it should not be removed.
+        """
+        test_peer = Peer(default_eccrypto.generate_key(u"very-low"))
+        self.community.network.add_verified_peer(test_peer)
+        self.community.get_peers_return.append(test_peer)
+
+        self.strategy.take_step()
+
+        self.assertSetEqual({test_peer}, self.community.network.verified_peers)
+
+    def test_strategy_multi_peer(self):
+        """
+        If we have over 20 peers, one should be removed.
+        """
+        for _ in range(21):
+            test_peer = Peer(default_eccrypto.generate_key(u"very-low"))
+            self.community.network.add_verified_peer(test_peer)
+            self.community.get_peers_return.append(test_peer)
+
+        self.strategy.take_step()
+
+        self.assertEqual(20, len(self.community.network.verified_peers))

--- a/src/tribler-core/tribler_core/session.py
+++ b/src/tribler-core/tribler_core/session.py
@@ -236,7 +236,7 @@ class Session(TaskManager):
         # Gigachannel Community
         if self.config.get_chant_enabled():
             from tribler_core.modules.metadata_store.community.gigachannel_community import GigaChannelCommunity, GigaChannelTestnetCommunity
-            from tribler_core.modules.metadata_store.community.sync_strategy import SyncChannels
+            from tribler_core.modules.metadata_store.community.sync_strategy import RemovePeers, SyncChannels
 
             community_cls = GigaChannelTestnetCommunity if self.config.get_chant_testnet() else GigaChannelCommunity
             self.gigachannel_community = community_cls(peer, self.ipv8.endpoint, self.ipv8.network, self.mds,
@@ -245,7 +245,7 @@ class Session(TaskManager):
             self.ipv8.overlays.append(self.gigachannel_community)
 
             self.ipv8.strategies.append((RandomWalk(self.gigachannel_community), 20))
-            self.ipv8.strategies.append((SyncChannels(self.gigachannel_community), 20))
+            self.ipv8.strategies.append((SyncChannels(self.gigachannel_community), -1))
 
             # Gigachannel RemoteQuery Community
             from tribler_core.modules.metadata_store.community.remote_query_community \
@@ -256,7 +256,8 @@ class Session(TaskManager):
                                                         notifier=self.notifier)
 
             self.ipv8.overlays.append(self.remote_query_community)
-            self.ipv8.strategies.append((RandomWalk(self.remote_query_community), 50))
+            self.ipv8.strategies.append((RandomWalk(self.remote_query_community), 30))
+            self.ipv8.strategies.append((RemovePeers(self.remote_query_community), -1))
 
     def enable_ipv8_statistics(self):
         if self.config.get_ipv8_statistics():


### PR DESCRIPTION
Fixes #5699

Changes:

 - Isolated the walking of the `RemoteQueryCommunity` in its own `Network` instance.
 - Added a `RemovePeers` strategy to actively cycle peers in the `RemoteQueryCommunity`.
 - Fixed the `SyncChannels` strategy only running when there are less than 20 peers.