### PR TITLE
Apply `error_reporting_requires_user_consent` to all core's errors

### DIFF
--- a/src/tribler-core/tribler_core/restapi/events_endpoint.py
+++ b/src/tribler-core/tribler_core/restapi/events_endpoint.py
@@ -115,11 +115,12 @@ class EventsEndpoint(RESTEndpoint, TaskManager):
 
     # An exception has occurred in Tribler. The event includes a readable
     # string of the error and a Sentry event.
-    def on_tribler_exception(self, exception_text, sentry_event):
+    def on_tribler_exception(self, exception_text, sentry_event, error_reporting_requires_user_consent):
         self.write_data({
             "type": NTFY.TRIBLER_EXCEPTION.value,
             "event": {"text": exception_text},
-            "sentry_event": sentry_event
+            "sentry_event": sentry_event,
+            "error_reporting_requires_user_consent": error_reporting_requires_user_consent
         })
 
     @docs(

--- a/src/tribler-core/tribler_core/restapi/tests/test_events_endpoint.py
+++ b/src/tribler-core/tribler_core/restapi/tests/test_events_endpoint.py
@@ -66,7 +66,7 @@ async def test_events(enable_api, session):
             session.notifier.notify(subject, *data)
         else:
             session.notifier.notify(subject)
-    session.api_manager.root_endpoint.endpoints['/events'].on_tribler_exception("hi", None)
+    session.api_manager.root_endpoint.endpoints['/events'].on_tribler_exception("hi", None, False)
     await events_future
 
     event_socket_task.cancel()

--- a/src/tribler-core/tribler_core/session.py
+++ b/src/tribler-core/tribler_core/session.py
@@ -254,7 +254,9 @@ class Session(TaskManager):
             if not self.api_manager:
                 return
             events = self.api_manager.get_endpoint('events')
-            events.on_tribler_exception(text_long, sentry_event)
+            events.on_tribler_exception(text_long,
+                                        sentry_event,
+                                        self.config.get_error_reporting_requires_user_consent())
 
             state = self.api_manager.get_endpoint('state')
             state.on_tribler_exception(text_long, sentry_event)

--- a/src/tribler-gui/tribler_gui/event_request_manager.py
+++ b/src/tribler-gui/tribler_gui/event_request_manager.py
@@ -118,8 +118,14 @@ class EventRequestManager(QNetworkAccessManager):
                         reaction()
                 elif event_type == NTFY.TRIBLER_EXCEPTION.value:
                     text = json_dict["event"]["text"]
-                    sentry_event = {'sentry_event': json_dict['sentry_event']}
-                    raise RuntimeError(text, sentry_event)
+                    backend_event = {
+                        'backend_event': {
+                            'sentry_event': json_dict['sentry_event'],
+                            'error_reporting_requires_user_consent': json_dict['error_reporting_requires_user_consent'],
+                        }
+                    }
+
+                    raise RuntimeError(text, backend_event)
             self.current_event_string = ""
 
     def on_finished(self):


### PR DESCRIPTION
This PR partially resolves #5799, #5857 by extending https://github.com/Tribler/tribler/pull/5870

Now, setting `error_reporting_requires_user_consent` covers all "core" errors. It will not be used by a regular Tribler user and will set to 'True' by default:

```
[error_handling]
error_reporting_requires_user_consent=boolean(default=True)
```

Note: this value does not affect errors that occurred in GUI.
