### PR TITLE
Fix process payload return values

### DIFF
--- a/src/tribler-core/tribler_core/modules/metadata_store/store.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/store.py
@@ -523,7 +523,9 @@ class MetadataStore(object):
         elif node.timestamp > payload.timestamp:
             return [(node, GOT_NEWER_VERSION)]
         # Otherwise, we got the same version locally and do nothing.
-        return []
+        # Nevertheless, it is important to indicate to upper levels that we recognised
+        # the entry, for e.g. channel votes bumping
+        return [(node, GOT_NEWER_VERSION)]
 
     @db_session
     def get_num_channels(self):


### PR DESCRIPTION
This commit fixes a defect introduced in https://github.com/Tribler/tribler/pull/5732, which prevents channels being voted more than one time.