### PR TITLE
Fix #5867

### DIFF
--- a/src/tribler-gui/tribler_gui/widgets/channelcontentswidget.py
+++ b/src/tribler-gui/tribler_gui/widgets/channelcontentswidget.py
@@ -268,8 +268,6 @@ class ChannelContentsWidget(AddBreadcrumbOnShowMixin, widget_form, widget_class)
     def on_breadcrumb_clicked(self, tgt_level):
         if int(tgt_level) + 1 != len(self.channels_stack):
             self.go_back_to_level(tgt_level)
-        else:
-            self.reset_view()
 
     def go_back_to_level(self, level):
         level = int(level)


### PR DESCRIPTION
This PR fixes #5867 by removing `self.reset_view()` calling after clicking on a "search result breadcrumb".

This call was the cause of sending `TriblerNetworkRequest` with unexpected arguments.