### PR TITLE
Combine subscribed column with state

### DIFF
--- a/src/tribler-gui/tribler_gui/widgets/tablecontentdelegate.py
+++ b/src/tribler-gui/tribler_gui/widgets/tablecontentdelegate.py
@@ -264,9 +264,16 @@ class SubscribedControlMixin(object):
         if data_item[u'state'] == u'Personal':
             return True
 
-        self.subscribe_control.paint(
-            painter, option.rect, index, toggled=data_item.get('subscribed'), hover=index == self.hover_index
-        )
+        # When cursor leaves the table, we must "forget" about the button_box
+        if self.hoverrow == -1:
+            self.button_box = QRect()
+
+        if index.row() == self.hoverrow:
+            self.subscribe_control.paint(
+                painter, option.rect, index, toggled=data_item.get('subscribed'), hover=index == self.hover_index
+            )
+        else:
+            self.draw_channel_state(painter, option, index, data_item)
 
         return True
 

--- a/src/tribler-gui/tribler_gui/widgets/tablecontentmodel.py
+++ b/src/tribler-gui/tribler_gui/widgets/tablecontentmodel.py
@@ -464,8 +464,8 @@ class SearchResultsModel(ChannelContentModel):
 
 
 class DiscoveredChannelsModel(ChannelContentModel):
-    columns = [u'subscribed', u'name', u'state', u'torrents', u'votes', u'updated']
-    column_headers = [tr('Subscribed'), tr('Name'), u'', tr('Torrents'), tr('Popularity'), tr('Updated')]
+    columns = [u'subscribed', u'name', u'torrents', u'votes', u'updated']
+    column_headers = [tr('Subscribed'), tr('Name'), tr('Torrents'), tr('Popularity'), tr('Updated')]
 
     column_width = dict(ChannelContentModel.column_width, **{u'name': lambda table_width: table_width - 540})
     default_sort_column = columns.index(u'votes')


### PR DESCRIPTION
This PR combines the state column with the subscription control column. The subscription toggle switch is now shown only for hovered rows. This reduces "*orangefication*" (:copyright:  @xoriole) of the interface and reduces its complexity as @qstokkink  suggested.
![lkj](https://user-images.githubusercontent.com/2509103/98687780-6b61a900-236a-11eb-87c0-17446b6dd0ce.png)
