### PR TITLE
Use mds instead of metadata_store

### DIFF
--- a/experiment/popularity_community/initial_filling.py
+++ b/experiment/popularity_community/initial_filling.py
@@ -1,3 +1,4 @@
+# flake8: noqa
 import argparse
 import asyncio
 import csv
@@ -54,8 +55,8 @@ class ObservablePopularityCommunity(PopularityCommunity):
 
     @db_session
     def get_torrents_info_tuple(self):
-        return count(ts for ts in self.metadata_store.TorrentState), \
-               count(ts for ts in self.metadata_store.TorrentState if ts.seeders > 0)
+        return count(ts for ts in self.mds.TorrentState), \
+               count(ts for ts in self.mds.TorrentState if ts.seeders > 0)
 
     def check(self):
         time_since_start = time.time() - self._start_time


### PR DESCRIPTION
This PR fixes #5849

This is the change that broke initial filling velocity experiment:
https://github.com/Tribler/tribler/pull/5736/files#diff-3b8a863c5e5d3d8d32101a33bbc9606b6c237d8eb9af4fc16e9d5b9d96d46fd6L33