### PR TITLE
ipv8 module catalog refactoring

### DIFF
--- a/src/tribler-core/tribler_core/modules/tests/test_ipv8_module_catalog.py
+++ b/src/tribler-core/tribler_core/modules/tests/test_ipv8_module_catalog.py
@@ -5,15 +5,4 @@ def test_hiddenimports():
     """
     Check if all hidden imports are detected
     """
-    hiddenimports = get_hiddenimports()
-
-    assert 'ipv8.dht.churn' in hiddenimports
-    assert 'ipv8.dht.discovery' in hiddenimports
-    assert 'ipv8.peerdiscovery.churn' in hiddenimports
-    assert 'ipv8.peerdiscovery.community' in hiddenimports
-    assert 'ipv8.peerdiscovery.discovery' in hiddenimports
-    assert 'tribler_core.modules.popularity.popularity_community' in hiddenimports
-    assert 'tribler_core.modules.metadata_store.community.gigachannel_community' in hiddenimports
-    assert 'tribler_core.modules.metadata_store.community.sync_strategy' in hiddenimports
-    assert 'tribler_core.modules.tunnel.community.discovery' in hiddenimports
-    assert 'tribler_core.modules.tunnel.community.triblertunnel_community' in hiddenimports
+    assert not get_hiddenimports()


### PR DESCRIPTION
This PR replaces some strings from `ipv8_module_catalog.py` which represents `Class.__module__` and `Class.__name__` by corresponding special attributes.

It makes navigation in IDE easy and will save us from changing them manually in case of class names changes or location changes.

What do you think?