### PR TITLE
Fix broken pre-commit on Mac

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
       types: [file, python]
 
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.3
+    rev: 3.8.4
     hooks:
     - id: flake8
       types: [file, python]


### PR DESCRIPTION
On Mac pre-commit flake8 hook currently gives an error when running on Python 3.8 or later:
```
multiprocessing.pool.RemoteTraceback: 
"""
Traceback (most recent call last):
  File "/usr/local/opt/python@3.8/Frameworks/Python.framework/Versions/3.8/lib/python3.8/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
  File "/Users/kozlovsky/.cache/pre-commit/repogu4fw2mp/py_env-python3.8/lib/python3.8/site-packages/flake8/checker.py", line 677, in _run_checks
    return checker.run_checks()
  File "/Users/kozlovsky/.cache/pre-commit/repogu4fw2mp/py_env-python3.8/lib/python3.8/site-packages/flake8/checker.py", line 616, in run_checks
    self.run_ast_checks()
  File "/Users/kozlovsky/.cache/pre-commit/repogu4fw2mp/py_env-python3.8/lib/python3.8/site-packages/flake8/checker.py", line 512, in run_ast_checks
    for (line_number, offset, text, check) in runner:
  File "/Users/kozlovsky/.cache/pre-commit/repogu4fw2mp/py_env-python3.8/lib/python3.8/site-packages/flake8_import_order/flake8_linter.py", line 91, in run
    for error in self.check_order():
  File "/Users/kozlovsky/.cache/pre-commit/repogu4fw2mp/py_env-python3.8/lib/python3.8/site-packages/flake8_import_order/checker.py", line 55, in check_order
    style_entry_point = self.options['import_order_style']
TypeError: 'NoneType' object is not subscriptable
"""

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/kozlovsky/.cache/pre-commit/repogu4fw2mp/py_env-python3.8/bin/flake8", line 8, in <module>
    sys.exit(main())
  File "/Users/kozlovsky/.cache/pre-commit/repogu4fw2mp/py_env-python3.8/lib/python3.8/site-packages/flake8/main/cli.py", line 18, in main
    app.run(argv)
  File "/Users/kozlovsky/.cache/pre-commit/repogu4fw2mp/py_env-python3.8/lib/python3.8/site-packages/flake8/main/application.py", line 393, in run
    self._run(argv)
  File "/Users/kozlovsky/.cache/pre-commit/repogu4fw2mp/py_env-python3.8/lib/python3.8/site-packages/flake8/main/application.py", line 381, in _run
    self.run_checks()
  File "/Users/kozlovsky/.cache/pre-commit/repogu4fw2mp/py_env-python3.8/lib/python3.8/site-packages/flake8/main/application.py", line 300, in run_checks
    self.file_checker_manager.run()
  File "/Users/kozlovsky/.cache/pre-commit/repogu4fw2mp/py_env-python3.8/lib/python3.8/site-packages/flake8/checker.py", line 330, in run
    self.run_parallel()
  File "/Users/kozlovsky/.cache/pre-commit/repogu4fw2mp/py_env-python3.8/lib/python3.8/site-packages/flake8/checker.py", line 294, in run_parallel
    for ret in pool_map:
  File "/usr/local/opt/python@3.8/Frameworks/Python.framework/Versions/3.8/lib/python3.8/multiprocessing/pool.py", line 868, in next
    raise value
TypeError: 'NoneType' object is not subscriptable
```

The reason for the error is the following:
- `flake8` internally uses `multiprocessing` to make child processes;
- starting from Python 3.8 `multiprocessing` on Mac uses `spawn` instead of `fork` for creating subprocesses;
- `spawn` does not keep the internal state of the flake8 checker object, so inside the subprocess `checker.options` becomes `None` instead of dict, which results in a TypeError.

The fix is simple, as a new version of `flake8`  already knows about the problem and uses a single-threaded sequential execution model on Mac instead. 