### PR TITLE
Set libtorrent max upload/download rate limit

### DIFF
--- a/src/tribler-common/tribler_common/simpledefs.py
+++ b/src/tribler-common/tribler_common/simpledefs.py
@@ -100,3 +100,11 @@ class NTFY(Enum):
     LOW_SPACE = "low_space"
     EVENTS_START = "events_start"
     TRIBLER_EXCEPTION = "tribler_exception"
+
+
+# Max download or upload rate limit for libtorrent.
+# On Win64, the compiled version of libtorrent only supported 2^31 - 1
+# as rate limit values instead of sys.maxsize or 2^63 -1. Since 2^31
+# is a sufficiently large value for download/upload rate limit,
+# here we set the max values for these parameters.
+MAX_LIBTORRENT_RATE_LIMIT = 2**31 - 1  # bytes per second

--- a/src/tribler-core/tribler_core/config/test_tribler_config.py
+++ b/src/tribler-core/tribler_core/config/test_tribler_config.py
@@ -1,3 +1,4 @@
+from tribler_common.simpledefs import MAX_LIBTORRENT_RATE_LIMIT
 
 from tribler_core.config.tribler_config import CONFIG_FILENAME, TriblerConfig
 from tribler_core.tests.tools.base_test import TriblerCoreTest
@@ -195,6 +196,19 @@ class TestTriblerConfig(TriblerCoreTest):
         self.assertEqual(self.tribler_config.get_libtorrent_max_download_rate(), True)
         self.tribler_config.set_libtorrent_dht_enabled(False)
         self.assertFalse(self.tribler_config.get_libtorrent_dht_enabled())
+
+        # Add tests for setting libtorrent rate limits
+        rate_limit = MAX_LIBTORRENT_RATE_LIMIT - 1024  # lower than the max value set
+        self.tribler_config.set_libtorrent_max_upload_rate(rate_limit)
+        self.assertEqual(self.tribler_config.get_libtorrent_max_upload_rate(), rate_limit)
+        self.tribler_config.set_libtorrent_max_download_rate(rate_limit)
+        self.assertEqual(self.tribler_config.get_libtorrent_max_download_rate(), rate_limit)
+
+        rate_limit = MAX_LIBTORRENT_RATE_LIMIT + 1024  # higher than the max value set
+        self.tribler_config.set_libtorrent_max_upload_rate(rate_limit)
+        self.assertEqual(self.tribler_config.get_libtorrent_max_upload_rate(), MAX_LIBTORRENT_RATE_LIMIT)
+        self.tribler_config.set_libtorrent_max_download_rate(rate_limit)
+        self.assertEqual(self.tribler_config.get_libtorrent_max_download_rate(), MAX_LIBTORRENT_RATE_LIMIT)
 
     def test_get_set_methods_tunnel_community(self):
         """

--- a/src/tribler-core/tribler_core/config/tribler_config.py
+++ b/src/tribler-core/tribler_core/config/tribler_config.py
@@ -8,6 +8,8 @@ from configobj import ConfigObj
 
 from validate import Validator
 
+from tribler_common.simpledefs import MAX_LIBTORRENT_RATE_LIMIT
+
 from tribler_core.exceptions import InvalidConfigException
 from tribler_core.modules.libtorrent.download_config import get_default_dest_dir
 from tribler_core.utilities import path_util
@@ -406,7 +408,7 @@ class TriblerConfig(object):
 
         :return: the maximum upload rate in kB / s
         """
-        return self.config['libtorrent'].as_int('max_upload_rate')
+        return min(self.config['libtorrent'].as_int('max_upload_rate'), MAX_LIBTORRENT_RATE_LIMIT)
 
     def set_libtorrent_max_download_rate(self, value):
         """
@@ -423,7 +425,7 @@ class TriblerConfig(object):
 
         :return: the maximum download rate in kB / s
         """
-        return self.config['libtorrent'].as_int('max_download_rate')
+        return min(self.config['libtorrent'].as_int('max_download_rate'), MAX_LIBTORRENT_RATE_LIMIT)
 
     def set_libtorrent_dht_enabled(self, value):
         self.config['libtorrent']['dht'] = value

--- a/src/tribler-gui/tribler_gui/widgets/settingspage.py
+++ b/src/tribler-gui/tribler_gui/widgets/settingspage.py
@@ -1,9 +1,9 @@
-import sys
-
 from PIL.ImageQt import ImageQt
 
 from PyQt5 import QtCore, QtGui
 from PyQt5.QtWidgets import QFileDialog, QLabel, QSizePolicy, QWidget
+
+from tribler_common.simpledefs import MAX_LIBTORRENT_RATE_LIMIT
 
 import tribler_core.utilities.json_util as json
 
@@ -455,14 +455,14 @@ class SettingsPage(QWidget):
 
         try:
             if self.window().upload_rate_limit_input.text():
-                user_upload_rate_limit = int(self.window().upload_rate_limit_input.text()) * 1024
-                if user_upload_rate_limit < sys.maxsize:
+                user_upload_rate_limit = int(float(self.window().upload_rate_limit_input.text()) * 1024)
+                if user_upload_rate_limit < MAX_LIBTORRENT_RATE_LIMIT:
                     settings_data['libtorrent']['max_upload_rate'] = user_upload_rate_limit
                 else:
                     raise ValueError
             if self.window().download_rate_limit_input.text():
-                user_download_rate_limit = int(self.window().download_rate_limit_input.text()) * 1024
-                if user_download_rate_limit < sys.maxsize:
+                user_download_rate_limit = int(float(self.window().download_rate_limit_input.text()) * 1024)
+                if user_download_rate_limit < MAX_LIBTORRENT_RATE_LIMIT:
                     settings_data['libtorrent']['max_download_rate'] = user_download_rate_limit
                 else:
                     raise ValueError
@@ -470,8 +470,9 @@ class SettingsPage(QWidget):
             ConfirmationDialog.show_error(
                 self.window(),
                 "Invalid value for bandwidth limit",
-                "You've entered an invalid value for the maximum upload/download rate. "
-                "Please enter a whole number (max: %d)" % (sys.maxsize / 1000),
+                "You've entered an invalid value for the maximum upload/download rate. \n"
+                "The rate is specified in KB/s and the value permitted is between 0 and %d KB/s.\n"
+                "Note that the decimal values are truncated." % (MAX_LIBTORRENT_RATE_LIMIT / 1024),
             )
             return
 


### PR DESCRIPTION
This PR sets a max values for download and upload rate limit parameters. The maximum is set to `2^31 - 1` to avoid overflow error.

Fixes https://github.com/Tribler/tribler/issues/5680