### PR TITLE
Fix Reporter

### DIFF
--- a/src/run_tribler.py
+++ b/src/run_tribler.py
@@ -11,7 +11,6 @@ from tribler_common.sentry_reporter.sentry_scrubber import SentryScrubber
 import tribler_core
 from tribler_core.config.tribler_config import CONFIG_FILENAME
 from tribler_core.dependencies import check_for_missing_dependencies
-from tribler_core.session import IGNORED_ERRORS
 from tribler_core.upgrade.version_manager import fork_state_directory_if_necessary, get_versioned_state_directory
 from tribler_core.utilities.osutils import get_root_state_directory
 from tribler_core.version import sentry_url, version_id
@@ -89,24 +88,9 @@ def start_tribler_core(base_path, api_port, api_key, root_state_dir, core_test_m
     get_event_loop().run_forever()
 
 
-def excepthook(exctype, value, traceback):  # pylint: disable=unused-argument
-    ignored_message = None
-    try:
-        ignored_message = IGNORED_ERRORS.get((value.__class__, value.errno),
-                                             IGNORED_ERRORS.get(value.__class__))
-    except (ValueError, AttributeError):
-        pass
-    if ignored_message is not None:
-        return
-
-    SentryReporter.send_exception_with_confirmation(value)
-
-
 if __name__ == "__main__":
     SentryReporter.init(sentry_url=sentry_url, scrubber=SentryScrubber())
     SentryReporter.allow_sending_globally(False, 'run_tribler.__main__()')
-
-    sys.excepthook = excepthook
 
     # Get root state directory (e.g. from environment variable or from system default)
     root_state_dir = get_root_state_directory()

--- a/src/tribler-gui/tribler_gui/dialogs/feedbackdialog.py
+++ b/src/tribler-gui/tribler_gui/dialogs/feedbackdialog.py
@@ -152,7 +152,7 @@ class FeedbackDialog(QDialog):
 
         # if no backend_sentry_event, then try to restore GUI exception
         sentry_event = self.backend_sentry_event or SentryReporter.last_event
-        SentryReporter.send(sentry_event, post_data, sys_info_dict)
+        SentryReporter.send_event(sentry_event, post_data, sys_info_dict)
 
         TriblerNetworkRequest(endpoint, self.on_report_sent, raw_data=tribler_urlencode(post_data), method='POST')
 


### PR DESCRIPTION
Two changes:
1. `excepthook` has been removed
1. The SentryReporter function call has been fixed.

Description of 2:
While refactoring, the one file has not been affected.
It causes the sending report to fail.