### PR TITLE
Fixed bug in relay payouts

### DIFF
--- a/src/tribler-core/tribler_core/modules/tunnel/community/triblertunnel_community.py
+++ b/src/tribler-core/tribler_core/modules/tunnel/community/triblertunnel_community.py
@@ -354,7 +354,7 @@ class TriblerTunnelCommunity(HiddenTunnelCommunity):
         if payload.circuit_id in self.relay_from_to and tx.amount > payload.base_amount:
             relay = self.relay_from_to[payload.circuit_id]
             self._logger.info("Sending next payout to peer %s", relay.peer)
-            self.do_payout(relay.peer, relay.circuit_id, tx.amount - payload.base_amount * 2, payload.base_amount)
+            self.do_payout(relay.peer, relay.circuit_id, payload.base_amount * 2, payload.base_amount)
 
     def clean_from_slots(self, circuit_id):
         """


### PR DESCRIPTION
When a relay initiates a payout to the next hop in the circuit, the values were computed incorrectly. This PR fixes the behaviour and extends the payout tests to capture such bugs.

At this point, the damage is already done but we should at least fix it to reduce the impact of this bug.

Fixes #5789