### PR TITLE
Removed encoding from json loads call

### DIFF
--- a/src/tribler-gui/tribler_gui/tribler_request_manager.py
+++ b/src/tribler-gui/tribler_gui/tribler_request_manager.py
@@ -200,7 +200,7 @@ class TriblerNetworkRequest(QObject):
             if not self.decode_json_response:
                 self.received_json.emit(data)
                 return
-            json_result = json.loads(bytes(data), encoding='latin_1')
+            json_result = json.loads(bytes(data))
             if (
                 'error' in json_result
                 and self.capture_core_errors


### PR DESCRIPTION
This fixes compatibility with Python 3.9.

Fixes #5744 