### PR TITLE
READY: Updated IPv8 pointer

### DIFF
--- a/src/tribler-core/tribler_core/modules/metadata_store/community/tests/test_gigachannel_community.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/community/tests/test_gigachannel_community.py
@@ -199,7 +199,7 @@ class TestGigaChannelUnits(TestBase):
 
         def mock_notify(overlay, args):
             overlay.notified_results = True
-            self.assertTrue("results" in args[0])
+            self.assertTrue("results" in args)
 
         self.nodes[1].overlay.notifier = MockObject()
         self.nodes[1].overlay.notifier.notify = lambda sub, args: mock_notify(self.nodes[1].overlay, args)

--- a/src/tribler-core/tribler_core/modules/metadata_store/community/tests/test_remote_query_community.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/community/tests/test_remote_query_community.py
@@ -117,7 +117,7 @@ class TestRemoteQueryCommunity(TestBase):
 
         def mock_notify(overlay, args):
             overlay.notified_results = True
-            self.assertTrue("results" in args[0])
+            self.assertTrue("results" in args)
 
         self.nodes[1].overlay.notifier = Notifier()
         self.nodes[1].overlay.notifier.notify = lambda sub, args: mock_notify(self.nodes[1].overlay, args)


### PR DESCRIPTION
Fixes #5683
NOTE: anything outside of TestBase will still hide these types of exceptions. This, for example, will still have a hidden error:

```python
def test_a_thing():
    import asyncio
    def this_is_bad():
        raise Exception()
    asyncio.get_event_loop().call_soon(this_is_bad)
```

This will not:

```python
class MyBeautifulTestCase(TestBase):
    def test_a_thing(self):
        import asyncio
        def this_is_bad():
            raise Exception()
        asyncio.get_event_loop().call_soon(this_is_bad)
```

This PR uncovers and fixes two tests that were secretly failing:

```
FAILED src/tribler-core/tribler_core/modules/metadata_store/community/tests/test_gigachannel_community.py::TestGigaChannelUnits::test_gigachannel_search
FAILED src/tribler-core/tribler_core/modules/metadata_store/community/tests/test_remote_query_community.py::TestRemoteQueryCommunity::test_remote_select_subscribed_channels
```