### PR TITLE
Add sentry

### DIFF
--- a/build/update_version_from_git.py
+++ b/build/update_version_from_git.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import logging
+import os
 import sys
 from os import linesep, path
 from subprocess import PIPE, Popen
@@ -28,13 +29,24 @@ if __name__ == '__main__':
     commit_id = run_command(cmd).strip()[1:].replace("'", "")
     logger.info("Commit: %s", commit_id)
 
+    sentry_url = os.environ.get('SENTRY_URL', None)
+    logger.info(f'Sentry url: {sentry_url}')
+    if not sentry_url:
+        logger.critical('Sentry url is not defined. To define sentry url use:'
+                        'EXPORT SENTRY_URL=<sentry_url>')
+        sys.exit(1)
+
     build_date = ctime()
     logger.info("Build date: %s", build_date)
 
     logger.info('Writing runtime version info.')
     with open(path.join('src', 'tribler-core', 'tribler_core', 'version.py'), 'w') as f:
-        f.write('version_id = "%s"%sbuild_date = "%s"%scommit_id = "%s"%s' %
-                (version_id, linesep, build_date, linesep, commit_id, linesep))
+        f.write(
+            f'version_id = "{version_id}"{linesep}'
+            f'build_date = "{build_date}"{linesep}'
+            f'commit_id = "{commit_id}"{linesep}'
+            f'sentry_url = "{sentry_url}"{linesep}'
+        )
 
     with open('.TriblerVersion', 'w') as f:
         f.write(version_id)

--- a/src/README.md
+++ b/src/README.md
@@ -25,8 +25,13 @@ Export to PYTHONPATH the following directories:
 * tribler-core
 * tribler-gui
 
+Shortcut for macOS:
+```shell script
+export PYTHONPATH=${PYTHONPATH}:`echo {pyipv8,tribler-common,tribler-core,tribler-gui} | tr " " :`
+```
 Execute:
 ```
 python3 -m pytest tribler-core
+python3 -m pytest tribler-common
 python3 -m pytest tribler-gui --guitests
 ```

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -15,6 +15,8 @@ aiohttp
 aiohttp_apispec
 pyyaml
 marshmallow
+sentry_sdk
+Faker
 Pillow
 netifaces
 pyqtgraph

--- a/src/run_tribler.py
+++ b/src/run_tribler.py
@@ -5,12 +5,15 @@ import signal
 import sys
 from asyncio import ensure_future, get_event_loop
 
+from tribler_common.sentry_reporter.sentry_reporter import SentryReporter
+from tribler_common.sentry_reporter.sentry_scrubber import SentryScrubber
+
 import tribler_core
 from tribler_core.config.tribler_config import CONFIG_FILENAME
 from tribler_core.dependencies import check_for_missing_dependencies
 from tribler_core.upgrade.version_manager import fork_state_directory_if_necessary, get_versioned_state_directory
 from tribler_core.utilities.osutils import get_root_state_directory
-from tribler_core.version import version_id
+from tribler_core.version import sentry_url, version_id
 
 import tribler_gui
 
@@ -86,6 +89,9 @@ def start_tribler_core(base_path, api_port, api_key, root_state_dir, core_test_m
 
 
 if __name__ == "__main__":
+    SentryReporter.init(sentry_url=sentry_url, scrubber=SentryScrubber())
+    SentryReporter.allow_sending_globally(False, 'run_tribler.__main__()')
+
     # Get root state directory (e.g. from environment variable or from system default)
     root_state_dir = get_root_state_directory()
 

--- a/src/tribler-common/tribler_common/sentry_reporter/sentry_reporter.py
+++ b/src/tribler-common/tribler_common/sentry_reporter/sentry_reporter.py
@@ -1,0 +1,330 @@
+import logging
+from contextvars import ContextVar
+from hashlib import md5
+
+from faker import Faker
+
+import sentry_sdk
+from sentry_sdk.integrations.logging import LoggingIntegration
+from sentry_sdk.integrations.threading import ThreadingIntegration
+
+from tribler_common.sentry_reporter.sentry_tools import (
+    delete_item,
+    get_first_item,
+    get_value,
+    parse_os_environ,
+    parse_stacktrace,
+)
+
+PLATFORM_DETAILS = 'platform.details'
+STACKTRACE = '_stacktrace'
+SYSINFO = 'sysinfo'
+OS_ENVIRON = 'os.environ'
+SYS_ARGV = 'sys.argv'
+TAGS = 'tags'
+CONTEXTS = 'contexts'
+EXTRA = 'extra'
+BREADCRUMBS = 'breadcrumbs'
+LOGENTRY = 'logentry'
+REPORTER = 'reporter'
+
+
+class SentryReporter:
+    """SentryReporter designed for sending reports to the Sentry server from
+    a Tribler Client.
+
+    # Main concept
+
+    It aims to work in a Tribler Client with the following specifics:
+
+    1. An exception can be raised in two separate processes: GUI and Core.
+    2. A report will be sent after a user presses the "send report" button.
+
+    The main concept behind this class is the following: let's add controls that
+    can allow or disallow sending Sentry reports by-default.
+
+    If we have these controls, then it is easy to use Sentry with a Tribler
+    Client.
+
+    Algorithm:
+    1. Initialise Sentry.
+    2. Disallow sending messages (but storing the last event).
+    3. Waiting for user action: the "sent report" button is pressed.
+    4. Allow Sentry sending messages
+    5. Send the last event.
+
+    SentryReporter is thread-safe.
+   """
+
+    last_event = None
+
+    _allow_sending_global = False
+    _allow_sending_in_thread = ContextVar('Sentry')
+
+    _scrubber = None
+    _logger = logging.getLogger('SentryReporter')
+
+    @staticmethod
+    def init(sentry_url='', scrubber=None):
+        """ Initialization.
+
+        This method should be called in each process that uses SentryReporter.
+
+        Args:
+            sentry_url: URL for Sentry server. If it is empty then Sentry's
+                sending mechanism will not be initialized.
+
+            scrubber: a class that will be used for scrubbing sending events.
+                Only a single method should be implemented in the class:
+                ```
+                    def scrub_event(self, event):
+                        pass
+                ```
+        Returns:
+            Sentry Guard.
+        """
+        SentryReporter._logger.info(f"Init: {sentry_url}")
+
+        SentryReporter._scrubber = scrubber
+        return sentry_sdk.init(
+            sentry_url,
+            release=None,
+            # https://docs.sentry.io/platforms/python/configuration/integrations/
+            integrations=[
+                LoggingIntegration(
+                    level=logging.INFO,  # Capture info and above as breadcrumbs
+                    event_level=logging.ERROR,  # Send errors as events
+                ),
+                ThreadingIntegration(propagate_hub=True),
+            ],
+            before_send=SentryReporter._before_send,
+        )
+
+    @staticmethod
+    def send(event, post_data, sys_info):
+        """Send the event to the Sentry server
+
+        This method
+            1. Enable Sentry's sending mechanism.
+            2. Extend sending event by the information from post_data.
+            3. Send the event.
+            4. Disables Sentry's sending mechanism.
+
+        Scrubbing the information will be performed in the `_before_send` method.
+
+        During the execution of this method, all unhandled exceptions that
+        will be raised, will be sent to Sentry automatically.
+
+        Args:
+            event: event to send. It should be taken from SentryReporter at
+            post_data: dictionary made by the feedbackdialog.py
+                previous stages of executing.
+            sys_info: dictionary made by the feedbackdialog.py
+
+        Returns:
+            Event that was sent to Sentry server
+        """
+        SentryReporter._logger.info(f"Send: {post_data}, {event}")
+
+        if event is None:
+            return event
+
+        with AllowSentryReports(value=True, description='SentryReporter.send()'):
+            # prepare event
+            if CONTEXTS not in event:
+                event[CONTEXTS] = {}
+
+            if TAGS not in event:
+                event[TAGS] = {}
+
+            event[CONTEXTS][REPORTER] = {}
+
+            # tags
+            tags = event[TAGS]
+            tags['version'] = get_value(post_data, 'version')
+            tags['machine'] = get_value(post_data, 'machine')
+            tags['os'] = get_value(post_data, 'os')
+            tags['platform'] = get_first_item(get_value(sys_info, 'platform'))
+            tags[('%s' % PLATFORM_DETAILS)] = get_first_item(get_value(sys_info, PLATFORM_DETAILS))
+
+            # context
+            context = event[CONTEXTS]
+            reporter = context[REPORTER]
+            version = get_value(post_data, 'version')
+
+            context['browser'] = {'version': version, 'name': 'Tribler'}
+
+            reporter[STACKTRACE] = parse_stacktrace(get_value(post_data, 'stack'))
+            reporter['comments'] = get_value(post_data, 'comments')
+
+            reporter[OS_ENVIRON] = parse_os_environ(get_value(sys_info, OS_ENVIRON))
+            delete_item(sys_info, OS_ENVIRON)
+            reporter[SYSINFO] = sys_info
+
+            sentry_sdk.capture_event(event)
+
+            return event
+
+    @staticmethod
+    def set_user(user_id):
+        """ Set the user to identify the event on a Sentry server
+
+        The algorithm is the following:
+        1. Calculate hash from `user_id`.
+        2. Generate fake user, based on the hash.
+
+        No real `user_id` will be used in Sentry.
+
+        Args:
+            user_id: Real user id.
+
+        Returns:
+            Generated user (dictionary: {id, username}).
+        """
+        # calculate hash to keep real `user_id` in secret
+        user_id_hash = md5(user_id).hexdigest()
+
+        SentryReporter._logger.info(f"Set user: {user_id_hash}")
+
+        Faker.seed(user_id_hash)
+        user_name = Faker().name()
+        user = {'id': user_id_hash, 'username': user_name}
+
+        sentry_sdk.set_user(user)
+        return user
+
+    @staticmethod
+    def get_allow_sending():
+        """ Indicate whether Sentry allowed or disallowed to sent events.
+
+        Returns:
+            Bool
+        """
+        allow_sending_in_thread = SentryReporter._allow_sending_in_thread.get(None)
+        if allow_sending_in_thread is not None:
+            return allow_sending_in_thread
+
+        return SentryReporter._allow_sending_global
+
+    @staticmethod
+    def allow_sending_globally(value, info=None):
+        """ Setter for `_allow_sending_global` variable.
+
+        It globally allows or disallows Sentry to send events.
+        If `_allow_sending_in_thread` is not set, then `_allow_sending_global`
+        will be used.
+
+        Args:
+            value: Bool
+            info: String that will be used as an indicator of allowing or
+            disallowing reason (or the place from which this method has been
+            invoked).
+
+        Returns:
+            None
+        """
+        SentryReporter._logger.info(f"Allow sending globally: {value}. Info: {info}")
+        SentryReporter._allow_sending_global = value
+
+    @staticmethod
+    def allow_sending_in_thread(value, info=None):
+        """ Setter for `_allow_sending` variable.
+
+        It allows or disallows Sentry to send events in the current thread.
+        If `_allow_sending_in_thread` is not set, then `_allow_sending_global`
+        will be used.
+
+        Args:
+            value: Bool
+            info: String that will be used as an indicator of allowing or
+            disallowing reason (or the place from which this method has been
+            invoked).
+
+        Returns:
+            None
+        """
+        SentryReporter._logger.info(f"Allow sending in thread: {value}. Info: {info}")
+        SentryReporter._allow_sending_in_thread.set(value)
+
+    @staticmethod
+    def _before_send(event, _):
+        """The method that is called before each send. Both allowed and
+        disallowed.
+
+        The algorithm:
+        1. If sending is allowed, then scrub the event and send.
+        2. If sending is disallowed, then store the event in
+            `SentryReporter.last_event`
+
+        Args:
+            event: event that generated by Sentry
+            hint: root exception (can be used in some cases)
+
+        Returns:
+            The event, prepared for sending, or `None`, if sending is suppressed.
+        """
+        if not event:
+            return event
+
+        SentryReporter._logger.info(f"Before send event: {event}")
+        SentryReporter._logger.info(f"Is allow sending: {SentryReporter._allow_sending_global}")
+        # to synchronise error reporter and sentry, we should suppress all events
+        # until user clicked on "send crash report"
+        if not SentryReporter.get_allow_sending():
+            SentryReporter._logger.info("Suppress sending. Storing the event.")
+            SentryReporter.last_event = event
+            return None
+
+        # clean up the event
+        SentryReporter._logger.info(f"Clean up the event with scrubber: {SentryReporter._scrubber}")
+        if SentryReporter._scrubber:
+            event = SentryReporter._scrubber.scrub_event(event)
+
+        return event
+
+
+class AllowSentryReports:
+    """ This class designed for simplifying allowing and disallowing
+    Sentry's sending mechanism for particular blocks of code.
+
+    It is thread-safe, and use `SentryReporter.allow_sending_in_thread` method
+    for setting corresponding variable.
+
+    Example of use:
+    ```
+        with AllowSentryReports(value=True):
+            do_some_work()
+    ```
+    """
+
+    def __init__(self, value=True, description='', reporter=None):
+        """ Initialising a value and a reporter
+
+        Args:
+            value: Value that will be used for passing in
+                `SentryReporter.allow_sending`.
+            description: Will be used while logging.
+            reporter: Instance of a reporter. This argument mostly use for
+                testing purposes.
+        """
+        self._logger = logging.getLogger(self.__class__.__name__)
+        self._logger.info(f'Value: {value}, description: {description}')
+
+        self._value = value
+        self._saved_state = None
+        self._reporter = reporter or SentryReporter()
+
+    def __enter__(self):
+        """Set SentryReporter.allow_sending(value)
+        """
+        self._logger.info('Enter')
+        self._saved_state = self._reporter.get_allow_sending()
+
+        self._reporter.allow_sending_in_thread(self._value, 'AllowSentryReports.__enter__()')
+        return self._reporter
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Restore SentryReporter.allow_sending(old_value)
+        """
+        self._logger.info('Exit')
+        self._reporter.allow_sending_in_thread(self._saved_state, 'AllowSentryReports.__exit__()')

--- a/src/tribler-common/tribler_common/sentry_reporter/sentry_scrubber.py
+++ b/src/tribler-common/tribler_common/sentry_reporter/sentry_scrubber.py
@@ -1,0 +1,165 @@
+import re
+
+from tribler_common.sentry_reporter.sentry_reporter import (
+    BREADCRUMBS,
+    CONTEXTS,
+    EXTRA,
+    LOGENTRY,
+    OS_ENVIRON,
+    REPORTER,
+    STACKTRACE,
+    SYSINFO,
+)
+from tribler_common.sentry_reporter.sentry_tools import delete_item, modify_value
+
+
+class SentryScrubber:
+    """ This class has been created to be responsible for scrubbing all sensitive
+    and unnecessary information from Sentry event.
+    """
+
+    def __init__(self):
+        # https://en.wikipedia.org/wiki/Home_directory
+        self.home_folders = [
+            'users',
+            'usr',
+            'home',
+            'u01',
+            'var',
+            r'data\/media',
+            r'WINNT\\Profiles',
+            'Documents and Settings',
+        ]
+
+        self.event_fields_to_cut = ['modules']
+
+        self.placeholder_user = '<user>'
+        self.placeholder_ip = '<IP>'
+        self.placeholder_hash = '<hash>'
+
+        self.exclusions = ['local', '127.0.0.1']
+
+        self.user_name = None
+
+        self.re_folders = []
+        self.re_ip = None
+        self.re_hash = None
+
+        self._compile_re()
+
+    def _compile_re(self):
+        """ Compile all regular expressions.
+        """
+        for folder in self.home_folders:
+            folder_pattern = r'(?<=' + folder + r'[/\\])\w+(?=[/\\])'
+            self.re_folders.append(re.compile(folder_pattern, re.I))
+
+        self.re_ip = re.compile(r'(?<!\.)\b(\d{1,3}\.){3}\d{1,3}\b(?!\.)', re.I)
+        self.re_hash = re.compile(r'\b[0-9a-f]{40}\b', re.I)
+
+    def scrub_event(self, event):
+        """ Main method. Removes all sensitive and unnecessary information.
+
+        Args:
+            event: a Sentry event.
+
+        Returns:
+            Scrubbed the Sentry event.
+        """
+        if not event:
+            return event
+
+        for field_name in self.event_fields_to_cut:
+            delete_item(event, field_name)
+
+        modify_value(event, EXTRA, self.scrub_entity_recursively)
+        modify_value(event, LOGENTRY, self.scrub_entity_recursively)
+        modify_value(event, BREADCRUMBS, self.scrub_entity_recursively)
+
+        reporter = event.get(CONTEXTS, {}).get(REPORTER, None)
+        if not reporter:
+            return event
+
+        modify_value(reporter, OS_ENVIRON, self.scrub_entity_recursively)
+        modify_value(reporter, STACKTRACE, self.scrub_entity_recursively)
+        modify_value(reporter, SYSINFO, self.scrub_entity_recursively)
+
+        return event
+
+    def scrub_text(self, text):
+        """ Replace all sensitive information from `text` by corresponding
+        placeholders.
+
+        Sensitive information:
+            * IP
+            * User Name
+            * 40-symbols-long hash
+
+        A found user name will be stored and used for further replacements.
+        Args:
+            text:
+
+        Returns:
+            The text with removed sensitive information.
+        """
+        if text is None:
+            return text
+
+        def cut_username(m):
+            group = m.group(0)
+            if group in self.exclusions:
+                return group
+            self.user_name = group
+            replacement = self.placeholder_user
+            return replacement
+
+        for regex in self.re_folders:
+            text = regex.sub(cut_username, text)
+
+        # cut an IP
+        def cut_ip(m):
+            return self.placeholder_ip if m.group(0) not in self.exclusions else m.group(0)
+
+        text = self.re_ip.sub(cut_ip, text)
+
+        # cut hash
+        text = self.re_hash.sub(self.placeholder_hash, text)
+
+        # replace all user name occurrences in the whole string
+        if self.user_name:
+            text = re.sub(r'\b' + re.escape(self.user_name) + r'\b', self.placeholder_user, text)
+
+        return text
+
+    def scrub_entity_recursively(self, entity, depth=10):
+        """Recursively traverses entity and remove all sensitive information.
+
+        Can work with:
+            1. Text
+            2. Dictionaries
+            3. Lists
+
+        All other fields just will be skipped.
+
+        Args:
+            entity: an entity to process.
+            depth: depth of recursion.
+
+        Returns:
+            The entity with removed sensitive information.
+        """
+        if depth < 0 or not entity:
+            return entity
+
+        depth -= 1
+
+        if isinstance(entity, str):
+            return self.scrub_text(entity)
+
+        if isinstance(entity, list):
+            return [self.scrub_entity_recursively(item, depth) for item in entity]
+
+        if isinstance(entity, dict):
+            return dict((key, self.scrub_entity_recursively(entity[key], depth)) for key in entity)
+
+        return entity

--- a/src/tribler-common/tribler_common/sentry_reporter/sentry_tools.py
+++ b/src/tribler-common/tribler_common/sentry_reporter/sentry_tools.py
@@ -1,0 +1,77 @@
+""" This a collection of tools for SentryReporter and SentryScrubber aimed to
+simplify work with several data structures.
+"""
+
+
+def parse_os_environ(array):
+    """ Parse os.environ field.
+
+    Args:
+        array: strings that represents tuples delimited by `:`
+            Example: ["KEY:VALUE", "PATH:~/"]
+
+    Returns:
+        Dictionary that made from given array.
+            Example: {"KEY": "VALUE", "PATH": "~/"}
+
+    """
+    result = {}
+
+    if not array:
+        return result
+
+    for line in array:
+        items = line.split(':', 1)
+        if len(items) < 2:
+            continue
+        result[items[0]] = items[1]
+
+    return result
+
+
+def parse_stacktrace(stacktrace):
+    """ Parse stacktrace field.
+
+    Args:
+        stacktrace: a string with '\n' delimiter.
+            Example: "line1\nline2"
+
+    Returns:
+        The list of strings made from the given string.
+            Example: ["line1", "line2"]
+    """
+    if not stacktrace:
+        return []
+
+    return [line for line in stacktrace.split('\n') if line]
+
+
+def get_first_item(items, default=None):
+    return items[0] if items else default
+
+
+def get_last_item(items, default=None):
+    return items[-1] if items else default
+
+
+def delete_item(d, key):
+    if not d:
+        return d
+
+    if key in d:
+        del d[key]
+    return d
+
+
+def get_value(d, key, default=None):
+    return d.get(key, default) if d else default
+
+
+def modify_value(d, key, function):
+    if not d or not key or not function:
+        return d
+
+    if key in d:
+        d[key] = function(d[key])
+
+    return d

--- a/src/tribler-common/tribler_common/sentry_reporter/tests/test_sentry_reporter.py
+++ b/src/tribler-common/tribler_common/sentry_reporter/tests/test_sentry_reporter.py
@@ -1,0 +1,198 @@
+import pytest
+
+from tribler_common.sentry_reporter.sentry_reporter import (
+    AllowSentryReports,
+    OS_ENVIRON,
+    PLATFORM_DETAILS,
+    SentryReporter,
+)
+from tribler_common.sentry_reporter.sentry_scrubber import SentryScrubber
+
+
+@pytest.fixture(name="reporter")  # this workaround implemented only for pylint
+def fixture_reporter():
+    return SentryReporter()
+
+
+@pytest.fixture(name="mock_reporter")  # this workaround implemented only for pylint
+def fixture_mock_reporter():
+    class MockReporter:
+        def __init__(self):
+            self._allow_sending = None
+
+        def get_allow_sending(self):
+            return self._allow_sending
+
+        def allow_sending(self, value, _=None):
+            self._allow_sending = value
+
+    return MockReporter()
+
+
+def test_init(reporter):
+    assert reporter.init('')
+
+
+def test_states():
+    instance1 = SentryReporter()
+    instance2 = SentryReporter()
+    assert instance1 != instance2
+    assert instance1.get_allow_sending() == instance2.get_allow_sending()
+
+    instance1.allow_sending_globally(not instance2.get_allow_sending())
+    assert instance1.get_allow_sending() == instance2.get_allow_sending()
+
+
+def test_set_user(reporter):
+    assert reporter.set_user('some_id'.encode('utf-8')) == {
+        'id': 'db69fe66ec6b6b013c2f7d271ce17cae',
+        'username': 'Wanda Brown',
+    }
+
+    assert reporter.set_user(b'11111100100') == {
+        'id': '91f900f528d5580581197c2c6a4adbbc',
+        'username': 'Jennifer Herrera',
+    }
+
+
+def test_allow_sentry(reporter):
+    reporter.allow_sending_in_thread(None)
+
+    reporter.allow_sending_globally(True)
+    assert reporter.get_allow_sending()
+
+    reporter.allow_sending_globally(False)
+    assert not reporter.get_allow_sending()
+
+    reporter.allow_sending_globally(True)
+    reporter.allow_sending_in_thread(True)
+    assert reporter.get_allow_sending()
+
+    reporter.allow_sending_globally(True)
+    reporter.allow_sending_in_thread(False)
+    assert not reporter.get_allow_sending()
+
+    reporter.allow_sending_globally(False)
+    reporter.allow_sending_in_thread(True)
+    assert reporter.get_allow_sending()
+
+    reporter.allow_sending_globally(False)
+    reporter.allow_sending_in_thread(False)
+    assert not reporter.get_allow_sending()
+
+
+def test_allow_sentry_reports(reporter):
+    # test base logic
+
+    # test allow_sending_globally=True
+    reporter.allow_sending_in_thread(None)
+    reporter.allow_sending_globally(True)
+    assert reporter.get_allow_sending()
+
+    with AllowSentryReports(reporter=reporter):
+        assert reporter.get_allow_sending() is True
+
+    with AllowSentryReports(value=False, reporter=reporter):
+        assert reporter.get_allow_sending() is False
+    assert reporter.get_allow_sending() is True
+
+    # test allow_sending_globally=False
+    reporter.allow_sending_in_thread(None)
+    reporter.allow_sending_globally(False)
+    assert reporter.get_allow_sending() is False
+
+    with AllowSentryReports(reporter=reporter):
+        assert reporter.get_allow_sending() is True
+
+    with AllowSentryReports(value=False, reporter=reporter):
+        assert reporter.get_allow_sending() is False
+    assert reporter.get_allow_sending() is False
+
+
+def test_send(reporter):
+    assert reporter.send(None, None, None) is None
+
+    # test return defaults
+    assert reporter.send({}, None, None) == {
+        'contexts': {
+            'browser': {'name': 'Tribler', 'version': None},
+            'reporter': {'_stacktrace': [], 'comments': None, OS_ENVIRON: {}, 'sysinfo': None},
+        },
+        'tags': {'machine': None, 'os': None, 'platform': None, PLATFORM_DETAILS: None, 'version': None},
+    }
+
+    # test post_data
+    post_data = {
+        "version": '0.0.0',
+        "machine": 'x86_64',
+        "os": 'posix',
+        "timestamp": 42,
+        "sysinfo": '',
+        "comments": 'comment',
+        "stack": 'some\nstack',
+    }
+
+    assert reporter.send({'a': 'b'}, post_data, None) == {
+        'a': 'b',
+        'contexts': {
+            'browser': {'name': 'Tribler', 'version': '0.0.0'},
+            'reporter': {'_stacktrace': ['some', 'stack'], 'comments': 'comment', 'os.environ': {}, 'sysinfo': None},
+        },
+        'tags': {'machine': 'x86_64', 'os': 'posix', 'platform': None, 'platform.details': None, 'version': '0.0.0'},
+    }
+
+    # test sys_info
+    post_data = {"sysinfo": 'key\tvalue\nkey1\tvalue1\n'}
+
+    assert reporter.send({}, post_data, None) == {
+        'contexts': {
+            'browser': {'name': 'Tribler', 'version': None},
+            'reporter': {'_stacktrace': [], 'comments': None, 'os.environ': {}, 'sysinfo': None},
+        },
+        'tags': {'machine': None, 'os': None, 'platform': None, 'platform.details': None, 'version': None},
+    }
+
+    sys_info = {'platform': ['darwin'], 'platform.details': ['details'], OS_ENVIRON: ['KEY:VALUE', 'KEY1:VALUE1']}
+    assert reporter.send({}, None, sys_info) == {
+        'contexts': {
+            'browser': {'name': 'Tribler', 'version': None},
+            'reporter': {
+                '_stacktrace': [],
+                'comments': None,
+                'os.environ': {'KEY': 'VALUE', 'KEY1': 'VALUE1'},
+                'sysinfo': sys_info,
+            },
+        },
+        'tags': {'machine': None, 'os': None, 'platform': 'darwin', 'platform.details': 'details', 'version': None},
+    }
+
+
+def test_before_send(reporter):
+    scrubber = SentryScrubber()
+    reporter.init('', scrubber)
+
+    # pylint: disable=protected-access
+
+    assert reporter._before_send({}, {}) == {}
+    assert reporter._before_send(None, {}) is None
+    assert reporter._before_send(None, None) is None
+
+    reporter.allow_sending_in_thread(None)
+    reporter.allow_sending_globally(False)
+    assert reporter.last_event is None
+    assert not reporter.get_allow_sending()
+
+    # check that an event is stored
+    assert reporter._before_send({'a': 'b'}, None) is None
+    assert reporter.last_event == {'a': 'b'}
+
+    # check an event has been processed
+    reporter.allow_sending_globally(True)
+    assert reporter.get_allow_sending()
+    assert reporter._before_send({'c': 'd'}, None) == {'c': 'd'}
+    assert reporter.last_event == {'a': 'b'}
+
+    # check information has been scrubbed
+    assert reporter._before_send({'contexts': {'reporter': {'_stacktrace': ['/Users/username/']}}}, None) == {
+        'contexts': {'reporter': {'_stacktrace': [f'/Users/{scrubber.placeholder_user}/']}}
+    }

--- a/src/tribler-common/tribler_common/sentry_reporter/tests/test_sentry_scrubber.py
+++ b/src/tribler-common/tribler_common/sentry_reporter/tests/test_sentry_scrubber.py
@@ -1,0 +1,253 @@
+import pytest
+
+from tribler_common.sentry_reporter.sentry_reporter import BREADCRUMBS, CONTEXTS, EXTRA, LOGENTRY, OS_ENVIRON, \
+    REPORTER, \
+    STACKTRACE, \
+    SYSINFO, \
+    SYS_ARGV
+from tribler_common.sentry_reporter.sentry_scrubber import SentryScrubber
+
+
+@pytest.fixture(name="scrubber")  # this workaround implemented only for pylint
+def fixture_scrubber():
+    return SentryScrubber()
+
+
+def test_patterns(scrubber):
+    # folders negative
+    assert not any(regex.search('') for regex in scrubber.re_folders)
+    assert not any(regex.search('some text') for regex in scrubber.re_folders)
+    assert not any(regex.search('/home//some/') for regex in scrubber.re_folders)
+
+    # folders positive
+    assert any(regex.search('/home/username/some/') for regex in scrubber.re_folders)
+    assert any(regex.search('/usr/local/path/') for regex in scrubber.re_folders)
+    assert any(regex.search('/Users/username/some/') for regex in scrubber.re_folders)
+    assert any(regex.search('/users/username/some/long_path') for regex in scrubber.re_folders)
+    assert any(regex.search('/home/username/some/') for regex in scrubber.re_folders)
+    assert any(regex.search('/data/media/username3/some/') for regex in scrubber.re_folders)
+    assert any(regex.search('WINNT\\Profiles\\username\\some') for regex in scrubber.re_folders)
+    assert any(regex.search('Documents and Settings\\username\\some') for regex in scrubber.re_folders)
+
+    # ip negative
+    assert not scrubber.re_ip.search('0.0.0')
+    assert not scrubber.re_ip.search('0.0.0.0.0')
+    assert not scrubber.re_ip.search('0.1000.0.1')
+    assert not scrubber.re_ip.search('0.a.0.1')
+    assert not scrubber.re_ip.search('0123.0.0.1')
+    assert not scrubber.re_ip.search('03.0.0.1234')
+    assert not scrubber.re_ip.search('a0.0.0.1')
+
+    # ip positive
+    assert scrubber.re_ip.search('127.0.0.1')
+    assert scrubber.re_ip.search('0.0.0.1')
+    assert scrubber.re_ip.search('0.100.0.1')
+    assert scrubber.re_ip.search('(0.100.0.1)')
+
+    # hash negative
+    assert not scrubber.re_hash.search('0a303030303030303030303030303030303030300')
+    assert not scrubber.re_hash.search('0a3030303030303030303303030303030303030')
+    assert not scrubber.re_hash.search('z030303030303030303030303030303030303030')
+
+    # hash positive
+    assert scrubber.re_hash.search('3030303030303030303030303030303030303030')
+    assert scrubber.re_hash.search('0a30303030303030303030303030303030303030')
+    assert scrubber.re_hash.search('hash:3030303030303030303030303030303030303030')
+
+
+def test_scrub_path(scrubber):
+    # scrub negative
+    assert scrubber.scrub_text('/usr/local/path/') == '/usr/local/path/'
+    assert scrubber.scrub_text('some text') == 'some text'
+
+    assert scrubber.user_name is None
+
+    # scrub positive
+
+    # this particular example is kinda bug (<<user>>)
+    # but it is not really important what placeholder we use
+    # hence, let's leave it at that for now.
+    assert scrubber.scrub_text('/users/user/apps') == \
+           f'/users/<{scrubber.placeholder_user}>/apps'
+    assert scrubber.user_name == 'user'
+
+    assert scrubber.scrub_text('/users/username/some/long_path') == \
+           f'/users/{scrubber.placeholder_user}/some/long_path'
+    assert scrubber.user_name == 'username'
+
+
+def test_scrub_text_ip(scrubber):
+    # negative
+    assert scrubber.scrub_text('127.0.0.1') == '127.0.0.1'
+    assert scrubber.scrub_text('0.0.0') == '0.0.0'
+
+    # positive
+    assert scrubber.scrub_text('0.0.0.1') == scrubber.placeholder_ip
+    assert scrubber.scrub_text('0.100.0.1') == scrubber.placeholder_ip
+
+    assert scrubber.user_name is None
+
+
+def test_scrub_text_hash(scrubber):
+    # negative
+    assert scrubber.scrub_text('0a303030303030303030303030303030303030300') == \
+           '0a303030303030303030303030303030303030300'
+    assert scrubber.scrub_text('0a3030303030303030303303030303030303030') == \
+           '0a3030303030303030303303030303030303030'
+
+    # positive
+    assert scrubber.scrub_text('3030303030303030303030303030303030303030') == \
+           scrubber.placeholder_hash
+    assert scrubber.scrub_text('hash:3030303030303030303030303030303030303030') == \
+           f'hash:{scrubber.placeholder_hash}'
+
+    assert scrubber.user_name is None
+
+
+def test_scrub_text_complex_string(scrubber):
+    source = 'this is a string that have been sent from ' \
+             '192.168.1.1(3030303030303030303030303030303030303030) ' \
+             'located at usr/someuser/path at ' \
+             'someuser machine(someuserany)'
+
+    actual = scrubber.scrub_text(source)
+
+    assert actual == f'this is a string that have been sent from ' \
+                     f'{scrubber.placeholder_ip}({scrubber.placeholder_hash}) ' \
+                     f'located at usr/{scrubber.placeholder_user}/path at ' \
+                     f'{scrubber.placeholder_user} machine(someuserany)'
+
+    assert scrubber.user_name == 'someuser'
+    assert scrubber.scrub_text('someuser') == scrubber.placeholder_user
+
+
+def test_scrub_simple_event(scrubber):
+    assert scrubber.scrub_event(None) is None
+    assert scrubber.scrub_event({}) == {}
+    assert scrubber.scrub_event({'some': 'field'}) == {'some': 'field'}
+
+
+def test_scrub_event(scrubber):
+    event = {
+        CONTEXTS: {
+            REPORTER: {
+                OS_ENVIRON: {
+                    'PATH': '/users/username/apps'
+                },
+                STACKTRACE: ['Traceback (most recent call last):',
+                             'File "/Users/username/Tribler/tribler/src/tribler-gui/tribler_gui/"'],
+                SYSINFO: {'sys.path': ['/Users/username/Tribler/',
+                                       '/Users/username/',
+                                       '.']},
+            }
+        },
+        EXTRA: {
+            SYS_ARGV: ['/Users/username/Tribler']
+        },
+        LOGENTRY: {
+            'message': 'Exception with username',
+            'params': ['Traceback File: /Users/username/Tribler/']
+        },
+        BREADCRUMBS: {
+            'values': [
+                {'type': 'log', 'message': 'Traceback File: /Users/username/Tribler/'},
+                {'type': 'log', 'message': 'IP: 192.168.1.1'}
+            ]
+        },
+
+    }
+
+    assert scrubber.scrub_event(event) == {
+        CONTEXTS: {
+            REPORTER: {
+                OS_ENVIRON: {
+                    'PATH': f'/users/{scrubber.placeholder_user}/apps'
+                },
+                STACKTRACE: ['Traceback (most recent call last):',
+                             f'File "/Users/{scrubber.placeholder_user}/Tribler/tribler/src/tribler-gui/tribler_gui/"'],
+                SYSINFO: {'sys.path': [f'/Users/{scrubber.placeholder_user}/Tribler/',
+                                       f'/Users/{scrubber.placeholder_user}/',
+                                       '.']},
+            },
+        },
+        LOGENTRY: {
+            'message': f'Exception with {scrubber.placeholder_user}',
+            'params': [f'Traceback File: /Users/{scrubber.placeholder_user}/Tribler/']
+        },
+        EXTRA: {
+            SYS_ARGV: [f'/Users/{scrubber.placeholder_user}/Tribler']
+        },
+        BREADCRUMBS: {
+            'values': [
+                {'type': 'log',
+                 'message': f'Traceback File: /Users/{scrubber.placeholder_user}/Tribler/'},
+                {'type': 'log',
+                 'message': f'IP: {scrubber.placeholder_ip}'}
+            ]
+        },
+    }
+
+
+def test_entities_recursively(scrubber):
+    # positive
+    assert scrubber.scrub_entity_recursively(None) is None
+    assert scrubber.scrub_entity_recursively({}) == {}
+    assert scrubber.scrub_entity_recursively([]) == []
+    assert scrubber.scrub_entity_recursively('') == ''
+    assert scrubber.scrub_entity_recursively(42) == 42
+
+    event = {'some': {'value': [{'path': '/Users/username/Tribler'}]}}
+    assert scrubber.scrub_entity_recursively(event) == {
+        'some': {'value': [{'path': f'/Users/{scrubber.placeholder_user}/Tribler'}]}}
+    # stop on depth
+
+    assert scrubber.scrub_entity_recursively(event) != event
+    assert scrubber.scrub_entity_recursively(event, depth=2) == event
+
+
+def test_scrub_unnecessary_fields(scrubber):
+    # default
+    assert scrubber.scrub_event({'default': 'field'}) == {'default': 'field'}
+    assert scrubber.scrub_event({'modules': {}}) == {}
+
+    # custom
+    custom_scrubber = SentryScrubber()
+    custom_scrubber.event_fields_to_cut = ['new', 'default']
+    assert custom_scrubber.scrub_event(
+        {
+            'default': 'event',
+            'new': 'field',
+            'modules': {}
+
+        }) == {
+               'modules': {}
+           }
+
+
+def test_scrub_text_none(scrubber):
+    assert scrubber.scrub_text(None) is None
+
+
+def test_scrub_text_some(scrubber):
+    assert scrubber.scrub_text('some text') == 'some text'
+    assert scrubber.user_name is None
+
+
+def test_scrub_dict(scrubber):
+    assert scrubber.scrub_entity_recursively(None) is None
+    assert scrubber.scrub_entity_recursively({}) == {}
+
+    assert scrubber.scrub_entity_recursively({'PATH': '/home/username/some/',
+                                              'USER': 'username'}) \
+           == {'PATH': f'/home/{scrubber.placeholder_user}/some/',
+               'USER': scrubber.placeholder_user}
+    assert scrubber.user_name == 'username'
+
+
+def test_scrub_list(scrubber):
+    assert scrubber.scrub_entity_recursively(None) is None
+    assert scrubber.scrub_entity_recursively([]) == []
+
+    assert scrubber.scrub_entity_recursively(['/home/username/some/']) == \
+           [f'/home/{scrubber.placeholder_user}/some/']
+    assert scrubber.user_name == 'username'

--- a/src/tribler-common/tribler_common/sentry_reporter/tests/test_sentry_tools.py
+++ b/src/tribler-common/tribler_common/sentry_reporter/tests/test_sentry_tools.py
@@ -1,0 +1,88 @@
+from tribler_common.sentry_reporter.sentry_tools import (
+    delete_item,
+    get_first_item,
+    get_last_item,
+    get_value,
+    modify_value,
+    parse_os_environ,
+    parse_stacktrace,
+)
+
+
+def test_first():
+    assert get_first_item(None, '') == ''
+    assert get_first_item([], '') == ''
+    assert get_first_item(['some'], '') == 'some'
+    assert get_first_item(['some', 'value'], '') == 'some'
+
+    assert get_first_item((), '') == ''
+    assert get_first_item(('some', 'value'), '') == 'some'
+
+    assert get_first_item(None, None) is None
+
+
+def test_last():
+    assert get_last_item(None, '') == ''
+    assert get_last_item([], '') == ''
+    assert get_last_item(['some'], '') == 'some'
+    assert get_last_item(['some', 'value'], '') == 'value'
+
+    assert get_last_item((), '') == ''
+    assert get_last_item(('some', 'value'), '') == 'value'
+
+    assert get_last_item(None, None) is None
+
+
+def test_delete():
+    assert delete_item({}, None) == {}
+
+    assert delete_item({'key': 'value'}, None) == {'key': 'value'}
+    assert delete_item({'key': 'value'}, 'missed_key') == {'key': 'value'}
+    assert delete_item({'key': 'value'}, 'key') == {}
+
+
+def test_parse_os_environ():
+    # simple tests
+    assert parse_os_environ(None) == {}
+    assert parse_os_environ([]) == {}
+    assert parse_os_environ(['KEY:value']) == {'KEY': 'value'}
+
+    assert parse_os_environ(['KEY:value', 'KEY1:value1', 'KEY2:value2']) == {
+        'KEY': 'value',
+        'KEY1': 'value1',
+        'KEY2': 'value2',
+    }
+
+    # test multiply `:`
+    assert parse_os_environ(['KEY:value:and:some']) == {'KEY': 'value:and:some'}
+
+    # test no `:`
+    assert parse_os_environ(['KEY:value', 'key']) == {'KEY': 'value'}
+
+
+def test_parse_stacktrace():
+    assert parse_stacktrace(None) == []
+    assert parse_stacktrace('') == []
+    assert parse_stacktrace('\n') == []
+    assert parse_stacktrace('\n\n') == []
+    assert parse_stacktrace('some\n\nvalue') == ['some', 'value']
+
+
+def test_modify():
+    assert modify_value(None, None, None) is None
+    assert modify_value({}, None, None) == {}
+    assert modify_value({}, '', None) == {}
+
+    assert modify_value({}, 'key', lambda value: '') == {}
+    assert modify_value({'a': 'b'}, 'key', lambda value: '') == {'a': 'b'}
+    assert modify_value({'a': 'b', 'key': 'value'}, 'key', lambda value: '') == {'a': 'b', 'key': ''}
+
+
+def test_safe_get():
+    assert get_value(None, None, None) is None
+    assert get_value(None, None, {}) == {}
+
+    assert get_value(None, 'key', {}) == {}
+
+    assert get_value({'key': 'value'}, 'key', {}) == 'value'
+    assert get_value({'key': 'value'}, 'key1', {}) == {}

--- a/src/tribler-core/tribler_core/restapi/events_endpoint.py
+++ b/src/tribler-core/tribler_core/restapi/events_endpoint.py
@@ -113,9 +113,14 @@ class EventsEndpoint(RESTEndpoint, TaskManager):
         for request in self.events_responses:
             await request.write(message_bytes)
 
-    # An exception has occurred in Tribler. The event includes a readable string of the error.
-    def on_tribler_exception(self, exception_text):
-        self.write_data({"type": NTFY.TRIBLER_EXCEPTION.value, "event": {"text": exception_text}})
+    # An exception has occurred in Tribler. The event includes a readable
+    # string of the error and a Sentry event.
+    def on_tribler_exception(self, exception_text, sentry_event):
+        self.write_data({
+            "type": NTFY.TRIBLER_EXCEPTION.value,
+            "event": {"text": exception_text},
+            "sentry_event": sentry_event
+        })
 
     @docs(
         tags=["General"],

--- a/src/tribler-core/tribler_core/restapi/state_endpoint.py
+++ b/src/tribler-core/tribler_core/restapi/state_endpoint.py
@@ -20,6 +20,7 @@ class StateEndpoint(RESTEndpoint):
         super(StateEndpoint, self).__init__(session)
         self.tribler_state = STATE_STARTING
         self.last_exception = None
+        self.sentry_event = None
 
         self.session.notifier.add_observer(NTFY.UPGRADER_STARTED, self.on_tribler_upgrade_started)
         self.session.notifier.add_observer(NTFY.UPGRADER_DONE, self.on_tribler_upgrade_finished)
@@ -37,9 +38,10 @@ class StateEndpoint(RESTEndpoint):
     def on_tribler_started(self, *_):
         self.tribler_state = STATE_STARTED
 
-    def on_tribler_exception(self, exception_text):
+    def on_tribler_exception(self, exception_text, sentry_event):
         self.tribler_state = STATE_EXCEPTION
         self.last_exception = exception_text
+        self.sentry_event = sentry_event
 
     @docs(
         tags=["General"],

--- a/src/tribler-core/tribler_core/restapi/tests/test_events_endpoint.py
+++ b/src/tribler-core/tribler_core/restapi/tests/test_events_endpoint.py
@@ -49,13 +49,13 @@ async def test_events(enable_api, session):
 
     testdata = {
         NTFY.CHANNEL_ENTITY_UPDATED: {"state": "Complete"},
-        NTFY.UPGRADER_TICK: ("bla", ),
+        NTFY.UPGRADER_TICK: ("bla",),
         NTFY.UPGRADER_DONE: None,
-        NTFY.WATCH_FOLDER_CORRUPT_FILE: ("foo", ),
+        NTFY.WATCH_FOLDER_CORRUPT_FILE: ("foo",),
         NTFY.TRIBLER_NEW_VERSION: ("123",),
         NTFY.CHANNEL_DISCOVERED: {"result": "bla"},
         NTFY.TORRENT_FINISHED: (b'a' * 10, None, False),
-        NTFY.LOW_SPACE: ("", ),
+        NTFY.LOW_SPACE: ("",),
         NTFY.TUNNEL_REMOVE: (Circuit(1234, None), 'test'),
         NTFY.REMOTE_QUERY_RESULTS: {"query": "test"},
     }
@@ -66,7 +66,7 @@ async def test_events(enable_api, session):
             session.notifier.notify(subject, *data)
         else:
             session.notifier.notify(subject)
-    session.api_manager.root_endpoint.endpoints['/events'].on_tribler_exception("hi")
+    session.api_manager.root_endpoint.endpoints['/events'].on_tribler_exception("hi", None)
     await events_future
 
     event_socket_task.cancel()

--- a/src/tribler-core/tribler_core/restapi/tests/test_state_endpoint.py
+++ b/src/tribler-core/tribler_core/restapi/tests/test_state_endpoint.py
@@ -8,6 +8,6 @@ async def test_get_state(enable_api, session):
     """
     Testing whether the API returns a correct state when requested
     """
-    session.api_manager.root_endpoint.endpoints['/state'].on_tribler_exception("abcd")
+    session.api_manager.root_endpoint.endpoints['/state'].on_tribler_exception("abcd", None)
     expected_json = {"state": "EXCEPTION", "last_exception": "abcd", "readable_state": "Started"}
     await do_request(session, 'state', expected_code=200, expected_json=expected_json)

--- a/src/tribler-core/tribler_core/version.py
+++ b/src/tribler-core/tribler_core/version.py
@@ -1,3 +1,4 @@
 version_id = "7.5.0-GIT"
 build_date = "Mon Jan 01 00:00:01 1970"
 commit_id = "none"
+sentry_url = ""

--- a/src/tribler-gui/tribler_gui/event_request_manager.py
+++ b/src/tribler-gui/tribler_gui/event_request_manager.py
@@ -99,7 +99,9 @@ class EventRequestManager(QNetworkAccessManager):
                     else:
                         reaction()
                 elif event_type == NTFY.TRIBLER_EXCEPTION.value:
-                    raise RuntimeError(json_dict["event"]["text"])
+                    text = json_dict["event"]["text"]
+                    sentry_event = {'sentry_event': json_dict['sentry_event']}
+                    raise RuntimeError(text, sentry_event)
             self.current_event_string = ""
 
     def on_finished(self):


### PR DESCRIPTION
Resolves #5727

This PR adds Sentry support to Tribler Client.
The UX keeps unchanged.

The main concept: suppress (but store) all Sentry events until a user clicked on the "send report" button.

There are two new entities:

1. `SentryReporter`(singleton) for managing work with Sentry
1. `SentryScrubber` for scrubbing sensitive and redundant information.

# How it works
Basically, Sentry-based reporting works the same way the old Reporter did:

* catch the error in the Core (or in the GUI)
* send it to the GUI over the Events endpoint (GUI errors are handled directly)
* present the "report error" dialog to the user
* send the report when the user clicks the "send report" button

# Protecting user identities
A user will now be assigned a unique pseudonym (e.g.Jonh Doe) based on the `hash` of their `public_key`.

Note. The current implementation specifies user only for errors raised in the Core process, but it can be extended in the future.

# Simplified python-friendly explanation

```python
# `SentryReporter` will be inited at the start of a Tribler Client run
SentryReporter.init(sentry_url=sentry_url, scrubber=SentryScrubber())

# Then all Sentry events will be suppressed (`session.py`):
SentryReporter.allow_sending_globally(False)

# In a case of an error in  the `Core process`, the Sentry event will be obtained and sent to `GUI` (`session.py`):
sentry_event = SentryReporter.last_event
self.api_manager.get_endpoint('events').on_tribler_exception(text_long, sentry_event)
```

In the case of an error inside the GUI process, the event will be obtained directly in the GUI process.

After the user's click on the "sent report" button, the Sentry event will be sent to the server (`feedbackdialog.py`):

```python
SentryReporter.send(post_data, sentry_event, sys_info_dict)
```

# Removing sensitive and redundant information

`SentryScrubber` is the class responsible for scrubbing.
It is calling on every Sentry's attempt to sent an event.
By using regex it scans all the necessary event fields and replaces real information with placeholders.

What is sensitive information:
* IPs
* User Name
* 40-symbols-long hashes

What is redundant information:
* Information on installed python modules

Which fields will be affected by scrubbing:
* Extra
* Logentry
* Breadcrumbds
* Os.environ
* Stacktrace
* Sysinfo

## Tests
This PR introduced the first tests for the `tribler-common` module. 
All the corresponding Jenkin's jobs have to be updated:
- [x] PR Linux
- [x] PR macOS
- [x] PR Windows

Thanks to @ichorid for contributing to the description.