### PR TITLE
READY: Cherry-picked release-7.5 SyncChannels target_peers fix

### DIFF
--- a/src/tribler-core/tribler_core/modules/ipv8_module_catalog.py
+++ b/src/tribler-core/tribler_core/modules/ipv8_module_catalog.py
@@ -104,7 +104,7 @@ class PopularityCommunityLauncher(IPv8CommunityLauncher):
 @overlay('tribler_core.modules.metadata_store.community.gigachannel_community', 'GigaChannelCommunity')
 @kwargs(metadata_store='session.mds', notifier='session.notifier')
 @walk_strategy('ipv8.peerdiscovery.discovery', 'RandomWalk')
-@walk_strategy('tribler_core.modules.metadata_store.community.sync_strategy', 'SyncChannels')
+@walk_strategy('tribler_core.modules.metadata_store.community.sync_strategy', 'SyncChannels', target_peers=-1)
 class GigaChannelCommunityLauncher(IPv8CommunityLauncher):
     pass
 


### PR DESCRIPTION
This was part of the fixes on `release-7.5`, but apparently it did not make its way into `devel`:

https://github.com/Tribler/tribler/blob/1c4335c98b9e7121ba0175b91879a2bd5f4b088b/src/tribler-core/tribler_core/session.py#L248