### PR TITLE
Add unhandled exceptions catching 

### DIFF
--- a/src/run_tribler.py
+++ b/src/run_tribler.py
@@ -89,16 +89,14 @@ def start_tribler_core(base_path, api_port, api_key, root_state_dir, core_test_m
 
 
 if __name__ == "__main__":
-    SentryReporter.init(sentry_url=sentry_url, scrubber=SentryScrubber())
-    SentryReporter.allow_sending_globally(False, 'run_tribler.__main__()')
-
+    SentryReporter.init(sentry_url=sentry_url, scrubber=SentryScrubber(),
+                        strategy=SentryReporter.Strategy.SEND_ALLOWED_WITH_CONFIRMATION)
     # Get root state directory (e.g. from environment variable or from system default)
     root_state_dir = get_root_state_directory()
     # Check whether we need to start the core or the user interface
     if 'CORE_PROCESS' in os.environ:
         # Check for missing Core dependencies
         check_for_missing_dependencies(scope='core')
-
         base_path = os.environ['CORE_BASE_PATH']
         api_port = os.environ['CORE_API_PORT']
         api_key = os.environ['CORE_API_KEY']

--- a/src/tribler-core/tribler_core/session.py
+++ b/src/tribler-core/tribler_core/session.py
@@ -20,7 +20,7 @@ from ipv8.taskmanager import TaskManager
 
 from ipv8_service import IPv8
 
-from tribler_common.sentry_reporter.sentry_reporter import AllowSentryReports, SentryReporter
+from tribler_common.sentry_reporter.sentry_reporter import SentryReporter
 from tribler_common.simpledefs import (
     NTFY,
     STATEDIR_CHANNELS_DIR,
@@ -219,8 +219,13 @@ class Session(TaskManager):
         This method is called when an unhandled error in Tribler is observed.
         It broadcasts the tribler_exception event.
         """
+        sentry_saved_strategy = SentryReporter.strategy.get()
         try:
+            SentryReporter.strategy.set(SentryReporter.Strategy.SEND_SUPPRESSED)
+            SentryReporter.ignore_logger(self._logger.name)
+
             exception = context.get('exception')
+            SentryReporter.capture_exception(exception)
             ignored_message = None
             try:
                 ignored_message = IGNORED_ERRORS.get(
@@ -231,15 +236,12 @@ class Session(TaskManager):
             if ignored_message is not None:
                 self._logger.error(ignored_message if ignored_message != "" else context.get('message'))
                 return
-
             text = str(exception or context.get('message'))
-
             # We already have a check for invalid infohash when adding a torrent, but if somehow we get this
             # error then we simply log and ignore it.
             if isinstance(exception, RuntimeError) and 'invalid info-hash' in text:
                 self._logger.error("Invalid info-hash found")
                 return
-
             text_long = text
             exc = context.get('exception')
             if exc:
@@ -247,10 +249,7 @@ class Session(TaskManager):
                     print_exception(type(exc), exc, exc.__traceback__, file=buffer)
                     text_long = text_long + "\n--LONG TEXT--\n" + buffer.getvalue()
             text_long = text_long + "\n--CONTEXT--\n" + str(context)
-
-            description = 'session.unhandled_error_observer()'
-            with AllowSentryReports(value=False, description=description):
-                self._logger.error("Unhandled exception occurred! %s", text_long)
+            self._logger.error("Unhandled exception occurred! %s", text_long, exc_info=None)
             sentry_event = SentryReporter.last_event
 
             if not self.api_manager:
@@ -261,9 +260,8 @@ class Session(TaskManager):
 
             state = self.api_manager.get_endpoint('state')
             state.on_tribler_exception(text_long, sentry_event)
-        except Exception as e:
-            SentryReporter.send_exception_with_confirmation(e)
-            raise e
+        finally:
+            SentryReporter.strategy.set(sentry_saved_strategy)
 
     def get_tribler_statistics(self):
         """Return a dictionary with general Tribler statistics."""


### PR DESCRIPTION
This PR restores https://github.com/Tribler/tribler/pull/5747 by capturing all unhandled exceptions with mandatory confirmation before sending.

## The issue:
https://github.com/Tribler/tribler/pull/5747 handles all types of exceptions, which caused false reports. Because of that, it has been temporarily disabled.

## The solution:
Сapturing all unhandled exceptions with mandatory confirmation before sending has been added.
Now Sentry can operate in three modes:

1. Send reports are allowed
1. Send reports are allowed with a confirmation dialog
1. Send reports are suppressed (disallowed, but the last event will be stored)

By default, it works in the second mode.

Exception filtering for unhandled exceptions has been added as well: 
```python
ignored_exceptions = [KeyboardInterrupt, SystemExit]
```