### PR TITLE
Add an option to automatically send exceptions

### DIFF
--- a/src/run_tribler.py
+++ b/src/run_tribler.py
@@ -5,7 +5,7 @@ import signal
 import sys
 from asyncio import ensure_future, get_event_loop
 
-from tribler_common.sentry_reporter.sentry_reporter import SentryReporter
+from tribler_common.sentry_reporter.sentry_reporter import SentryReporter, SentryStrategy
 from tribler_common.sentry_reporter.sentry_scrubber import SentryScrubber
 
 import tribler_core
@@ -64,6 +64,10 @@ def start_tribler_core(base_path, api_port, api_key, root_state_dir, core_test_m
         state_dir = get_versioned_state_directory(root_state_dir)
 
         config = TriblerConfig(state_dir, config_file=state_dir / CONFIG_FILENAME)
+
+        if not config.get_error_reporting_requires_user_consent():
+            SentryReporter.global_strategy = SentryStrategy.SEND_ALLOWED
+
         config.set_api_http_port(int(api_port))
         # If the API key is set to an empty string, it will remain disabled
         if config.get_api_key() not in ('', api_key):
@@ -90,7 +94,7 @@ def start_tribler_core(base_path, api_port, api_key, root_state_dir, core_test_m
 
 if __name__ == "__main__":
     SentryReporter.init(sentry_url=sentry_url, release_version=version_id, scrubber=SentryScrubber(),
-                        strategy=SentryReporter.Strategy.SEND_ALLOWED_WITH_CONFIRMATION)
+                        strategy=SentryStrategy.SEND_ALLOWED_WITH_CONFIRMATION)
     # Get root state directory (e.g. from environment variable or from system default)
     root_state_dir = get_root_state_directory()
     # Check whether we need to start the core or the user interface

--- a/src/tribler-core/tribler_core/config/test_tribler_config.py
+++ b/src/tribler-core/tribler_core/config/test_tribler_config.py
@@ -305,3 +305,7 @@ def test_get_set_discovery_community_enabled(tribler_config):
     assert not tribler_config.get_discovery_community_enabled()
     tribler_config.set_discovery_community_enabled(True)
     assert tribler_config.get_discovery_community_enabled()
+
+
+def test_get_error_handling(tribler_config):
+    assert tribler_config.get_error_reporting_requires_user_consent()

--- a/src/tribler-core/tribler_core/config/tribler_config.py
+++ b/src/tribler-core/tribler_core/config/tribler_config.py
@@ -626,3 +626,6 @@ class TriblerConfig(object):
 
     def get_resource_monitor_history_size(self):
         return self.config['resource_monitor']['history_size']
+
+    def get_error_reporting_requires_user_consent(self):
+        return self.config['error_handling']['error_reporting_requires_user_consent']

--- a/src/tribler-core/tribler_core/config/tribler_config.spec
+++ b/src/tribler-core/tribler_core/config/tribler_config.spec
@@ -106,3 +106,6 @@ history_size = integer(min=1, default=20)
 [popularity_community]
 enabled = boolean(default=True)
 cache_dir = string(default=health_cache)
+
+[error_handling]
+error_reporting_requires_user_consent=boolean(default=True)


### PR DESCRIPTION
Partially resolves #5799 by adding an option to send unhandled exceptions automatically.

To enable or disable this option you need to change "tribler.conf":
```
[error_handling]
error_reporting_requires_user_consent=boolean(default=True)
```

It is turn on or turn off mechanism for sending unhandled exceptions **only**. 
Ordinary crash reports will not be affected.

This change has entailed SentryReporter refactoring:
* `this_sentry_strategy` context manager has been extracted 
* ContextVar's strategy has been extended by global strategy