### PR TITLE
Add to makedirs the argument `exist_ok=True`

### DIFF
--- a/src/tribler-core/tribler_core/config/tribler_config.py
+++ b/src/tribler-core/tribler_core/config/tribler_config.py
@@ -88,9 +88,10 @@ class TriblerConfig(object):
         """
         Write the configuration to the config file in the state dir as specified in the config.
         """
-        if not self.get_state_dir().exists():
-            os.makedirs(self.get_state_dir())
-        self.config.filename = self.get_state_dir() / CONFIG_FILENAME
+        state_dir = self.get_state_dir()
+        if not state_dir.exists():
+            os.makedirs(state_dir, exist_ok=True)
+        self.config.filename = state_dir / CONFIG_FILENAME
         self.config.write()
 
     def _obtain_port(self, section, option):


### PR DESCRIPTION
This PR fixes #5831 by adding the argument `exist_ok=True` to  `os.makedirs` call.

It is not obvious how this code could produce "FileExistsError":

```python
 if not self.get_state_dir().exists():
            os.makedirs(self.get_state_dir())
```

But adding `exist_ok=True` solves the issue and looks safe.