### PR TITLE
Fixed move file callback function

### DIFF
--- a/src/tribler-gui/tribler_gui/widgets/downloadspage.py
+++ b/src/tribler-gui/tribler_gui/widgets/downloadspage.py
@@ -391,7 +391,7 @@ class DownloadsPage(QWidget):
 
         TriblerNetworkRequest(
             "downloads/%s" % _infohash,
-            lambda res, _, name=_name, target=dest_dir: self.on_files_moved(res, name, target),
+            lambda res: self.on_files_moved(res, _name, dest_dir),
             data=data,
             method='PATCH',
         )


### PR DESCRIPTION
Fixes #5754 (again 😃). See issue for steps to reproduce.

This is the conclusion of running through **every single instance of using `TriblerNetworkRequest` manually**. Now there should be absolutely nothing left.