### PR TITLE
Fixes #5762: unset 'auto_managed' flag to prevent torrents resuming automatically

### DIFF
--- a/src/tribler-core/tribler_core/modules/libtorrent/download.py
+++ b/src/tribler-core/tribler_core/modules/libtorrent/download.py
@@ -182,6 +182,11 @@ class Download(TaskManager):
 
         self.handle = alert.handle
         self._logger.debug("Added torrent %s", str(self.handle.info_hash()))
+        # In LibTorrent auto_managed flag is now on by default, and as a result
+        # any torrent's state can change from Stopped to Downloading at any time.
+        # Here we unset this flag to prevent auto-resuming of stopped torrents.
+        if hasattr(self.handle, 'unset_flags'):
+            self.handle.unset_flags(lt.add_torrent_params_flags_t.flag_auto_managed)
 
         self.set_selected_files()
 


### PR DESCRIPTION
In LibTorrent auto_managed flag is now on by default, and as a result, any torrent's state can change from Stopped to Downloading at any time. Here I unset this flag to prevent auto-resuming of stopped torrents.