### PR TITLE
Add popular torrents in torrent checker periodic loop

### DIFF
--- a/src/tribler-core/tribler_core/modules/torrent_checker/torrent_checker.py
+++ b/src/tribler-core/tribler_core/modules/torrent_checker/torrent_checker.py
@@ -168,11 +168,11 @@ class TorrentChecker(TaskManager):
         2. Old torrents (50%)
         By old torrents, we refer to those checked quite farther in the past, sorted by the last_check value.
         """
-        four_hours_ago = time.time() - HEALTH_FRESHNESS_SECONDS
-        popular_torrents = list(self.tribler_session.mds.TorrentState.select(lambda g: g.last_check < four_hours_ago).
+        last_fresh_time = time.time() - HEALTH_FRESHNESS_SECONDS
+        popular_torrents = list(self.tribler_session.mds.TorrentState.select(lambda g: g.last_check < last_fresh_time).
                                 order_by(lambda g: (desc(g.seeders), g.last_check)).limit(TORRENT_SELECTION_POOL_SIZE))
 
-        old_torrents = list(self.tribler_session.mds.TorrentState.select(lambda g: g.last_check < four_hours_ago).
+        old_torrents = list(self.tribler_session.mds.TorrentState.select(lambda g: g.last_check < last_fresh_time).
                             order_by(lambda g: (g.last_check, desc(g.seeders))).limit(TORRENT_SELECTION_POOL_SIZE))
 
         selected_torrents = popular_torrents + old_torrents

--- a/src/tribler-core/tribler_core/modules/torrent_checker/torrent_checker.py
+++ b/src/tribler-core/tribler_core/modules/torrent_checker/torrent_checker.py
@@ -8,7 +8,7 @@ from asyncio import CancelledError, gather
 from ipv8.database import database_blob
 from ipv8.taskmanager import TaskManager, task
 
-from pony.orm import db_session, select, desc
+from pony.orm import db_session, desc, select
 
 from tribler_common.simpledefs import NTFY
 


### PR DESCRIPTION
To improve the sharing of the popular torrents via popularity community, this PR adds local popular torrents in the list to be checked periodically and be eventually shared via the community. 

Note, no changes in the popularity community is needed (yet) to include popular torrents for sharing. It is because the community only makes use of `torrents_checked` set which is updated when torrent health check is processed.

This will follow another PR to store the information about who did the torrent check so the recent torrent checks data can be reused to populate the popularity community message.