### PR TITLE
Add upgrade procedure for Channels DB v8 to v10

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/Tribler/mirrors-autoflake
-    rev: v1.1
+    rev: v1.4
     hooks:
       - id: autoflake
         args: ['--in-place', '--remove-all-unused-imports', '--remove-unused-variable']
@@ -13,7 +13,7 @@ repos:
       types: [file, python]
 
 -   repo: https://github.com/ambv/black
-    rev: 19.3b0
+    rev: 20.8b1
     hooks:
     - id: black
       files: |
@@ -24,8 +24,11 @@ repos:
           )
       types: [file, python]
 
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.2.3
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7.3
     hooks:
-    -  id: flake8
-       types: [file, python]
+    - id: flake8
+      types: [file, python]
+      additional_dependencies: [
+              'flake8-import-order==0.18',
+          ]

--- a/src/tribler-core/tribler_core/modules/metadata_store/store.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/store.py
@@ -112,8 +112,9 @@ class MetadataStore(object):
         def sqlite_disable_sync(_, connection):
             cursor = connection.cursor()
             cursor.execute("PRAGMA journal_mode = WAL")
-            cursor.execute("PRAGMA synchronous = 1")
-            cursor.execute("PRAGMA temp_store = 2")
+            cursor.execute("PRAGMA synchronous = NORMAL")
+            cursor.execute("PRAGMA temp_store = MEMORY")
+            cursor.execute("PRAGMA foreign_keys = ON")
 
             # Disable disk sync for special cases
             if disable_sync:

--- a/src/tribler-core/tribler_core/session.py
+++ b/src/tribler-core/tribler_core/session.py
@@ -293,10 +293,7 @@ class Session(TaskManager):
         if self.upgrader_enabled and not self.core_test_mode:
             self.upgrader = TriblerUpgrader(self)
             self.readable_status = STATE_UPGRADING_READABLE
-            try:
-                await self.upgrader.run()
-            except Exception as e:
-                self._logger.error("Error in Upgrader callback chain: %s", e)
+            await self.upgrader.run()
 
         self.tracker_manager = TrackerManager(self)
 

--- a/src/tribler-core/tribler_core/upgrade/db8_to_db10.py
+++ b/src/tribler-core/tribler_core/upgrade/db8_to_db10.py
@@ -1,0 +1,124 @@
+import contextlib
+import datetime
+import logging
+import sqlite3
+from asyncio import sleep
+
+TABLE_NAMES = (
+    "ChannelNode", "TorrentState", "TorrentState_TrackerState", "ChannelPeer", "ChannelVote", "TrackerState", "Vsids")
+
+
+class PonyToPonyMigration(object):
+
+    def __init__(self, old_db_path, new_db_path, notifier_callback=None, logger=None):
+        self._logger = logger or logging.getLogger(self.__class__.__name__)
+        self.notifier_callback = notifier_callback
+        self.old_db_path = old_db_path
+        self.new_db_path = new_db_path
+        self.shutting_down = False
+
+    async def update_convert_progress(self, amount, total, elapsed, message=""):
+        if self.notifier_callback:
+            elapsed = 0.0001 if elapsed == 0.0 else elapsed
+            amount = amount or 1
+            est_speed = amount / elapsed
+            eta = str(datetime.timedelta(seconds=int((total - amount) / est_speed)))
+            self.notifier_callback(
+                f"{message}\nConverted: {amount}/{total} ({(amount * 100) // total}%).\nTime remaining: {eta}"
+            )
+            await sleep(0.001)
+
+    async def convert_async(self, convert_command, total_to_convert, offset=0, message=""):
+        """
+        This method copies entries from one Pony db into another one splitting the process into chunks dynamically.
+        Chunks splitting uses congestion-control-like algorithm. Awaits are necessary so the
+        reactor can get an opportunity at serving other tasks, such as sending progress notifications to
+        the GUI through the REST API.
+        """
+        start_time = datetime.datetime.utcnow()
+        batch_size = 100
+
+        reference_timedelta = datetime.timedelta(milliseconds=1000)
+        while offset < total_to_convert:
+            if self.shutting_down:
+                break
+            end = offset + batch_size
+
+            batch_start_time = datetime.datetime.now()
+            convert_command(offset, batch_size)
+            batch_end_time = datetime.datetime.now() - batch_start_time
+
+            elapsed = (datetime.datetime.utcnow() - start_time).total_seconds()
+            await self.update_convert_progress(offset, total_to_convert, elapsed, message)
+            target_coeff = (batch_end_time.total_seconds() / reference_timedelta.total_seconds())
+            if target_coeff < 0.8:
+                batch_size += batch_size
+            elif target_coeff > 1.1:
+                batch_size = int(float(batch_size) / target_coeff)
+            # we want to guarantee that at least some entries will go through
+            batch_size = batch_size if batch_size > 10 else 10
+            self._logger.info("Converted: %i/%i %f ",
+                              offset + batch_size, total_to_convert, float(batch_end_time.total_seconds()))
+            offset = end
+
+    def get_table_entries_count(self, cursor, table_name):
+        return cursor.execute(f"SELECT COUNT(*) FROM {table_name};").fetchone()[0]
+
+    async def convert_table(self, cursor, table_name, column_names):
+        def convert_command(offset, batch_size):
+            sql_command = None
+            try:
+                column_names_joined = ", ".join(column_names)
+                if "rowid" in column_names:
+                    order_column = "rowid"
+                else:
+                    order_column = column_names[0]
+                sql_command = f"INSERT OR IGNORE INTO {table_name} ({column_names_joined}) " + \
+                              f"SELECT {column_names_joined} FROM old_db.{table_name} " + \
+                              f"ORDER BY {order_column} " + \
+                              f"LIMIT {batch_size} {('OFFSET ' + str(offset)) if offset else ''} ;"
+                cursor.execute(sql_command)
+            except Exception as e:
+                # Bail out and stop the upgrade process
+                self.shutting_down = True
+                self._logger.error("Error while executing conversion command: %s, SQL %s ", str(e), sql_command)
+
+        old_entries_count = self.get_table_entries_count(cursor, f"old_db.{table_name}")
+        await self.convert_async(convert_command, old_entries_count, message=f"Converting DB table {table_name}")
+
+    async def do_migration(self):
+
+        old_table_columns = {}
+        for table_name in TABLE_NAMES:
+            old_table_columns[table_name] = get_table_columns(self.old_db_path, table_name)
+
+        with contextlib.closing(sqlite3.connect(self.new_db_path)) as connection, connection:
+            cursor = connection.cursor()
+            cursor.execute("PRAGMA journal_mode = OFF;")
+            cursor.execute("PRAGMA synchronous = OFF;")
+            cursor.execute("PRAGMA foreign_keys = OFF;")
+            cursor.execute("PRAGMA temp_store = MEMORY;")
+            cursor.execute(f'ATTACH DATABASE "{self.old_db_path}" as old_db;')
+
+            for table_name in TABLE_NAMES:
+                cursor.execute("BEGIN TRANSACTION;")
+                if not self.shutting_down:
+                    await self.convert_table(cursor, table_name, old_table_columns[table_name])
+                cursor.execute("COMMIT;")
+        self.notifier_callback("Synchronizing the upgraded DB to disk, please wait.")
+
+
+def get_table_columns(db_path, table_name):
+    with contextlib.closing(sqlite3.connect(db_path)) as connection, connection:
+        cursor = connection.cursor()
+        cursor.execute(f'SELECT * FROM {table_name} LIMIT 1')
+        names = [description[0] for description in cursor.description]
+    return names
+
+
+def get_db_version(db_path):
+    with contextlib.closing(sqlite3.connect(db_path)) as connection, connection:
+        cursor = connection.cursor()
+        cursor.execute('SELECT value FROM MiscData WHERE name == "db_version"')
+        version = int(cursor.fetchone()[0])
+    return version

--- a/src/tribler-core/tribler_core/version.py
+++ b/src/tribler-core/tribler_core/version.py
@@ -1,4 +1,4 @@
-version_id = "7.5.0-GIT"
+version_id = "7.6.0-GIT"
 build_date = "Mon Jan 01 00:00:01 1970"
 commit_id = "none"
 sentry_url = ""

--- a/src/tribler-gui/tribler_gui/widgets/channelcontentswidget.py
+++ b/src/tribler-gui/tribler_gui/widgets/channelcontentswidget.py
@@ -106,7 +106,7 @@ class ChannelContentsWidget(widget_form, widget_class):
     def commit_channels(self):
         TriblerNetworkRequest("channels/mychannel/0/commit", self.on_channel_committed, method='POST')
 
-    def initialize_content_page(self, autocommit_enabled=True, hide_xxx=None):
+    def initialize_content_page(self, autocommit_enabled=False, hide_xxx=None):
         if self.initialized:
             return
 

--- a/src/tribler-gui/tribler_gui/widgets/loadingpage.py
+++ b/src/tribler-gui/tribler_gui/widgets/loadingpage.py
@@ -26,6 +26,7 @@ class LoadingPage(QWidget):
         self.window().loading_svg_view.setScene(svg_container)
         self.window().core_manager.events_manager.upgrader_tick.connect(self.on_upgrader_tick)
         self.window().core_manager.events_manager.upgrader_finished.connect(self.upgrader_finished)
+        self.window().core_manager.events_manager.change_loading_text.connect(self.change_loading_text)
         self.window().skip_conversion_btn.hide()
 
         # Hide the force shutdown button initially. Should be triggered by shutdown timer from main window.
@@ -38,4 +39,7 @@ class LoadingPage(QWidget):
         if not self.upgrading:
             self.upgrading = True
             self.window().skip_conversion_btn.show()
+        self.window().loading_text_label.setText(text)
+
+    def change_loading_text(self, text):
         self.window().loading_text_label.setText(text)


### PR DESCRIPTION
The upgrade procedure creates a temporary Channels DB and directly dumps the old Channels tables into the corresponding tables in the new DB.
If the upgrade finishes correctly, the new DB replaces the old one.
If the upgrade is skipped by the user, the old DB is removed
If the upgrade crashes, at the next Tribler startup it will be tried anew.

The main reason to upgrade is the removal of unused unique indexes that mess up the new DB logic. Unfortunately, it is impossible to remove them without recreating the whole database.


5 GB database converts in 5 minutes on my PC.