### PR TITLE
READY: Enable RemoteQueryCommunity to query channel senders for preview content

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,5 @@
 [tool.black]
 line-length = 120
-py27 = true
 skip-string-normalization = true
 include = '(src/tribler-gui|src/tribler-common|src/tribler-core/tribler_core/modules/metadata_store)/.*\.pyi?$'
 

--- a/src/tribler-core/tribler_core/modules/metadata_store/community/gigachannel_community.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/community/gigachannel_community.py
@@ -28,7 +28,7 @@ class GigaChannelCommunitySettings(RemoteQueryCommunitySettings):
 
 
 class GigaChannelCommunity(RemoteQueryCommunity):
-    community_id = unhexlify('dce2e4e31c57b7b54600251ce3bc8945ee31b7eb')
+    community_id = unhexlify('cccce4e31c57b7b54600251ce3bc8945ee31b7eb')
 
     def __init__(self, my_peer, endpoint, network, metadata_store, **kwargs):
         kwargs["settings"] = kwargs.get("settings", GigaChannelCommunitySettings())

--- a/src/tribler-core/tribler_core/modules/metadata_store/community/gigachannel_community.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/community/gigachannel_community.py
@@ -1,337 +1,102 @@
-from asyncio import get_event_loop
+import uuid
 from binascii import unhexlify
+from dataclasses import dataclass
 from random import sample
 
-from ipv8.community import Community
-from ipv8.database import database_blob
-from ipv8.lazy_community import lazy_wrapper
-from ipv8.messaging.lazy_payload import VariablePayload, vp_compile
-from ipv8.peer import Peer
-from ipv8.requestcache import RequestCache
+from ipv8.peerdiscovery.network import Network
 
-from pony.orm import CacheIndexError, TransactionIntegrityError, db_session
+from pony.orm import db_session
 
 from tribler_common.simpledefs import CHANNELS_VIEW_UUID, NTFY
 
-from tribler_core.modules.metadata_store.community.payload import SearchRequestPayload, SearchResponsePayload
-from tribler_core.modules.metadata_store.community.request import SearchRequestCache
-from tribler_core.modules.metadata_store.orm_bindings.channel_metadata import entries_to_chunk
-from tribler_core.modules.metadata_store.serialization import CHANNEL_TORRENT, COLLECTION_NODE, REGULAR_TORRENT
-from tribler_core.modules.metadata_store.store import (
-    GOT_NEWER_VERSION,
-    UNKNOWN_CHANNEL,
-    UNKNOWN_COLLECTION,
-    UNKNOWN_TORRENT,
-    UPDATED_OUR_VERSION,
+from tribler_core.modules.metadata_store.community.remote_query_community import (
+    RemoteQueryCommunity,
+    RemoteQueryCommunitySettings,
 )
-from tribler_core.utilities.utilities import is_channel_public_key, is_hex_string, is_simple_match_query
+from tribler_core.modules.metadata_store.serialization import CHANNEL_TORRENT
+from tribler_core.modules.metadata_store.store import UNKNOWN_CHANNEL, UNKNOWN_COLLECTION, UNKNOWN_TORRENT
 
 minimal_blob_size = 200
 maximum_payload_size = 1024
 max_entries = maximum_payload_size // minimal_blob_size
 max_search_peers = 5
 
-metadata_type_to_v1_field = {
-    frozenset((REGULAR_TORRENT, CHANNEL_TORRENT)): "",
-    frozenset((CHANNEL_TORRENT,)): "channel",
-    frozenset((REGULAR_TORRENT,)): "torrent",
-}
 
-v1_md_field_to_metadata_type = {
-    "": frozenset((REGULAR_TORRENT, CHANNEL_TORRENT)),
-    "channel": frozenset((CHANNEL_TORRENT,)),
-    "torrent": frozenset((REGULAR_TORRENT,)),
-}
+@dataclass
+class GigaChannelCommunitySettings(RemoteQueryCommunitySettings):
+    queried_peers_limit: int = 1000
 
 
-@vp_compile
-class RawBlobPayload(VariablePayload):
-    format_list = ['raw']
-    names = ['raw_blob']
-
-
-def gen_have_newer_results_blob(md_list):
-    with db_session:
-        reply_list = [
-            md
-            for md, result in md_list
-            if (md and (md.metadata_type == CHANNEL_TORRENT)) and (result == GOT_NEWER_VERSION)
-        ]
-        return entries_to_chunk(reply_list, maximum_payload_size)[0] if reply_list else None
-
-
-class GigaChannelCommunity(Community):
-    """
-    Community to gossip around gigachannels.
-    """
-
+class GigaChannelCommunity(RemoteQueryCommunity):
     community_id = unhexlify('dce2e4e31c57b7b54600251ce3bc8945ee31b7eb')
 
-    NEWS_PUSH_MESSAGE = 1
-    SEARCH_REQUEST = 2
-    SEARCH_RESPONSE = 3
+    def __init__(self, my_peer, endpoint, network, metadata_store, **kwargs):
+        kwargs["settings"] = kwargs.get("settings", GigaChannelCommunitySettings())
+        self.notifier = kwargs.pop("notifier", None)
 
-    def __init__(self, my_peer, endpoint, network, metadata_store, notifier=None):
-        super(GigaChannelCommunity, self).__init__(my_peer, endpoint, network)
-        self.metadata_store = metadata_store
-        self.add_message_handler(self.NEWS_PUSH_MESSAGE, self.on_blob)
-        self.add_message_handler(self.SEARCH_REQUEST, self.on_search_request)
-        self.add_message_handler(self.SEARCH_RESPONSE, self.on_search_response)
-        self.request_cache = RequestCache()
-        self.notifier = notifier
+        # ACHTUNG! We create a separate instance of Network for this community because it
+        # walks aggressively and wants lots of peers, which can interfere with other communities
+        super().__init__(my_peer, endpoint, Network(), metadata_store, **kwargs)
 
-        self.gossip_blob = None
-        self.gossip_blob_personal_channel = None
+        # This set contains all the peers that we queried for subscribed channels over time.
+        # It is emptied regularly. The purpose of this set is to work as a filter so we never query the same
+        # peer twice. If we do, this should happen really rarely
+        # TODO: use Bloom filter here instead. We actually *want* it to be all-false-positives eventually.
+        self.queried_peers = set()
 
-        # We regularly regenerate the gossip blobs to account for changes in the local DB
-        self.register_task("Renew channel gossip cache", self.prepare_gossip_blob_cache, interval=600)
+    def get_random_peers(self, sample_size=None):
+        # Randomly sample sample_size peers from the complete list of our peers
+        all_peers = self.get_peers()
+        if sample_size is not None and sample_size < len(all_peers):
+            return sample(all_peers, sample_size)
+        return all_peers
 
-    async def unload(self):
-        await self.request_cache.shutdown()
-        await super(GigaChannelCommunity, self).unload()
-
-    def _prepare_gossip_blob_cache(self):
-        # Choose some random entries and try to pack them into maximum_payload_size bytes
-        with db_session:
-            # Generate and cache the gossip blob for the personal channel
-            personal_channels = list(
-                self.metadata_store.ChannelMetadata.get_my_channels().where(lambda g: g.num_entries > 0).random(1)
-            )
-            personal_channel = personal_channels[0] if personal_channels else None
-            md_list = (
-                [personal_channel] + list(personal_channel.get_random_contents(max_entries - 1))
-                if personal_channel
-                else None
-            )
-            self.gossip_blob_personal_channel = (
-                entries_to_chunk(md_list, maximum_payload_size)[0] if md_list and len(md_list) > 1 else None
-            )
-
-            # Generate and cache the gossip blob for a subscribed channel
-            # TODO: when the health table will be there, send popular torrents instead
-            channel_l = list(
-                self.metadata_store.ChannelMetadata.get_random_channels(1, only_subscribed=True, only_downloaded=True)
-            )
-            md_list = channel_l + list(channel_l[0].get_random_contents(max_entries - 1)) if channel_l else None
-            self.gossip_blob = entries_to_chunk(md_list, maximum_payload_size)[0] if md_list else None
-        self.metadata_store.disconnect_thread()
-
-    async def prepare_gossip_blob_cache(self):
-        await get_event_loop().run_in_executor(None, self._prepare_gossip_blob_cache)
-
-    def send_random_to(self, peer):
-        """
-        Send random entries from our subscribed channels to another peer.
-
-        To speed-up propagation of original content, we send two distinct packets on each walk step:
-        the first packet contains user's personal channel, the second one contains a random subscribed channel.
-
-        :param peer: the peer to send to
-        :type peer: Peer
-        :returns: None
-        """
-
-        # Send personal channel
-        if self.gossip_blob_personal_channel:
-            self.endpoint.send(
-                peer.address, self.ezr_pack(self.NEWS_PUSH_MESSAGE, RawBlobPayload(self.gossip_blob_personal_channel))
-            )
-
-        # Send subscribed channel
-        if self.gossip_blob:
-            self.endpoint.send(peer.address, self.ezr_pack(self.NEWS_PUSH_MESSAGE, RawBlobPayload(self.gossip_blob)))
-
-    def _update_db_with_blob(self, raw_blob):
-        result = None
-        try:
-            with db_session:
-                try:
-                    result = self.metadata_store.process_compressed_mdblob(raw_blob)
-                except (TransactionIntegrityError, CacheIndexError) as err:
-                    self._logger.error("DB transaction error when tried to process payload: %s", str(err))
-        # Unfortunately, we have to catch the exception twice, because Pony can raise them both on the exit from
-        # db_session, and on calling the line of code
-        except (TransactionIntegrityError, CacheIndexError) as err:
-            self._logger.error("DB transaction error when tried to process payload: %s", str(err))
-        finally:
-            self.metadata_store.disconnect_thread()
-        return result
-
-    @lazy_wrapper(RawBlobPayload)
-    async def on_blob(self, peer, blob):
-        """
-        Callback for when a MetadataBlob message comes in.
-
-        :param peer: the peer that sent us the blob
-        :param blob: payload raw data
-        """
-
-        def _process_received_blob():
-            md_results = self._update_db_with_blob(blob.raw_blob)
-            if not md_results:
-                self.metadata_store.disconnect_thread()
-                return None, None
-            # Update votes counters
-            with db_session:
-                # This check ensures, in a bit hackish way, that we do not bump responses
-                # sent by respond_with_updated_metadata
-                if len(md_results) > 1:
-                    for c in [md for md, _ in md_results if md and (md.metadata_type == CHANNEL_TORRENT)]:
-                        self.metadata_store.vote_bump(c.public_key, c.id_, peer.public_key.key_to_bin()[10:])
-                        # We only want to bump the leading channel entry in the payload, since the rest is content
-                        break
-
-            with db_session:
-                # Get the list of new channels for notifying the GUI
-                new_channels = [
-                    md.to_simple_dict()
-                    for md, result in md_results
-                    if md
-                    and md.metadata_type == CHANNEL_TORRENT
-                    and result == UNKNOWN_CHANNEL
-                    and md.origin_id == 0
-                    and md.num_entries > 0
-                ]
-            result = gen_have_newer_results_blob(md_results), new_channels
-            self.metadata_store.disconnect_thread()
-            return result
-
-        reply_blob, new_channels = await get_event_loop().run_in_executor(None, _process_received_blob)
-
-        # Notify the discovered torrents and channels to the GUI
-        if self.notifier and new_channels:
-            self.notifier.notify(NTFY.CHANNEL_DISCOVERED, {"results": new_channels, "uuid": str(CHANNELS_VIEW_UUID)})
-
-        # Check if the guy who send us this metadata actually has an older version of this md than
-        # we do, and queue to send it back.
-        self.respond_with_updated_metadata(peer, reply_blob)
-
-    def respond_with_updated_metadata(self, peer, reply_blob):
-        if reply_blob:
-            self.endpoint.send(peer.address, self.ezr_pack(self.NEWS_PUSH_MESSAGE, RawBlobPayload(reply_blob)))
-
-    def send_search_request(self, txt_filter, metadata_type=None, sort_by=None, sort_asc=0, hide_xxx=True, uuid=None):
-        """
-        Sends request to max_search_peers from peer list. The request is cached in request cached. The past cache is
-        cleared before adding a new search request to prevent incorrect results being pushed to the GUI.
-        Returns: request cache number which uniquely identifies each search request
-        """
-        sort_by = sort_by or "HEALTH"
-        peers = self.get_peers()
-        search_candidates = sample(peers, max_search_peers) if len(peers) > max_search_peers else peers
-        search_request_cache = SearchRequestCache(self.request_cache, uuid, search_candidates)
-        self.request_cache.clear()
-        self.request_cache.add(search_request_cache)
-
-        search_request_payload = SearchRequestPayload(
-            search_request_cache.number,
-            txt_filter.encode('utf8'),
-            metadata_type_to_v1_field.get(metadata_type, "").encode('utf8'),  # Compatibility with v1.0
-            sort_by.encode('utf8'),
-            sort_asc,
-            hide_xxx,
-        )
-        self._logger.info("Started remote search for query:%s", txt_filter)
-
-        for peer in search_candidates:
-            self.endpoint.send(peer.address, self.ezr_pack(self.SEARCH_REQUEST, search_request_payload))
-        return search_request_cache.number
-
-    @lazy_wrapper(SearchRequestPayload)
-    async def on_search_request(self, peer, request):
-        # Caution: beware of potential SQL injection!
-        # Since this string 'txt_filter' is passed as it is to fetch the results, there could be a chance for
-        # SQL injection. But since we use Pony which is supposed to be doing proper variable bindings, it should
-        # be relatively safe.
-        txt_filter = request.txt_filter.decode('utf8')
-
-        # Check if the txt_filter is a simple query
-        if not is_simple_match_query(txt_filter):
-            self.logger.error("Dropping a complex remote search query:%s", txt_filter)
+    def introduction_response_callback(self, peer, dist, payload):
+        if peer.address in self.network.blacklist or peer.mid in self.queried_peers:
             return
+        if len(self.queried_peers) >= self.settings.queried_peers_limit:
+            self.queried_peers.clear()
+        self.queried_peers.add(peer.mid)
+        self.send_remote_select_subscribed_channels(peer)
 
-        metadata_type = v1_md_field_to_metadata_type.get(
-            request.metadata_type.decode('utf8'), frozenset((REGULAR_TORRENT, CHANNEL_TORRENT))
-        )
-        # If we get a hex-encoded public key in the txt_filter field, we drop the filter,
-        # and instead query by public_key. However, we only do this if there is no channel_pk or
-        # origin_id attributes set, because it is only for support of GigaChannel v1.0 channel preview requests.
-        channel_pk = None
-        normal_filter = txt_filter.replace('"', '').replace("*", "")
-        if (
-            metadata_type == frozenset((REGULAR_TORRENT, COLLECTION_NODE))
-            and is_hex_string(normal_filter)
-            and len(normal_filter) % 2 == 0
-            and is_channel_public_key(normal_filter)
-        ):
-            channel_pk = database_blob(unhexlify(normal_filter))
-            txt_filter = None
+    def send_remote_select_subscribed_channels(self, peer):
+        def on_packet_callback(_, processing_results):
+            # We use responses for requests about subscribed channels to bump our local channels ratings
+            with db_session:
+                for c in [md for md, _ in processing_results if md.metadata_type == CHANNEL_TORRENT]:
+                    self.mds.vote_bump(c.public_key, c.id_, peer.public_key.key_to_bin()[10:])
+
+            # Notify GUI about the new channels
+            new_channels = [md for md, result in processing_results if result == UNKNOWN_CHANNEL and md.origin_id == 0]
+            if self.notifier and new_channels:
+                self.notifier.notify(
+                    NTFY.CHANNEL_DISCOVERED,
+                    {"results": [md.to_simple_dict() for md in new_channels], "uuid": str(CHANNELS_VIEW_UUID)},
+                )
 
         request_dict = {
-            "first": 1,
-            "last": max_entries,
-            "sort_by": request.sort_by.decode('utf8'),
-            "sort_desc": not request.sort_asc if request.sort_asc is not None else None,
-            "txt_filter": txt_filter,
-            "hide_xxx": request.hide_xxx,
-            "metadata_type": metadata_type,
-            "exclude_legacy": True,
-            "channel_pk": channel_pk,
+            "metadata_type": [CHANNEL_TORRENT],
+            "subscribed": True,
+            "attribute_ranges": (("num_entries", 1, None),),
         }
+        self.send_remote_select(peer, **request_dict, processing_callback=on_packet_callback)
 
-        def _get_search_results():
-            with db_session:
-                db_results = self.metadata_store.MetadataNode.get_entries(**request_dict)
-                result = entries_to_chunk(db_results[:max_entries], maximum_payload_size)[0] if db_results else None
-            self.metadata_store.disconnect_thread()
-            return result
+    def send_search_request(self, **kwargs):
+        # Send a remote query request to multiple random peers to search for some terms
+        request_uuid = uuid.uuid4()
 
-        result_blob = await get_event_loop().run_in_executor(None, _get_search_results)
-
-        if result_blob:
-            self.endpoint.send(
-                peer.address, self.ezr_pack(self.SEARCH_RESPONSE, SearchResponsePayload(request.id, result_blob))
-            )
-
-    @lazy_wrapper(SearchResponsePayload)
-    async def on_search_response(self, peer, response):
-        search_request_cache = self.request_cache.get(u"remote-search-request", response.id)
-        if not search_request_cache or not search_request_cache.process_peer_response(peer):
-            return
-
-        def _process_received_blob():
-            md_results = self._update_db_with_blob(response.raw_blob)
-            if not md_results:
-                self.metadata_store.disconnect_thread()
-                return None, None
-
-            # it is incorrect to call md.simple_dict() for metadata objects from md_results
-            # as previous db_session is already over, so we are going to fetch them again in a new db_session
-            md_ids = [
-                md.rowid for md, action in md_results
-                if md
-                   and (md.metadata_type in [CHANNEL_TORRENT, REGULAR_TORRENT])
-                   and action in [UNKNOWN_CHANNEL, UNKNOWN_TORRENT, UPDATED_OUR_VERSION, UNKNOWN_COLLECTION]
+        def notify_gui(_, processing_results):
+            search_results = [
+                md.to_simple_dict()
+                for md, result in processing_results
+                if result in (UNKNOWN_TORRENT, UNKNOWN_CHANNEL, UNKNOWN_COLLECTION)
             ]
+            self.notifier.notify(NTFY.REMOTE_QUERY_RESULTS, {"uuid": str(request_uuid), "results": search_results})
 
-            with db_session:
-                md_list = self.metadata_store.ChannelNode.select(lambda md: md.rowid in md_ids)[:]
-                result = (
-                    [md.to_simple_dict() for md in md_list],
-                    gen_have_newer_results_blob(md_results),
-                )
-            self.metadata_store.disconnect_thread()
-            return result
+        for p in self.get_random_peers(self.settings.max_query_peers):
+            self.send_remote_select(p, **kwargs, processing_callback=notify_gui)
 
-        search_results, reply_blob = await get_event_loop().run_in_executor(None, _process_received_blob)
-
-        if self.notifier and search_results:
-            self.notifier.notify(
-                NTFY.REMOTE_QUERY_RESULTS, {"uuid": search_request_cache.uuid, "results": search_results}
-            )
-
-        # Send the updated metadata if any to the responding peer
-        self.respond_with_updated_metadata(peer, reply_blob)
+        return request_uuid
 
 
 class GigaChannelTestnetCommunity(GigaChannelCommunity):

--- a/src/tribler-core/tribler_core/modules/metadata_store/community/gigachannel_community.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/community/gigachannel_community.py
@@ -78,6 +78,7 @@ class GigaChannelCommunity(RemoteQueryCommunity):
             "metadata_type": [CHANNEL_TORRENT],
             "subscribed": True,
             "attribute_ranges": (("num_entries", 1, None),),
+            "complete_channel": True,
         }
         self.send_remote_select(peer, **request_dict, processing_callback=on_packet_callback)
 

--- a/src/tribler-core/tribler_core/modules/metadata_store/community/gigachannel_community.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/community/gigachannel_community.py
@@ -28,7 +28,7 @@ class GigaChannelCommunitySettings(RemoteQueryCommunitySettings):
 
 
 class GigaChannelCommunity(RemoteQueryCommunity):
-    community_id = unhexlify('cccce4e31c57b7b54600251ce3bc8945ee31b7eb')
+    community_id = unhexlify('dc43e3465cbd83948f30d3d3e8336d71cce33aa7')
 
     def __init__(self, my_peer, endpoint, network, metadata_store, **kwargs):
         kwargs["settings"] = kwargs.get("settings", GigaChannelCommunitySettings())
@@ -105,4 +105,4 @@ class GigaChannelTestnetCommunity(GigaChannelCommunity):
     This community defines a testnet for the giga channels, used for testing purposes.
     """
 
-    community_id = unhexlify('f58df52d10f7339ff6e2888322011489e9ab3d59')
+    community_id = unhexlify('ad8cece0dfdb0e03344b59a4d31a38fe9812da9d')

--- a/src/tribler-core/tribler_core/modules/metadata_store/community/gigachannel_community.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/community/gigachannel_community.py
@@ -1,8 +1,11 @@
+import json
 import uuid
 from binascii import unhexlify
 from dataclasses import dataclass
 from random import sample
 
+from ipv8.lazy_community import lazy_wrapper
+from ipv8.messaging.lazy_payload import VariablePayload, vp_compile
 from ipv8.peerdiscovery.network import Network
 
 from pony.orm import db_session
@@ -12,14 +15,32 @@ from tribler_common.simpledefs import CHANNELS_VIEW_UUID, NTFY
 from tribler_core.modules.metadata_store.community.remote_query_community import (
     RemoteQueryCommunity,
     RemoteQueryCommunitySettings,
+    SelectRequest,
 )
 from tribler_core.modules.metadata_store.serialization import CHANNEL_TORRENT
 from tribler_core.modules.metadata_store.store import UNKNOWN_CHANNEL, UNKNOWN_COLLECTION, UNKNOWN_TORRENT
+from tribler_core.utilities.unicode import hexlify
 
 minimal_blob_size = 200
 maximum_payload_size = 1024
 max_entries = maximum_payload_size // minimal_blob_size
 max_search_peers = 5
+
+MAGIC_GIGACHAN_VERSION_MARK = b'\x01'
+
+
+@vp_compile
+class LegacyRemoteSelectPayload(VariablePayload):
+    msg_id = 1
+    format_list = ['I', 'varlenH']
+    names = ['id', 'json']
+
+
+@vp_compile
+class LegacySelectResponsePayload(VariablePayload):
+    msg_id = 2
+    format_list = ['I', 'raw']
+    names = ['id', 'raw_blob']
 
 
 @dataclass
@@ -27,8 +48,15 @@ class GigaChannelCommunitySettings(RemoteQueryCommunitySettings):
     queried_peers_limit: int = 1000
 
 
-class GigaChannelCommunity(RemoteQueryCommunity):
+class NonLegacyGigaChannelCommunity(RemoteQueryCommunity):
     community_id = unhexlify('dc43e3465cbd83948f30d3d3e8336d71cce33aa7')
+
+    def create_introduction_response(self, *args, introduction=None, extra_bytes=b'', prefix=None):
+        # ACHTUNG! We add extra_bytes here to identify the newer, 7.6+ version RemoteQuery/GigaChannel community
+        # dialect, so that other 7.6+ are able to distinguish between the older and newer versions.
+        return super().create_introduction_response(
+            *args, introduction=introduction, extra_bytes=MAGIC_GIGACHAN_VERSION_MARK, prefix=prefix
+        )
 
     def __init__(self, my_peer, endpoint, network, metadata_store, **kwargs):
         kwargs["settings"] = kwargs.get("settings", GigaChannelCommunitySettings())
@@ -98,6 +126,107 @@ class GigaChannelCommunity(RemoteQueryCommunity):
             self.send_remote_select(p, **kwargs, processing_callback=notify_gui)
 
         return request_uuid
+
+
+class GigaChannelCommunity(NonLegacyGigaChannelCommunity):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # Register legacy payload
+        self.add_message_handler(LegacySelectResponsePayload, self.legacy_on_remote_select_response)
+
+        self.new_style_peers = set()
+
+    def legacy_send_remote_select_subscribed_channels(self, peer):
+        def on_packet_callback(_, processing_results):
+            # We use responses for requests about subscribed channels to bump our local channels ratings
+            with db_session:
+                for c in [md for md, _ in processing_results if md.metadata_type == CHANNEL_TORRENT]:
+                    self.mds.vote_bump(c.public_key, c.id_, peer.public_key.key_to_bin()[10:])
+
+            # Notify GUI about the new channels
+            new_channels = [md for md, result in processing_results if result == UNKNOWN_CHANNEL and md.origin_id == 0]
+            if self.notifier and new_channels:
+                self.notifier.notify(
+                    NTFY.CHANNEL_DISCOVERED,
+                    {"results": [md.to_simple_dict() for md in new_channels], "uuid": str(CHANNELS_VIEW_UUID)},
+                )
+
+        request_dict = {
+            "metadata_type": [CHANNEL_TORRENT],
+            "subscribed": True,
+            "attribute_ranges": (("num_entries", 1, None),),
+        }
+        self.legacy_send_remote_select(peer, **request_dict, processing_callback=on_packet_callback)
+
+    def legacy_send_remote_select(self, peer, processing_callback=None, **kwargs):
+
+        request = SelectRequest(self.request_cache, hexlify(peer.mid), kwargs, processing_callback)
+        self.request_cache.add(request)
+
+        self.logger.info(f"Select to {hexlify(peer.mid)} with ({kwargs})")
+        self.ez_send(peer, LegacyRemoteSelectPayload(request.number, json.dumps(kwargs).encode('utf8')))
+
+    @lazy_wrapper(LegacySelectResponsePayload)
+    async def legacy_on_remote_select_response(self, peer, response_payload):
+        """
+        Match the the response that we received from the network to a query cache
+        and process it by adding the corresponding entries to the MetadataStore database.
+        This processes both direct responses and pushback (updates) responses
+        """
+        self.logger.info(f"Legacy response from {hexlify(peer.mid)}")
+
+        # ACHTUNG! the returned request cache can be either a SelectRequest or PushbackWindow
+        request = self.request_cache.get(hexlify(peer.mid), response_payload.id)
+        if request is None:
+            self.logger.info("No request for response")
+            return
+
+        # Check for limit on the number of packets per request
+        if request.packets_limit > 1:
+            request.packets_limit -= 1
+        else:
+            self.request_cache.pop(hexlify(peer.mid), response_payload.id)
+
+        processing_results = await self.mds.process_compressed_mdblob_threaded(response_payload.raw_blob)
+        self.logger.info(f"Response result: {processing_results}")
+
+        # Query back the sender for preview contents for the new channels
+        if self.settings.channel_query_back_enabled:
+            new_channels = [md for md, result in processing_results if result in (UNKNOWN_CHANNEL, UNKNOWN_COLLECTION)]
+            for channel in new_channels:
+                request_dict = {
+                    # FIXME: This is a dirty hack, since this is exploitable
+                    "origin_id": channel.id_,
+                    "first": 0,
+                    "last": self.settings.max_channel_query_back,
+                }
+                self.legacy_send_remote_select(peer=peer, **request_dict)
+
+        if isinstance(request, SelectRequest) and request.processing_callback:
+            request.processing_callback(request, processing_results)
+
+    def introduction_response_callback(self, peer, dist, payload):
+        if peer.address in self.network.blacklist or peer.mid in self.queried_peers:
+            return
+        if len(self.queried_peers) >= self.settings.queried_peers_limit:
+            self.new_style_peers.clear()
+            self.queried_peers.clear()
+        self.queried_peers.add(peer.mid)
+
+        if not payload.extra_bytes:
+            # We were introduced to a legacy peer, so send old-style channel request to it
+            self.legacy_send_remote_select_subscribed_channels(peer)
+        elif payload.extra_bytes == MAGIC_GIGACHAN_VERSION_MARK:
+            self.send_remote_select_subscribed_channels(peer)
+            self.new_style_peers.add(peer)
+
+    def get_random_peers(self, sample_size=None):
+        # Randomly sample sample_size peers from the complete list of our peers excluding legacy peers
+        all_peers = set(self.get_peers()).intersection(self.new_style_peers)
+        if sample_size is not None and sample_size < len(all_peers):
+            return sample(all_peers, sample_size)
+        return all_peers
 
 
 class GigaChannelTestnetCommunity(GigaChannelCommunity):

--- a/src/tribler-core/tribler_core/modules/metadata_store/community/remote_query_community.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/community/remote_query_community.py
@@ -1,56 +1,60 @@
 import json
 from binascii import unhexlify
-from random import sample
+from dataclasses import dataclass
 
 from ipv8.community import Community
 from ipv8.lazy_community import lazy_wrapper
 from ipv8.messaging.lazy_payload import VariablePayload, vp_compile
-from ipv8.peerdiscovery.network import Network
 from ipv8.requestcache import RandomNumberCache, RequestCache
 
 from pony.orm.dbapiprovider import OperationalError
 
-from tribler_common.simpledefs import CHANNELS_VIEW_UUID, NTFY
-
 from tribler_core.modules.metadata_store.orm_bindings.channel_metadata import entries_to_chunk
-from tribler_core.modules.metadata_store.serialization import CHANNEL_TORRENT
-from tribler_core.modules.metadata_store.store import UNKNOWN_CHANNEL
+from tribler_core.modules.metadata_store.store import UNKNOWN_CHANNEL, UNKNOWN_COLLECTION
 from tribler_core.utilities.unicode import hexlify
+
+BINARY_FIELDS = ("infohash", "channel_pk")
 
 
 def sanitize_query(query_dict, cap=100):
+    sanitized_dict = dict(query_dict)
+
     # We impose a cap on max numbers of returned entries to prevent DDOS-like attacks
-    first, last = query_dict.get("first", None), query_dict.get("last", None)
+    first = sanitized_dict.get("first", None)
+    last = sanitized_dict.get("last", None)
     first = first or 0
     last = last if (last is not None and last <= (first + cap)) else (first + cap)
-    query_dict.update({"first": first, "last": last})
+    sanitized_dict.update({"first": first, "last": last})
 
-    # convert hex infohash to binary
-    infohash = query_dict.get('infohash', None)
-    if infohash:
-        query_dict['infohash'] = unhexlify(infohash)
+    # convert hex fields to binary
+    for field in BINARY_FIELDS:
+        value = sanitized_dict.get(field)
+        if value is not None:
+            sanitized_dict[field] = unhexlify(value)
 
-    return query_dict
+    return sanitized_dict
 
 
 @vp_compile
 class RemoteSelectPayload(VariablePayload):
-    msg_id = 1
+    msg_id = 201
     format_list = ['I', 'varlenH']
     names = ['id', 'json']
 
 
 @vp_compile
 class SelectResponsePayload(VariablePayload):
-    msg_id = 2
+    msg_id = 202
     format_list = ['I', 'raw']
     names = ['id', 'raw_blob']
 
 
 class SelectRequest(RandomNumberCache):
-    def __init__(self, request_cache, prefix, request_kwargs):
-        super(SelectRequest, self).__init__(request_cache, prefix)
+    def __init__(self, request_cache, prefix, request_kwargs, processing_callback=None):
+        super().__init__(request_cache, prefix)
         self.request_kwargs = request_kwargs
+        # The callback to call on results of processing of the response payload
+        self.processing_callback = processing_callback
         # The maximum number of packets to receive from any given peer from a single request.
         # This limit is imposed as a safety precaution to prevent spam/flooding
         self.packets_limit = 10
@@ -59,13 +63,18 @@ class SelectRequest(RandomNumberCache):
         pass
 
 
+@dataclass
 class RemoteQueryCommunitySettings:
-    def __init__(self):
-        self.minimal_blob_size = 200
-        self.maximum_payload_size = 1300
-        self.max_entries = self.maximum_payload_size // self.minimal_blob_size
-        self.max_query_peers = 5
-        self.max_response_size = 100  # Max number of entries returned by SQL query
+    minimal_blob_size: int = 200
+    maximum_payload_size: int = 1300
+    max_entries: int = maximum_payload_size // minimal_blob_size
+    max_query_peers: int = 5
+    max_response_size: int = 100  # Max number of entries returned by SQL query
+    max_channel_query_back: int = 4  # Max number of entries to query back on receiving an unknown channel
+
+    @property
+    def channel_query_back_enabled(self):
+        return self.max_channel_query_back > 0
 
 
 class RemoteQueryCommunity(Community):
@@ -73,71 +82,27 @@ class RemoteQueryCommunity(Community):
     Community for general purpose SELECT-like queries into remote Channels database
     """
 
-    community_id = unhexlify('dc43e3465cbd83948f30d3d3e8336d71cce33aa7')
-
-    def __init__(self, my_peer, endpoint, network, metadata_store, settings=None, notifier=None):
-        super().__init__(my_peer, endpoint, Network())
-
-        self.notifier = notifier
+    def __init__(self, my_peer, endpoint, network, metadata_store, settings=None):
+        super().__init__(my_peer, endpoint, network=network)
 
         self.settings = settings or RemoteQueryCommunitySettings()
-
         self.mds = metadata_store
+        self.request_cache = RequestCache()
 
-        # This set contains all the peers that we queried for subscribed channels over time.
-        # It is emptied regularly. The purpose of this set is to work as a filter so we never query the same
-        # peer twice. If we do, this should happen realy rarely
-        # TODO: use Bloom filter here instead. We actually *want* it to be all-false-positives eventually.
-        self.queried_subscribed_channels_peers = set()
-        self.queried_peers_limit = 1000
-
-        if self.notifier:
-            self.notifier.add_observer(NTFY.POPULARITY_COMMUNITY_ADD_UNKNOWN_TORRENT, self.on_pc_add_unknown_torrent)
-
-        # this flag enable or disable https://github.com/Tribler/tribler/pull/5657
-        # it can be changed in runtime
-        self.enable_resolve_unknown_torrents_feature = False
         self.add_message_handler(RemoteSelectPayload, self.on_remote_select)
         self.add_message_handler(SelectResponsePayload, self.on_remote_select_response)
 
-        self.request_cache = RequestCache()
+    def send_remote_select(self, peer, processing_callback=None, **kwargs):
 
-    def on_pc_add_unknown_torrent(self, peer, infohash):
-        if not self.enable_resolve_unknown_torrents_feature:
-            return
-        query = {'infohash': hexlify(infohash)}
-        self.send_remote_select(peer, **query)
-
-    def get_random_peers(self, sample_size=None):
-        # Randomly sample sample_size peers from the complete list of our peers
-        all_peers = self.get_peers()
-        if sample_size is not None and sample_size < len(all_peers):
-            return sample(all_peers, sample_size)
-        return all_peers
-
-    def send_remote_select(self, peer, **kwargs):
-        request = SelectRequest(self.request_cache, hexlify(peer.mid), kwargs)
+        request = SelectRequest(self.request_cache, hexlify(peer.mid), kwargs, processing_callback)
         self.request_cache.add(request)
 
         self.logger.info(f"Select to {hexlify(peer.mid)} with ({kwargs})")
         self.ez_send(peer, RemoteSelectPayload(request.number, json.dumps(kwargs).encode('utf8')))
 
-    def send_remote_select_to_many(self, **kwargs):
-        for p in self.get_random_peers(self.settings.max_query_peers):
-            self.send_remote_select(p, **kwargs)
-
-    def send_remote_select_subscribed_channels(self, peer):
-        request_dict = {
-            "metadata_type": [CHANNEL_TORRENT],
-            "subscribed": True,
-            "attribute_ranges": (("num_entries", 1, None),),
-        }
-        self.send_remote_select(peer, **request_dict)
-
     async def process_rpc_query(self, json_bytes: bytes):
         """
         Retrieve the result of a database query from a third party, encoded as raw JSON bytes (through `dumps`).
-
         :raises TypeError: if the JSON contains invalid keys.
         :raises ValueError: if no JSON could be decoded.
         :raises pony.orm.dbapiprovider.OperationalError: if an illegal query was performed.
@@ -161,6 +126,10 @@ class RemoteQueryCommunity(Community):
 
     @lazy_wrapper(SelectResponsePayload)
     async def on_remote_select_response(self, peer, response):
+        """
+        Match the the response that we received from the network to a query cache
+        and process it by adding the corresponding entries to the MetadataStore database
+        """
         self.logger.info(f"Response from {hexlify(peer.mid)}")
 
         request = self.request_cache.get(hexlify(peer.mid), response.id)
@@ -173,39 +142,25 @@ class RemoteQueryCommunity(Community):
         else:
             self.request_cache.pop(hexlify(peer.mid), response.id)
 
-        # We use responses for requests about subscribed channels to bump our local channels ratings
-        peer_vote = peer if request.request_kwargs.get("subscribed", None) is True else None
+        processing_results = await self.mds.process_compressed_mdblob_threaded(response.raw_blob)
+        self.logger.info(f"Response result: {processing_results}")
 
-        result = await self.mds.process_compressed_mdblob_threaded(response.raw_blob, peer_vote_for_channels=peer_vote)
+        # Query back the sender for preview contents for the new channels
+        # TODO: maybe transform this into a processing_callback?
+        if self.settings.channel_query_back_enabled:
+            new_channels = [md for md, result in processing_results if result in (UNKNOWN_CHANNEL, UNKNOWN_COLLECTION)]
+            for channel in new_channels:
+                request_dict = {
+                    "channel_pk": hexlify(channel.public_key),
+                    "origin_id": channel.id_,
+                    "first": 0,
+                    "last": self.settings.max_channel_query_back,
+                }
+                self.send_remote_select(peer=peer, **request_dict)
 
-        self.logger.info(f"Response result: {result}")
-        # Maybe move this callback to MetadataStore side?
-        if self.notifier:
-            new_channels = [
-                md.to_simple_dict()
-                for md, result in result
-                if md and md.metadata_type == CHANNEL_TORRENT and result == UNKNOWN_CHANNEL and md.origin_id == 0
-            ]
-            if new_channels:
-                self.notifier.notify(
-                    NTFY.CHANNEL_DISCOVERED, {"results": new_channels, "uuid": str(CHANNELS_VIEW_UUID)}
-                )
-
-    def introduction_response_callback(self, peer, dist, payload):
-        if peer.address in self.network.blacklist or peer.mid in self.queried_subscribed_channels_peers:
-            return
-        if len(self.queried_subscribed_channels_peers) >= self.queried_peers_limit:
-            self.queried_subscribed_channels_peers.clear()
-        self.queried_subscribed_channels_peers.add(peer.mid)
-        self.send_remote_select_subscribed_channels(peer)
+        if request.processing_callback:
+            request.processing_callback(request, processing_results)
 
     async def unload(self):
         await self.request_cache.shutdown()
-        await super(RemoteQueryCommunity, self).unload()
-
-        if self.notifier:
-            self.notifier.remove_observer(NTFY.POPULARITY_COMMUNITY_ADD_UNKNOWN_TORRENT, self.on_pc_add_unknown_torrent)
-
-
-class RemoteQueryTestnetCommunity(RemoteQueryCommunity):
-    community_id = unhexlify('ad8cece0dfdb0e03344b59a4d31a38fe9812da9d')
+        await super().unload()

--- a/src/tribler-core/tribler_core/modules/metadata_store/community/tests/test_gigachannel_community.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/community/tests/test_gigachannel_community.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from ipv8.database import database_blob
 from ipv8.keyvault.crypto import default_eccrypto
 from ipv8.peer import Peer
@@ -6,10 +8,8 @@ from ipv8.test.base import TestBase
 from pony.orm import db_session
 
 from tribler_core.modules.metadata_store.community.gigachannel_community import GigaChannelCommunity
-from tribler_core.modules.metadata_store.orm_bindings.channel_node import LEGACY_ENTRY, NEW
-from tribler_core.modules.metadata_store.serialization import REGULAR_TORRENT
 from tribler_core.modules.metadata_store.store import MetadataStore
-from tribler_core.tests.tools.base_test import MockObject
+from tribler_core.notifier import Notifier
 from tribler_core.utilities.path_util import Path
 from tribler_core.utilities.random_utils import random_infohash
 
@@ -17,291 +17,153 @@ EMPTY_BLOB = database_blob(b"")
 
 
 class TestGigaChannelUnits(TestBase):
-    """
-    Unit tests for the GigaChannel community which do not need a real Session.
-    """
-
     def setUp(self):
-        super(TestGigaChannelUnits, self).setUp()
+        super().setUp()
         self.count = 0
-        self.initialize(GigaChannelCommunity, 2)
+        self.initialize(GigaChannelCommunity, 3)
+        self.torrent_template = {"title": "", "infohash": b"", "torrent_date": datetime(1970, 1, 1), "tags": "video"}
 
     def create_node(self, *args, **kwargs):
         metadata_store = MetadataStore(
-            Path(self.temporary_directory()) / ("%d.db" % self.count),
+            Path(self.temporary_directory()) / f"{self.count}.db",
             Path(self.temporary_directory()),
             default_eccrypto.generate_key(u"curve25519"),
+            disable_sync=True,
         )
         kwargs['metadata_store'] = metadata_store
-        node = super(TestGigaChannelUnits, self).create_node(*args, **kwargs)
+        node = super().create_node(*args, **kwargs)
         self.count += 1
         return node
 
-    def add_random_torrent(self, metadata_cls, name="test", channel=None):
-        d = {"infohash": random_infohash(), "title": name, "tags": "", "size": 1234, "status": NEW}
-        if channel:
-            d.update({"origin_id": channel.id_})
-        torrent_metadata = metadata_cls.from_dict(d)
-        torrent_metadata.sign()
+    def channel_metadata(self, i):
+        return self.nodes[i].overlay.mds.ChannelMetadata
 
-    async def test_send_random_subscribed_channel(self):
-        """
-        Test whether sending a single channel with a single torrent to another peer works correctly
-        """
-        with db_session:
-            channel = self.nodes[0].overlay.metadata_store.ChannelMetadata.create_channel("test", "bla")
-            self.add_random_torrent(self.nodes[0].overlay.metadata_store.TorrentMetadata, channel=channel)
-            channel.commit_channel_torrent()
-        # We must change the key for the first node so the created channel becomes foreign
-        self.nodes[0].overlay.metadata_store.ChannelNode._my_key = default_eccrypto.generate_key(u"curve25519")
-        await self.nodes[0].overlay.prepare_gossip_blob_cache()
-
-        self.nodes[0].overlay.send_random_to(Peer(self.nodes[1].my_peer.public_key, self.nodes[1].endpoint.wan_address))
-        await self.deliver_messages(timeout=0.5)
-        with db_session:
-            self.assertEqual(len(self.nodes[1].overlay.metadata_store.ChannelMetadata.select()), 1)
-            channel = self.nodes[1].overlay.metadata_store.ChannelMetadata.select()[:][0]
-            self.assertEqual(channel.contents_len, 1)
-
-    async def test_send_random_personal_channel(self):
-        """
-        Test whether sending the personal channel works correctly
-        """
-        with db_session:
-            channel = self.nodes[0].overlay.metadata_store.ChannelMetadata.create_channel("test", "bla")
-            self.add_random_torrent(self.nodes[0].overlay.metadata_store.TorrentMetadata, channel=channel)
-            channel.commit_channel_torrent()
-
-        await self.nodes[0].overlay.prepare_gossip_blob_cache()
-        self.nodes[0].overlay.send_random_to(Peer(self.nodes[1].my_peer.public_key, self.nodes[1].endpoint.wan_address))
-
-        await self.deliver_messages(timeout=0.5)
-
-        with db_session:
-            self.assertEqual(len(self.nodes[1].overlay.metadata_store.ChannelMetadata.select()), 1)
-            channel = self.nodes[1].overlay.metadata_store.ChannelMetadata.select()[:][0]
-            self.assertEqual(channel.contents_len, 1)
-
-    async def test_send_personal_and_random_channels(self):
-        """
-        Test whether sending the personal channel works correctly
-        """
-        with db_session:
-            # Add non-personal channel
-            channel = self.nodes[0].overlay.metadata_store.ChannelMetadata.create_channel("non-personal", "bla")
-            self.add_random_torrent(self.nodes[0].overlay.metadata_store.TorrentMetadata, channel=channel)
-            channel.commit_channel_torrent()
-
-            # Add personal channel
-            self.nodes[0].overlay.metadata_store.ChannelNode._my_key = default_eccrypto.generate_key(u"curve25519")
-            # After the previous line the previously created channel becomes non-personal
-            channel = self.nodes[0].overlay.metadata_store.ChannelMetadata.create_channel("personal", "bla")
-            self.add_random_torrent(self.nodes[0].overlay.metadata_store.TorrentMetadata, channel=channel)
-            channel.commit_channel_torrent()
-
-        await self.nodes[0].overlay.prepare_gossip_blob_cache()
-        self.nodes[0].overlay.send_random_to(Peer(self.nodes[1].my_peer.public_key, self.nodes[1].endpoint.wan_address))
-        await self.deliver_messages(timeout=0.5)
-        with db_session:
-            self.assertEqual(len(self.nodes[1].overlay.metadata_store.ChannelMetadata.select()), 2)
-            channels = self.nodes[1].overlay.metadata_store.ChannelMetadata.select()[:]
-            self.assertEqual(channels[0].contents_len, 1)
-            self.assertEqual(channels[1].contents_len, 1)
-
-    async def test_send_random_multiple_torrents(self):
-        """
-        Test whether sending a single channel with a multiple torrents to another peer works correctly
-        """
-        with db_session:
-            channel = self.nodes[0].overlay.metadata_store.ChannelMetadata.create_channel("test", "bla")
-            for _ in range(10):
-                self.add_random_torrent(self.nodes[0].overlay.metadata_store.TorrentMetadata, channel=channel)
-            channel.commit_channel_torrent()
-
-        await self.nodes[0].overlay.prepare_gossip_blob_cache()
-        self.nodes[0].overlay.send_random_to(Peer(self.nodes[1].my_peer.public_key, self.nodes[1].endpoint.wan_address))
-
-        await self.deliver_messages(timeout=0.5)
-
-        with db_session:
-            channel = self.nodes[1].overlay.metadata_store.ChannelMetadata.get()
-            torrents1 = self.nodes[1].overlay.metadata_store.TorrentMetadata.select()[:]
-            self.assertLess(channel.contents_len, 10)
-            self.assertLess(0, channel.contents_len)
-
-        # We must delete the old and create all-new torrent entries for the next test.
-        # Otherwise, it becomes non-deterministic.
-        with db_session:
-            channel = self.nodes[0].overlay.metadata_store.ChannelMetadata.get()
-            self.nodes[0].overlay.metadata_store.TorrentMetadata.select(
-                lambda g: g.metadata_type == REGULAR_TORRENT
-            ).delete()
-            self.nodes[1].overlay.metadata_store.TorrentMetadata.select().delete()
-
-            for _ in range(10):
-                self.add_random_torrent(self.nodes[0].overlay.metadata_store.TorrentMetadata, channel=channel)
-            channel.commit_channel_torrent()
-
-        # Initiate the gossip again. This time, it should be sent from the blob cache
-        # so the torrents on the receiving end should not change this time.
-        self.nodes[0].overlay.send_random_to(Peer(self.nodes[1].my_peer.public_key, self.nodes[1].endpoint.wan_address))
-
-        await self.deliver_messages(timeout=0.5)
-        with db_session:
-            torrents2 = self.nodes[1].overlay.metadata_store.TorrentMetadata.select()[:]
-            self.assertEqual(len(torrents1), len(torrents2))
-
-        await self.nodes[0].overlay.prepare_gossip_blob_cache()
-        self.nodes[0].overlay.send_random_to(Peer(self.nodes[1].my_peer.public_key, self.nodes[1].endpoint.wan_address))
-
-        await self.deliver_messages(timeout=0.5)
-        with db_session:
-            torrents3 = self.nodes[1].overlay.metadata_store.TorrentMetadata.select()[:]
-            self.assertLess(len(torrents2), len(torrents3))
-
-    async def test_send_and_get_channel_update_back(self):
-        """
-        Test if sending back information on updated version of a channel works
-        """
-        with db_session:
-            # Add channel to node 0
-            channel = self.nodes[0].overlay.metadata_store.ChannelMetadata.create_channel("test", "bla")
-            for _ in range(20):
-                self.add_random_torrent(self.nodes[0].overlay.metadata_store.TorrentMetadata, channel=channel)
-            channel.commit_channel_torrent()
-            channel_v1_dict = channel.to_dict()
-            channel_v1_dict.pop("health")
-            self.add_random_torrent(self.nodes[0].overlay.metadata_store.TorrentMetadata, channel=channel)
-            channel.commit_channel_torrent()
-
-        with db_session:
-            # Add the outdated version of the channel to node 1
-            self.nodes[1].overlay.metadata_store.ChannelMetadata.from_dict(channel_v1_dict)
-
-        # node1 --outdated_channel--> node0
-        await self.nodes[1].overlay.prepare_gossip_blob_cache()
-        self.nodes[1].overlay.send_random_to(Peer(self.nodes[0].my_peer.public_key, self.nodes[0].endpoint.wan_address))
-
-        await self.deliver_messages(timeout=0.5)
-
-        with db_session:
-            self.assertEqual(
-                self.nodes[1].overlay.metadata_store.ChannelMetadata.select()[:][0].timestamp,
-                self.nodes[0].overlay.metadata_store.ChannelMetadata.select()[:][0].timestamp,
-            )
+    def torrent_metadata(self, i):
+        return self.nodes[i].overlay.mds.TorrentMetadata
 
     async def test_gigachannel_search(self):
         """
-        Scenario: Node 0 is setup with a channel with 20 ubuntu related torrents. Node 1 searches for 'ubuntu' and
-        expects to receive some results. The search results are processed by node 1 when it receives and adds to its
-        database. Max number of results is 5, so we expect 5 torrents are added the database.
+        Test searching several nodes for metadata entries based on title text
         """
+
+        # We do not want the query back mechanism and introduction callback to interfere with this test
+        for node in self.nodes:
+            node.overlay.settings.max_channel_query_back = 0
+
+        await self.introduce_nodes()
+
+        U_CHANNEL = "ubuntu channel"
+        U_TORRENT = "ubuntu torrent"
+
+        # Add test metadata to node 0
+        with db_session:
+            self.nodes[0].overlay.mds.ChannelMetadata.create_channel(U_CHANNEL, "")
+            self.nodes[0].overlay.mds.ChannelMetadata.create_channel("debian channel", "")
+
+        # Add test metadata to node 1
+        with db_session:
+            self.nodes[1].overlay.mds.TorrentMetadata(title=U_TORRENT, infohash=random_infohash())
+            self.nodes[1].overlay.mds.TorrentMetadata(title="debian torrent", infohash=random_infohash())
+
+        notification_calls = []
+
+        def mock_notify(_, args):
+            notification_calls.append(args)
+
+        self.nodes[2].overlay.notifier = Notifier()
+        self.nodes[2].overlay.notifier.notify = lambda sub, args: mock_notify(self.nodes[2].overlay, args)
+
+        self.nodes[2].overlay.send_search_request(**{"txt_filter": "ubuntu*"})
+
+        await self.deliver_messages(timeout=0.5)
+
+        with db_session:
+            assert self.nodes[2].overlay.mds.ChannelNode.select().count() == 2
+            assert (
+                self.nodes[2].overlay.mds.ChannelNode.select(lambda g: g.title in (U_CHANNEL, U_TORRENT)).count() == 2
+            )
+
+        # Check that the notifier callback was called on both entries
+        assert [U_CHANNEL, U_TORRENT] == sorted([c["results"][0]["name"] for c in notification_calls])
+
+    def test_query_on_introduction(self):
+        """
+        Test querying a peer that was just introduced to us.
+        """
+
+        send_ok = []
+
+        def mock_send(_):
+            send_ok.append(1)
+
+        self.nodes[1].overlay.send_remote_select_subscribed_channels = mock_send
+        peer = self.nodes[0].my_peer
+        self.nodes[1].overlay.introduction_response_callback(peer, None, None)
+        self.assertIn(peer.mid, self.nodes[1].overlay.queried_peers)
+        self.assertTrue(send_ok)
+
+        # Make sure the same peer will not be queried twice in case the walker returns to it
+        self.nodes[1].overlay.introduction_response_callback(peer, None, None)
+        self.assertEqual(len(send_ok), 1)
+
+        # Test clearing queried peers set when it outgrows its capacity
+        self.nodes[1].overlay.settings.queried_peers_limit = 2
+        self.nodes[1].overlay.introduction_response_callback(Peer(default_eccrypto.generate_key("low")), None, None)
+        self.assertEqual(len(self.nodes[1].overlay.queried_peers), 2)
+
+        self.nodes[1].overlay.introduction_response_callback(Peer(default_eccrypto.generate_key("low")), None, None)
+        # The set has been cleared, so the number of queried peers must be dropped back to 1
+        self.assertEqual(len(self.nodes[1].overlay.queried_peers), 1)
+
+    async def test_remote_select_subscribed_channels(self):
+        """
+        Test querying remote peers for subscribed channels and updating local votes accordingly.
+        """
+
+        # We do not want the query back mechanism to interfere with this test
+        self.nodes[1].overlay.settings.max_channel_query_back = 0
+
+        num_channels = 5
+
+        with db_session:
+            # Create one channel with zero contents, to check that only non-empty channels are served
+            self.nodes[0].overlay.mds.ChannelMetadata.create_channel("channel sub", "")
+            for _ in range(0, num_channels):
+                chan = self.nodes[0].overlay.mds.ChannelMetadata.create_channel("channel sub", "")
+                chan.num_entries = 10
+                chan.sign()
+            for _ in range(0, num_channels):
+                channel_uns = self.nodes[0].overlay.mds.ChannelMetadata.create_channel("channel unsub", "")
+                channel_uns.subscribed = False
 
         def mock_notify(overlay, args):
             overlay.notified_results = True
             self.assertTrue("results" in args)
 
-        self.nodes[1].overlay.notifier = MockObject()
+        self.nodes[1].overlay.notifier = Notifier()
         self.nodes[1].overlay.notifier.notify = lambda sub, args: mock_notify(self.nodes[1].overlay, args)
 
+        peer = self.nodes[0].my_peer
         await self.introduce_nodes()
-
-        with db_session:
-            # add some free-for-all entries
-            self.nodes[0].overlay.metadata_store.TorrentMetadata.add_ffa_from_dict(
-                dict(title="ubuntu legacy", infohash=random_infohash())
-            )
-            self.nodes[0].overlay.metadata_store.ChannelMetadata(
-                title="ubuntu legacy chan", infohash=random_infohash(), public_key=b"", status=LEGACY_ENTRY, id_=0
-            )
-            channel = self.nodes[0].overlay.metadata_store.ChannelMetadata.create_channel("ubuntu", "ubuntu")
-            for i in range(20):
-                self.add_random_torrent(
-                    self.nodes[0].overlay.metadata_store.TorrentMetadata, name="ubuntu %s" % i, channel=channel
-                )
-            channel.commit_channel_torrent()
-
-        # Node 1 has no torrents and searches for 'ubuntu'
-        with db_session:
-            torrents = self.nodes[1].overlay.metadata_store.TorrentMetadata.select()[:]
-            self.assertEqual(len(torrents), 0)
-        self.nodes[1].overlay.send_search_request(u'"ubuntu"*')
 
         await self.deliver_messages(timeout=0.5)
 
-        with db_session:
-            torrents = self.nodes[1].overlay.metadata_store.TorrentMetadata.select()[:]
-            self.assertEqual(len(torrents), 5)
+        # TODO: query only "complete" channels
 
-            # Only non-legacy FFA torrents should be sent on search
-            torrents_ffa = self.nodes[1].overlay.metadata_store.TorrentMetadata.select(
-                lambda g: g.public_key == EMPTY_BLOB
-            )[:]
-            self.assertEqual(len(torrents_ffa), 1)
-            # Legacy FFA channel should not be sent
-            channels_ffa = self.nodes[1].overlay.metadata_store.ChannelMetadata.select(
-                lambda g: g.public_key == EMPTY_BLOB
-            )[:]
-            self.assertEqual(len(channels_ffa), 0)
+        with db_session:
+            received_channels = self.nodes[1].overlay.mds.ChannelMetadata.select(lambda g: g.title == "channel sub")
+            self.assertEqual(num_channels, received_channels.count())
+
+            # Only subscribed channels should have been transported
+            received_channels_all = self.nodes[1].overlay.mds.ChannelMetadata.select()
+            self.assertEqual(num_channels, received_channels_all.count())
+
+            # Make sure the subscribed channels transport counted as voting
+            self.assertEqual(
+                self.nodes[1].overlay.mds.ChannelPeer.select().first().public_key, peer.public_key.key_to_bin()[10:]
+            )
+            for chan in self.nodes[1].overlay.mds.ChannelMetadata.select():
+                self.assertTrue(chan.votes > 0.0)
+
+        # Check that the notifier callback is called on new channel entries
         self.assertTrue(self.nodes[1].overlay.notified_results)
-
-    async def test_gigachannel_search_reject_stale_result(self):
-        """
-        Scenario: If two search requests are sent one after another, the response for the first query becomes stale and
-        is rejected.
-        """
-        await self.introduce_nodes()
-
-        with db_session:
-            channel = self.nodes[0].overlay.metadata_store.ChannelMetadata.create_channel("linux", "ubuntu")
-            for i in range(10):
-                self.add_random_torrent(
-                    self.nodes[0].overlay.metadata_store.TorrentMetadata, name="ubuntu %s" % i, channel=channel
-                )
-            for i in range(10):
-                self.add_random_torrent(
-                    self.nodes[0].overlay.metadata_store.TorrentMetadata, name="debian %s" % i, channel=channel
-                )
-            channel.commit_channel_torrent()
-
-        # Assert Node 1 has no previous torrents in the database
-        with db_session:
-            torrents = self.nodes[1].overlay.metadata_store.TorrentMetadata.select()[:]
-            self.assertEqual(len(torrents), 0)
-
-        # Node 1 sent two consecutive queries
-        self.nodes[1].overlay.send_search_request(u'"ubuntu"*')
-        self.nodes[1].overlay.send_search_request(u'"debian"*')
-
-        await self.deliver_messages(timeout=0.5)
-
-        # Assert that only the last result is accepted
-        with db_session:
-            torrents = self.nodes[1].overlay.metadata_store.TorrentMetadata.select()[:]
-            self.assertEqual(len(torrents), 5)
-            for torrent in torrents:
-                self.assertIn("debian", torrent.to_simple_dict()['name'])
-
-    async def test_gigachannel_search_with_no_result(self):
-        """
-        Test giga channel search which yields no result
-        """
-        await self.introduce_nodes()
-
-        # Both node 0 and node 1 have no torrents in the database
-        with db_session:
-            torrents = self.nodes[1].overlay.metadata_store.TorrentMetadata.select()[:]
-            torrents2 = self.nodes[1].overlay.metadata_store.TorrentMetadata.select()[:]
-            self.assertEqual(len(torrents), 0)
-            self.assertEqual(len(torrents2), 0)
-
-        # Node 1 searches for 'A ubuntu'
-        query = u'"\xc1 ubuntu"*'
-        self.nodes[1].overlay.send_search_request(query)
-
-        await self.deliver_messages(timeout=0.5)
-
-        # Expect no data received in search and nothing processed to the database
-        with db_session:
-            torrents = self.nodes[1].overlay.metadata_store.TorrentMetadata.select()[:]
-            self.assertEqual(len(torrents), 0)

--- a/src/tribler-core/tribler_core/modules/metadata_store/community/tests/test_gigachannel_community.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/community/tests/test_gigachannel_community.py
@@ -153,8 +153,6 @@ class TestGigaChannelUnits(TestBase):
 
         await self.deliver_messages(timeout=0.5)
 
-        # TODO: query only "complete" channels
-
         with db_session:
             received_channels = self.nodes[1].overlay.mds.ChannelMetadata.select(lambda g: g.title == "channel sub")
             self.assertEqual(num_channels, received_channels.count())

--- a/src/tribler-core/tribler_core/modules/metadata_store/community/tests/test_gigachannel_community.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/community/tests/test_gigachannel_community.py
@@ -128,8 +128,13 @@ class TestGigaChannelUnits(TestBase):
         with db_session:
             # Create one channel with zero contents, to check that only non-empty channels are served
             self.nodes[0].overlay.mds.ChannelMetadata.create_channel("channel sub", "")
+            # Create one channel that has not yet been processed (with local_version<timestamp)
+            incomplete_chan = self.nodes[0].overlay.mds.ChannelMetadata.create_channel("channel sub", "")
+            incomplete_chan.num_entries = 10
+            incomplete_chan.sign()
             for _ in range(0, num_channels):
                 chan = self.nodes[0].overlay.mds.ChannelMetadata.create_channel("channel sub", "")
+                chan.local_version = chan.timestamp
                 chan.num_entries = 10
                 chan.sign()
             for _ in range(0, num_channels):

--- a/src/tribler-core/tribler_core/modules/metadata_store/community/tests/test_remote_query_community.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/community/tests/test_remote_query_community.py
@@ -1,20 +1,18 @@
+from binascii import unhexlify
 from datetime import datetime
 from json import dumps
+from unittest.mock import Mock
 
 from ipv8.keyvault.crypto import default_eccrypto
-from ipv8.peer import Peer
 from ipv8.test.base import TestBase
 
 from pony.orm import db_session
 from pony.orm.dbapiprovider import OperationalError
 
-from tribler_common.simpledefs import NTFY
-
 from tribler_core.modules.metadata_store.community.remote_query_community import RemoteQueryCommunity, sanitize_query
 from tribler_core.modules.metadata_store.orm_bindings.channel_node import NEW
 from tribler_core.modules.metadata_store.serialization import CHANNEL_TORRENT, REGULAR_TORRENT
 from tribler_core.modules.metadata_store.store import MetadataStore
-from tribler_core.notifier import Notifier
 from tribler_core.utilities.path_util import Path
 from tribler_core.utilities.random_utils import random_infohash, random_string
 from tribler_core.utilities.unicode import hexlify
@@ -28,15 +26,19 @@ def add_random_torrent(metadata_cls, name="test", channel=None):
     torrent_metadata.sign()
 
 
+class BasicRemoteQueryCommunity(RemoteQueryCommunity):
+    community_id = unhexlify('eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee')
+
+
 class TestRemoteQueryCommunity(TestBase):
     """
-    Unit tests for the GigaChannel community which do not need a real Session.
+    Unit tests for the base RemoteQueryCommunity which do not need a real Session.
     """
 
     def setUp(self):
         super(TestRemoteQueryCommunity, self).setUp()
         self.count = 0
-        self.initialize(RemoteQueryCommunity, 2)
+        self.initialize(BasicRemoteQueryCommunity, 2)
         self.torrent_template = {"title": "", "infohash": b"", "torrent_date": datetime(1970, 1, 1), "tags": "video"}
 
     def create_node(self, *args, **kwargs):
@@ -47,7 +49,6 @@ class TestRemoteQueryCommunity(TestBase):
             disable_sync=True,
         )
         kwargs['metadata_store'] = metadata_store
-        kwargs['notifier'] = Notifier()
         node = super(TestRemoteQueryCommunity, self).create_node(*args, **kwargs)
         self.count += 1
         return node
@@ -58,108 +59,80 @@ class TestRemoteQueryCommunity(TestBase):
     def torrent_metadata(self, i):
         return self.nodes[i].overlay.mds.TorrentMetadata
 
-    def overlay(self, i):
-        return self.nodes[i].overlay
-
     async def test_remote_select(self):
-        # Fill Node 0 DB with channels and torrents entries
+        """
+        Test querying metadata entries from a remote machine
+        """
+
+        # We do not want the query back mechanism to interfere with this test
+        self.nodes[1].overlay.settings.max_channel_query_back = 0
+
+        # Fill Node 0 DB with channels and torrents
         with db_session:
-            channel_uns = self.nodes[0].overlay.mds.ChannelMetadata.create_channel("ubuntu channel unsub", "ubuntu")
-            channel_uns.subscribed = False
             channel = self.nodes[0].overlay.mds.ChannelMetadata.create_channel("ubuntu channel", "ubuntu")
-            channel_id, channel_pk = channel.id_, channel.public_key
             for i in range(20):
                 add_random_torrent(self.nodes[0].overlay.mds.TorrentMetadata, name="ubuntu %s" % i, channel=channel)
-            channel.commit_channel_torrent()
-
-        await self.introduce_nodes()
-        await self.deliver_messages(timeout=0.5)
-
-        # On introduction, the subscribed channel should be sent, so Node 1's DB should immediately get a channel
-        # Node 1 DB is empty. It searches for 'ubuntu'
-        with db_session:
-            torrents = self.nodes[1].overlay.mds.TorrentMetadata.select()[:]
-            self.assertEqual(len(torrents), 1)
-
-        # Node 1 DB is empty. It searches for 'ubuntu'
-        with db_session:
-            # Clean the db from the previous test
-            self.nodes[1].overlay.mds.TorrentMetadata.select().delete()
-            torrents = self.nodes[1].overlay.mds.TorrentMetadata.select()[:]
-            self.assertEqual(len(torrents), 0)
 
         kwargs_dict = {"txt_filter": "ubuntu*", "metadata_type": [REGULAR_TORRENT]}
-        self.nodes[1].overlay.send_remote_select_to_many(**kwargs_dict)
+        callback = Mock()
+        self.nodes[1].overlay.send_remote_select(self.nodes[0].my_peer, **kwargs_dict, processing_callback=callback)
 
         await self.deliver_messages(timeout=0.5)
+        # Test optional response processing callback
+        callback.assert_called()
 
+        # All the matching torrent entries should have been sent to Node 1
         with db_session:
             torrents0 = self.nodes[0].overlay.mds.MetadataNode.get_entries(**kwargs_dict)
             torrents1 = self.nodes[1].overlay.mds.MetadataNode.get_entries(**kwargs_dict)
             self.assertEqual(len(torrents0), len(torrents1))
+            self.assertEqual(len(torrents0), 20)
 
-        # Now try querying for subscribed "ubuntu" channels
-        channels1 = self.nodes[1].overlay.mds.MetadataNode.get_entries(channel_pk=channel_pk, id_=channel_id)
-        self.assertEqual(0, len(channels1))
-        kwargs_dict = {"txt_filter": "ubuntu*", "metadata_type": [CHANNEL_TORRENT], "subscribed": True}
-        self.nodes[1].overlay.send_remote_select_to_many(**kwargs_dict)
-
-        await self.deliver_messages(timeout=0.5)
-
-        with db_session:
-            channels1 = self.nodes[1].overlay.mds.MetadataNode.get_entries(channel_pk=channel_pk, id_=channel_id)
-            self.assertEqual(1, len(channels1))
-
-    async def test_remote_select_subscribed_channels(self):
+    async def test_remote_select_query_back(self):
         """
-        Test querying remote peers for subscribed channels and updating local votes accordingly
+        Test querying back preview contents for previously unknown channels.
         """
 
-        def mock_notify(overlay, args):
-            overlay.notified_results = True
-            self.assertTrue("results" in args)
-
-        self.nodes[1].overlay.notifier = Notifier()
-        self.nodes[1].overlay.notifier.notify = lambda sub, args: mock_notify(self.nodes[1].overlay, args)
+        num_channels = 5
+        max_received_torrents_per_channel_query_back = 4
 
         with db_session:
-            # Create one channel with zero contents, to check that only non-empty channels are served
-            self.nodes[0].overlay.mds.ChannelMetadata.create_channel("channel sub", "")
-            for _ in range(0, 5):
-                chan = self.nodes[0].overlay.mds.ChannelMetadata.create_channel("channel sub", "")
-                chan.num_entries = 5
-                chan.sign()
-            for _ in range(0, 5):
-                channel_uns = self.nodes[0].overlay.mds.ChannelMetadata.create_channel("channel unsub", "")
-                channel_uns.subscribed = False
+            # Generate channels on Node 0
+            for _ in range(0, num_channels):
+                chan = self.nodes[0].overlay.mds.ChannelMetadata.create_channel("channel", "")
+                # Generate torrents in each channel
+                for _ in range(0, max_received_torrents_per_channel_query_back):
+                    self.nodes[0].overlay.mds.TorrentMetadata(origin_id=chan.id_, infohash=random_infohash())
 
         peer = self.nodes[0].my_peer
-        self.nodes[1].overlay.send_remote_select_subscribed_channels(peer)
+        kwargs_dict = {"metadata_type": [CHANNEL_TORRENT]}
+        self.nodes[1].overlay.send_remote_select(peer, **kwargs_dict)
 
         await self.deliver_messages(timeout=0.5)
 
         with db_session:
-            received_channels = self.nodes[1].overlay.mds.ChannelMetadata.select(lambda g: g.title == "channel sub")
-            self.assertEqual(received_channels.count(), 5)
-            # Only subscribed channels should have been transported
-            received_channels_all = self.nodes[1].overlay.mds.ChannelMetadata.select()
-            self.assertEqual(received_channels_all.count(), 5)
+            received_channels = self.nodes[1].overlay.mds.ChannelMetadata.select(lambda g: g.title == "channel")
+            self.assertEqual(received_channels.count(), num_channels)
 
-            # Make sure the subscribed channels transport counted as voting
-            self.assertEqual(
-                self.nodes[1].overlay.mds.ChannelPeer.select().first().public_key, peer.public_key.key_to_bin()[10:]
+            # For each unknown channel that we received, we should have queried the sender for 4 preview torrents.
+            received_torrents = self.nodes[1].overlay.mds.TorrentMetadata.select(
+                lambda g: g.metadata_type == REGULAR_TORRENT
             )
-            for chan in self.nodes[1].overlay.mds.ChannelMetadata.select():
-                self.assertTrue(chan.votes > 0.0)
+            self.assertEqual(num_channels * max_received_torrents_per_channel_query_back, received_torrents.count())
 
-        # Check that the notifier callback is called on new channel entries
-        self.assertTrue(self.nodes[1].overlay.notified_results)
+    async def test_push_entry_update(self):
+        """
+        Test if sending back information on updated version of a metadata entry works
+        """
 
     async def test_remote_select_packets_limit(self):
         """
         Test dropping packets that go over the response limit for a remote select.
 
         """
+        # We do not want the query back mechanism to interfere with this test
+        self.nodes[1].overlay.settings.max_channel_query_back = 0
+
         with db_session:
             for _ in range(0, 100):
                 self.nodes[0].overlay.mds.ChannelMetadata.create_channel(random_string(100), "")
@@ -180,142 +153,36 @@ class TestRemoteQueryCommunity(TestBase):
             # The list of outstanding requests should be empty
             self.assertFalse(self.nodes[1].overlay.request_cache._identifiers)
 
-    def test_query_on_introduction(self):
-        """
-        Test querying a peer that was just introduced to us.
-        """
-
-        send_ok = []
-
-        def mock_send(_):
-            send_ok.append(1)
-
-        self.nodes[1].overlay.send_remote_select_subscribed_channels = mock_send
-        peer = self.nodes[0].my_peer
-        self.nodes[1].overlay.introduction_response_callback(peer, None, None)
-        self.assertIn(peer.mid, self.nodes[1].overlay.queried_subscribed_channels_peers)
-        self.assertTrue(send_ok)
-
-        # Make sure the same peer will not be queried twice in case the walker returns to it
-        self.nodes[1].overlay.introduction_response_callback(peer, None, None)
-        self.assertEqual(len(send_ok), 1)
-
-        # Test clearing queried peers set when it outgrows its capacity
-        self.nodes[1].overlay.queried_peers_limit = 2
-        self.nodes[1].overlay.introduction_response_callback(Peer(default_eccrypto.generate_key("low")), None, None)
-        self.assertEqual(len(self.nodes[1].overlay.queried_subscribed_channels_peers), 2)
-
-        self.nodes[1].overlay.introduction_response_callback(Peer(default_eccrypto.generate_key("low")), None, None)
-        self.assertEqual(len(self.nodes[1].overlay.queried_subscribed_channels_peers), 1)
-
     def test_sanitize_query(self):
         req_response_list = [
             ({"first": None, "last": None}, {"first": 0, "last": 100}),
             ({"first": 123, "last": None}, {"first": 123, "last": 223}),
             ({"first": None, "last": 1000}, {"first": 0, "last": 100}),
             ({"first": 100, "last": None}, {"first": 100, "last": 200}),
+            ({"first": 123}, {"first": 123, "last": 223}),
+            ({"last": 123}, {"first": 0, "last": 100}),
             ({}, {"first": 0, "last": 100}),
         ]
         for req, resp in req_response_list:
-            self.assertDictEqual(sanitize_query(req), resp)
+            assert sanitize_query(req) == resp
 
-    def test_sanitize_query_infohash(self):
-        infohash_in_b = b'0' * 20
-        infohash_in_hex = hexlify(infohash_in_b)
-
-        query = {'infohash': infohash_in_hex}
-        sanitize_query(query)
-        assert query['infohash'] == infohash_in_b
-
-        # assert no exception raises when 'infohash' is missed
-        sanitize_query({})
-
-    async def test_infohash_select(self):
-        db1 = self.nodes[0].overlay.mds.TorrentMetadata
-        db2 = self.nodes[1].overlay.mds.TorrentMetadata
-
-        torrent_infohash = b'0' * 20
-        torrent_title = 'title'
-
-        def has_testing_infohash(t):
-            return t.infohash == torrent_infohash
-
-        with db_session:
-            db1.from_dict({"infohash": torrent_infohash, "title": torrent_title}).sign()
-
-            torrent_has_been_added_to_db1 = db1.select(has_testing_infohash).count() == 1
-            torrent_not_presented_on_db2 = db2.select(has_testing_infohash).count() == 0
-
-        assert torrent_has_been_added_to_db1
-        assert torrent_not_presented_on_db2
-
-        await self.introduce_nodes()
-        remote_query = {"infohash": hexlify(torrent_infohash)}
-        self.nodes[1].overlay.send_remote_select_to_many(**remote_query)
-
-        await self.deliver_messages(timeout=0.5)
-        with db_session:
-            torrents = list(db2.select(has_testing_infohash))
-
-        torrent_is_presented_on_db2 = len(torrents) == 1
-        torrent_has_valid_title = torrents[0].title == torrent_title
-
-        assert torrent_is_presented_on_db2
-        assert torrent_has_valid_title
-
-    async def add_unknown_torrent(self, enabled):
-        rqc1 = self.nodes[0].overlay
-        rqc2 = self.nodes[1].overlay
-
-        rqc1.enable_resolve_unknown_torrents_feature = enabled
-        rqc2.enable_resolve_unknown_torrents_feature = enabled
-
-        db1 = rqc1.mds.TorrentMetadata
-        db2 = rqc2.mds.TorrentMetadata
-
-        torrent_infohash = random_infohash()
-
-        def has_testing_infohash(t):
-            return t.infohash == torrent_infohash
-
-        with db_session:
-            db1.from_dict({"infohash": torrent_infohash, "title": 'title'}).sign()
-
-            torrent_has_been_added_to_db1 = db1.select(has_testing_infohash).count() == 1
-            torrent_not_presented_on_db2 = db2.select(has_testing_infohash).count() == 0
-
-        assert torrent_has_been_added_to_db1
-        assert torrent_not_presented_on_db2
-
-        # notify second node that new torrent hash has been received from the first node
-        rqc2.notifier.notify(NTFY.POPULARITY_COMMUNITY_ADD_UNKNOWN_TORRENT, self.nodes[0].my_peer, torrent_infohash)
-
-        await self.deliver_messages(timeout=0.5)
-        with db_session:
-            torrent_is_presented_on_db2 = db2.select(has_testing_infohash).count() == 1
-
-        if rqc2.enable_resolve_unknown_torrents_feature:
-            assert torrent_is_presented_on_db2
-        else:
-            assert not torrent_is_presented_on_db2
-
-    async def test_add_unknown_torrent(self):
-        await self.add_unknown_torrent(True)
-        await self.add_unknown_torrent(False)
+    def test_sanitize_query_binary_fields(self):
+        for field in ("infohash", "channel_pk"):
+            field_in_b = b'0' * 20
+            field_in_hex = hexlify(field_in_b)
+            assert sanitize_query({field: field_in_hex})[field] == field_in_b
 
     async def test_unknown_query_attribute(self):
+        rqc_node1 = self.nodes[0].overlay
         rqc_node2 = self.nodes[1].overlay
 
         # only the new attribute
-        rqc_node2.send_remote_select_to_many(**{'new_attribute': 'some_value'})
+        rqc_node2.send_remote_select(rqc_node1.my_peer, **{'new_attribute': 'some_value'})
         await self.deliver_messages(timeout=0.1)
 
         # mixed: the old and a new attribute
-        rqc_node2.send_remote_select_to_many(**{'infohash': hexlify(b'0' * 20), 'new_attribute': 'some_value'})
+        rqc_node2.send_remote_select(rqc_node1.my_peer, **{'infohash': hexlify(b'0' * 20), 'foo': 'bar'})
         await self.deliver_messages(timeout=0.1)
-
-        # no exception have been raised
-        assert True
 
     async def test_process_rpc_query_match_many(self):
         """

--- a/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/channel_metadata.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/channel_metadata.py
@@ -354,27 +354,6 @@ def define_binding(db):
 
         @classmethod
         @db_session
-        def get_random_channels(cls, limit, only_subscribed=False, only_downloaded=False):
-            """
-            Fetch up to some limit of torrents from this channel
-
-            :param limit: the maximum amount of torrents to fetch
-            :param only_subscribed: whether we only want random channels we are subscribed to
-            :param only_downloaded: whether we only want channels that were downloaded/seeded from a torrent
-            :return: the subset of random channels we are subscribed to
-            :rtype: list
-            """
-            query = db.ChannelMetadata.select(
-                lambda g: g.status not in [LEGACY_ENTRY, NEW, UPDATED, TODELETE]
-                and g.num_entries > 0
-                and g.public_key != database_blob(cls._my_key.pub().key_to_bin()[10:])
-            )
-            query = query.where(subscribed=True) if only_subscribed else query
-            query = query.where(lambda g: g.local_version == g.timestamp) if only_downloaded else query
-            return query.random(limit)
-
-        @classmethod
-        @db_session
         def get_updated_channels(cls):
             return select(
                 g

--- a/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/channel_node.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/channel_node.py
@@ -65,6 +65,7 @@ def define_binding(db, logger=None, key=None):
         public_key = orm.Required(database_blob, index=True)
         id_ = orm.Required(int, size=64)
         orm.composite_key(public_key, id_)
+        orm.composite_index(public_key, origin_id)
 
         timestamp = orm.Required(int, size=64, default=0)
         # Signature is nullable. This means that "None" entries are stored in DB as NULLs instead of empty strings.

--- a/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/metadata_node.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/metadata_node.py
@@ -6,7 +6,7 @@ from pony.orm import db_session, desc, raw_sql, select
 
 from tribler_core.modules.metadata_store.orm_bindings.channel_node import LEGACY_ENTRY, TODELETE
 from tribler_core.modules.metadata_store.orm_bindings.torrent_metadata import NULL_KEY_SUBST
-from tribler_core.modules.metadata_store.serialization import METADATA_NODE, MetadataNodePayload
+from tribler_core.modules.metadata_store.serialization import CHANNEL_TORRENT, METADATA_NODE, MetadataNodePayload
 from tribler_core.utilities.unicode import hexlify
 
 
@@ -72,6 +72,7 @@ def define_binding(db):
             attribute_ranges=None,
             infohash=None,
             id_=None,
+            complete_channel=None,
         ):
             """
             This method implements REST-friendly way to get entries from the database. It is overloaded by the higher
@@ -111,6 +112,12 @@ def define_binding(db):
             pony_query = pony_query.where(lambda g: g.xxx == 0) if hide_xxx else pony_query
             pony_query = pony_query.where(lambda g: g.status != LEGACY_ENTRY) if exclude_legacy else pony_query
             pony_query = pony_query.where(lambda g: g.infohash == infohash) if infohash else pony_query
+            # ACHTUNG! Setting complete_channel to True forces the metadata type to Channels only!
+            pony_query = (
+                pony_query.where(lambda g: g.metadata_type == CHANNEL_TORRENT and g.timestamp == g.local_version)
+                if complete_channel
+                else pony_query
+            )
 
             # Sort the query
             if sort_by == "HEALTH":

--- a/src/tribler-core/tribler_core/modules/metadata_store/restapi/tests/test_remote_query_endpoint.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/restapi/tests/test_remote_query_endpoint.py
@@ -1,3 +1,4 @@
+import uuid
 from unittest.mock import Mock
 
 import pytest
@@ -10,25 +11,30 @@ async def test_create_remote_search_request(enable_chant, enable_api, session):
     """
     Test that remote search call is sent on a REST API search request
     """
-    sent = []
+    sent = {}
+    request_uuid = uuid.uuid4()
 
-    def mock_send(txt_filter, **__):
-        sent.append(txt_filter)
+    def mock_send(**kwargs):
+        sent.update(kwargs)
+        return request_uuid
 
+    # Test querying for keywords
     session.gigachannel_community = Mock()
     session.gigachannel_community.send_search_request = mock_send
     search_txt = "foo"
-    await do_request(session, f'remote_query?txt_filter={search_txt}&uuid=333', request_type="PUT", expected_code=200)
-    assert search_txt in sent
+    await do_request(
+        session,
+        f'remote_query?txt_filter={search_txt}',
+        request_type="PUT",
+        expected_code=200,
+        expected_json={"request_uuid": str(request_uuid)},
+    )
+    assert sent['txt_filter'] == search_txt
+    sent.clear()
 
     # Test querying channel data by public key, e.g. for channel preview purposes
     channel_pk = "ff"
-    await do_request(session, f'remote_query?channel_pk={channel_pk}&uuid=333', request_type="PUT", expected_code=200)
-    assert f'"{channel_pk}"*' in sent
-
     await do_request(
-        session,
-        f'remote_query?txt_filter={search_txt}&channel_pk={channel_pk}&uuid=333',
-        request_type="PUT",
-        expected_code=400,
+        session, f'remote_query?channel_pk={channel_pk}&metadata_type=torrent', request_type="PUT", expected_code=200
     )
+    assert sent['channel_pk'] == channel_pk

--- a/src/tribler-core/tribler_core/modules/metadata_store/store.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/store.py
@@ -42,7 +42,7 @@ from tribler_core.utilities.path_util import str_path
 from tribler_core.utilities.unicode import hexlify
 
 BETA_DB_VERSIONS = [0, 1, 2, 3, 4, 5]
-CURRENT_DB_VERSION = 9
+CURRENT_DB_VERSION = 10
 
 NO_ACTION = 0
 UNKNOWN_CHANNEL = 1

--- a/src/tribler-core/tribler_core/modules/metadata_store/store.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/store.py
@@ -344,7 +344,7 @@ class MetadataStore(object):
             return []
         return self.process_squashed_mdblob(decompressed_data, **kwargs)
 
-    def process_squashed_mdblob(self, chunk_data, external_thread=False, peer_vote_for_channels=None, **kwargs):
+    def process_squashed_mdblob(self, chunk_data, external_thread=False, **kwargs):
         """
         Process raw concatenated payloads blob. This routine breaks the database access into smaller batches.
         It uses a congestion-control like algorithm to determine the optimal batch size, targeting the
@@ -354,7 +354,6 @@ class MetadataStore(object):
         :param external_thread: if this is set to True, we add some sleep between batches to allow other threads
             to get the database lock. This is an ugly workaround for Python and asynchronous programming (locking)
             imperfections. It only makes sense to use it when this routine runs on a non-reactor thread.
-        :peer_vote_for_channels: Channel entries found in the blob will be vote bumped for the corresponding peer
         :return: a list of tuples of (<metadata or payload>, <action type>)
         """
 
@@ -402,12 +401,6 @@ class MetadataStore(object):
             if external_thread:
                 sleep(self.sleep_on_external_thread)
 
-        # TODO: this is not the best place to bump votes. It is more correct to do it directly in process_payload.
-        if peer_vote_for_channels is not None:
-            with db_session:
-                peer = peer_vote_for_channels
-                for c in [md for md, _ in result if md and (md.metadata_type == CHANNEL_TORRENT)]:
-                    self.vote_bump(c.public_key, c.id_, peer.public_key.key_to_bin()[10:])
         return result
 
     @db_session

--- a/src/tribler-core/tribler_core/modules/metadata_store/tests/test_channel_metadata.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/tests/test_channel_metadata.py
@@ -272,6 +272,17 @@ def test_vsids(metadata_store):
     assert metadata_store.Vsids[0].bump_amount == 1.0
     assert channel.votes == 1.0
 
+    # Ensure that vote by another person counts
+    peer_key = default_eccrypto.generate_key(u"curve25519")
+    metadata_store.vote_bump(channel.public_key, channel.id_, peer_key.pub().key_to_bin()[10:])
+    assert channel.votes == 2.0
+
+    sleep(0.1)  # Necessary mostly on Windows, because of the lower timer resolution
+    # Ensure that a repeated vote supersedes the first vote but does not count as a new one
+    metadata_store.vote_bump(channel.public_key, channel.id_, peer_key.pub().key_to_bin()[10:])
+    assert channel.votes > 2.0
+    assert channel.votes < 2.1
+
 
 @db_session
 def test_commit_channel_torrent(metadata_store):

--- a/src/tribler-core/tribler_core/modules/metadata_store/tests/test_store.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/tests/test_store.py
@@ -4,7 +4,7 @@ import string
 from binascii import unhexlify
 from datetime import datetime
 from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 from ipv8.database import database_blob
 from ipv8.keyvault.crypto import default_eccrypto
@@ -276,30 +276,6 @@ def test_process_payload(metadata_store):
 
         # Check that payload processing returns the local node in case we already now about it
         assert processed_node, NO_ACTION == metadata_store.process_payload(node_payload)[0]
-
-
-@db_session
-def test_process_squashed_mdblob_update_vsids(metadata_store):
-    """
-    Test if VSIDS channels votes stats are updated after processing a channel metadata entry
-    """
-    channel = metadata_store.ChannelMetadata(
-        infohash=database_blob(random_infohash()), sign_with=default_eccrypto.generate_key(u"curve25519")
-    )
-    serialized = channel.serialized()
-    channel.delete()
-    mock_peer = Mock()
-    mock_peer.public_key = default_eccrypto.generate_key(u"curve25519").pub()
-    metadata_store.process_squashed_mdblob(serialized, peer_vote_for_channels=mock_peer)
-    assert metadata_store.ChannelVote.get()
-    channel = metadata_store.ChannelMetadata.get()
-    channel_votes1 = channel.votes
-
-    # Now test that the bump happens if another host votes for the same channel
-    mock_peer.public_key = default_eccrypto.generate_key(u"curve25519").pub()
-    metadata_store.process_squashed_mdblob(serialized, peer_vote_for_channels=mock_peer)
-    channel = metadata_store.ChannelMetadata.get()
-    assert channel.votes > channel_votes1
 
 
 @db_session

--- a/src/tribler-core/tribler_core/modules/metadata_store/tests/test_torrent_metadata.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/tests/test_torrent_metadata.py
@@ -263,6 +263,17 @@ def test_get_entries(metadata_store):
     torrents = metadata_store.TorrentMetadata.get_entries(first=1, last=10, **args)
     assert list(torrents) == [entry]
 
+    # Test getting complete channels
+    with db_session:
+        complete_chan = metadata_store.ChannelMetadata(
+            infohash=random_infohash(), title='bla', local_version=222, timestamp=222
+        )
+        incomplete_chan = metadata_store.ChannelMetadata(
+            infohash=random_infohash(), title='bla', local_version=222, timestamp=223
+        )
+        channels = metadata_store.ChannelMetadata.get_entries(complete_channel=True)
+        assert [complete_chan] == channels
+
 
 @db_session
 def test_metadata_conflicting(metadata_store):

--- a/src/tribler-core/tribler_core/modules/tests/test_ipv8_module_catalog.py
+++ b/src/tribler-core/tribler_core/modules/tests/test_ipv8_module_catalog.py
@@ -14,7 +14,6 @@ def test_hiddenimports():
     assert 'ipv8.peerdiscovery.discovery' in hiddenimports
     assert 'tribler_core.modules.popularity.popularity_community' in hiddenimports
     assert 'tribler_core.modules.metadata_store.community.gigachannel_community' in hiddenimports
-    assert 'tribler_core.modules.metadata_store.community.remote_query_community' in hiddenimports
     assert 'tribler_core.modules.metadata_store.community.sync_strategy' in hiddenimports
     assert 'tribler_core.modules.tunnel.community.discovery' in hiddenimports
     assert 'tribler_core.modules.tunnel.community.triblertunnel_community' in hiddenimports

--- a/src/tribler-core/tribler_core/session.py
+++ b/src/tribler-core/tribler_core/session.py
@@ -132,7 +132,6 @@ class Session(TaskManager):
         self.wallets = {}
         self.popularity_community = None
         self.gigachannel_community = None
-        self.remote_query_community = None
 
         self.dht_community = None
         self.payout_manager = None

--- a/src/tribler-core/tribler_core/tests/test_session.py
+++ b/src/tribler-core/tribler_core/tests/test_session.py
@@ -10,7 +10,6 @@ import pytest
 from tribler_core.session import IGNORED_ERRORS
 from tribler_core.tests.tools.base_test import MockObject
 
-
 # Pylint does not agree with the way pytest handles fixtures.
 # pylint: disable=W0613,W0621
 
@@ -123,8 +122,6 @@ async def test_load_ipv8_overlays(mocked_endpoints, enable_ipv8, session):
     assert "PopularityCommunity" in loaded_launchers
     assert "GigaChannelCommunity" in loaded_launchers
     assert "GigaChannelTestnetCommunity" not in loaded_launchers
-    assert "RemoteQueryCommunity" in loaded_launchers
-    assert "RemoteQueryTestnetCommunity" not in loaded_launchers
 
 
 @pytest.mark.asyncio
@@ -152,5 +149,3 @@ async def test_load_ipv8_overlays_testnet(mocked_endpoints, enable_ipv8, session
     assert "PopularityCommunity" in loaded_launchers
     assert "GigaChannelCommunity" not in loaded_launchers
     assert "GigaChannelTestnetCommunity" in loaded_launchers
-    assert "RemoteQueryCommunity" not in loaded_launchers
-    assert "RemoteQueryTestnetCommunity" in loaded_launchers

--- a/src/tribler-gui/tribler_gui/widgets/channelcontentswidget.py
+++ b/src/tribler-gui/tribler_gui/widgets/channelcontentswidget.py
@@ -1,4 +1,3 @@
-import uuid
 from base64 import b64encode
 
 from PyQt5 import uic
@@ -286,9 +285,7 @@ class ChannelContentsWidget(widget_form, widget_class):
     #    self.tray_show_message("Copied channel ID", self.channel_info["public_key"])
 
     def preview_clicked(self):
-        request_uuid = uuid.uuid4()
-        self.model.remote_queries.add(request_uuid)
-        params = {'uuid': request_uuid}
+        params = dict()
 
         if "public_key" in self.model.channel_info:
             # This is a channel contents query, limit the search by channel_pk and torrent md type
@@ -306,7 +303,12 @@ class ChannelContentsWidget(widget_form, widget_class):
         if self.model.category_filter is not None:
             params.update({'category_filter': self.model.category_filter})
 
-        TriblerNetworkRequest('remote_query', None, method="PUT", url_params=params)
+        def add_request_uuid(response):
+            request_uuid = response["request_uuid"]
+            if self.model:
+                self.model.remote_queries.add(request_uuid)
+
+        TriblerNetworkRequest('remote_query', add_request_uuid, method="PUT", url_params=params)
 
     def create_new_channel(self):
         NewChannelDialog(self, self.model.create_new_channel)


### PR DESCRIPTION
EDITED: 24.11.20

This PR refactors RemoteQueryCommunity into a base class that is now inherited by PopularityCommunity and GigaChannelCommunity. The class enables rich communication via the RQC protocol, e.g. allowing PopC to query back the sender of popularity gossip for metadata of unknown infohashes.

In addition, whenever RQC receives a previously unknown Channel entry, it will query the sender for four entries from it. This guarantees that at least some preview content will be available for any channel.


To circumvent the problem of no new content for new clients, as suggested by @egbertbouman,  I added `extra_bytes` field to the renewed introduction request. This allows the new version to distinguish its folk from the previous versions and do not send them requests that will crash them.
This required copy-pasting some code from the base class. We can safely delete those lines in a few weeks when most of the network will migrate to the new version.
