### PR TITLE
Sentry fixes for release

### DIFF
--- a/build/update_version_from_git.py
+++ b/build/update_version_from_git.py
@@ -31,9 +31,11 @@ if __name__ == '__main__':
 
     sentry_url = os.environ.get('SENTRY_URL', None)
     logger.info(f'Sentry url: {sentry_url}')
-    if not sentry_url:
+    if sentry_url is None:
         logger.critical('Sentry url is not defined. To define sentry url use:'
-                        'EXPORT SENTRY_URL=<sentry_url>')
+                        'EXPORT SENTRY_URL=<sentry_url>\n'
+                        'If you want to disable sentry, then define the following:'
+                        'EXPORT SENTRY_URL=')
         sys.exit(1)
 
     build_date = ctime()

--- a/src/tribler-common/tribler_common/sentry_reporter/sentry_reporter.py
+++ b/src/tribler-common/tribler_common/sentry_reporter/sentry_reporter.py
@@ -94,7 +94,7 @@ class SentryReporter:
             integrations=[
                 LoggingIntegration(
                     level=logging.INFO,  # Capture info and above as breadcrumbs
-                    event_level=logging.ERROR,  # Send errors as events
+                    event_level=None,  # Send no errors as events
                 ),
                 ThreadingIntegration(propagate_hub=True),
             ],


### PR DESCRIPTION
This PR contains two changes:
1. Disallowing sentry to send events while logging an error
1. Allow `update_version_from_git.py` has an empty SENTRY_URL

These changes were requested during the release testing.