### PR TITLE
Catch ParseError on config conversion

### DIFF
--- a/src/tribler-core/tribler_core/upgrade/tests/test_config_upgrade_to_74.py
+++ b/src/tribler-core/tribler_core/upgrade/tests/test_config_upgrade_to_74.py
@@ -2,9 +2,14 @@ import os
 import shutil
 from pathlib import Path
 
+from configobj import ParseError as ConfigObjParseError
+
+import pytest
+
 from tribler_common.simpledefs import STATEDIR_CHECKPOINT_DIR
 
 from tribler_core.tests.tools.common import TESTS_DATA_DIR
+from tribler_core.upgrade import config_converter
 from tribler_core.upgrade.config_converter import convert_state_file_to_conf_74
 
 
@@ -44,3 +49,43 @@ def test_convert_state_file_to_conf_74(tmpdir):
     converted_file_path = Path(tmpdir) / STATEDIR_CHECKPOINT_DIR / "ubuntu_corrupted.conf"
     assert not os.path.exists(converted_file_path)
     assert not os.path.exists(dest_path)
+
+
+@pytest.fixture(name='faulty_config_parser')
+async def fixture_faulty_config_parser():
+    def load_config_with_parse_error(filename):
+        raise ConfigObjParseError(f"Error parsing config file {filename}")
+
+    original_load_config = config_converter.load_config
+    config_converter.load_config = load_config_with_parse_error
+    yield config_converter
+    config_converter.load_config = original_load_config
+
+
+def test_convert_state_file_to_conf74_with_parse_error(tmpdir, faulty_config_parser):
+    """
+    Tests conversion of the state files (pre-7.4.0) files to .conf files (7.4) when there is parsing error.
+    ParseError happens for some users for some unknown reason. We simply remove the files that we cannot
+    parse. This test tests that such a corrupted file is actual deleted.
+    """
+    from lib2to3.refactor import RefactoringTool, get_fixers_from_package
+    refactoring_tool = RefactoringTool(fixer_names=get_fixers_from_package('lib2to3.fixes'))
+
+    state_dir = Path(tmpdir)
+    os.makedirs(state_dir / STATEDIR_CHECKPOINT_DIR)
+
+    # Copy Ubuntu pstate file with corrupted metainfo data
+    src_path = CONFIG_PATH / "194257a7bf4eaea978f4b5b7fbd3b4efcdd99e43.state"
+    dest_path = state_dir / STATEDIR_CHECKPOINT_DIR / "ubuntu_corrupted.state"
+    shutil.copyfile(src_path, dest_path)
+
+    # Try converting the state file to 7.4 conf format
+    convert_state_file_to_conf_74(dest_path, refactoring_tool)
+
+    # Path where the file should be saved after conversion
+    converted_file_path = state_dir / STATEDIR_CHECKPOINT_DIR / "ubuntu_corrupted.conf"
+
+    # We expect ParseError and the file to be deleted.
+    assert not os.path.exists(converted_file_path)
+    assert not os.path.exists(dest_path)
+

--- a/src/tribler-core/tribler_core/upgrade/tests/test_config_upgrade_to_75.py
+++ b/src/tribler-core/tribler_core/upgrade/tests/test_config_upgrade_to_75.py
@@ -1,0 +1,51 @@
+import os
+import shutil
+from pathlib import Path
+
+from configobj import ParseError as ConfigObjParseError
+
+import pytest
+
+from tribler_common.simpledefs import STATEDIR_CHECKPOINT_DIR
+
+from tribler_core.modules.libtorrent.download_config import DownloadConfig
+from tribler_core.tests.tools.common import TESTS_DATA_DIR
+from tribler_core.upgrade.config_converter import convert_config_to_tribler75
+
+CONFIG_PATH = TESTS_DATA_DIR / "config_files"
+
+
+@pytest.fixture(name='faulty_download_config_parser')
+async def fixture_faulty_download_config_parser():
+    def load_config_with_parse_error(filename):
+        raise ConfigObjParseError(f"Error parsing config file {filename}")
+
+    original_load_config = DownloadConfig.load
+    DownloadConfig.load = load_config_with_parse_error
+    yield DownloadConfig
+    DownloadConfig.load = original_load_config
+
+
+def test_convert_state_file_to_conf75_with_parse_error(tmpdir, faulty_download_config_parser):
+    """
+    Tests conversion of the conf files (7.4.0) files to .conf files (7.5) when there is parsing error.
+    ParseError happens for some users for some unknown reason. We simply remove the files that we cannot
+    parse. This test tests that such a corrupted file is actual deleted.
+    """
+    state_dir = Path(tmpdir)
+    os.makedirs(state_dir / STATEDIR_CHECKPOINT_DIR)
+
+    # Copy Ubuntu conf file with corrupted metainfo data
+    src_path = CONFIG_PATH / "13a25451c761b1482d3e85432f07c4be05ca8a56.conf"
+    dest_path = state_dir / STATEDIR_CHECKPOINT_DIR / "ubuntu_corrupted.conf"
+    shutil.copyfile(src_path, dest_path)
+
+    # Try converting the conf file to 7.5 conf format
+    convert_config_to_tribler75(Path(tmpdir))
+
+    # Path where the file should be saved after conversion
+    converted_file_path = state_dir / STATEDIR_CHECKPOINT_DIR / "ubuntu_corrupted.conf"
+
+    # We expect ParseError and the file to be deleted.
+    assert not os.path.exists(converted_file_path)
+    assert not os.path.exists(dest_path)


### PR DESCRIPTION
In this PR parse error if happens during the conversion, the error is caught and the faulty config is removed so the conversion can continue. There are only a few reports of the issue and we don't know the actual cause of the issue, neither we can reproduce yet. So, this is only a temporary fix.

Related issue: https://github.com/Tribler/tribler/issues/5778