### PR TITLE
Fix AttributeError: 'TriblerConfig' object has no attribute 'set_market_community_enabled'

### DIFF
--- a/experiment/README.md
+++ b/experiment/README.md
@@ -3,3 +3,18 @@
 This folder contains experiments performed on a live Tribler network.
 
 Usually, they are scheduled on a daily basis.
+
+## Prerequisites
+
+Install requirements:
+
+```bash
+python -m pip install -r requirements.txt 
+```
+
+Specify [Sentry](https://develop.sentry.dev/) url.
+It can be taken directly from a corresponding Sentry project.
+
+```bash
+export SENTRY_URL=<sentry_url>
+```

--- a/experiment/popularity_community/analyze_crawled_data.py
+++ b/experiment/popularity_community/analyze_crawled_data.py
@@ -54,12 +54,20 @@ import csv
 import json
 import logging
 import math
+import os
 from pathlib import Path
 
 from pony.orm import Database, db_session
 
+import sentry_sdk
+
 db = Database()
 logger = logging.getLogger(__name__)
+
+sentry_sdk.init(
+    os.environ.get('SENTRY_URL'),
+    traces_sample_rate=1.0
+)
 
 
 @db_session

--- a/experiment/popularity_community/crawl_torrents.py
+++ b/experiment/popularity_community/crawl_torrents.py
@@ -29,6 +29,7 @@ import argparse
 import asyncio
 import json
 import logging
+import os
 from collections import defaultdict
 from datetime import datetime
 from pathlib import Path
@@ -41,6 +42,8 @@ from ipv8.peerdiscovery.discovery import RandomWalk
 import lz4
 
 from pony.orm import Database, Required, db_session
+
+import sentry_sdk
 
 from experiment.tool.tiny_tribler_service import TinyTriblerService
 
@@ -63,6 +66,11 @@ CRAWLER_SELECT_COUNT_LIMIT_PER_ONE_REQUEST = 20
 CRAWLER_REQUEST_TIMEOUT_IN_SEC = 60
 
 db = Database()
+
+sentry_sdk.init(
+    os.environ.get('SENTRY_URL'),
+    traces_sample_rate=1.0
+)
 
 
 class RawData(db.Entity):

--- a/experiment/popularity_community/initial_filling.py
+++ b/experiment/popularity_community/initial_filling.py
@@ -2,6 +2,7 @@ import argparse
 import asyncio
 import csv
 import logging
+import os
 import time
 from pathlib import Path
 
@@ -10,6 +11,8 @@ from ipv8.peerdiscovery.discovery import RandomWalk
 
 from pony.orm import count, db_session
 
+import sentry_sdk
+
 from experiment.tool.tiny_tribler_service import TinyTriblerService
 
 from tribler_core.modules.popularity.popularity_community import PopularityCommunity
@@ -17,6 +20,11 @@ from tribler_core.modules.popularity.popularity_community import PopularityCommu
 _logger = logging.getLogger(__name__)
 
 TARGET_PEERS_COUNT = 20  # Tribler uses this number for walking strategy
+
+sentry_sdk.init(
+    os.environ.get('SENTRY_URL'),
+    traces_sample_rate=1.0
+)
 
 
 class ObservablePopularityCommunity(PopularityCommunity):

--- a/experiment/requirements.txt
+++ b/experiment/requirements.txt
@@ -1,0 +1,1 @@
+sentry-sdk

--- a/experiment/tool/tiny_tribler_service.py
+++ b/experiment/tool/tiny_tribler_service.py
@@ -48,7 +48,6 @@ class TinyTriblerService:
         config = TriblerConfig(working_dir, config_path)
 
         config.set_tunnel_community_enabled(False)
-        config.set_market_community_enabled(False)
         config.set_popularity_community_enabled(False)
         config.set_bootstrap_enabled(False)
 


### PR DESCRIPTION
This PR fixes the following error in https://jenkins-ci.tribler.org/job/popularity_experiments/job/Initial_filling_velocity/86/console
```
AttributeError: 'TriblerConfig' object has no attribute 'set_market_community_enabled'
```

Also, it adds Sentry support to the following experiments:
1. Initial Filling Velocity
1. Popular Torrents Distribution