### PR TITLE
Add try-except block to dependency message box

### DIFF
--- a/src/tribler-core/tribler_core/dependencies.py
+++ b/src/tribler-core/tribler_core/dependencies.py
@@ -41,20 +41,28 @@ def _show_system_popup(title, text):
     :param text: the pop-up body
     """
     sep = "*" * 80
-    print('\n'.join([sep, title, sep, text, sep]), file=sys.stderr)
+
+    # pylint: disable=import-outside-toplevel, import-error, broad-except
+    print('\n'.join([sep, title, sep, text, sep]), file=sys.stderr)  # noqa: T001
 
     system = platform.system()
-    if system == 'Windows':
-        import win32api
-        win32api.MessageBox(0, text, title)
-    elif system == 'Linux':
-        import subprocess
-        subprocess.Popen(['xmessage', '-center', text])
-    elif system == 'Darwin':
-        import subprocess
-        subprocess.Popen(['/usr/bin/osascript', '-e', text])
-    else:
-        print(f'cannot create native pop-up for system {system}')
+    try:
+        if system == 'Windows':
+            import win32api
+            win32api.MessageBox(0, text, title)
+        elif system == 'Linux':
+            import subprocess
+            subprocess.Popen(['xmessage', '-center', text])
+        elif system == 'Darwin':
+            import subprocess
+            subprocess.Popen(['/usr/bin/osascript', '-e', text])
+        else:
+            print(f'cannot create native pop-up for system {system}')  # noqa: T001
+    except Exception as exception:
+        # Use base Exception, because code above can raise many
+        # non-obvious types of exceptions:
+        # (SubprocessError, ImportError, win32api.error, FileNotFoundError)
+        print(f'Error while showing a message box: {exception}')  # noqa: T001
 
 
 def check_for_missing_dependencies(scope='both'):


### PR DESCRIPTION
Fixes #5832 by adding try-except block.

Fix uses broad exception handling as a savest way to catch all exceptions. 
It can't cause any harm in an unobvious way, to further Tribler's execution, because, at the step, when the dependency message box is shown, Tribler stops his work.