### PR TITLE
Add release for Sentry

### DIFF
--- a/src/run_tribler.py
+++ b/src/run_tribler.py
@@ -89,7 +89,7 @@ def start_tribler_core(base_path, api_port, api_key, root_state_dir, core_test_m
 
 
 if __name__ == "__main__":
-    SentryReporter.init(sentry_url=sentry_url, scrubber=SentryScrubber(),
+    SentryReporter.init(sentry_url=sentry_url, release_version=version_id, scrubber=SentryScrubber(),
                         strategy=SentryReporter.Strategy.SEND_ALLOWED_WITH_CONFIRMATION)
     # Get root state directory (e.g. from environment variable or from system default)
     root_state_dir = get_root_state_directory()

--- a/src/tribler-common/tribler_common/sentry_reporter/sentry_reporter.py
+++ b/src/tribler-common/tribler_common/sentry_reporter/sentry_reporter.py
@@ -32,6 +32,7 @@ BREADCRUMBS = 'breadcrumbs'
 LOGENTRY = 'logentry'
 REPORTER = 'reporter'
 VALUES = 'values'
+RELEASE = 'release'
 
 
 class SentryReporter:
@@ -66,7 +67,7 @@ class SentryReporter:
     _logger = logging.getLogger(_sentry_logger_name)
 
     @staticmethod
-    def init(sentry_url='', scrubber=None, strategy=Strategy.SEND_ALLOWED_WITH_CONFIRMATION):
+    def init(sentry_url='', release_version='', scrubber=None, strategy=Strategy.SEND_ALLOWED_WITH_CONFIRMATION):
         """Initialization.
 
         This method should be called in each process that uses SentryReporter.
@@ -81,6 +82,10 @@ class SentryReporter:
                     def scrub_event(self, event):
                         pass
                 ```
+            release_version: string that represents a release version.
+                See Also: https://docs.sentry.io/platforms/python/configuration/releases/
+            strategy: a Sentry strategy for sending events (see class Strategy
+                for more information)
         Returns:
             Sentry Guard.
         """
@@ -90,7 +95,7 @@ class SentryReporter:
 
         rv = sentry_sdk.init(
             sentry_url,
-            release=None,
+            release=release_version,
             # https://docs.sentry.io/platforms/python/configuration/integrations/
             integrations=[
                 LoggingIntegration(
@@ -113,7 +118,7 @@ class SentryReporter:
 
     @staticmethod
     def add_breadcrumb(message='', category='', level='info', **kwargs):
-        """ Adds a breadcrumb for current Sentry client.
+        """Adds a breadcrumb for current Sentry client.
 
         It is necessary to specify a message, a category and a level to make this
         breadcrumb visible in Sentry server.

--- a/src/tribler-common/tribler_common/sentry_reporter/sentry_scrubber.py
+++ b/src/tribler-common/tribler_common/sentry_reporter/sentry_scrubber.py
@@ -6,12 +6,13 @@ from tribler_common.sentry_reporter.sentry_reporter import (
     EXTRA,
     LOGENTRY,
     OS_ENVIRON,
+    RELEASE,
     REPORTER,
     STACKTRACE,
     SYSINFO,
     VALUES,
 )
-from tribler_common.sentry_reporter.sentry_tools import delete_item, distinct_by, modify_value
+from tribler_common.sentry_reporter.sentry_tools import delete_item, distinct_by, modify_value, skip_dev_version
 
 
 class SentryScrubber:
@@ -79,6 +80,9 @@ class SentryScrubber:
             return modify_value(breadcrumbs, VALUES, lambda values: distinct_by(values, 'timestamp'))
 
         modify_value(event, BREADCRUMBS, _remove_duplicates_from_breadcrumbs)
+
+        # skip dev version
+        modify_value(event, RELEASE, skip_dev_version)
 
         # remove sensitive information
         modify_value(event, EXTRA, self.scrub_entity_recursively)

--- a/src/tribler-common/tribler_common/sentry_reporter/sentry_tools.py
+++ b/src/tribler-common/tribler_common/sentry_reporter/sentry_tools.py
@@ -4,7 +4,7 @@ simplify work with several data structures.
 
 
 def parse_os_environ(array):
-    """ Parse os.environ field.
+    """Parse os.environ field.
 
     Args:
         array: strings that represents tuples delimited by `:`
@@ -30,7 +30,7 @@ def parse_os_environ(array):
 
 
 def parse_stacktrace(stacktrace):
-    """ Parse stacktrace field.
+    """Parse stacktrace field.
 
     Args:
         stacktrace: a string with '\n' delimiter.
@@ -78,7 +78,7 @@ def modify_value(d, key, function):
 
 
 def distinct_by(list_of_dict, key):
-    """ This function removes all duplicates from a list of dictionaries. A duplicate
+    """This function removes all duplicates from a list of dictionaries. A duplicate
     here is a dictionary that have the same value of the given key.
 
     If no key field is presented in the item, then the item will not be considered
@@ -110,3 +110,23 @@ def distinct_by(list_of_dict, key):
         values_viewed.add(value)
 
     return result
+
+
+def skip_dev_version(version):
+    """
+    For the release version let's ignore all "developers" versions
+    to keep the meaning of the `latest` keyword:
+    See Also:https://docs.sentry.io/product/sentry-basics/search/
+    Args:
+        version: version string
+
+    Returns: version if it is not a dev version, and Null otherwise
+
+    """
+    if not version:
+        return version
+
+    if 'GIT' in version:
+        return None
+
+    return version

--- a/src/tribler-common/tribler_common/sentry_reporter/tests/test_sentry_reporter.py
+++ b/src/tribler-common/tribler_common/sentry_reporter/tests/test_sentry_reporter.py
@@ -100,7 +100,7 @@ def test_send(reporter):
 
 def test_before_send(reporter):
     scrubber = SentryScrubber()
-    reporter.init('', scrubber)
+    reporter.init('', scrubber=scrubber)
 
     # pylint: disable=protected-access
     SentryReporter.last_event = None
@@ -128,6 +128,10 @@ def test_before_send(reporter):
     assert reporter._before_send({'contexts': {'reporter': {'_stacktrace': ['/Users/username/']}}}, None) == {
         'contexts': {'reporter': {'_stacktrace': [f'/Users/{scrubber.placeholder_user}/']}}
     }
+
+    # check release
+    assert reporter._before_send({'release': '7.6.0'}, None) == {'release': '7.6.0'}
+    assert reporter._before_send({'release': '7.6.0-GIT'}, None) == {'release': None}
 
     # check confirmation
     reporter.strategy.set(SentryReporter.Strategy.SEND_ALLOWED_WITH_CONFIRMATION)

--- a/src/tribler-common/tribler_common/sentry_reporter/tests/test_sentry_tools.py
+++ b/src/tribler-common/tribler_common/sentry_reporter/tests/test_sentry_tools.py
@@ -7,6 +7,7 @@ from tribler_common.sentry_reporter.sentry_tools import (
     modify_value,
     parse_os_environ,
     parse_stacktrace,
+    skip_dev_version,
 )
 
 
@@ -92,8 +93,18 @@ def test_safe_get():
 def test_distinct():
     assert distinct_by(None, None) is None
     assert distinct_by([], None) == []
-    assert distinct_by([{'key': 'b'}, {'key': 'b'}, {'key': 'c'}, {'': ''}], 'key') == \
-           [{'key': 'b'}, {'key': 'c'}, {'': ''}]
+    assert distinct_by([{'key': 'b'}, {'key': 'b'}, {'key': 'c'}, {'': ''}], 'key') == [
+        {'key': 'b'},
+        {'key': 'c'},
+        {'': ''},
+    ]
 
     # test nested
     assert distinct_by([{'a': {}}], 'b') == [{'a': {}}]
+
+
+def test_skip_dev_version():
+    assert skip_dev_version(None) is None
+    assert skip_dev_version('') == ''
+    assert skip_dev_version('7.6.0') == '7.6.0'
+    assert skip_dev_version('7.6.0-GIT') is None


### PR DESCRIPTION
This PR enables [the Sentry release](https://docs.sentry.io/product/releases/) feature for Tribler.

All versions that contain 'GIT' will be recognized as 'dev-versions' and skipped by Sentry.