### PR TITLE
Update tribler_window.py call setWindowIcon

### DIFF
--- a/src/tribler-gui/tribler_gui/tribler_window.py
+++ b/src/tribler-gui/tribler_gui/tribler_window.py
@@ -137,6 +137,8 @@ class TriblerWindow(QMainWindow):
         QCoreApplication.setOrganizationName("TUDelft")
         QCoreApplication.setApplicationName("Tribler")
 
+        self.setWindowIcon(QIcon(QPixmap(get_image_path('tribler.png'))))
+
         self.gui_settings = QSettings()
         api_port = api_port or int(get_gui_setting(self.gui_settings, "api_port", DEFAULT_API_PORT))
         api_key = api_key or get_gui_setting(self.gui_settings, "api_key", hexlify(os.urandom(16)).encode('utf-8'))


### PR DESCRIPTION
Call setWindowIcon() to get rid of the default icon...

Under debian/mate tribler has a default icon in the task panel, and it was bugging me. I have no experience on other platforms.

This is my first day on github, and I have not learned my way around tribler, yet. There is probably a better place to put this, but it works for me as is. It seems pretty safe. I stole the icon from the system tray code.

Fixes #5606