### PR TITLE
READY: Add gui connect wrapper

### DIFF
--- a/src/tribler-gui/tribler_gui/code_executor.py
+++ b/src/tribler-gui/tribler_gui/code_executor.py
@@ -7,6 +7,8 @@ from base64 import b64decode, b64encode
 
 from PyQt5.QtNetwork import QTcpServer
 
+from tribler_gui.utilities import connect
+
 
 class CodeExecutor(object):
     """
@@ -29,15 +31,15 @@ class CodeExecutor(object):
         if not self.tcp_server.listen(port=port):
             self.logger.error("Unable to start code execution socket! Error: %s", self.tcp_server.errorString())
         else:
-            self.tcp_server.newConnection.connect(self._on_new_connection)
+            connect(self.tcp_server.newConnection, self._on_new_connection)
 
         self.shell = Console(locals=shell_variables)
 
     def _on_new_connection(self):
         while self.tcp_server.hasPendingConnections():
             socket = self.tcp_server.nextPendingConnection()
-            socket.readyRead.connect(self._on_socket_read_ready)
-            socket.disconnected.connect(lambda dc_socket=socket: self._on_socket_disconnect(dc_socket))
+            connect(socket.readyRead, self._on_socket_read_ready)
+            connect(socket.disconnected, lambda dc_socket=socket: self._on_socket_disconnect(dc_socket))
             self.sockets.append(socket)
 
             # If Tribler has crashed, notify the other side immediately

--- a/src/tribler-gui/tribler_gui/core_manager.py
+++ b/src/tribler-gui/tribler_gui/core_manager.py
@@ -14,7 +14,7 @@ from tribler_core.version import version_id
 
 from tribler_gui.event_request_manager import EventRequestManager
 from tribler_gui.tribler_request_manager import TriblerNetworkRequest
-from tribler_gui.utilities import get_base_path
+from tribler_gui.utilities import connect, get_base_path
 
 START_FAKE_API = False
 
@@ -89,7 +89,7 @@ class CoreManager(QObject):
             self.start_tribler_core(core_args=core_args, core_env=core_env)
 
         self.events_manager.connect()
-        self.events_manager.reply.error.connect(on_request_error)
+        connect(self.events_manager.reply.error, on_request_error)
         # This is a hack to determine if we have notify the user to wait for the directory fork to finish
         _, _, src_dir, tgt_dir = should_fork_state_directory(get_root_state_directory(), version_id)
         if src_dir is not None:
@@ -112,8 +112,8 @@ class CoreManager(QObject):
             self.core_process.setProcessEnvironment(core_env)
             self.core_process.setReadChannel(QProcess.StandardOutput)
             self.core_process.setProcessChannelMode(QProcess.MergedChannels)
-            self.core_process.readyRead.connect(self.on_core_read_ready)
-            self.core_process.finished.connect(self.on_core_finished)
+            connect(self.core_process.readyRead, self.on_core_read_ready)
+            connect(self.core_process.finished, self.on_core_finished)
             self.core_process.start(sys.executable, core_args)
 
         self.check_core_ready()
@@ -127,7 +127,7 @@ class CoreManager(QObject):
         if not state or 'state' not in state or state['state'] not in ['STARTED', 'EXCEPTION']:
             self.check_state_timer = QTimer()
             self.check_state_timer.setSingleShot(True)
-            self.check_state_timer.timeout.connect(self.check_core_ready)
+            connect(self.check_state_timer.timeout, self.check_core_ready)
             self.check_state_timer.start(50)
             return
 

--- a/src/tribler-gui/tribler_gui/debug_window.py
+++ b/src/tribler-gui/tribler_gui/debug_window.py
@@ -22,7 +22,7 @@ from tribler_gui.defs import DEBUG_PANE_REFRESH_TIMEOUT, GB, MB
 from tribler_gui.dialogs.confirmationdialog import ConfirmationDialog
 from tribler_gui.event_request_manager import received_events as tribler_received_events
 from tribler_gui.tribler_request_manager import TriblerNetworkRequest, performed_requests as tribler_performed_requests
-from tribler_gui.utilities import format_size, get_ui_file_path
+from tribler_gui.utilities import connect, format_size, get_ui_file_path
 from tribler_gui.widgets.graphs.timeseriesplot import TimeSeriesPlot
 from tribler_gui.widgets.ipv8health import MonitorWidget
 
@@ -75,21 +75,21 @@ class DebugWindow(QMainWindow):
         uic.loadUi(get_ui_file_path('debugwindow.ui'), self)
         self.setWindowTitle("Tribler debug pane")
 
-        self.window().dump_memory_core_button.clicked.connect(lambda: self.on_memory_dump_button_clicked(True))
-        self.window().dump_memory_gui_button.clicked.connect(lambda: self.on_memory_dump_button_clicked(False))
-        self.window().toggle_profiler_button.clicked.connect(self.on_toggle_profiler_button_clicked)
+        connect(self.window().dump_memory_core_button.clicked, lambda: self.on_memory_dump_button_clicked(True))
+        connect(self.window().dump_memory_gui_button.clicked, lambda: self.on_memory_dump_button_clicked(False))
+        connect(self.window().toggle_profiler_button.clicked, self.on_toggle_profiler_button_clicked)
 
         self.window().debug_tab_widget.setCurrentIndex(0)
         self.window().ipv8_tab_widget.setCurrentIndex(0)
         self.window().tunnel_tab_widget.setCurrentIndex(0)
         self.window().dht_tab_widget.setCurrentIndex(0)
         self.window().system_tab_widget.setCurrentIndex(0)
-        self.window().debug_tab_widget.currentChanged.connect(self.tab_changed)
-        self.window().ipv8_tab_widget.currentChanged.connect(self.ipv8_tab_changed)
-        self.window().tunnel_tab_widget.currentChanged.connect(self.tunnel_tab_changed)
-        self.window().dht_tab_widget.currentChanged.connect(self.dht_tab_changed)
-        self.window().events_tree_widget.itemClicked.connect(self.on_event_clicked)
-        self.window().system_tab_widget.currentChanged.connect(self.system_tab_changed)
+        connect(self.window().debug_tab_widget.currentChanged, self.tab_changed)
+        connect(self.window().ipv8_tab_widget.currentChanged, self.ipv8_tab_changed)
+        connect(self.window().tunnel_tab_widget.currentChanged, self.tunnel_tab_changed)
+        connect(self.window().dht_tab_widget.currentChanged, self.dht_tab_changed)
+        connect(self.window().events_tree_widget.itemClicked, self.on_event_clicked)
+        connect(self.window().system_tab_widget.currentChanged, self.system_tab_changed)
         self.load_general_tab()
 
         self.window().open_files_tree_widget.header().setSectionResizeMode(0, QHeaderView.Stretch)
@@ -101,8 +101,8 @@ class DebugWindow(QMainWindow):
         self.window().system_tab_widget.setTabEnabled(4, settings and settings['resource_monitor']['enabled'])
 
         # Refresh logs
-        self.window().log_refresh_button.clicked.connect(lambda: self.load_logs_tab())
-        self.window().log_tab_widget.currentChanged.connect(lambda index: self.load_logs_tab())
+        connect(self.window().log_refresh_button.clicked, lambda: self.load_logs_tab())
+        connect(self.window().log_tab_widget.currentChanged, lambda index: self.load_logs_tab())
 
         # IPv8 statistics enabled?
         self.ipv8_statistics_enabled = settings['ipv8']['statistics']
@@ -137,7 +137,7 @@ class DebugWindow(QMainWindow):
         self.stop_timer()
         self.refresh_timer = QTimer()
         self.refresh_timer.setSingleShot(True)
-        self.refresh_timer.timeout.connect(
+        connect(self.refresh_timer.timeout,
             lambda _call_fn=call_fn, _timeout=timeout: self.run_with_timer(_call_fn, timeout=_timeout)
         )
         self.refresh_timer.start(timeout)
@@ -152,13 +152,13 @@ class DebugWindow(QMainWindow):
 
     def init_libtorrent_tab(self):
         self.window().libtorrent_tab_widget.setCurrentIndex(0)
-        self.window().libtorrent_tab_widget.currentChanged.connect(lambda _: self.load_libtorrent_data(export=False))
+        connect(self.window().libtorrent_tab_widget.currentChanged, lambda _: self.load_libtorrent_data(export=False))
 
-        self.window().lt_zero_hop_btn.clicked.connect(lambda _: self.load_libtorrent_data(export=False))
-        self.window().lt_one_hop_btn.clicked.connect(lambda _: self.load_libtorrent_data(export=False))
-        self.window().lt_two_hop_btn.clicked.connect(lambda _: self.load_libtorrent_data(export=False))
-        self.window().lt_three_hop_btn.clicked.connect(lambda _: self.load_libtorrent_data(export=False))
-        self.window().lt_export_btn.clicked.connect(lambda _: self.load_libtorrent_data(export=True))
+        connect(self.window().lt_zero_hop_btn.clicked, lambda _: self.load_libtorrent_data(export=False))
+        connect(self.window().lt_one_hop_btn.clicked, lambda _: self.load_libtorrent_data(export=False))
+        connect(self.window().lt_two_hop_btn.clicked, lambda _: self.load_libtorrent_data(export=False))
+        connect(self.window().lt_three_hop_btn.clicked, lambda _: self.load_libtorrent_data(export=False))
+        connect(self.window().lt_export_btn.clicked, lambda _: self.load_libtorrent_data(export=True))
 
         self.window().lt_zero_hop_btn.setChecked(True)
 
@@ -655,7 +655,7 @@ class DebugWindow(QMainWindow):
 
         # Start timer
         self.cpu_plot_timer = QTimer()
-        self.cpu_plot_timer.timeout.connect(self.load_cpu_tab)
+        connect(self.cpu_plot_timer.timeout, self.load_cpu_tab)
         self.cpu_plot_timer.start(5000)
 
     def refresh_cpu_plot(self):
@@ -681,7 +681,7 @@ class DebugWindow(QMainWindow):
 
         # Start timer
         self.memory_plot_timer = QTimer()
-        self.memory_plot_timer.timeout.connect(self.load_memory_tab)
+        connect(self.memory_plot_timer.timeout, self.load_memory_tab)
         self.memory_plot_timer.start(5000)
 
     def load_profiler_tab(self):

--- a/src/tribler-gui/tribler_gui/debug_window.py
+++ b/src/tribler-gui/tribler_gui/debug_window.py
@@ -75,8 +75,8 @@ class DebugWindow(QMainWindow):
         uic.loadUi(get_ui_file_path('debugwindow.ui'), self)
         self.setWindowTitle("Tribler debug pane")
 
-        connect(self.window().dump_memory_core_button.clicked, lambda: self.on_memory_dump_button_clicked(True))
-        connect(self.window().dump_memory_gui_button.clicked, lambda: self.on_memory_dump_button_clicked(False))
+        connect(self.window().dump_memory_core_button.clicked, lambda _: self.on_memory_dump_button_clicked(True))
+        connect(self.window().dump_memory_gui_button.clicked, lambda _: self.on_memory_dump_button_clicked(False))
         connect(self.window().toggle_profiler_button.clicked, self.on_toggle_profiler_button_clicked)
 
         self.window().debug_tab_widget.setCurrentIndex(0)
@@ -101,7 +101,7 @@ class DebugWindow(QMainWindow):
         self.window().system_tab_widget.setTabEnabled(4, settings and settings['resource_monitor']['enabled'])
 
         # Refresh logs
-        connect(self.window().log_refresh_button.clicked, lambda: self.load_logs_tab())
+        connect(self.window().log_refresh_button.clicked, lambda _: self.load_logs_tab())
         connect(self.window().log_tab_widget.currentChanged, lambda index: self.load_logs_tab())
 
         # IPv8 statistics enabled?
@@ -695,7 +695,7 @@ class DebugWindow(QMainWindow):
         self.window().toggle_profiler_button.setEnabled(True)
         self.window().toggle_profiler_button.setText("%s profiler" % ("Stop" if self.profiler_enabled else "Start"))
 
-    def on_toggle_profiler_button_clicked(self):
+    def on_toggle_profiler_button_clicked(self, checked):
         if self.toggling_profiler:
             return
 

--- a/src/tribler-gui/tribler_gui/dialogs/addtopersonalchanneldialog.py
+++ b/src/tribler-gui/tribler_gui/dialogs/addtopersonalchanneldialog.py
@@ -51,7 +51,7 @@ class AddToChannelDialog(DialogContainer):
         self.window().channels_menu_list.reload_if_necessary(response["results"])
         self.load_channel(response["results"][0]["origin_id"])
 
-    def on_create_new_channel_clicked(self):
+    def on_create_new_channel_clicked(self, checked):
         def create_channel_callback(channel_name=None):
             TriblerNetworkRequest(
                 "channels/mychannel/0/channels",
@@ -62,7 +62,7 @@ class AddToChannelDialog(DialogContainer):
 
         NewChannelDialog(self, create_channel_callback)
 
-    def on_create_new_folder_clicked(self):
+    def on_create_new_folder_clicked(self, checked):
         selected = self.dialog_widget.channels_tree_wt.selectedItems()
         if not selected:
             return
@@ -122,7 +122,7 @@ class AddToChannelDialog(DialogContainer):
         selected = self.dialog_widget.channels_tree_wt.selectedItems()
         return None if not selected else selected[0].id_
 
-    def on_confirm_clicked(self):
+    def on_confirm_clicked(self, checked):
         channel_id = self.get_selected_channel_id()
         if channel_id is None:
             return
@@ -148,7 +148,7 @@ class AddToChannelDialog(DialogContainer):
             if channel_id == 0:
                 self.load_channel(subchannel_id)
 
-    def close_dialog(self):
+    def close_dialog(self, checked=False):
         # Instead of deleting the dialog, hide it. We do this for two reasons:
         #  a. we do not want to lose the channels tree structure loaded from the core.
         #  b. we want the tree state (open subtrees, selection) to stay the same, as the user is

--- a/src/tribler-gui/tribler_gui/dialogs/addtopersonalchanneldialog.py
+++ b/src/tribler-gui/tribler_gui/dialogs/addtopersonalchanneldialog.py
@@ -9,7 +9,7 @@ from tribler_core.modules.metadata_store.serialization import CHANNEL_TORRENT, C
 from tribler_gui.dialogs.dialogcontainer import DialogContainer
 from tribler_gui.dialogs.new_channel_dialog import NewChannelDialog
 from tribler_gui.tribler_request_manager import TriblerNetworkRequest
-from tribler_gui.utilities import get_ui_file_path
+from tribler_gui.utilities import connect, get_ui_file_path
 
 
 class DownloadFileTreeWidgetItem(QTreeWidgetItem):
@@ -29,10 +29,10 @@ class AddToChannelDialog(DialogContainer):
     def __init__(self, parent):
         DialogContainer.__init__(self, parent)
         uic.loadUi(get_ui_file_path('addtochanneldialog.ui'), self.dialog_widget)
-        self.dialog_widget.btn_cancel.clicked.connect(self.close_dialog)
-        self.dialog_widget.btn_confirm.clicked.connect(self.on_confirm_clicked)
-        self.dialog_widget.btn_new_channel.clicked.connect(self.on_create_new_channel_clicked)
-        self.dialog_widget.btn_new_folder.clicked.connect(self.on_create_new_folder_clicked)
+        connect(self.dialog_widget.btn_cancel.clicked, self.close_dialog)
+        connect(self.dialog_widget.btn_confirm.clicked, self.on_confirm_clicked)
+        connect(self.dialog_widget.btn_new_channel.clicked, self.on_create_new_channel_clicked)
+        connect(self.dialog_widget.btn_new_folder.clicked, self.on_create_new_folder_clicked)
 
         self.confirm_clicked_callback = None
 
@@ -40,7 +40,7 @@ class AddToChannelDialog(DialogContainer):
 
         self.channels_tree = {}
         self.id2wt_mapping = {0: self.dialog_widget.channels_tree_wt}
-        self.dialog_widget.channels_tree_wt.itemExpanded.connect(self.on_item_expanded)
+        connect(self.dialog_widget.channels_tree_wt.itemExpanded, self.on_item_expanded)
 
         self.dialog_widget.channels_tree_wt.setHeaderLabels(['Name'])
         self.on_main_window_resize()

--- a/src/tribler-gui/tribler_gui/dialogs/confirmationdialog.py
+++ b/src/tribler-gui/tribler_gui/dialogs/confirmationdialog.py
@@ -95,4 +95,4 @@ class ConfirmationDialog(DialogContainer):
         )
 
         self.dialog_widget.dialog_button_container.layout().addWidget(button)
-        connect(button.clicked, lambda: self.button_clicked.emit(index))
+        connect(button.clicked, lambda _: self.button_clicked.emit(index))

--- a/src/tribler-gui/tribler_gui/dialogs/confirmationdialog.py
+++ b/src/tribler-gui/tribler_gui/dialogs/confirmationdialog.py
@@ -5,7 +5,7 @@ from PyQt5.QtWidgets import QSizePolicy, QSpacerItem
 
 from tribler_gui.defs import BUTTON_TYPE_NORMAL
 from tribler_gui.dialogs.dialogcontainer import DialogContainer
-from tribler_gui.utilities import get_ui_file_path
+from tribler_gui.utilities import connect, get_ui_file_path
 from tribler_gui.widgets.ellipsebutton import EllipseButton
 
 
@@ -28,7 +28,7 @@ class ConfirmationDialog(DialogContainer):
         if not show_input:
             self.dialog_widget.dialog_input.setHidden(True)
         else:
-            self.dialog_widget.dialog_input.returnPressed.connect(lambda: self.button_clicked.emit(0))
+            connect(self.dialog_widget.dialog_input.returnPressed, lambda: self.button_clicked.emit(0))
 
         if not checkbox_text:
             self.dialog_widget.checkbox.setHidden(True)
@@ -45,7 +45,7 @@ class ConfirmationDialog(DialogContainer):
         hspacer_right = QSpacerItem(1, 1, QSizePolicy.Expanding, QSizePolicy.Fixed)
         self.dialog_widget.dialog_button_container.layout().addSpacerItem(hspacer_right)
 
-        self.window().escape_pressed.connect(self.close_dialog)
+        connect(self.window().escape_pressed, self.close_dialog)
         self.on_main_window_resize()
 
     @classmethod
@@ -55,7 +55,7 @@ class ConfirmationDialog(DialogContainer):
         def on_close():
             error_dialog.close_dialog()
 
-        error_dialog.button_clicked.connect(on_close)
+        connect(error_dialog.button_clicked, on_close)
         error_dialog.show()
         return error_dialog
 
@@ -66,7 +66,7 @@ class ConfirmationDialog(DialogContainer):
         def on_close():
             error_dialog.close_dialog()
 
-        error_dialog.button_clicked.connect(on_close)
+        connect(error_dialog.button_clicked, on_close)
         error_dialog.show()
         return error_dialog
 
@@ -95,4 +95,4 @@ class ConfirmationDialog(DialogContainer):
         )
 
         self.dialog_widget.dialog_button_container.layout().addWidget(button)
-        button.clicked.connect(lambda: self.button_clicked.emit(index))
+        connect(button.clicked, lambda: self.button_clicked.emit(index))

--- a/src/tribler-gui/tribler_gui/dialogs/createtorrentdialog.py
+++ b/src/tribler-gui/tribler_gui/dialogs/createtorrentdialog.py
@@ -11,7 +11,7 @@ from tribler_gui.dialogs.confirmationdialog import ConfirmationDialog
 from tribler_gui.dialogs.dialogcontainer import DialogContainer
 from tribler_gui.tribler_action_menu import TriblerActionMenu
 from tribler_gui.tribler_request_manager import TriblerNetworkRequest
-from tribler_gui.utilities import get_ui_file_path, is_dir_writable
+from tribler_gui.utilities import connect, get_ui_file_path, is_dir_writable
 
 
 class DownloadFileTreeWidgetItem(QTreeWidgetItem):
@@ -29,13 +29,13 @@ class CreateTorrentDialog(DialogContainer):
         uic.loadUi(get_ui_file_path('createtorrentdialog.ui'), self.dialog_widget)
 
         self.dialog_widget.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Expanding)
-        self.dialog_widget.btn_cancel.clicked.connect(self.close_dialog)
-        self.dialog_widget.create_torrent_choose_files_button.clicked.connect(self.on_choose_files_clicked)
-        self.dialog_widget.create_torrent_choose_dir_button.clicked.connect(self.on_choose_dir_clicked)
-        self.dialog_widget.btn_create.clicked.connect(self.on_create_clicked)
-        self.dialog_widget.create_torrent_files_list.customContextMenuRequested.connect(self.on_right_click_file_item)
+        connect(self.dialog_widget.btn_cancel.clicked, self.close_dialog)
+        connect(self.dialog_widget.create_torrent_choose_files_button.clicked, self.on_choose_files_clicked)
+        connect(self.dialog_widget.create_torrent_choose_dir_button.clicked, self.on_choose_dir_clicked)
+        connect(self.dialog_widget.btn_create.clicked, self.on_create_clicked)
+        connect(self.dialog_widget.create_torrent_files_list.customContextMenuRequested, self.on_right_click_file_item)
         self.dialog_widget.create_torrent_files_list.clear()
-        self.dialog_widget.save_directory_chooser.clicked.connect(self.on_select_save_directory)
+        connect(self.dialog_widget.save_directory_chooser.clicked, self.on_select_save_directory)
         self.dialog_widget.edit_channel_create_torrent_progress_label.setText("")
         self.dialog_widget.file_export_dir.setText(os.path.expanduser("~"))
         self.dialog_widget.adjustSize()
@@ -86,7 +86,7 @@ class CreateTorrentDialog(DialogContainer):
                 [('CLOSE', BUTTON_TYPE_NORMAL)],
             )
 
-            dialog.button_clicked.connect(dialog.close_dialog)
+            connect(dialog.button_clicked, dialog.close_dialog)
             dialog.show()
             return
 
@@ -165,7 +165,7 @@ class CreateTorrentDialog(DialogContainer):
         selected_item_index = self.dialog_widget.create_torrent_files_list.row(item_clicked)
 
         remove_action = QAction('Remove file', self)
-        remove_action.triggered.connect(lambda index=selected_item_index: self.on_remove_entry(index))
+        connect(remove_action.triggered, lambda index=selected_item_index: self.on_remove_entry(index))
 
         menu = TriblerActionMenu(self)
         menu.addAction(remove_action)

--- a/src/tribler-gui/tribler_gui/dialogs/createtorrentdialog.py
+++ b/src/tribler-gui/tribler_gui/dialogs/createtorrentdialog.py
@@ -46,7 +46,7 @@ class CreateTorrentDialog(DialogContainer):
         self.rest_request1 = None
         self.rest_request2 = None
 
-    def close_dialog(self):
+    def close_dialog(self, checked=False):
         if self.rest_request1:
             self.rest_request1.cancel_request()
         if self.rest_request2:
@@ -54,13 +54,13 @@ class CreateTorrentDialog(DialogContainer):
 
         super(CreateTorrentDialog, self).close_dialog()
 
-    def on_choose_files_clicked(self):
+    def on_choose_files_clicked(self, checked):
         filenames, _ = QFileDialog.getOpenFileNames(self.window(), "Please select the files", QDir.homePath())
 
         for filename in filenames:
             self.dialog_widget.create_torrent_files_list.addItem(filename)
 
-    def on_choose_dir_clicked(self):
+    def on_choose_dir_clicked(self, checked):
         chosen_dir = QFileDialog.getExistingDirectory(
             self.window(), "Please select the directory containing the files", "", QFileDialog.ShowDirsOnly
         )
@@ -77,7 +77,7 @@ class CreateTorrentDialog(DialogContainer):
         for filename in files:
             self.dialog_widget.create_torrent_files_list.addItem(filename)
 
-    def on_create_clicked(self):
+    def on_create_clicked(self, checked):
         if self.dialog_widget.create_torrent_files_list.count() == 0:
             dialog = ConfirmationDialog(
                 self.dialog_widget,
@@ -145,7 +145,7 @@ class CreateTorrentDialog(DialogContainer):
         if 'added' in result:
             self.create_torrent_notification.emit({"msg": "Torrent successfully added to the channel"})
 
-    def on_select_save_directory(self):
+    def on_select_save_directory(self, checked):
         chosen_dir = QFileDialog.getExistingDirectory(
             self.window(), "Please select the directory containing the files", "", QFileDialog.ShowDirsOnly
         )

--- a/src/tribler-gui/tribler_gui/dialogs/dialogcontainer.py
+++ b/src/tribler-gui/tribler_gui/dialogs/dialogcontainer.py
@@ -2,6 +2,8 @@ from PyQt5.QtCore import QPoint
 from PyQt5.QtGui import QPainter
 from PyQt5.QtWidgets import QStyle, QStyleOption, QWidget
 
+from tribler_gui.utilities import connect
+
 
 class DialogContainer(QWidget):
     def __init__(self, parent):
@@ -11,7 +13,7 @@ class DialogContainer(QWidget):
 
         self.dialog_widget = QWidget(self)
 
-        self.window().resize_event.connect(self.on_main_window_resize)
+        connect(self.window().resize_event, self.on_main_window_resize)
 
     def paintEvent(self, _):
         opt = QStyleOption()

--- a/src/tribler-gui/tribler_gui/dialogs/dialogcontainer.py
+++ b/src/tribler-gui/tribler_gui/dialogs/dialogcontainer.py
@@ -21,7 +21,7 @@ class DialogContainer(QWidget):
         painter = QPainter(self)
         self.style().drawPrimitive(QStyle.PE_Widget, opt, painter, self)
 
-    def close_dialog(self):
+    def close_dialog(self, checked=False):
         try:
             self.setParent(None)
             self.deleteLater()

--- a/src/tribler-gui/tribler_gui/dialogs/feedbackdialog.py
+++ b/src/tribler-gui/tribler_gui/dialogs/feedbackdialog.py
@@ -17,7 +17,7 @@ from tribler_gui.tribler_request_manager import (
     performed_requests as tribler_performed_requests,
     tribler_urlencode,
 )
-from tribler_gui.utilities import get_ui_file_path
+from tribler_gui.utilities import connect, get_ui_file_path
 
 
 class FeedbackDialog(QDialog):
@@ -42,8 +42,8 @@ class FeedbackDialog(QDialog):
 
         self.error_text_edit.setPlainText(exception_text.rstrip())
 
-        self.cancel_button.clicked.connect(self.on_cancel_clicked)
-        self.send_report_button.clicked.connect(self.on_send_clicked)
+        connect(self.cancel_button.clicked, self.on_cancel_clicked)
+        connect(self.send_report_button.clicked, self.on_send_clicked)
 
         # Add machine information to the tree widget
         add_item_to_info_widget('os.getcwd', '%s' % os.getcwd())
@@ -83,7 +83,7 @@ class FeedbackDialog(QDialog):
             events_ind += 1
 
         # Users can remove specific lines in the report
-        self.env_variables_list.customContextMenuRequested.connect(self.on_right_click_item)
+        connect(self.env_variables_list.customContextMenuRequested, self.on_right_click_item)
 
     def on_remove_entry(self):
         self.env_variables_list.takeTopLevelItem(self.selected_item_index)
@@ -98,7 +98,7 @@ class FeedbackDialog(QDialog):
         menu = TriblerActionMenu(self)
 
         remove_action = QAction('Remove entry', self)
-        remove_action.triggered.connect(self.on_remove_entry)
+        connect(remove_action.triggered, self.on_remove_entry)
         menu.addAction(remove_action)
         menu.exec_(self.env_variables_list.mapToGlobal(pos))
 

--- a/src/tribler-gui/tribler_gui/dialogs/feedbackdialog.py
+++ b/src/tribler-gui/tribler_gui/dialogs/feedbackdialog.py
@@ -102,7 +102,7 @@ class FeedbackDialog(QDialog):
         menu.addAction(remove_action)
         menu.exec_(self.env_variables_list.mapToGlobal(pos))
 
-    def on_cancel_clicked(self):
+    def on_cancel_clicked(self, checked):
         QApplication.quit()
 
     def on_report_sent(self, response):
@@ -121,7 +121,7 @@ class FeedbackDialog(QDialog):
 
         QApplication.quit()
 
-    def on_send_clicked(self):
+    def on_send_clicked(self, checked):
         self.send_report_button.setEnabled(False)
         self.send_report_button.setText("SENDING...")
 

--- a/src/tribler-gui/tribler_gui/dialogs/new_channel_dialog.py
+++ b/src/tribler-gui/tribler_gui/dialogs/new_channel_dialog.py
@@ -1,5 +1,6 @@
 from tribler_gui.defs import BUTTON_TYPE_CONFIRM, BUTTON_TYPE_NORMAL
 from tribler_gui.dialogs.confirmationdialog import ConfirmationDialog
+from tribler_gui.utilities import connect
 
 
 class NewChannelDialog(ConfirmationDialog):
@@ -19,7 +20,7 @@ class NewChannelDialog(ConfirmationDialog):
         self.create_channel_callback = create_channel_callback
         self.dialog_widget.dialog_input.setPlaceholderText('Channel name')
         self.dialog_widget.dialog_input.setFocus()
-        self.button_clicked.connect(self.on_channel_name_dialog_done)
+        connect(self.button_clicked, self.on_channel_name_dialog_done)
         self.show()
 
     def on_channel_name_dialog_done(self, action):

--- a/src/tribler-gui/tribler_gui/dialogs/startdownloaddialog.py
+++ b/src/tribler-gui/tribler_gui/dialogs/startdownloaddialog.py
@@ -13,6 +13,7 @@ from tribler_gui.dialogs.confirmationdialog import ConfirmationDialog
 from tribler_gui.dialogs.dialogcontainer import DialogContainer
 from tribler_gui.tribler_request_manager import TriblerNetworkRequest
 from tribler_gui.utilities import (
+    connect,
     format_size,
     get_checkbox_style,
     get_gui_setting,
@@ -51,13 +52,13 @@ class StartDownloadDialog(DialogContainer):
 
         self.dialog_widget.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Expanding)
 
-        self.dialog_widget.browse_dir_button.clicked.connect(self.on_browse_dir_clicked)
-        self.dialog_widget.cancel_button.clicked.connect(lambda: self.button_clicked.emit(0))
-        self.dialog_widget.download_button.clicked.connect(self.on_download_clicked)
-        self.dialog_widget.select_all_files_button.clicked.connect(self.on_all_files_selected_clicked)
-        self.dialog_widget.deselect_all_files_button.clicked.connect(self.on_all_files_deselected_clicked)
-        self.dialog_widget.loading_files_label.clicked.connect(self.on_reload_torrent_info)
-        self.dialog_widget.anon_download_checkbox.clicked.connect(self.on_reload_torrent_info)
+        connect(self.dialog_widget.browse_dir_button.clicked, self.on_browse_dir_clicked)
+        connect(self.dialog_widget.cancel_button.clicked, lambda: self.button_clicked.emit(0))
+        connect(self.dialog_widget.download_button.clicked, self.on_download_clicked)
+        connect(self.dialog_widget.select_all_files_button.clicked, self.on_all_files_selected_clicked)
+        connect(self.dialog_widget.deselect_all_files_button.clicked, self.on_all_files_deselected_clicked)
+        connect(self.dialog_widget.loading_files_label.clicked, self.on_reload_torrent_info)
+        connect(self.dialog_widget.anon_download_checkbox.clicked, self.on_reload_torrent_info)
 
         self.dialog_widget.destination_input.setStyleSheet(
             """
@@ -107,7 +108,7 @@ class StartDownloadDialog(DialogContainer):
 
         self.dialog_widget.torrent_name_label.setText(torrent_name)
 
-        self.dialog_widget.anon_download_checkbox.stateChanged.connect(self.on_anon_download_state_changed)
+        connect(self.dialog_widget.anon_download_checkbox.stateChanged, self.on_anon_download_state_changed)
         self.dialog_widget.anon_download_checkbox.setChecked(
             self.window().tribler_settings['download_defaults']['anonymity_enabled']
         )
@@ -171,7 +172,7 @@ class StartDownloadDialog(DialogContainer):
                 loading_message if not self.metainfo_retries else timeout_message
             )
             self.metainfo_fetch_timer = QTimer()
-            self.metainfo_fetch_timer.timeout.connect(self.perform_files_request)
+            connect(self.metainfo_fetch_timer.timeout, self.perform_files_request)
             self.metainfo_fetch_timer.setSingleShot(True)
             self.metainfo_fetch_timer.start(METAINFO_TIMEOUT)
 

--- a/src/tribler-gui/tribler_gui/dialogs/startdownloaddialog.py
+++ b/src/tribler-gui/tribler_gui/dialogs/startdownloaddialog.py
@@ -53,7 +53,7 @@ class StartDownloadDialog(DialogContainer):
         self.dialog_widget.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Expanding)
 
         connect(self.dialog_widget.browse_dir_button.clicked, self.on_browse_dir_clicked)
-        connect(self.dialog_widget.cancel_button.clicked, lambda: self.button_clicked.emit(0))
+        connect(self.dialog_widget.cancel_button.clicked, lambda _: self.button_clicked.emit(0))
         connect(self.dialog_widget.download_button.clicked, self.on_download_clicked)
         connect(self.dialog_widget.select_all_files_button.clicked, self.on_all_files_selected_clicked)
         connect(self.dialog_widget.deselect_all_files_button.clicked, self.on_all_files_deselected_clicked)
@@ -131,7 +131,7 @@ class StartDownloadDialog(DialogContainer):
 
         self.rest_request = None
 
-    def close_dialog(self):
+    def close_dialog(self, checked=False):
         if self.rest_request:
             self.rest_request.cancel_request()
 
@@ -229,7 +229,7 @@ class StartDownloadDialog(DialogContainer):
 
         self.received_metainfo.emit(metainfo)
 
-    def on_reload_torrent_info(self):
+    def on_reload_torrent_info(self, checked):
         """
         This method is called when user clicks the QLabel text showing loading or error message. Here, we reset
         the number of retries to fetch the metainfo. Note color of QLabel is also reset to white.
@@ -238,7 +238,7 @@ class StartDownloadDialog(DialogContainer):
         self.metainfo_retries = 0
         self.perform_files_request()
 
-    def on_browse_dir_clicked(self):
+    def on_browse_dir_clicked(self, checked):
         chosen_dir = QFileDialog.getExistingDirectory(
             self.window(), "Please select the destination directory of your download", "", QFileDialog.ShowDirsOnly
         )
@@ -259,7 +259,7 @@ class StartDownloadDialog(DialogContainer):
             self.dialog_widget.safe_seed_checkbox.setChecked(True)
         self.dialog_widget.safe_seed_checkbox.setEnabled(not self.dialog_widget.anon_download_checkbox.isChecked())
 
-    def on_download_clicked(self):
+    def on_download_clicked(self, checked):
         if self.has_metainfo and len(self.get_selected_files()) == 0:  # User deselected all torrents
             ConfirmationDialog.show_error(
                 self.window(), "No files selected", "Please select at least one file to download."
@@ -277,12 +277,12 @@ class StartDownloadDialog(DialogContainer):
             else:
                 self.button_clicked.emit(1)
 
-    def on_all_files_selected_clicked(self):
+    def on_all_files_selected_clicked(self, checked):
         for ind in range(self.dialog_widget.files_list_view.topLevelItemCount()):
             item = self.dialog_widget.files_list_view.topLevelItem(ind)
             item.setCheckState(2, Qt.Checked)
 
-    def on_all_files_deselected_clicked(self):
+    def on_all_files_deselected_clicked(self, checked):
         for ind in range(self.dialog_widget.files_list_view.topLevelItemCount()):
             item = self.dialog_widget.files_list_view.topLevelItem(ind)
             item.setCheckState(2, Qt.Unchecked)

--- a/src/tribler-gui/tribler_gui/dialogs/trustexplanationdialog.py
+++ b/src/tribler-gui/tribler_gui/dialogs/trustexplanationdialog.py
@@ -2,7 +2,7 @@ from PyQt5 import uic
 from PyQt5.QtWidgets import QSizePolicy
 
 from tribler_gui.dialogs.dialogcontainer import DialogContainer
-from tribler_gui.utilities import get_ui_file_path
+from tribler_gui.utilities import connect, get_ui_file_path
 
 
 class TrustExplanationDialog(DialogContainer):
@@ -12,7 +12,7 @@ class TrustExplanationDialog(DialogContainer):
         uic.loadUi(get_ui_file_path('trustexplanation.ui'), self.dialog_widget)
 
         self.dialog_widget.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Expanding)
-        self.dialog_widget.close_button.clicked.connect(self.close_dialog)
+        connect(self.dialog_widget.close_button.clicked, self.close_dialog)
 
         self.update_window()
 

--- a/src/tribler-gui/tribler_gui/event_request_manager.py
+++ b/src/tribler-gui/tribler_gui/event_request_manager.py
@@ -8,6 +8,8 @@ from tribler_common.simpledefs import NTFY
 
 import tribler_core.utilities.json_util as json
 
+from tribler_gui.utilities import connect
+
 received_events = []
 
 
@@ -75,12 +77,12 @@ class EventRequestManager(QNetworkAccessManager):
             # Reschedule an attempt
             self.connect_timer = QTimer()
             self.connect_timer.setSingleShot(True)
-            self.connect_timer.timeout.connect(self.connect)
+            connect(self.connect_timer.timeout, self.connect)
             self.connect_timer.start(500)
 
     def on_read_data(self):
         if self.receivers(self.finished) == 0:
-            self.finished.connect(lambda reply: self.on_finished())
+            connect(self.finished, lambda reply: self.on_finished())
         self.connect_timer.stop()
         data = self.reply.readAll()
         self.current_event_string += bytes(data).decode('utf8')
@@ -126,5 +128,5 @@ class EventRequestManager(QNetworkAccessManager):
         self._logger.info("Will connect to events endpoint")
         self.reply = self.get(self.request)
 
-        self.reply.readyRead.connect(self.on_read_data)
-        self.reply.error.connect(lambda error: self.on_error(error, reschedule_on_err=reschedule_on_err))
+        connect(self.reply.readyRead, self.on_read_data)
+        connect(self.reply.error, lambda error: self.on_error(error, reschedule_on_err=reschedule_on_err))

--- a/src/tribler-gui/tribler_gui/single_application.py
+++ b/src/tribler-gui/tribler_gui/single_application.py
@@ -7,6 +7,8 @@ from PyQt5.QtCore import QTextStream, Qt, pyqtSignal
 from PyQt5.QtNetwork import QLocalServer, QLocalSocket
 from PyQt5.QtWidgets import QApplication
 
+from tribler_gui.utilities import connect, disconnect
+
 LOGVARSTR = "%25s = '%s'"
 
 
@@ -55,7 +57,7 @@ class QtSingleApplication(QApplication):
             self._outSocket = None
             self._server = QLocalServer()
             self._server.listen(self._id)
-            self._server.newConnection.connect(self._on_new_connection)
+            connect(self._server.newConnection, self._on_new_connection)
 
         logfunc(sys._getframe().f_code.co_name + '(): returning')
 
@@ -98,13 +100,13 @@ class QtSingleApplication(QApplication):
 
     def _on_new_connection(self):
         if self._inSocket:
-            self._inSocket.readyRead.disconnect(self._on_ready_read)
+            disconnect(self._inSocket.readyRead, self._on_ready_read)
         self._inSocket = self._server.nextPendingConnection()
         if not self._inSocket:
             return
         self._inStream = QTextStream(self._inSocket)
         self._inStream.setCodec('UTF-8')
-        self._inSocket.readyRead.connect(self._on_ready_read)
+        connect(self._inSocket.readyRead, self._on_ready_read)
         if self._activate_on_message:
             self.activate_window()
 

--- a/src/tribler-gui/tribler_gui/tests/test_gui.py
+++ b/src/tribler-gui/tribler_gui/tests/test_gui.py
@@ -39,7 +39,7 @@ def window(api_port):
     QTest.qWaitForWindowExposed(window)
 
     screenshot(window, name="tribler_loading")
-    wait_for_signal(window.core_manager.events_manager.tribler_started, no_args=True)
+    wait_for_signal(window.core_manager.events_manager.tribler_started)
     window.downloads_page.can_update_items = True
     yield window
     QApplication.quit()
@@ -88,15 +88,12 @@ class TimeoutException(Exception):
     pass
 
 
-def wait_for_signal(signal, timeout=10, no_args=False):
-    def on_signal(_):
+def wait_for_signal(signal, timeout=10):
+    def on_signal(*args, **kwargs):
         global signal_received
         signal_received = True
 
-    if no_args:
-        connect(signal, lambda: on_signal(None))
-    else:
-        connect(signal, on_signal)
+    connect(signal, on_signal)
 
     for _ in range(0, timeout * 1000, 100):
         QTest.qWait(100)
@@ -252,7 +249,7 @@ def test_discovered_page(tribler_api, window):
     tst_channels_widget(window, window.discovered_page, "discovered_page", sort_column=2)
 
 
-@pytest.mark.guitest
+#@pytest.mark.guitest
 def test_edit_channel_torrents(tribler_api, window):
     wait_for_list_populated(window.channels_menu_list)
     idx = window.channels_menu_list.model().index(0, 0)

--- a/src/tribler-gui/tribler_gui/tests/test_gui.py
+++ b/src/tribler-gui/tribler_gui/tests/test_gui.py
@@ -17,6 +17,7 @@ import tribler_gui.core_manager as core_manager
 from tribler_gui.dialogs.feedbackdialog import FeedbackDialog
 from tribler_gui.tribler_app import TriblerApplication
 from tribler_gui.tribler_window import TriblerWindow
+from tribler_gui.utilities import connect
 from tribler_gui.widgets.loading_list_item import LoadingListItem
 
 RUN_TRIBLER_PY = Path(tribler_gui.__file__).parent.parent.parent / "run_tribler.py"
@@ -67,7 +68,7 @@ def tribler_api(api_port, tmpdir_factory):
     core_process.setProcessEnvironment(core_env)
     core_process.setReadChannel(QProcess.StandardOutput)
     core_process.setProcessChannelMode(QProcess.MergedChannels)
-    core_process.readyRead.connect(on_core_read_ready)
+    connect(core_process.readyRead, on_core_read_ready)
     core_process.start("python3", [str(RUN_TRIBLER_PY.absolute())])
     yield core_process
     core_process.kill()
@@ -93,9 +94,9 @@ def wait_for_signal(signal, timeout=10, no_args=False):
         signal_received = True
 
     if no_args:
-        signal.connect(lambda: on_signal(None))
+        connect(signal, lambda: on_signal(None))
     else:
-        signal.connect(on_signal)
+        connect(signal, on_signal)
 
     for _ in range(0, timeout * 1000, 100):
         QTest.qWait(100)

--- a/src/tribler-gui/tribler_gui/tribler_app.py
+++ b/src/tribler-gui/tribler_gui/tribler_app.py
@@ -8,6 +8,7 @@ from tribler_core.utilities.unicode import ensure_unicode
 from tribler_gui.code_executor import CodeExecutor
 from tribler_gui.i18n import get_default_system_translator
 from tribler_gui.single_application import QtSingleApplication
+from tribler_gui.utilities import connect
 
 # Set the QT application parameters before creating any instances of the application.
 QCoreApplication.setAttribute(Qt.AA_UseHighDpiPixmaps)
@@ -23,7 +24,7 @@ class TriblerApplication(QtSingleApplication):
     def __init__(self, app_name, args):
         QtSingleApplication.__init__(self, app_name, args)
         self.code_executor = None
-        self.messageReceived.connect(self.on_app_message)
+        connect(self.messageReceived, self.on_app_message)
         self.translator = get_default_system_translator()
 
     def on_app_message(self, msg):
@@ -47,7 +48,7 @@ class TriblerApplication(QtSingleApplication):
             variables.update(locals())
             variables['window'] = self.activation_window()
             self.code_executor = CodeExecutor(5500, shell_variables=variables)
-            self.activation_window().tribler_crashed.connect(self.code_executor.on_crash)
+            connect(self.activation_window().tribler_crashed, self.code_executor.on_crash)
 
         if '--testnet' in sys.argv[1:]:
             os.environ['TESTNET'] = "YES"

--- a/src/tribler-gui/tribler_gui/tribler_request_manager.py
+++ b/src/tribler-gui/tribler_gui/tribler_request_manager.py
@@ -11,6 +11,7 @@ import tribler_core.utilities.json_util as json
 
 from tribler_gui.defs import BUTTON_TYPE_NORMAL, DEFAULT_API_HOST, DEFAULT_API_PORT, DEFAULT_API_PROTOCOL
 from tribler_gui.dialogs.confirmationdialog import ConfirmationDialog
+from tribler_gui.utilities import connect
 
 
 def tribler_urlencode(data):
@@ -82,7 +83,7 @@ class TriblerRequestManager(QNetworkAccessManager):
         def on_close():
             error_dialog.close_dialog()
 
-        error_dialog.button_clicked.connect(on_close)
+        connect(error_dialog.button_clicked, on_close)
         error_dialog.show()
 
     def clear(self):
@@ -117,7 +118,7 @@ class TriblerRequestManager(QNetworkAccessManager):
         request.reply = self.sendCustomRequest(qt_request, request.method.encode("utf8"), buf)
         buf.setParent(request.reply)
 
-        request.reply.finished.connect(lambda: request.on_finished(request))
+        connect(request.reply.finished, lambda: request.on_finished(request))
 
 
 # Request manager singleton.
@@ -172,11 +173,11 @@ class TriblerNetworkRequest(QObject):
         self.raw_data = raw_data if (issubclass(type(raw_data), bytes) or raw_data is None) else raw_data.encode('utf8')
         self.reply_callback = reply_callback
         if self.reply_callback:
-            self.received_json.connect(self.reply_callback)
+            connect(self.received_json, self.reply_callback)
 
         self.on_error_callback = on_error_callback
         if on_error_callback is not None:
-            self.received_error.connect(on_error_callback)
+            connect(self.received_error, on_error_callback)
         self.reply = None  # to hold the associated QNetworkReply object
 
         # Pass the newly created object to the manager singleton, so the object can be dispatched immediately

--- a/src/tribler-gui/tribler_gui/tribler_window.py
+++ b/src/tribler-gui/tribler_gui/tribler_window.py
@@ -252,7 +252,7 @@ class TriblerWindow(QMainWindow):
             show_downloads_action = QAction('Show downloads', self)
             connect(show_downloads_action.triggered, self.clicked_menu_button_downloads)
             token_balance_action = QAction('Show token balance', self)
-            connect(token_balance_action.triggered, lambda: self.on_token_balance_click(None))
+            connect(token_balance_action.triggered, lambda _: self.on_token_balance_click(None))
             quit_action = QAction('Quit Tribler', self)
             connect(quit_action.triggered, self.close_tribler)
             menu.addSeparator()
@@ -345,7 +345,7 @@ class TriblerWindow(QMainWindow):
                 lambda data: self.channels_menu_list.reload_if_necessary([data]))
         connect(self.left_menu_button_new_channel.clicked, self.create_new_channel)
 
-    def create_new_channel(self):
+    def create_new_channel(self, checked):
         # TODO: DRY this with tablecontentmodel, possibly using QActions
 
         def create_channel_callback(channel_name):
@@ -769,7 +769,7 @@ class TriblerWindow(QMainWindow):
 
         return menu
 
-    def on_create_torrent(self):
+    def on_create_torrent(self, checked):
         if self.create_dialog:
             self.create_dialog.close_dialog()
 
@@ -780,7 +780,7 @@ class TriblerWindow(QMainWindow):
     def on_create_torrent_updates(self, update_dict):
         self.tray_show_message("Torrent updates", update_dict['msg'])
 
-    def on_add_torrent_browse_file(self):
+    def on_add_torrent_browse_file(self, index):
         filenames = QFileDialog.getOpenFileNames(
             self, "Please select the .torrent file", QDir.homePath(), "Torrent files (*.torrent)"
         )
@@ -860,7 +860,7 @@ class TriblerWindow(QMainWindow):
         if action == 0:  # We do this after removing the dialog since process_uri_request is blocking
             self.process_uri_request()
 
-    def on_add_torrent_browse_dir(self):
+    def on_add_torrent_browse_dir(self, checked):
         chosen_dir = QFileDialog.getExistingDirectory(
             self, "Please select the directory containing the .torrent files", QDir.homePath(), QFileDialog.ShowDirsOnly
         )
@@ -907,7 +907,7 @@ class TriblerWindow(QMainWindow):
             self.dialog.close_dialog()
             self.dialog = None
 
-    def on_add_torrent_from_url(self):
+    def on_add_torrent_from_url(self, checked=False):
         # Make sure that the window is visible (this action might be triggered from the tray icon)
         self.raise_window()
 
@@ -970,7 +970,7 @@ class TriblerWindow(QMainWindow):
             button.setEnabled(True)
             button.setChecked(False)
 
-    def clicked_search_bar(self):
+    def clicked_search_bar(self, checked=False):
         query = self.top_search_bar.text()
         if query and self.has_search_results:
             self.deselect_all_menu_buttons()
@@ -991,13 +991,13 @@ class TriblerWindow(QMainWindow):
         self.deselect_all_menu_buttons(self.left_menu_button_trust_graph)
         self.stackedWidget.setCurrentIndex(PAGE_TRUST_GRAPH_PAGE)
 
-    def clicked_menu_button_downloads(self):
+    def clicked_menu_button_downloads(self, checked):
         self.deselect_all_menu_buttons(self.left_menu_button_downloads)
         self.raise_window()
         self.left_menu_button_downloads.setChecked(True)
         self.stackedWidget.setCurrentIndex(PAGE_DOWNLOADS)
 
-    def clicked_menu_button_debug(self):
+    def clicked_menu_button_debug(self, index):
         if not self.debug_window:
             self.debug_window = DebugWindow(self.tribler_settings, self.tribler_version)
         self.debug_window.show()
@@ -1006,7 +1006,7 @@ class TriblerWindow(QMainWindow):
         # This thing here is necessary to send the resize event to dialogs, etc.
         self.resize_event.emit()
 
-    def close_tribler(self):
+    def close_tribler(self, checked=False):
         if self.core_manager.shutting_down:
             return
 

--- a/src/tribler-gui/tribler_gui/widgets/channelcontentswidget.py
+++ b/src/tribler-gui/tribler_gui/widgets/channelcontentswidget.py
@@ -104,7 +104,7 @@ class ChannelContentsWidget(widget_form, widget_class):
                 self.model.reset()
                 self.update_labels()
 
-    def commit_channels(self):
+    def commit_channels(self, checked=False):
         TriblerNetworkRequest("channels/mychannel/0/commit", self.on_channel_committed, method='POST')
 
     def initialize_content_page(self, autocommit_enabled=False, hide_xxx=None):
@@ -242,7 +242,7 @@ class ChannelContentsWidget(widget_form, widget_class):
                    self.model.on_new_entry_received)
         self.controller.unset_model()  # Disconnect the selectionChanged signal
 
-    def go_back(self):
+    def go_back(self, checked=False):
         if len(self.channels_stack) > 1:
             self.disconnect_current_model()
             self.channels_stack.pop().deleteLater()
@@ -283,7 +283,7 @@ class ChannelContentsWidget(widget_form, widget_class):
     #    copy_to_clipboard(self.channel_info["public_key"])
     #    self.tray_show_message("Copied channel ID", self.channel_info["public_key"])
 
-    def preview_clicked(self):
+    def preview_clicked(self, checked):
         params = dict()
 
         if "public_key" in self.model.channel_info:
@@ -309,7 +309,7 @@ class ChannelContentsWidget(widget_form, widget_class):
 
         TriblerNetworkRequest('remote_query', add_request_uuid, method="PUT", url_params=params)
 
-    def create_new_channel(self):
+    def create_new_channel(self, checked):
         NewChannelDialog(self, self.model.create_new_channel)
 
     def initialize_with_channel(self, channel_info):
@@ -416,7 +416,7 @@ class ChannelContentsWidget(widget_form, widget_class):
         return channel_options_menu
 
     # Torrent addition-related methods
-    def on_add_torrents_browse_dir(self):
+    def on_add_torrents_browse_dir(self, checked):
         chosen_dir = QFileDialog.getExistingDirectory(
             self, "Please select the directory containing the .torrent files", QDir.homePath(), QFileDialog.ShowDirsOnly
         )
@@ -443,7 +443,7 @@ class ChannelContentsWidget(widget_form, widget_class):
             self.dialog = None
             self.chosen_dir = None
 
-    def on_add_torrent_browse_file(self):
+    def on_add_torrent_browse_file(self, checked):
         filenames = QFileDialog.getOpenFileNames(
             self, "Please select the .torrent file", "", "Torrent files (*.torrent)"
         )
@@ -453,7 +453,7 @@ class ChannelContentsWidget(widget_form, widget_class):
         for filename in filenames[0]:
             self.add_torrent_to_channel(filename)
 
-    def on_add_torrent_from_url(self):
+    def on_add_torrent_from_url(self, checked):
         self.dialog = ConfirmationDialog(
             self,
             "Add torrent from URL/magnet link",

--- a/src/tribler-gui/tribler_gui/widgets/channelsmenulistwidget.py
+++ b/src/tribler-gui/tribler_gui/widgets/channelsmenulistwidget.py
@@ -87,13 +87,13 @@ class ChannelsMenuListWidget(QListWidget):
         menu.addAction(rename_action)
         return menu
 
-    def _trigger_name_editor(self):
+    def _trigger_name_editor(self, checked):
         self.editItem(self.currentItem())
 
-    def _on_unsubscribe_action(self):
+    def _on_unsubscribe_action(self, checked):
         self.window().on_channel_unsubscribe(self.currentItem().channel_info)
 
-    def _on_delete_action(self):
+    def _on_delete_action(self, checked):
         self.window().on_channel_delete(self.currentItem().channel_info)
 
     def on_query_results(self, response):
@@ -119,7 +119,7 @@ class ChannelsMenuListWidget(QListWidget):
 
         self.items_set = frozenset(entry_to_tuple(channel_info) for channel_info in channels)
 
-    def load_channels(self):
+    def load_channels(self, request=None):
         TriblerNetworkRequest(self.base_url, self.on_query_results, url_params={"subscribed": True, "last": 1000})
 
     def reload_if_necessary(self, changed_entries):

--- a/src/tribler-gui/tribler_gui/widgets/channelsmenulistwidget.py
+++ b/src/tribler-gui/tribler_gui/widgets/channelsmenulistwidget.py
@@ -10,7 +10,7 @@ from tribler_core.modules.metadata_store.serialization import CHANNEL_TORRENT
 
 from tribler_gui.tribler_action_menu import TriblerActionMenu
 from tribler_gui.tribler_request_manager import TriblerNetworkRequest
-from tribler_gui.utilities import get_image_path
+from tribler_gui.utilities import connect, get_image_path
 
 
 def entry_to_tuple(entry):
@@ -72,18 +72,18 @@ class ChannelsMenuListWidget(QListWidget):
     def create_foreign_menu(self):
         menu = TriblerActionMenu(self)
         unsubscribe_action = QAction('Unsubscribe', self)
-        unsubscribe_action.triggered.connect(self._on_unsubscribe_action)
+        connect(unsubscribe_action.triggered, self._on_unsubscribe_action)
         menu.addAction(unsubscribe_action)
         return menu
 
     def create_personal_menu(self):
         menu = TriblerActionMenu(self)
         delete_action = QAction('Delete channel', self)
-        delete_action.triggered.connect(self._on_delete_action)
+        connect(delete_action.triggered, self._on_delete_action)
         menu.addAction(delete_action)
 
         rename_action = QAction('Rename channel', self)
-        rename_action.triggered.connect(self._trigger_name_editor)
+        connect(rename_action.triggered, self._trigger_name_editor)
         menu.addAction(rename_action)
         return menu
 

--- a/src/tribler-gui/tribler_gui/widgets/clickable_line_edit.py
+++ b/src/tribler-gui/tribler_gui/widgets/clickable_line_edit.py
@@ -9,5 +9,5 @@ class ClickableLineEdit(QLineEdit):
     clicked = pyqtSignal()
 
     def mousePressEvent(self, event):
-        self.clicked.emit()
+        self.clicked.emit(False)
         QLineEdit.mousePressEvent(self, event)

--- a/src/tribler-gui/tribler_gui/widgets/clickablewidgets.py
+++ b/src/tribler-gui/tribler_gui/widgets/clickablewidgets.py
@@ -7,5 +7,5 @@ class ClickableLabel(QLabel):
     clicked = pyqtSignal()
 
     def mousePressEvent(self, event):
-        self.clicked.emit()
+        self.clicked.emit(False)
         QLabel.mousePressEvent(self, event)

--- a/src/tribler-gui/tribler_gui/widgets/createtorrentpage.py
+++ b/src/tribler-gui/tribler_gui/widgets/createtorrentpage.py
@@ -43,16 +43,16 @@ class CreateTorrentPage(QWidget):
 
             self.initialized = True
 
-    def on_create_torrent_manage_back_clicked(self):
+    def on_create_torrent_manage_back_clicked(self, checked):
         self.window().edit_channel_details_stacked_widget.setCurrentIndex(PAGE_EDIT_CHANNEL_TORRENTS)
 
-    def on_choose_files_clicked(self):
+    def on_choose_files_clicked(self, checked):
         filenames, _ = QFileDialog.getOpenFileNames(self.window(), "Please select the files", QDir.homePath())
 
         for filename in filenames:
             self.window().create_torrent_files_list.addItem(filename)
 
-    def on_choose_dir_clicked(self):
+    def on_choose_dir_clicked(self, checked):
         chosen_dir = QFileDialog.getExistingDirectory(
             self.window(), "Please select the directory containing the files", "", QFileDialog.ShowDirsOnly
         )
@@ -69,7 +69,7 @@ class CreateTorrentPage(QWidget):
         for filename in files:
             self.window().create_torrent_files_list.addItem(filename)
 
-    def on_create_clicked(self):
+    def on_create_clicked(self, checked):
         if self.window().create_torrent_files_list.count() == 0:
             self.dialog = ConfirmationDialog(
                 self, "Notice", "You should add at least one file to your torrent.", [('CLOSE', BUTTON_TYPE_NORMAL)]

--- a/src/tribler-gui/tribler_gui/widgets/createtorrentpage.py
+++ b/src/tribler-gui/tribler_gui/widgets/createtorrentpage.py
@@ -8,7 +8,7 @@ from tribler_gui.defs import BUTTON_TYPE_NORMAL, PAGE_EDIT_CHANNEL_TORRENTS
 from tribler_gui.dialogs.confirmationdialog import ConfirmationDialog
 from tribler_gui.tribler_action_menu import TriblerActionMenu
 from tribler_gui.tribler_request_manager import TriblerNetworkRequest
-from tribler_gui.utilities import get_image_path
+from tribler_gui.utilities import connect, get_image_path
 
 
 class CreateTorrentPage(QWidget):
@@ -34,11 +34,12 @@ class CreateTorrentPage(QWidget):
         if not self.initialized:
             self.window().manage_channel_create_torrent_back.setIcon(QIcon(get_image_path('page_back.png')))
 
-            self.window().create_torrent_files_list.customContextMenuRequested.connect(self.on_right_click_file_item)
-            self.window().manage_channel_create_torrent_back.clicked.connect(self.on_create_torrent_manage_back_clicked)
-            self.window().create_torrent_choose_files_button.clicked.connect(self.on_choose_files_clicked)
-            self.window().create_torrent_choose_dir_button.clicked.connect(self.on_choose_dir_clicked)
-            self.window().edit_channel_create_torrent_button.clicked.connect(self.on_create_clicked)
+            connect(self.window().create_torrent_files_list.customContextMenuRequested, self.on_right_click_file_item)
+            connect(self.window().manage_channel_create_torrent_back.clicked,
+                    self.on_create_torrent_manage_back_clicked)
+            connect(self.window().create_torrent_choose_files_button.clicked, self.on_choose_files_clicked)
+            connect(self.window().create_torrent_choose_dir_button.clicked, self.on_choose_dir_clicked)
+            connect(self.window().edit_channel_create_torrent_button.clicked, self.on_create_clicked)
 
             self.initialized = True
 
@@ -73,7 +74,7 @@ class CreateTorrentPage(QWidget):
             self.dialog = ConfirmationDialog(
                 self, "Notice", "You should add at least one file to your torrent.", [('CLOSE', BUTTON_TYPE_NORMAL)]
             )
-            self.dialog.button_clicked.connect(self.on_dialog_ok_clicked)
+            connect(self.dialog.button_clicked, self.on_dialog_ok_clicked)
             self.dialog.show()
             return
 
@@ -129,6 +130,6 @@ class CreateTorrentPage(QWidget):
         menu = TriblerActionMenu(self)
 
         remove_action = QAction('Remove file', self)
-        remove_action.triggered.connect(self.on_remove_entry)
+        connect(remove_action.triggered, self.on_remove_entry)
         menu.addAction(remove_action)
         menu.exec_(self.window().create_torrent_files_list.mapToGlobal(pos))

--- a/src/tribler-gui/tribler_gui/widgets/discoveringpage.py
+++ b/src/tribler-gui/tribler_gui/widgets/discoveringpage.py
@@ -1,7 +1,7 @@
 from PyQt5.QtSvg import QGraphicsSvgItem, QSvgRenderer
 from PyQt5.QtWidgets import QGraphicsScene, QWidget
 
-from tribler_gui.utilities import get_image_path
+from tribler_gui.utilities import connect, get_image_path
 
 
 class DiscoveringPage(QWidget):
@@ -20,13 +20,13 @@ class DiscoveringPage(QWidget):
         svg_item = QGraphicsSvgItem()
 
         svg = QSvgRenderer(get_image_path("loading_animation.svg"))
-        svg.repaintNeeded.connect(svg_item.update)
+        connect(svg.repaintNeeded, svg_item.update)
         svg_item.setSharedRenderer(svg)
         svg_container.addItem(svg_item)
 
         self.window().discovering_svg_view.setScene(svg_container)
 
-        self.window().core_manager.events_manager.discovered_channel.connect(self.on_discovered_channel)
+        connect(self.window().core_manager.events_manager.discovered_channel, self.on_discovered_channel)
 
     def on_discovered_channel(self, _):
         self.found_channels += 1

--- a/src/tribler-gui/tribler_gui/widgets/downloadsdetailstabwidget.py
+++ b/src/tribler-gui/tribler_gui/widgets/downloadsdetailstabwidget.py
@@ -215,7 +215,7 @@ class DownloadsDetailsTabWidget(QTabWidget):
             "downloads/%s" % self.current_download['infohash'], lambda _: None, method='PATCH', data=post_data
         )
 
-    def on_copy_magnet_clicked(self):
+    def on_copy_magnet_clicked(self, checked):
         trackers = [
             tr['url'] for tr in self.current_download['trackers'] if 'url' in tr and tr['url'] not in ['[DHT]', '[PeX]']
         ]

--- a/src/tribler-gui/tribler_gui/widgets/downloadsdetailstabwidget.py
+++ b/src/tribler-gui/tribler_gui/widgets/downloadsdetailstabwidget.py
@@ -6,7 +6,7 @@ from tribler_common.simpledefs import dlstatus_strings
 from tribler_gui.defs import *
 from tribler_gui.tribler_action_menu import TriblerActionMenu
 from tribler_gui.tribler_request_manager import TriblerNetworkRequest
-from tribler_gui.utilities import compose_magnetlink, copy_to_clipboard, format_size, format_speed
+from tribler_gui.utilities import compose_magnetlink, connect, copy_to_clipboard, format_size, format_speed
 from tribler_gui.widgets.downloadfilewidgetitem import DownloadFileWidgetItem
 
 
@@ -22,14 +22,14 @@ class DownloadsDetailsTabWidget(QTabWidget):
         self.files_widgets = {}  # dict of file name -> widget
 
     def initialize_details_widget(self):
-        self.window().download_files_list.customContextMenuRequested.connect(self.on_right_click_file_item)
+        connect(self.window().download_files_list.customContextMenuRequested, self.on_right_click_file_item)
         self.window().download_files_list.header().resizeSection(0, 220)
         self.setCurrentIndex(0)
         # make name, infohash and download destination selectable to copy
         self.window().download_detail_infohash_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
         self.window().download_detail_name_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
         self.window().download_detail_destination_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
-        self.window().download_detail_copy_magnet_button.clicked.connect(self.on_copy_magnet_clicked)
+        connect(self.window().download_detail_copy_magnet_button.clicked, self.on_copy_magnet_clicked)
 
     def update_with_download(self, download):
         did_change = self.current_download != download
@@ -180,9 +180,9 @@ class DownloadsDetailsTabWidget(QTabWidget):
         include_action = QAction('Include file' + ('(s)' if num_selected > 1 else ''), self)
         exclude_action = QAction('Exclude file' + ('(s)' if num_selected > 1 else ''), self)
 
-        include_action.triggered.connect(lambda: self.on_files_included(selected_files_info))
+        connect(include_action.triggered, lambda: self.on_files_included(selected_files_info))
         include_action.setEnabled(True)
-        exclude_action.triggered.connect(lambda: self.on_files_excluded(selected_files_info))
+        connect(exclude_action.triggered, lambda: self.on_files_excluded(selected_files_info))
         exclude_action.setEnabled(not (num_excludes + num_includes_selected == len(item_infos)))
 
         menu.addAction(include_action)

--- a/src/tribler-gui/tribler_gui/widgets/downloadspage.py
+++ b/src/tribler-gui/tribler_gui/widgets/downloadspage.py
@@ -277,7 +277,7 @@ class DownloadsPage(QWidget):
             self.window().stop_download_button.setEnabled(DownloadsPage.stop_download_enabled(self.selected_items))
             self.window().download_details_widget.hide()
 
-    def on_start_download_clicked(self):
+    def on_start_download_clicked(self, checked):
         for selected_item in self.selected_items:
             infohash = selected_item.download_info["infohash"]
             TriblerNetworkRequest(
@@ -292,7 +292,7 @@ class DownloadsPage(QWidget):
                     selected_item.update_item()
                     self.on_download_item_clicked()
 
-    def on_stop_download_clicked(self):
+    def on_stop_download_clicked(self, checked):
         for selected_item in self.selected_items:
             infohash = selected_item.download_info["infohash"]
             TriblerNetworkRequest(
@@ -307,7 +307,7 @@ class DownloadsPage(QWidget):
                     selected_item.update_item()
                     self.on_download_item_clicked()
 
-    def on_remove_download_clicked(self):
+    def on_remove_download_clicked(self, checked):
         self.dialog = ConfirmationDialog(
             self,
             "Remove download",
@@ -341,7 +341,7 @@ class DownloadsPage(QWidget):
             self.load_downloads()
             self.window().download_details_widget.hide()
 
-    def on_force_recheck_download(self):
+    def on_force_recheck_download(self, checked):
         for selected_item in self.selected_items:
             infohash = selected_item.download_info["infohash"]
             TriblerNetworkRequest(
@@ -366,12 +366,12 @@ class DownloadsPage(QWidget):
                 "downloads/%s" % infohash, self.on_change_anonymity, method='PATCH', data={"anon_hops": hops}
             )
 
-    def on_explore_files(self):
+    def on_explore_files(self, checked):
         for selected_item in self.selected_items:
             path = os.path.normpath(selected_item.download_info["destination"])
             QDesktopServices.openUrl(QUrl.fromLocalFile(path))
 
-    def on_move_files(self):
+    def on_move_files(self, checked):
         if len(self.selected_items) != 1:
             return
 
@@ -400,7 +400,7 @@ class DownloadsPage(QWidget):
         if "modified" in response and response["modified"]:
             self.window().tray_show_message(name, "Moved to %s" % dest_dir)
 
-    def on_export_download(self):
+    def on_export_download(self, checked):
         self.export_dir = QFileDialog.getExistingDirectory(
             self, "Please select the destination directory", "", QFileDialog.ShowDirsOnly
         )
@@ -449,7 +449,7 @@ class DownloadsPage(QWidget):
         else:
             self.window().tray_show_message("Torrent file exported", "Torrent file exported to %s" % dest_path)
 
-    def on_add_to_channel(self):
+    def on_add_to_channel(self, checked):
         def on_add_button_pressed(channel_id):
             for selected_item in self.selected_items:
                 infohash = selected_item.download_info["infohash"]
@@ -499,10 +499,10 @@ class DownloadsPage(QWidget):
         connect(explore_files_action.triggered, self.on_explore_files)
         connect(move_files_action.triggered, self.on_move_files)
 
-        connect(no_anon_action.triggered, lambda: self.change_anonymity(0))
-        connect(one_hop_anon_action.triggered, lambda: self.change_anonymity(1))
-        connect(two_hop_anon_action.triggered, lambda: self.change_anonymity(2))
-        connect(three_hop_anon_action.triggered, lambda: self.change_anonymity(3))
+        connect(no_anon_action.triggered, lambda _: self.change_anonymity(0))
+        connect(one_hop_anon_action.triggered, lambda _: self.change_anonymity(1))
+        connect(two_hop_anon_action.triggered, lambda _: self.change_anonymity(2))
+        connect(three_hop_anon_action.triggered, lambda _: self.change_anonymity(3))
 
         menu.addAction(start_action)
         menu.addAction(stop_action)

--- a/src/tribler-gui/tribler_gui/widgets/downloadspage.py
+++ b/src/tribler-gui/tribler_gui/widgets/downloadspage.py
@@ -27,7 +27,7 @@ from tribler_gui.defs import (
 from tribler_gui.dialogs.confirmationdialog import ConfirmationDialog
 from tribler_gui.tribler_action_menu import TriblerActionMenu
 from tribler_gui.tribler_request_manager import TriblerFileDownloadRequest, TriblerNetworkRequest
-from tribler_gui.utilities import compose_magnetlink, format_speed
+from tribler_gui.utilities import compose_magnetlink, connect, format_speed
 from tribler_gui.widgets.downloadwidgetitem import DownloadWidgetItem
 from tribler_gui.widgets.loading_list_item import LoadingListItem
 
@@ -76,20 +76,20 @@ class DownloadsPage(QWidget):
 
     def initialize_downloads_page(self):
         self.window().downloads_tab.initialize()
-        self.window().downloads_tab.clicked_tab_button.connect(self.on_downloads_tab_button_clicked)
+        connect(self.window().downloads_tab.clicked_tab_button, self.on_downloads_tab_button_clicked)
 
-        self.window().start_download_button.clicked.connect(self.on_start_download_clicked)
-        self.window().stop_download_button.clicked.connect(self.on_stop_download_clicked)
-        self.window().remove_download_button.clicked.connect(self.on_remove_download_clicked)
+        connect(self.window().start_download_button.clicked, self.on_start_download_clicked)
+        connect(self.window().stop_download_button.clicked, self.on_stop_download_clicked)
+        connect(self.window().remove_download_button.clicked, self.on_remove_download_clicked)
 
-        self.window().downloads_list.itemSelectionChanged.connect(self.on_download_item_clicked)
+        connect(self.window().downloads_list.itemSelectionChanged, self.on_download_item_clicked)
 
-        self.window().downloads_list.customContextMenuRequested.connect(self.on_right_click_item)
+        connect(self.window().downloads_list.customContextMenuRequested, self.on_right_click_item)
 
         self.window().download_details_widget.initialize_details_widget()
         self.window().download_details_widget.hide()
 
-        self.window().downloads_filter_input.textChanged.connect(self.on_filter_text_changed)
+        connect(self.window().downloads_filter_input.textChanged, self.on_filter_text_changed)
 
         self.window().downloads_list.header().setSortIndicator(12, Qt.AscendingOrder)
         self.window().downloads_list.header().resizeSection(12, 146)
@@ -111,12 +111,12 @@ class DownloadsPage(QWidget):
     def schedule_downloads_timer(self, now=False):
         self.downloads_timer = QTimer()
         self.downloads_timer.setSingleShot(True)
-        self.downloads_timer.timeout.connect(self.load_downloads)
+        connect(self.downloads_timer.timeout, self.load_downloads)
         self.downloads_timer.start(0 if now else 1000)
 
         self.downloads_timeout_timer = QTimer()
         self.downloads_timeout_timer.setSingleShot(True)
-        self.downloads_timeout_timer.timeout.connect(self.on_downloads_request_timeout)
+        connect(self.downloads_timeout_timer.timeout, self.on_downloads_request_timeout)
         self.downloads_timeout_timer.start(16000)
 
     def on_downloads_request_timeout(self):
@@ -318,7 +318,7 @@ class DownloadsPage(QWidget):
                 ('cancel', BUTTON_TYPE_CONFIRM),
             ],
         )
-        self.dialog.button_clicked.connect(self.on_remove_download_dialog)
+        connect(self.dialog.button_clicked, self.on_remove_download_dialog)
         self.dialog.show()
 
     def on_remove_download_dialog(self, action):
@@ -419,7 +419,7 @@ class DownloadsPage(QWidget):
             self.dialog.dialog_widget.dialog_input.setPlaceholderText('Torrent file name')
             self.dialog.dialog_widget.dialog_input.setText("%s.torrent" % torrent_name)
             self.dialog.dialog_widget.dialog_input.setFocus()
-            self.dialog.button_clicked.connect(self.on_export_download_dialog_done)
+            connect(self.dialog.button_clicked, self.on_export_download_dialog_done)
             self.dialog.show()
 
     def on_export_download_dialog_done(self, action):
@@ -487,22 +487,22 @@ class DownloadsPage(QWidget):
         two_hop_anon_action = QAction('Two hops', self)
         three_hop_anon_action = QAction('Three hops', self)
 
-        start_action.triggered.connect(self.on_start_download_clicked)
+        connect(start_action.triggered, self.on_start_download_clicked)
         start_action.setEnabled(DownloadsPage.start_download_enabled(self.selected_items))
-        stop_action.triggered.connect(self.on_stop_download_clicked)
+        connect(stop_action.triggered, self.on_stop_download_clicked)
         stop_action.setEnabled(DownloadsPage.stop_download_enabled(self.selected_items))
-        add_to_channel_action.triggered.connect(self.on_add_to_channel)
-        remove_download_action.triggered.connect(self.on_remove_download_clicked)
-        force_recheck_action.triggered.connect(self.on_force_recheck_download)
+        connect(add_to_channel_action.triggered, self.on_add_to_channel)
+        connect(remove_download_action.triggered, self.on_remove_download_clicked)
+        connect(force_recheck_action.triggered, self.on_force_recheck_download)
         force_recheck_action.setEnabled(DownloadsPage.force_recheck_download_enabled(self.selected_items))
-        export_download_action.triggered.connect(self.on_export_download)
-        explore_files_action.triggered.connect(self.on_explore_files)
-        move_files_action.triggered.connect(self.on_move_files)
+        connect(export_download_action.triggered, self.on_export_download)
+        connect(explore_files_action.triggered, self.on_explore_files)
+        connect(move_files_action.triggered, self.on_move_files)
 
-        no_anon_action.triggered.connect(lambda: self.change_anonymity(0))
-        one_hop_anon_action.triggered.connect(lambda: self.change_anonymity(1))
-        two_hop_anon_action.triggered.connect(lambda: self.change_anonymity(2))
-        three_hop_anon_action.triggered.connect(lambda: self.change_anonymity(3))
+        connect(no_anon_action.triggered, lambda: self.change_anonymity(0))
+        connect(one_hop_anon_action.triggered, lambda: self.change_anonymity(1))
+        connect(two_hop_anon_action.triggered, lambda: self.change_anonymity(2))
+        connect(three_hop_anon_action.triggered, lambda: self.change_anonymity(3))
 
         menu.addAction(start_action)
         menu.addAction(stop_action)

--- a/src/tribler-gui/tribler_gui/widgets/ipv8health.py
+++ b/src/tribler-gui/tribler_gui/widgets/ipv8health.py
@@ -6,6 +6,8 @@ from PyQt5.QtCore import QTimer, Qt
 from PyQt5.QtGui import QPainter
 from PyQt5.QtWidgets import QWidget
 
+from tribler_gui.utilities import connect
+
 
 class MonitorWidget(QWidget):
     """
@@ -34,7 +36,7 @@ class MonitorWidget(QWidget):
         self.walk_interval_target = "?"
 
         self.timer = QTimer()
-        self.timer.timeout.connect(self.repaint)
+        connect(self.timer.timeout, self.repaint)
         self.timer.start(33)
 
         self.backup_size = None

--- a/src/tribler-gui/tribler_gui/widgets/lazytableview.py
+++ b/src/tribler-gui/tribler_gui/widgets/lazytableview.py
@@ -5,7 +5,7 @@ from PyQt5.QtWidgets import QAbstractItemView, QTableView
 from tribler_core.modules.metadata_store.serialization import CHANNEL_TORRENT, COLLECTION_NODE, REGULAR_TORRENT
 
 from tribler_gui.defs import ACTION_BUTTONS, COMMIT_STATUS_COMMITTED
-from tribler_gui.utilities import data_item2uri, index2uri
+from tribler_gui.utilities import connect, data_item2uri, index2uri
 from tribler_gui.widgets.tablecontentdelegate import TriblerContentDelegate
 
 
@@ -30,16 +30,16 @@ class TriblerContentTableView(QTableView):
         self.delegate = TriblerContentDelegate()
 
         self.setItemDelegate(self.delegate)
-        self.mouse_moved.connect(self.delegate.on_mouse_moved)
-        self.delegate.redraw_required.connect(self.redraw)
+        connect(self.mouse_moved, self.delegate.on_mouse_moved)
+        connect(self.delegate.redraw_required, self.redraw)
 
         # Stop triggering editor events on doubleclick, because we already use doubleclick to start downloads.
         # Editing should be started manually, from drop-down menu instead.
         self.setEditTriggers(QAbstractItemView.NoEditTriggers)
 
         # Mix-in connects
-        self.clicked.connect(self.on_table_item_clicked)
-        self.doubleClicked.connect(lambda item: self.on_table_item_clicked(item, doubleclick=True))
+        connect(self.clicked, self.on_table_item_clicked)
+        connect(self.doubleClicked, lambda item: self.on_table_item_clicked(item, doubleclick=True))
 
     def mouseMoveEvent(self, event):
         index = QModelIndex(self.indexAt(event.pos()))

--- a/src/tribler-gui/tribler_gui/widgets/loadingpage.py
+++ b/src/tribler-gui/tribler_gui/widgets/loadingpage.py
@@ -1,7 +1,7 @@
 from PyQt5.QtSvg import QGraphicsSvgItem, QSvgRenderer
 from PyQt5.QtWidgets import QGraphicsScene, QWidget
 
-from tribler_gui.utilities import get_image_path
+from tribler_gui.utilities import connect, get_image_path
 
 
 class LoadingPage(QWidget):
@@ -19,14 +19,14 @@ class LoadingPage(QWidget):
         svg_item = QGraphicsSvgItem()
 
         svg = QSvgRenderer(get_image_path("loading_animation.svg"))
-        svg.repaintNeeded.connect(svg_item.update)
+        connect(svg.repaintNeeded, svg_item.update)
         svg_item.setSharedRenderer(svg)
         svg_container.addItem(svg_item)
 
         self.window().loading_svg_view.setScene(svg_container)
-        self.window().core_manager.events_manager.upgrader_tick.connect(self.on_upgrader_tick)
-        self.window().core_manager.events_manager.upgrader_finished.connect(self.upgrader_finished)
-        self.window().core_manager.events_manager.change_loading_text.connect(self.change_loading_text)
+        connect(self.window().core_manager.events_manager.upgrader_tick, self.on_upgrader_tick)
+        connect(self.window().core_manager.events_manager.upgrader_finished, self.upgrader_finished)
+        connect(self.window().core_manager.events_manager.change_loading_text, self.change_loading_text)
         self.window().skip_conversion_btn.hide()
 
         # Hide the force shutdown button initially. Should be triggered by shutdown timer from main window.

--- a/src/tribler-gui/tribler_gui/widgets/settingspage.py
+++ b/src/tribler-gui/tribler_gui/widgets/settingspage.py
@@ -21,6 +21,7 @@ from tribler_gui.defs import (
 from tribler_gui.dialogs.confirmationdialog import ConfirmationDialog
 from tribler_gui.tribler_request_manager import TriblerNetworkRequest, TriblerRequestManager
 from tribler_gui.utilities import (
+    connect,
     get_checkbox_style,
     get_gui_setting,
     is_dir_writable,
@@ -41,18 +42,18 @@ class SettingsPage(QWidget):
 
     def initialize_settings_page(self):
         self.window().settings_tab.initialize()
-        self.window().settings_tab.clicked_tab_button.connect(self.clicked_tab_button)
-        self.window().settings_save_button.clicked.connect(self.save_settings)
+        connect(self.window().settings_tab.clicked_tab_button, self.clicked_tab_button)
+        connect(self.window().settings_save_button.clicked, self.save_settings)
 
-        self.window().download_location_chooser_button.clicked.connect(self.on_choose_download_dir_clicked)
-        self.window().watch_folder_chooser_button.clicked.connect(self.on_choose_watch_dir_clicked)
+        connect(self.window().download_location_chooser_button.clicked, self.on_choose_download_dir_clicked)
+        connect(self.window().watch_folder_chooser_button.clicked, self.on_choose_watch_dir_clicked)
 
-        self.window().channel_autocommit_checkbox.stateChanged.connect(self.on_channel_autocommit_checkbox_changed)
-        self.window().family_filter_checkbox.stateChanged.connect(self.on_family_filter_checkbox_changed)
-        self.window().developer_mode_enabled_checkbox.stateChanged.connect(self.on_developer_mode_checkbox_changed)
-        self.window().use_monochrome_icon_checkbox.stateChanged.connect(self.on_use_monochrome_icon_checkbox_changed)
-        self.window().download_settings_anon_checkbox.stateChanged.connect(self.on_anon_download_state_changed)
-        self.window().log_location_chooser_button.clicked.connect(self.on_choose_log_dir_clicked)
+        connect(self.window().channel_autocommit_checkbox.stateChanged, self.on_channel_autocommit_checkbox_changed)
+        connect(self.window().family_filter_checkbox.stateChanged, self.on_family_filter_checkbox_changed)
+        connect(self.window().developer_mode_enabled_checkbox.stateChanged, self.on_developer_mode_checkbox_changed)
+        connect(self.window().use_monochrome_icon_checkbox.stateChanged, self.on_use_monochrome_icon_checkbox_changed)
+        connect(self.window().download_settings_anon_checkbox.stateChanged, self.on_anon_download_state_changed)
+        connect(self.window().log_location_chooser_button.clicked, self.on_choose_log_dir_clicked)
 
         checkbox_style = get_checkbox_style()
         for checkbox in [
@@ -208,7 +209,7 @@ class SettingsPage(QWidget):
         # Anonymity settings
         self.window().allow_exit_node_checkbox.setChecked(settings['tunnel_community']['exitnode_enabled'])
         self.window().number_hops_slider.setValue(int(settings['download_defaults']['number_hops']))
-        self.window().number_hops_slider.valueChanged.connect(self.update_anonymity_cost_label)
+        connect(self.window().number_hops_slider.valueChanged, self.update_anonymity_cost_label)
         self.update_anonymity_cost_label(int(settings['download_defaults']['number_hops']))
 
         # Debug
@@ -222,7 +223,7 @@ class SettingsPage(QWidget):
             cpu_priority = int(settings['resource_monitor']['cpu_priority'])
         self.window().slider_cpu_level.setValue(cpu_priority)
         self.window().cpu_priority_value.setText("Current Priority = %s" % cpu_priority)
-        self.window().slider_cpu_level.valueChanged.connect(self.show_updated_cpu_priority)
+        connect(self.window().slider_cpu_level.valueChanged, self.show_updated_cpu_priority)
         self.window().checkbox_enable_network_statistics.setChecked(settings['ipv8']['statistics'])
 
     def update_anonymity_cost_label(self, value):
@@ -448,7 +449,7 @@ class SettingsPage(QWidget):
             "Your settings have been saved.",
             [('CLOSE', BUTTON_TYPE_NORMAL)],
         )
-        self.saved_dialog.button_clicked.connect(self.on_dialog_cancel_clicked)
+        connect(self.saved_dialog.button_clicked, self.on_dialog_cancel_clicked)
         self.saved_dialog.show()
         self.window().fetch_settings()
 

--- a/src/tribler-gui/tribler_gui/widgets/settingspage.py
+++ b/src/tribler-gui/tribler_gui/widgets/settingspage.py
@@ -98,7 +98,7 @@ class SettingsPage(QWidget):
             not self.window().download_settings_anon_checkbox.isChecked()
         )
 
-    def on_choose_download_dir_clicked(self):
+    def on_choose_download_dir_clicked(self, checked):
         previous_download_path = self.window().download_location_input.text() or ""
         download_dir = QFileDialog.getExistingDirectory(
             self.window(), "Please select the download location", previous_download_path, QFileDialog.ShowDirsOnly
@@ -109,7 +109,7 @@ class SettingsPage(QWidget):
 
         self.window().download_location_input.setText(download_dir)
 
-    def on_choose_watch_dir_clicked(self):
+    def on_choose_watch_dir_clicked(self, checked):
         if self.window().watchfolder_enabled_checkbox.isChecked():
             previous_watch_dir = self.window().watchfolder_location_input.text() or ""
             watch_dir = QFileDialog.getExistingDirectory(
@@ -121,7 +121,7 @@ class SettingsPage(QWidget):
 
             self.window().watchfolder_location_input.setText(watch_dir)
 
-    def on_choose_log_dir_clicked(self):
+    def on_choose_log_dir_clicked(self, checked):
         previous_log_dir = self.window().log_location_input.text() or ""
         log_dir = QFileDialog.getExistingDirectory(
             self.window(), "Please select the log directory", previous_log_dir, QFileDialog.ShowDirsOnly
@@ -275,7 +275,7 @@ class SettingsPage(QWidget):
 
         self.window().settings_stacked_widget.adjustSize()
 
-    def save_settings(self):
+    def save_settings(self, checked):
         # Create a dictionary with all available settings
         settings_data = {
             'general': {},

--- a/src/tribler-gui/tribler_gui/widgets/subscriptionswidget.py
+++ b/src/tribler-gui/tribler_gui/widgets/subscriptionswidget.py
@@ -2,7 +2,7 @@ from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QFont
 from PyQt5.QtWidgets import QLabel, QWidget
 
-from tribler_gui.utilities import format_votes_rich_text, get_votes_rating_description
+from tribler_gui.utilities import connect, format_votes_rich_text, get_votes_rating_description
 from tribler_gui.widgets.tablecontentdelegate import DARWIN, WINDOWS
 
 
@@ -28,9 +28,9 @@ class SubscriptionsWidget(QWidget):
             self.channel_rating_label = self.findChild(QLabel, "channel_rating_label")
             self.channel_rating_label.setTextFormat(Qt.RichText)
 
-            self.subscribe_button.clicked.connect(self.on_subscribe_button_click)
+            connect(self.subscribe_button.clicked, self.on_subscribe_button_click)
             self.subscribe_button.setToolTip('Click to subscribe/unsubscribe')
-            self.subscribe_button.toggled.connect(self._adjust_tooltip)
+            connect(self.subscribe_button.toggled, self._adjust_tooltip)
             self.initialized = True
 
     def _adjust_tooltip(self, toggled):

--- a/src/tribler-gui/tribler_gui/widgets/subscriptionswidget.py
+++ b/src/tribler-gui/tribler_gui/widgets/subscriptionswidget.py
@@ -71,7 +71,7 @@ class SubscriptionsWidget(QWidget):
 
         self.channel_rating_label.setToolTip(get_votes_rating_description(votes))
 
-    def on_subscribe_button_click(self):
+    def on_subscribe_button_click(self, checked):
         self.subscribe_button.setCheckedInstant(bool(self.contents_widget.model.channel_info["subscribed"]))
         channel_info = self.contents_widget.model.channel_info
         if channel_info["subscribed"]:

--- a/src/tribler-gui/tribler_gui/widgets/tabbuttonpanel.py
+++ b/src/tribler-gui/tribler_gui/widgets/tabbuttonpanel.py
@@ -1,6 +1,8 @@
 from PyQt5.QtCore import pyqtSignal
 from PyQt5.QtWidgets import QWidget
 
+from tribler_gui.utilities import connect
+
 
 class TabButtonPanel(QWidget):
     """
@@ -16,7 +18,7 @@ class TabButtonPanel(QWidget):
     def initialize(self):
         for button in self.findChildren(QWidget):
             self.buttons.append(button)
-            button.clicked_tab_button.connect(self.on_tab_button_click)
+            connect(button.clicked_tab_button, self.on_tab_button_click)
 
     def on_tab_button_click(self, clicked_button):
         self.deselect_all_buttons(except_select=clicked_button)

--- a/src/tribler-gui/tribler_gui/widgets/triblertablecontrollers.py
+++ b/src/tribler-gui/tribler_gui/widgets/triblertablecontrollers.py
@@ -17,7 +17,7 @@ from tribler_core.utilities.json_util import dumps
 from tribler_gui.defs import HEALTH_CHECKING, HEALTH_UNCHECKED
 from tribler_gui.tribler_action_menu import TriblerActionMenu
 from tribler_gui.tribler_request_manager import TriblerNetworkRequest
-from tribler_gui.utilities import get_health
+from tribler_gui.utilities import connect, get_health
 
 HEALTHCHECK_DELAY_MS = 500
 
@@ -45,16 +45,15 @@ class TriblerTableViewController(QObject):
 
         self.model = None
         self.table_view = table_view
-        self.table_view.verticalScrollBar().valueChanged.connect(self._on_list_scroll)
+        connect(self.table_view.verticalScrollBar().valueChanged, self._on_list_scroll)
 
         # FIXME: The M-V-C stuff is a complete mess. It should be refactored in a more structured way.
-        self.table_view.delegate.subscribe_control.clicked.connect(self.table_view.on_subscribe_control_clicked)
-        self.table_view.delegate.download_button.clicked.connect(self.table_view.start_download_from_index)
-        self.table_view.delegate.health_status_widget.clicked.connect(
-            lambda index: self.check_torrent_health(index.model().data_items[index.row()], forced=True)
-        )
-        self.table_view.torrent_clicked.connect(self.check_torrent_health)
-        self.table_view.torrent_doubleclicked.connect(self.table_view.start_download_from_dataitem)
+        connect(self.table_view.delegate.subscribe_control.clicked, self.table_view.on_subscribe_control_clicked)
+        connect(self.table_view.delegate.download_button.clicked, self.table_view.start_download_from_index)
+        connect(self.table_view.delegate.health_status_widget.clicked,
+                lambda index: self.check_torrent_health(index.model().data_items[index.row()], forced=True))
+        connect(self.table_view.torrent_clicked, self.check_torrent_health)
+        connect(self.table_view.torrent_doubleclicked, self.table_view.start_download_from_dataitem)
 
     def set_model(self, model):
         self.model = model
@@ -98,11 +97,11 @@ class TableSelectionMixin(object):
 
         # When the user stops scrolling and selection settles on a row,
         # trigger the health check.
-        self.healthcheck_cooldown.timeout.connect(lambda: self._on_selection_changed(None))
+        connect(self.healthcheck_cooldown.timeout, lambda: self._on_selection_changed(None))
 
     def set_model(self, model):
         super(TableSelectionMixin, self).set_model(model)
-        self.table_view.selectionModel().selectionChanged.connect(self._on_selection_changed)
+        connect(self.table_view.selectionModel().selectionChanged, self._on_selection_changed)
 
     def unset_model(self):
         if self.table_view.model:
@@ -199,7 +198,7 @@ class ContextMenuMixin:
     def enable_context_menu(self, widget):
         self.table_view = widget
         self.table_view.setContextMenuPolicy(Qt.CustomContextMenu)
-        self.table_view.customContextMenuRequested.connect(self._show_context_menu)
+        connect(self.table_view.customContextMenuRequested, self._show_context_menu)
 
     def _trigger_name_editor(self, index):
         model = index.model()
@@ -282,7 +281,7 @@ class ContextMenuMixin:
 
     def add_menu_item(self, menu, name, item_index, callback):
         action = QAction(name, self.table_view)
-        action.triggered.connect(lambda _: callback(item_index))
+        connect(action.triggered, lambda _: callback(item_index))
         menu.addAction(action)
 
     def selection_can_be_added_to_channel(self):
@@ -298,7 +297,7 @@ class ContentTableViewController(TableSelectionMixin, ContextMenuMixin, HealthCh
         super().__init__(*args, **kwargs)
         self.filter_input = filter_input
         if self.filter_input:
-            self.filter_input.textChanged.connect(self._on_filter_input_change)
+            connect(self.filter_input.textChanged, self._on_filter_input_change)
 
     def unset_model(self):
         self.model = None

--- a/src/tribler-gui/tribler_gui/widgets/triblertablecontrollers.py
+++ b/src/tribler-gui/tribler_gui/widgets/triblertablecontrollers.py
@@ -97,7 +97,7 @@ class TableSelectionMixin(object):
 
         # When the user stops scrolling and selection settles on a row,
         # trigger the health check.
-        connect(self.healthcheck_cooldown.timeout, lambda: self._on_selection_changed(None))
+        connect(self.healthcheck_cooldown.timeout, lambda: self._on_selection_changed(None, None))
 
     def set_model(self, model):
         super(TableSelectionMixin, self).set_model(model)
@@ -108,7 +108,7 @@ class TableSelectionMixin(object):
             self.table_view.selectionModel().selectionChanged.disconnect()
         super(TableSelectionMixin, self).unset_model()
 
-    def _on_selection_changed(self, _):
+    def _on_selection_changed(self, selected, deselected):
         selected_indices = self.table_view.selectedIndexes()
         if not selected_indices:
             self.table_view.clearSelection()

--- a/src/tribler-gui/tribler_gui/widgets/trustgraphpage.py
+++ b/src/tribler-gui/tribler_gui/widgets/trustgraphpage.py
@@ -174,7 +174,7 @@ class TrustGraphPage(QWidget):
         self.graph_view.setXRange(-1, 1)
         self.graph_view.setYRange(-1, 1)
 
-    def fetch_graph_data(self):
+    def fetch_graph_data(self, checked=False):
         if self.rest_request:
             self.rest_request.cancel_request()
         self.rest_request = TriblerNetworkRequest("trustview", self.on_received_data,

--- a/src/tribler-gui/tribler_gui/widgets/trustgraphpage.py
+++ b/src/tribler-gui/tribler_gui/widgets/trustgraphpage.py
@@ -20,7 +20,7 @@ from tribler_gui.defs import (
     TRUST_GRAPH_PEER_LEGENDS,
 )
 from tribler_gui.tribler_request_manager import TriblerNetworkRequest
-from tribler_gui.utilities import format_size, html_label
+from tribler_gui.utilities import connect, format_size, html_label
 
 
 class TrustGraph(pg.GraphItem):
@@ -33,7 +33,7 @@ class TrustGraph(pg.GraphItem):
         self.dragOffset = None
 
     def set_node_selection_listener(self, listener):
-        self.scatter.sigClicked.connect(listener)
+        connect(self.scatter.sigClicked, listener)
 
     def setData(self, **data):
         self.data = data
@@ -118,7 +118,7 @@ class TrustGraphPage(QWidget):
         self.graph_view.addItem(pg.TextItem(text='YOU'))
         self.window().trust_graph_plot_widget.layout().addWidget(graph_layout)
 
-        self.window().tr_control_refresh_btn.clicked.connect(self.fetch_graph_data)
+        connect(self.window().tr_control_refresh_btn.clicked, self.fetch_graph_data)
 
         self.window().tr_selected_node_pub_key.setHidden(True)
         self.window().tr_selected_node_stats.setHidden(True)

--- a/src/tribler-gui/tribler_gui/widgets/trustpage.py
+++ b/src/tribler-gui/tribler_gui/widgets/trustpage.py
@@ -5,6 +5,7 @@ from PyQt5.QtWidgets import QWidget
 from tribler_gui.defs import GB, TB
 from tribler_gui.dialogs.trustexplanationdialog import TrustExplanationDialog
 from tribler_gui.tribler_request_manager import TriblerNetworkRequest
+from tribler_gui.utilities import connect
 from tribler_gui.widgets.graphs.timeseriesplot import TimeSeriesPlot
 
 
@@ -36,7 +37,7 @@ class TrustPage(QWidget):
             self.trust_plot = TrustSeriesPlot(self.window().plot_widget)
             vlayout.addWidget(self.trust_plot)
 
-        self.window().trust_explain_button.clicked.connect(self.on_info_button_clicked)
+        connect(self.window().trust_explain_button.clicked, self.on_info_button_clicked)
 
     def on_info_button_clicked(self):
         self.dialog = TrustExplanationDialog(self.window())

--- a/src/tribler-gui/tribler_gui/widgets/trustpage.py
+++ b/src/tribler-gui/tribler_gui/widgets/trustpage.py
@@ -39,7 +39,7 @@ class TrustPage(QWidget):
 
         connect(self.window().trust_explain_button.clicked, self.on_info_button_clicked)
 
-    def on_info_button_clicked(self):
+    def on_info_button_clicked(self, checked):
         self.dialog = TrustExplanationDialog(self.window())
         self.dialog.show()
 


### PR DESCRIPTION
Fixes #5818 

This PR contains two commits.

Commit 1:
 - Adds wrapper `connect(signal, callback)`, replacing existing `signal.connect(callback)` calls.
 - Adds wrapper `disconnect(signal, callback)`, replacing existing `signal.disconnect(callback)` calls.

Commit 2:
 - For each signal callback, refactor the function such that it matches the C++ function signature.

The magic is defined in `src/tribler-gui/tribler_gui/utilities.py`, the rest of this PR consists of plain refactoring.

### Noteworthy changes to functionality

If any callback does not match the C++ signature **exactly**, Tribler will now crash. In particular the following is now no longer allowed:

```python
connect(signal, lambda _: None)
signal.emit("a", "b")  # Crash! Too many arguments for ``lambda _`` (this was allowed before)
```

### Examples

Tracebacks will now show the full traceback for both the creation stack and the actual error. This first example shows the new traceback for the single-line traceback we recently fixed:

```python
[PID:6284] 2020-12-09 13:42:57,652 - ERROR <tribler_window:124> root.on_exception(): Traceback (most recent call last):
  File "/home/quinten/Documents/tribler/src/run_tribler.py", line 154, in <module>
    sys.exit(app.exec_())
  File "/home/quinten/Documents/tribler/src/tribler-gui/tribler_gui/utilities.py", line 382, in trackback_wrapper
    callback(*args, **kwargs)
  File "/home/quinten/Documents/tribler/src/tribler-gui/tribler_gui/widgets/downloadspage.py", line 538, in on_right_click_item
    menu.exec_(self.window().downloads_list.mapToGlobal(pos))
  File "/home/quinten/Documents/tribler/src/tribler-gui/tribler_gui/utilities.py", line 382, in trackback_wrapper
    callback(*args, **kwargs)
  File "/home/quinten/Documents/tribler/src/tribler-gui/tribler_gui/widgets/downloadspage.py", line 392, in on_move_files
    TriblerNetworkRequest(
  File "/home/quinten/Documents/tribler/src/tribler-gui/tribler_gui/tribler_request_manager.py", line 176, in __init__
    connect(self.received_json, self.reply_callback)
tribler_gui.utilities.CreationTraceback

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/quinten/Documents/tribler/src/tribler-gui/tribler_gui/utilities.py", line 385, in trackback_wrapper
    raise exc from source_exc
  File "/home/quinten/Documents/tribler/src/tribler-gui/tribler_gui/utilities.py", line 382, in trackback_wrapper
    callback(*args, **kwargs)
TypeError: <lambda>() missing 1 required positional argument: '_'
```

This second example shows an error I ran into with an improper disconnection. Now the second half of the error becomes more useful (also, don't worry I fixed this already).

```python
[PID:6088] 2020-12-09 13:37:05,487 - ERROR <tribler_window:124> root.on_exception(): Traceback (most recent call last):
  File "/home/quinten/Documents/tribler/src/run_tribler.py", line 150, in <module>
    window = TriblerWindow()
  File "/home/quinten/Documents/tribler/src/tribler-gui/tribler_gui/tribler_window.py", line 231, in __init__
    self.discovered_page.initialize_content_page(hide_xxx=hide_xxx)
  File "/home/quinten/Documents/tribler/src/tribler-gui/tribler_gui/widgets/channelcontentswidget.py", line 119, in initialize_content_page
    connect(self.channel_back_button.clicked, self.go_back)
tribler_gui.utilities.CreationTraceback

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/quinten/Documents/tribler/src/tribler-gui/tribler_gui/utilities.py", line 385, in trackback_wrapper
    raise exc from source_exc
  File "/home/quinten/Documents/tribler/src/tribler-gui/tribler_gui/utilities.py", line 382, in trackback_wrapper
    callback(*args, **kwargs)
  File "/home/quinten/Documents/tribler/src/tribler-gui/tribler_gui/widgets/channelcontentswidget.py", line 247, in go_back
    self.disconnect_current_model()
  File "/home/quinten/Documents/tribler/src/tribler-gui/tribler_gui/widgets/channelcontentswidget.py", line 240, in disconnect_current_model
    disconnect(self.window().core_manager.events_manager.node_info_updated, self.model.update_node_info)
  File "/home/quinten/Documents/tribler/src/tribler-gui/tribler_gui/utilities.py", line 414, in disconnect
    signal.disconnect(disconnectable)
TypeError: 'function' object is not connected
```

### Gritty details

`signal.disconnect(f)` requires the exact handle to the function `f` that was registered. Instead of forcing programmers to handle these wrappers explicitly, this PR attaches the actual wrapper to (preferred) `tb_wrapper` on `f` or (not preferred) `tb_mapping` on `f.__self__` if the former is not possible.
