### PR TITLE
Launch IPv8 with an IPv4 UDP endpoint only

### DIFF
--- a/src/tribler-core/tribler_core/modules/metadata_store/community/gigachannel_community.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/community/gigachannel_community.py
@@ -51,11 +51,12 @@ class GigaChannelCommunitySettings(RemoteQueryCommunitySettings):
 class NonLegacyGigaChannelCommunity(RemoteQueryCommunity):
     community_id = unhexlify('dc43e3465cbd83948f30d3d3e8336d71cce33aa7')
 
-    def create_introduction_response(self, *args, introduction=None, extra_bytes=b'', prefix=None):
+    def create_introduction_response(self, *args, introduction=None, extra_bytes=b'', prefix=None, new_style=False):
         # ACHTUNG! We add extra_bytes here to identify the newer, 7.6+ version RemoteQuery/GigaChannel community
         # dialect, so that other 7.6+ are able to distinguish between the older and newer versions.
         return super().create_introduction_response(
-            *args, introduction=introduction, extra_bytes=MAGIC_GIGACHAN_VERSION_MARK, prefix=prefix
+            *args, introduction=introduction, extra_bytes=MAGIC_GIGACHAN_VERSION_MARK, prefix=prefix,
+            new_style=new_style
         )
 
     def __init__(self, my_peer, endpoint, network, metadata_store, **kwargs):

--- a/src/tribler-core/tribler_core/session.py
+++ b/src/tribler-core/tribler_core/session.py
@@ -336,10 +336,17 @@ class Session(TaskManager):
                 community_file._DEFAULT_ADDRESSES = [self.config.get_ipv8_bootstrap_override()]
                 community_file._DNS_ADDRESSES = []
 
+            if self.core_test_mode:
+                endpoint = DispatcherEndpoint([])
+            else:
+                # IPv8 includes IPv6 support by default.
+                # We only load IPv4 to not kill all Tribler overlays (currently, it would instantly crash all users).
+                # If you want to test IPv6 in Tribler you can set ``endpoint = None`` here.
+                endpoint = DispatcherEndpoint(["UDPIPv4"], UDPIPv4={'port': self.config.get_ipv8_port(),
+                                                                    'ip': self.config.get_ipv8_address()})
             self.ipv8 = IPv8(ipv8_config_builder.finalize(),
-                             enable_statistics=self.config.get_ipv8_statistics()) \
-                if not self.core_test_mode else IPv8(ipv8_config_builder.finalize(),
-                                                     endpoint_override=DispatcherEndpoint([]))
+                             enable_statistics=self.config.get_ipv8_statistics() and not self.core_test_mode,
+                             endpoint_override=endpoint)
             await self.ipv8.start()
 
             self.config.set_anon_proxy_settings(2, ("127.0.0.1",

--- a/src/tribler-core/tribler_core/session.py
+++ b/src/tribler-core/tribler_core/session.py
@@ -394,6 +394,11 @@ class Session(TaskManager):
         if self.config.get_ipv8_enabled():
             self.payout_manager = PayoutManager(self.bandwidth_community, self.dht_community)
 
+            if self.core_test_mode:
+                from ipv8.messaging.interfaces.udp.endpoint import UDPv4Address
+                from ipv8.dht.routing import RoutingTable
+                self.dht_community.routing_tables[UDPv4Address] = RoutingTable('\x00' * 20)
+
         # GigaChannel Manager should be started *after* resuming the downloads,
         # because it depends on the states of torrent downloads
         if self.config.get_chant_enabled() and self.config.get_chant_manager_enabled() \


### PR DESCRIPTION
Fixes #5748

The new IPv8 should only be launched in IPv4 mode, or it will crash Tribler 😃 

Thanks to @egbertbouman for helping with inserting DHT test data.