### PR TITLE
Channels-related workarounds for another 7.5 release

### DIFF
--- a/src/tribler-core/tribler_core/modules/metadata_store/community/remote_query_community.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/community/remote_query_community.py
@@ -25,6 +25,16 @@ def sanitize_query(query_dict, cap=100):
     first = first or 0
     last = last if (last is not None and last <= (first + cap)) else (first + cap)
     query_dict.update({"first": first, "last": last})
+
+    # convert hex infohash to binary
+    infohash = query_dict.get('infohash', None)
+    if infohash:
+        query_dict['infohash'] = unhexlify(infohash)
+
+    channel_pk = query_dict.get('channel_pk', None)
+    if channel_pk:
+        query_dict['channel_pk'] = unhexlify(channel_pk)
+
     return query_dict
 
 

--- a/src/tribler-core/tribler_core/modules/metadata_store/tests/test_store.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/tests/test_store.py
@@ -328,6 +328,7 @@ class TestMetadataStore(TriblerCoreTest):
 
     @db_session
     def test_process_payload_merge_entries(self):
+        self.mds.pk_infohash_uniq_index_exists = True
         # Check the corner case where the new entry must replace two old entries: one with a matching infohash, and
         # another one with a non-matching id
         node = self.mds.TorrentMetadata(infohash=database_blob(random_infohash()))
@@ -371,6 +372,7 @@ class TestMetadataStore(TriblerCoreTest):
 
     @db_session
     def test_process_payload_reject_older_entry_with_known_infohash_or_merge(self):
+        self.mds.pk_infohash_uniq_index_exists = True
         # Check there is no action if the processed payload has a timestamp that is less than the
         # local_version of the corresponding local channel. (I.e. remote peer trying to push back a deleted entry)
         torrent = self.mds.TorrentMetadata(


### PR DESCRIPTION
Ok, this is going to be tricky to explain...

Apparently, when one specifies a `UNIQUE` index in SQLite, the index is created automatically as a special kind of `autoindex`. These indexes have two peculiar properties:
 1. autoindexes are only shown with a SQLite-specific `PRAGMA` (i.e. SQLitebrowser does not show them)
 2. unique autoindexes **cannot be deleted**.

Well, I happily left managing indexes stuff to Pony and never saw the results due to (1). However, the first versions of Channels included a unique `public_key+infohash` index to be compatible with the older GUI and REST logic. Later we completely change channels identification model in 7.4-7.5 by moving to the more robust `public_key+id_` approach. The logic for serving the corner case of unique public_key+infohash combination was still there, though, causing extreme slowdowns on channel processing *for people who started using Tribler since 7.5*! For those who used older, "upgraded" DBs, the index was still in place, speeding up the obsolete checks.

Now, we removed those checks in #5732 . But the index still remains there! Thus, user DB versions have split into two types: "with unique index" and "without unique index".


Note that if we turn the checks off for everyone, some people will experience crashes due to UNIQUE constraint fails. If we keep the checks on for everyone, some people (new users) will experience *extremely* slow Channels performance.

I'm going to do a full DB upgrade for 7.6, re-creating the DB completely. Til' that moment, I propose keeping the check ON for those users who have the "with unique index" DB, but turn the check OFF for those users who got no index in their DB.

This PR does just that - turns off the check for those DBs that must have it off. (It is ugly, but I checked it by hand - it works).

Also, this PR adds support for `infohash` and `public_key` -based queries in RemoteQueryCommunity. This will help smooth the transition to 7.6, where all Channels- related functions will be served by RemoteQueryCommunity.


We should do another 7.5 series release after merging this.