### PR TITLE
Fix trust graph node click and max node issue

### DIFF
--- a/src/tribler-core/tribler_core/modules/trust_calculation/trust_graph.py
+++ b/src/tribler-core/tribler_core/modules/trust_calculation/trust_graph.py
@@ -1,7 +1,6 @@
 import hashlib
+import logging
 import math
-
-from ipv8.taskmanager import TaskManager
 
 import networkx as nx
 
@@ -14,11 +13,11 @@ MAX_TRANSACTIONS = 2500
 ROOT_NODE_ID = 0
 
 
-class TrustGraph(nx.DiGraph, TaskManager):
+class TrustGraph(nx.DiGraph):
 
     def __init__(self, root_key, bandwidth_db, max_nodes=MAX_NODES, max_transactions=MAX_TRANSACTIONS):
         nx.DiGraph.__init__(self)
-        TaskManager.__init__(self)
+        self._logger = logging.getLogger(self.__class__.__name__)
 
         self.root_key = root_key
         self.bandwidth_db = bandwidth_db
@@ -70,14 +69,18 @@ class TrustGraph(nx.DiGraph, TaskManager):
 
     def compose_graph_data(self):
         layer_1 = self.bandwidth_db.get_latest_transactions(self.root_key)
-        for tx in layer_1:
-            self.add_bandwidth_transaction(tx)
+        try:
+            for tx in layer_1:
+                self.add_bandwidth_transaction(tx)
 
-            # Stop at layer 2
-            counter_party = tx.public_key_a if self.root_key != tx.public_key_a else tx.public_key_b
-            layer_2 = self.bandwidth_db.get_latest_transactions(counter_party)
-            for tx2 in layer_2:
-                self.add_bandwidth_transaction(tx2)
+                # Stop at layer 2
+                counter_party = tx.public_key_a if self.root_key != tx.public_key_a else tx.public_key_b
+                layer_2 = self.bandwidth_db.get_latest_transactions(counter_party)
+                for tx2 in layer_2:
+                    self.add_bandwidth_transaction(tx2)
+
+        except TrustGraphException as ex:
+            self._logger.info(ex)
 
     def compute_edge_id(self, transaction):
         sha2 = hashlib.sha3_224()  # any safe hashing should do
@@ -89,14 +92,16 @@ class TrustGraph(nx.DiGraph, TaskManager):
         # First, compose a unique edge id for the transaction and check if it is already added.
         edge_id = self.compute_edge_id(tx)
 
+        if len(self.edge_set) >= self.max_transactions:
+            raise TrustGraphException("Max transactions reached in the graph")
+
         if edge_id not in self.edge_set:
             peer1 = self.get_or_create_node(tx.public_key_a, add_if_not_exist=True)
             peer2 = self.get_or_create_node(tx.public_key_b, add_if_not_exist=True)
 
-            if peer2['id'] not in self.successors(peer1['id']):
+            if peer1 and peer2 and peer2['id'] not in self.successors(peer1['id']):
                 self.add_edge(peer1['id'], peer2['id'])
-
-            self.edge_set.add(edge_id)
+                self.edge_set.add(edge_id)
 
     def compute_node_graph(self):
         undirected_graph = self.to_undirected()

--- a/src/tribler-core/tribler_core/modules/trust_calculation/trust_graph.py
+++ b/src/tribler-core/tribler_core/modules/trust_calculation/trust_graph.py
@@ -37,9 +37,11 @@ class TrustGraph(nx.DiGraph):
 
         self.get_or_create_node(root_key)
 
-    def set_limits(self, max_peers, max_transactions):
-        self.max_nodes = max_peers
-        self.max_transactions = max_transactions
+    def set_limits(self, max_nodes=None, max_transactions=None):
+        if max_nodes:
+            self.max_nodes = max_nodes
+        if max_transactions:
+            self.max_transactions = max_transactions
 
     def get_or_create_node(self, peer_key, add_if_not_exist=True):
         if peer_key in self.node_public_keys:

--- a/src/tribler-core/tribler_core/modules/trust_calculation/trust_graph.py
+++ b/src/tribler-core/tribler_core/modules/trust_calculation/trust_graph.py
@@ -50,7 +50,7 @@ class TrustGraph(nx.DiGraph):
             return None
 
         if self.number_of_nodes() >= self.max_nodes:
-            raise TrustGraphException("Max node peers reached in graph")
+            raise TrustGraphException(f"Max node peers ({self.max_nodes}) reached in the graph")
 
         # Node does not exist in the graph so a new node at this point.
         # The numeric node id is used here so the id for the new node becomes
@@ -79,8 +79,8 @@ class TrustGraph(nx.DiGraph):
                 for tx2 in layer_2:
                     self.add_bandwidth_transaction(tx2)
 
-        except TrustGraphException as ex:
-            self._logger.info(ex)
+        except TrustGraphException as tge:
+            self._logger.warning("Error composing Trust graph: %s", tge)
 
     def compute_edge_id(self, transaction):
         sha2 = hashlib.sha3_224()  # any safe hashing should do
@@ -93,7 +93,7 @@ class TrustGraph(nx.DiGraph):
         edge_id = self.compute_edge_id(tx)
 
         if len(self.edge_set) >= self.max_transactions:
-            raise TrustGraphException("Max transactions reached in the graph")
+            raise TrustGraphException(f"Max transactions ({self.max_transactions}) reached in the graph")
 
         if edge_id not in self.edge_set:
             peer1 = self.get_or_create_node(tx.public_key_a, add_if_not_exist=True)

--- a/src/tribler-core/tribler_core/restapi/trustview_endpoint.py
+++ b/src/tribler-core/tribler_core/restapi/trustview_endpoint.py
@@ -71,6 +71,10 @@ class TrustViewEndpoint(RESTEndpoint):
             self.initialize_graph()
             self.trust_graph.compose_graph_data()
 
+        refresh_graph = int(request.query.get('refresh', '0'))
+        if refresh_graph:
+            self.trust_graph.compose_graph_data()
+
         graph_data = self.trust_graph.compute_node_graph()
 
         return RESTResponse(

--- a/src/tribler-gui/tribler_gui/widgets/trustgraphpage.py
+++ b/src/tribler-gui/tribler_gui/widgets/trustgraphpage.py
@@ -214,13 +214,13 @@ class TrustGraphPage(AddBreadcrumbOnShowMixin, QWidget):
 
     def get_node_size(self, node):
         # User root node is bigger than normal nodes
-        min_size = 0.01 if node[u'key'] != self.root_public_key else 0.05
+        min_size = 0.01 if node[u'key'] != self.root_public_key else 0.1
 
         diff = abs(node.get('total_up', 0) - node.get('total_down', 0))
         if diff == 0:
             return min_size
         elif diff > 10 * TB:  # max token balance limit
-            return 0.06  # max node size in graph
+            return 0.1  # max node size in graph
         elif diff > TB:
             return 0.05 + 0.005 * diff / TB  # 0.005 for each extra TB of balance
         return math.log(diff, 2) / 512 + min_size

--- a/src/tribler-gui/tribler_gui/widgets/trustgraphpage.py
+++ b/src/tribler-gui/tribler_gui/widgets/trustgraphpage.py
@@ -125,8 +125,8 @@ class TrustGraphPage(AddBreadcrumbOnShowMixin, QWidget):
         self.window().tr_selected_node_stats.setHidden(True)
         self.window().trust_graph_progress_bar.setHidden(True)
 
-    def on_node_clicked(self, points):
-        clicked_node_data = points.ptsClicked[0].data()
+    def on_node_clicked(self, top_point, *_other_overlapping_points):
+        clicked_node_data = top_point.ptsClicked[0].data()
         clicked_node = self.graph_data['node'][clicked_node_data[0]]
 
         if not self.selected_node:
@@ -138,9 +138,9 @@ class TrustGraphPage(AddBreadcrumbOnShowMixin, QWidget):
         self.selected_node['total_up'] = clicked_node.get('total_up', 0)
         self.selected_node['total_down'] = clicked_node.get('total_down', 0)
         self.selected_node['color'] = self.get_node_color(clicked_node)
-        self.selected_node['spot'] = points.ptsClicked[0]
+        self.selected_node['spot'] = top_point.ptsClicked[0]
 
-        spot = points.ptsClicked[0]
+        spot = top_point.ptsClicked[0]
         spot.setBrush(COLOR_SELECTED)
 
         self.update_status_bar(self.selected_node)


### PR DESCRIPTION
- It fixes the crash on clicking a node in the Trust graph. The issue was because of reorganization of the arguments in pyqtsignal. The list of items where user clicked was splited to a single top point and a list of rest points. (Qt signal is magic).
Fixes https://github.com/Tribler/tribler/issues/5858

- It fixes the crash occurring when there are nodes more than the max value. There was a test for that but the failure was suppressed as failure. The removal inheritance of unnecessary `TaskManager` fixes that apparently. Additionally, added separate tests for max nodes and max transactions.

- The query parameter was removed in the last refactor. It is fixed now. A test is added as well. The refresh from the GUI should work nicely now.

- Increased the size of nodes slightly.

**Screenshot**
![trust-graph](https://user-images.githubusercontent.com/1442867/102491338-50bcd700-4070-11eb-8ded-1c52394e176f.png)

