### PR TITLE
Migrate add_url_params over from IPv8

### DIFF
--- a/src/tribler-core/tribler_core/modules/torrent_checker/torrentchecker_session.py
+++ b/src/tribler-core/tribler_core/modules/torrent_checker/torrentchecker_session.py
@@ -11,12 +11,11 @@ from aiohttp import ClientResponseError, ClientSession, ClientTimeout
 
 import async_timeout
 
-from ipv8.messaging.deprecated.encoding import add_url_params
 from ipv8.taskmanager import TaskManager
 
 from tribler_core.modules.tunnel.socks5.aiohttp_connector import Socks5Connector
 from tribler_core.modules.tunnel.socks5.client import Socks5Client
-from tribler_core.utilities.tracker_utils import parse_tracker_url
+from tribler_core.utilities.tracker_utils import add_url_params, parse_tracker_url
 from tribler_core.utilities.unicode import hexlify
 from tribler_core.utilities.utilities import bdecode_compat
 

--- a/src/tribler-core/tribler_core/tests/test_utilities.py
+++ b/src/tribler-core/tribler_core/tests/test_utilities.py
@@ -1,8 +1,7 @@
 import logging
 
-from ipv8.messaging.deprecated.encoding import add_url_params
-
 from tribler_core import load_logger_config
+from tribler_core.utilities.tracker_utils import add_url_params
 from tribler_core.utilities.utilities import parse_magnetlink
 
 

--- a/src/tribler-core/tribler_core/utilities/tracker_utils.py
+++ b/src/tribler-core/tribler_core/utilities/tracker_utils.py
@@ -1,6 +1,7 @@
 import re
 from http.client import HTTP_PORT
-from urllib.parse import urlparse
+from json import dumps
+from urllib.parse import ParseResult, parse_qsl, unquote, urlencode, urlparse
 
 
 class MalformedTrackerURLException(Exception):
@@ -132,3 +133,43 @@ def parse_tracker_url(tracker_url):
         raise MalformedTrackerURLException(u'Missing announce path for HTTP tracker url (%s).' % tracker_url)
 
     return url.scheme, (url.hostname, url.port), url.path
+
+
+def add_url_params(url, params):
+    """ Add GET params to provided URL being aware of existing.
+    :param url: string of target URL
+    :param params: dict containing requested params to be added
+    :return: string with updated URL
+    >> url = 'http://stackoverflow.com/test?answers=true'
+    >> new_params = {'answers': False, 'data': ['some','values']}
+    >> add_url_params(url, new_params)
+    'http://stackoverflow.com/test?data=some&data=values&answers=false'
+    """
+    # Unquoting URL first so we don't loose existing args
+    url = unquote(url)
+    # Extracting url info
+    parsed_url = urlparse(url)
+    # Extracting URL arguments from parsed URL
+    get_args = parsed_url.query
+    # Converting URL arguments to dict
+    parsed_get_args = dict(parse_qsl(get_args))
+    # Merging URL arguments dict with new params
+    parsed_get_args.update(params)
+
+    # Bool and Dict values should be converted to json-friendly values
+    # you may throw this part away if you don't like it :)
+    parsed_get_args.update(
+        {k: dumps(v) for k, v in parsed_get_args.items()
+         if isinstance(v, (bool, dict))}
+    )
+
+    # Converting URL argument to proper query string
+    encoded_get_args = urlencode(parsed_get_args, doseq=True)
+    # Creating new parsed result object based on provided with new
+    # URL arguments. Same thing happens inside of urlparse.
+    new_url = ParseResult(
+        parsed_url.scheme, parsed_url.netloc, parsed_url.path,
+        parsed_url.params, encoded_get_args, parsed_url.fragment
+    ).geturl()
+
+    return new_url


### PR DESCRIPTION
The `add_url_params()` function has been in the IPv8 deprecated folder for over 2 years and is finally about to be removed. It is time to adopt this in the Tribler codebase to allow IPv8 pointer updates.