### PR TITLE
Rollback to "Tribler starts on events start received" logic

### DIFF
--- a/src/tribler-gui/tribler_gui/event_request_manager.py
+++ b/src/tribler-gui/tribler_gui/event_request_manager.py
@@ -28,7 +28,7 @@ class EventRequestManager(QNetworkAccessManager):
 
     node_info_updated = pyqtSignal(object)
     received_remote_query_results = pyqtSignal(object)
-    tribler_started = pyqtSignal(object, str)  # arguments are version and public_key
+    tribler_started = pyqtSignal(object)
     upgrader_tick = pyqtSignal(str)
     upgrader_finished = pyqtSignal()
     new_version_available = pyqtSignal(str)
@@ -59,12 +59,22 @@ class EventRequestManager(QNetworkAccessManager):
             NTFY.LOW_SPACE.value: self.low_storage_signal.emit,
             NTFY.REMOTE_QUERY_RESULTS.value: self.received_remote_query_results.emit,
             NTFY.TRIBLER_SHUTDOWN_STATE.value: self.tribler_shutdown_signal.emit,
-            NTFY.EVENTS_START.value: lambda _: None,
+            NTFY.EVENTS_START.value: self.events_start_received,
             NTFY.TRIBLER_STARTED.value: self.tribler_started_event,
         }
 
+    def events_start_received(self, event_dict):
+        if event_dict["tribler_started"]:
+            self.tribler_started.emit(event_dict["version"])
+
     def tribler_started_event(self, event_dict):
-        self.tribler_started.emit(event_dict["version"], event_dict["public_key"])
+        # if public key format will be changed, don't forget to change it
+        # at the core side as well
+        public_key = event_dict["public_key"]
+        if public_key:
+            SentryReporter.set_user(public_key.encode('utf-8'))
+
+        self.tribler_started.emit(event_dict["version"])
 
     def on_error(self, error, reschedule_on_err):
         self._logger.info("Got Tribler core error: %s" % error)

--- a/src/tribler-gui/tribler_gui/tribler_window.py
+++ b/src/tribler-gui/tribler_gui/tribler_window.py
@@ -443,15 +443,10 @@ class TriblerWindow(QMainWindow):
             except RuntimeError as e:
                 logging.error("Failed to set tray message: %s", str(e))
 
-    def on_tribler_started(self, version, public_key):
+    def on_tribler_started(self, version):
         if self.tribler_started:
             logging.warning("Received duplicate Tribler Core started event")
             return
-
-        if public_key:
-            # if public key format will be changed, don't forget to change it
-            # at the core side as well
-            SentryReporter.set_user(public_key.encode('utf-8'))
 
         self.tribler_started = True
         self.tribler_version = version


### PR DESCRIPTION
This PR fixes #5845 by rolling back to the old version "Tribler starts on event mechanism".

I don't like this version, because it looks like a tricky way to solve some unknown problem.
Probably we can spend some time on "unwinding the clew of Tribler's starting logic" in the future.
