### PR TITLE
Convert PyQt5 to local import in tribler common

### DIFF
--- a/src/tribler-common/tribler_common/sentry_reporter/sentry_reporter.py
+++ b/src/tribler-common/tribler_common/sentry_reporter/sentry_reporter.py
@@ -212,7 +212,11 @@ class SentryReporter:
         """
         # Prevent importing PyQt globally in tribler-common module.
         # pylint: disable=import-outside-toplevel
-        from PyQt5.QtWidgets import QApplication, QMessageBox
+        try:
+            from PyQt5.QtWidgets import QApplication, QMessageBox
+        except ImportError:
+            SentryReporter._logger.debug("PyQt5 is not available. User confirmation is not possible.")
+            return False
 
         SentryReporter._logger.debug(f"Get confirmation: {exception}")
 

--- a/src/tribler-common/tribler_common/sentry_reporter/sentry_reporter.py
+++ b/src/tribler-common/tribler_common/sentry_reporter/sentry_reporter.py
@@ -4,8 +4,6 @@ from contextvars import ContextVar
 from enum import Enum, auto
 from hashlib import md5
 
-from PyQt5.QtWidgets import QApplication, QMessageBox
-
 from faker import Faker
 
 import sentry_sdk
@@ -212,6 +210,10 @@ class SentryReporter:
         Args:
             exception: exception to be sent.
         """
+        # Prevent importing PyQt globally in tribler-common module.
+        # pylint: disable=import-outside-toplevel
+        from PyQt5.QtWidgets import QApplication, QMessageBox
+
         SentryReporter._logger.debug(f"Get confirmation: {exception}")
 
         _ = QApplication(sys.argv)


### PR DESCRIPTION
Tribler common is required by the core where it is best not to include PyQt dependency. I had an issue finding & resolving all required dependencies of PyQt5 while running in headless mode.