### PR TITLE
Refactor channels payload processing

### DIFF
--- a/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/channel_node.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/channel_node.py
@@ -273,14 +273,15 @@ def define_binding(db, logger=None, key=None):
             return self
 
         def get_parents_ids(self, max_recursion_depth=15):
-            if not max_recursion_depth:
+            if max_recursion_depth == 0:
                 return tuple()
             if self.origin_id == 0:
                 return (0,)
             parent = db.CollectionNode.get(public_key=self.public_key, id_=self.origin_id)
             if parent:
-                result = parent.get_parents_ids(max_recursion_depth=max_recursion_depth - 1)
-            return result + (parent.id_,)
+                return parent.get_parents_ids(max_recursion_depth=max_recursion_depth - 1) + (parent.id_,)
+            else:
+                return tuple()
 
         def make_copy(self, tgt_parent_id, attributes_override=None):
             dst_dict = attributes_override or {}

--- a/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/torrent_metadata.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/torrent_metadata.py
@@ -60,8 +60,6 @@ def define_binding(db):
         torrent_date = orm.Optional(datetime, default=datetime.utcnow, index=True)
         tracker_info = orm.Optional(str, default='')
 
-        orm.composite_key(db.ChannelNode.public_key, db.ChannelNode.origin_id, infohash)
-
         # Local
         xxx = orm.Optional(float, default=0)
         health = orm.Optional('TorrentState', reverse='metadata')

--- a/src/tribler-core/tribler_core/modules/metadata_store/store.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/store.py
@@ -42,7 +42,7 @@ from tribler_core.utilities.path_util import str_path
 from tribler_core.utilities.unicode import hexlify
 
 BETA_DB_VERSIONS = [0, 1, 2, 3, 4, 5]
-CURRENT_DB_VERSION = 8
+CURRENT_DB_VERSION = 9
 
 NO_ACTION = 0
 UNKNOWN_CHANNEL = 1
@@ -90,6 +90,7 @@ class MetadataStore(object):
         self.db_filename = db_filename
         self.channels_dir = channels_dir
         self.my_key = my_key
+        self.my_public_key_bin = bytes(database_blob(self.my_key.pub().key_to_bin()[10:]))
         self._logger = logging.getLogger(self.__class__.__name__)
 
         self._shutting_down = False
@@ -269,7 +270,7 @@ class MetadataStore(object):
                 ):
                     continue
             try:
-                self.process_mdblob_file(str(full_filename), **kwargs)
+                self.process_mdblob_file(str(full_filename), **kwargs, channel_public_key=public_key)
                 # If we stopped mdblob processing due to shutdown flag, we should stop
                 # processing immediately, so that the channel local version will not increase
                 if self._shutting_down:
@@ -410,7 +411,7 @@ class MetadataStore(object):
         return result
 
     @db_session
-    def process_payload(self, payload, skip_personal_metadata_payload=True):
+    def process_payload(self, payload, skip_personal_metadata_payload=True, channel_public_key=None):
         """
         This routine decides what to do with a given payload and executes the necessary actions.
         To do so, it looks into the database, compares version numbers, etc.
@@ -419,28 +420,24 @@ class MetadataStore(object):
         :param payload: payload to work on
         :param skip_personal_metadata_payload: if this is set to True, personal torrent metadata payload received
                 through gossip will be ignored. The default value is True.
+        :param channel_public_key: rejects payloads that do not belong to this key.
+               Enabling this allows to skip some costly checks during e.g. channel processing.
+
         :return: a list of tuples of (<metadata or payload>, <action type>)
         """
 
+        # In case we're processing a channel, we allow only payloads with the channel's public_key
+        if channel_public_key is not None and payload.public_key != channel_public_key:
+            return [(None, NO_ACTION)]
+
         if payload.metadata_type == DELETED:
+            if payload.public_key == self.my_public_key_bin and skip_personal_metadata_payload:
+                return [(None, NO_ACTION)]
             # We only allow people to delete their own entries, thus PKs must match
             node = self.ChannelNode.get_for_update(signature=payload.delete_signature, public_key=payload.public_key)
             if node:
                 node.delete()
                 return [(None, DELETED_METADATA)]
-
-        # Check if we already got an older version of the same node that we can update, and
-        # check the uniqueness constraint on public_key+infohash tuple. If the received entry
-        # has the same tuple as the entry we already have, update our entry if necessary.
-        # This procedure is necessary to handle the case when the original author of the payload
-        # had created another entry with the same infohash earlier, deleted it, and sent
-        # the different versions to two different peers.
-        # There is a corner case where there already exist 2 entries in our database that match both
-        # update conditions:
-        # A: (pk, id1, ih1)
-        # B: (pk, id2, ih2)
-        # When we receive the payload C1:(pk, id1, ih2) or C2:(pk, id2, ih1), we have to
-        # replace _both_ entries with a single one, to honor the DB uniqueness constraints.
 
         if payload.metadata_type not in [CHANNEL_TORRENT, REGULAR_TORRENT, COLLECTION_NODE]:
             return []
@@ -457,103 +454,69 @@ class MetadataStore(object):
                     return [(node, UNKNOWN_TORRENT)]
             return [(None, NO_ACTION)]
 
-        # Check if we already have this payload
-        node = self.ChannelNode.get(signature=payload.signature, public_key=payload.public_key)
-        if node:
-            return [(node, NO_ACTION)]
+        if channel_public_key is None and payload.metadata_type in [COLLECTION_NODE, REGULAR_TORRENT]:
+            # Check if the received payload is from a channel that we already have and send update if necessary
 
-        result = []
-        if payload.metadata_type in [CHANNEL_TORRENT, REGULAR_TORRENT]:
-            # Signed entry > FFA entry. Old FFA entry > new FFA entry
-            ffa_node = self.TorrentMetadata.get(public_key=database_blob(b""), infohash=database_blob(payload.infohash))
-            if ffa_node:
-                ffa_node.delete()
-
-            def check_update_opportunity():
-                # Check for possible update sending opportunity.
-                node = self.TorrentMetadata.get(
-                    lambda g: g.public_key == database_blob(payload.public_key)
-                    and g.id_ == payload.id_
-                    and g.timestamp > payload.timestamp
-                )
-                return [(node, GOT_NEWER_VERSION)] if node else [(None, NO_ACTION)]
-
-            # Check if the received payload is a deleted entry from a channel that we already have
-            parent_channel = self.ChannelMetadata.get(
-                public_key=database_blob(payload.public_key), id_=payload.origin_id
-            )
-            if parent_channel and parent_channel.local_version > payload.timestamp:
-                return check_update_opportunity()
-
-            # If we received a metadata payload signed by ourselves we simply ignore it since we are the only
-            # authoritative source of information about our own channel.
-            if skip_personal_metadata_payload and payload.public_key == bytes(
-                database_blob(self.my_key.pub().key_to_bin()[10:])
-            ):
-                return check_update_opportunity()
-
-            # Check for a node with the same infohash
-            node = self.TorrentMetadata.get_for_update(
-                public_key=database_blob(payload.public_key), infohash=database_blob(payload.infohash)
-            )
-            if node:
-                if node.timestamp < payload.timestamp:
-                    node.delete()
-                    result.append((None, DELETED_METADATA))
-                elif node.timestamp > payload.timestamp:
-                    result.append((node, GOT_NEWER_VERSION))
-                    return result
+            # Get the toplevel parent
+            parent = self.ChannelNode.get(public_key=payload.public_key, id_=payload.origin_id)
+            if parent:
+                parent_channel = None
+                if parent.origin_id == 0:
+                    parent_channel = parent
                 else:
-                    return result
-                # Otherwise, we got the same version locally and do nothing.
+                    parents_ids = parent.get_parents_ids()
+                    if 0 in parents_ids:
+                        parent_channel = self.ChannelNode.get(public_key=payload.public_key, id_=parents_ids[1])
+                if parent_channel and parent_channel.local_version > payload.timestamp:
+                    return [(parent_channel, GOT_NEWER_VERSION)]
 
-        # Check for the older version of the same node
+        # Check for the older version of the added node
         node = self.ChannelNode.get_for_update(public_key=database_blob(payload.public_key), id_=payload.id_)
         if node:
-            if node.timestamp < payload.timestamp:
-                # Workaround for a corner case of remote change of md type.
-                # We delete the original node and replace it with the updated one
-                if node.metadata_type != payload.metadata_type:
-                    if payload.metadata_type == REGULAR_TORRENT:
-                        node.delete()
-                        renewed_node = self.TorrentMetadata.from_payload(payload)
-                    elif payload.metadata_type == CHANNEL_TORRENT:
-                        node.delete()
-                        renewed_node = self.ChannelMetadata.from_payload(payload)
-                    elif payload.metadata_type == COLLECTION_NODE:
-                        node.delete()
-                        renewed_node = self.CollectionNode.from_payload(payload)
-                    else:
-                        self._logger.warning(
-                            f"Tried to update channel node to illegal type: "
-                            f" original type: {node.metadata_type}"
-                            f" updated type: {payload.metadata_type}"
-                            f" {hexlify(payload.public_key)}, {payload.id_} "
-                        )
-                        return result
-                    result.append((renewed_node, UPDATED_OUR_VERSION))
-                    return result
-                else:
-                    node.set(**payload.to_dict())
-                    result.append((node, UPDATED_OUR_VERSION))
-                    return result
-            elif node.timestamp > payload.timestamp:
-                result.append((node, GOT_NEWER_VERSION))
-                return result
-            # Otherwise, we got the same version locally and do nothing.
-            # The situation when something was marked for deletion, and then we got here (i.e. we have the same or
-            # newer version) should never happen, because this version should have removed the node we deleted earlier
-            if result:
-                self._logger.warning("Broken DB state!")
-            return result
+            return self.update_channel_node(node, payload, skip_personal_metadata_payload)
 
-        if payload.metadata_type == REGULAR_TORRENT:
-            result.append((self.TorrentMetadata.from_payload(payload), UNKNOWN_TORRENT))
-        elif payload.metadata_type == CHANNEL_TORRENT:
-            result.append((self.ChannelMetadata.from_payload(payload), UNKNOWN_CHANNEL))
-        elif payload.metadata_type == COLLECTION_NODE:
-            result.append((self.CollectionNode.from_payload(payload), UNKNOWN_COLLECTION))
-        return result
+        if payload.public_key == self.my_public_key_bin and skip_personal_metadata_payload:
+            return [(None, NO_ACTION)]
+        for orm_class, response in (
+            (self.TorrentMetadata, UNKNOWN_TORRENT),
+            (self.ChannelMetadata, UNKNOWN_CHANNEL),
+            (self.CollectionNode, UNKNOWN_COLLECTION),
+        ):
+            if orm_class._discriminator_ == payload.metadata_type:
+                return [(orm_class.from_payload(payload), response)]
+        return []
+
+    @db_session
+    def update_channel_node(self, node, payload, skip_personal_metadata_payload=True):
+        # The received metadata has newer version than the stuff we got, so we have to update our version.
+        if node.timestamp < payload.timestamp:
+            # If we received a metadata payload signed by ourselves we simply ignore it since we are the only
+            # authoritative source of information about our own channel.
+            if payload.public_key == self.my_public_key_bin and skip_personal_metadata_payload:
+                return [(None, NO_ACTION)]
+
+            # Update local metadata entry
+            if node.metadata_type == payload.metadata_type:
+                node.set(**payload.to_dict())
+                return [(node, UPDATED_OUR_VERSION)]
+            # Workaround for the corner case of remote change of md type.
+            # We delete the original node and replace it with the updated one.
+            for orm_class in (self.TorrentMetadata, self.ChannelMetadata, self.CollectionNode):
+                if orm_class._discriminator_ == payload.metadata_type:
+                    node.delete()
+                    return [(orm_class.from_payload(payload), UPDATED_OUR_VERSION)]
+            self._logger.warning(
+                f"Tried to update channel node to illegal type: "
+                f" original type: {node.metadata_type}"
+                f" updated type: {payload.metadata_type}"
+                f" {hexlify(payload.public_key)}, {payload.id_} "
+            )
+            return [(None, NO_ACTION)]
+
+        elif node.timestamp > payload.timestamp:
+            return [(node, GOT_NEWER_VERSION)]
+        # Otherwise, we got the same version locally and do nothing.
+        return []
 
     @db_session
     def get_num_channels(self):


### PR DESCRIPTION
This PR removes obsolete checks from `process_payload`. The changes result in 10x-20x speedup of channels processing for clients using DBs *created* by 7.5.x series (previous versions still use the obsolete index used by obsolete checks, so the speedup should be much less for those).

Also, we remove the unused public_key+id_+infohash unique index from DB and bump its version to `9`. Note we do not include the database upgrade procedure, because it will require rebuilding the whole DB. New DBs will be created without the index. The impact on old DBs should be negligible. This will be automatically solved by any other possible DB upgrade in the future.