### PR TITLE
Add an option to run Tribler with sentry URL for tests

### DIFF
--- a/src/run_tribler.py
+++ b/src/run_tribler.py
@@ -92,9 +92,30 @@ def start_tribler_core(base_path, api_port, api_key, root_state_dir, core_test_m
     get_event_loop().run_forever()
 
 
+def init_sentry_reporter():
+    """ Initialise sentry reporter
+
+    We use `sentry_url` as a URL for normal tribler mode and TEST_SENTRY_URL
+    as a URL for sending sentry's reports while a Tribler client running in
+    test mode
+    """
+    test_sentry_url = os.environ.get('TEST_SENTRY_URL', None)
+
+    if not test_sentry_url:
+        SentryReporter.init(sentry_url=sentry_url,
+                            release_version=version_id,
+                            scrubber=SentryScrubber(),
+                            strategy=SentryStrategy.SEND_ALLOWED_WITH_CONFIRMATION)
+    else:
+        SentryReporter.init(sentry_url=test_sentry_url,
+                            release_version=version_id,
+                            scrubber=None,
+                            strategy=SentryStrategy.SEND_ALLOWED)
+
+
 if __name__ == "__main__":
-    SentryReporter.init(sentry_url=sentry_url, release_version=version_id, scrubber=SentryScrubber(),
-                        strategy=SentryStrategy.SEND_ALLOWED_WITH_CONFIRMATION)
+    init_sentry_reporter()
+
     # Get root state directory (e.g. from environment variable or from system default)
     root_state_dir = get_root_state_directory()
     # Check whether we need to start the core or the user interface


### PR DESCRIPTION
This PR is referred to #5857 

It adds an option to run a Tribler client in test mode and send all the crash reports automatically.

To enable it you have to specify TEST_SENTRY_URL:

```bash
export TEST_SENTRY_URL=<some_url>
```

And enable crash reports auto-send in "triblerd.conf":

```
[error_handling]
error_reporting_requires_user_consent=False
```