### PR TITLE
Fix sorting search result by health

### DIFF
--- a/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/metadata_node.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/metadata_node.py
@@ -52,7 +52,7 @@ def define_binding(db):
                 """SELECT rowid FROM ChannelNode WHERE rowid IN (SELECT rowid FROM FtsIndex WHERE FtsIndex MATCH $query
                 ORDER BY bm25(FtsIndex) LIMIT $lim) GROUP BY infohash"""
             )
-            return left_join(g for g in cls if g.rowid in fts_ids)
+            return left_join(g for g in cls if g.rowid in fts_ids)  # pylint: disable=E1135
 
         @classmethod
         @db_session

--- a/src/tribler-core/tribler_core/modules/metadata_store/restapi/tests/test_channels_endpoint.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/restapi/tests/test_channels_endpoint.py
@@ -27,7 +27,7 @@ async def test_get_channels(enable_chant, enable_api, add_fake_torrents_channels
     json_dict = await do_request(session, 'channels')
     assert len(json_dict['results']) == 10
     # Default channel state should be METAINFO_LOOKUP
-    assert json_dict['results'][0]['state'] == CHANNEL_STATE.METAINFO_LOOKUP.value
+    assert json_dict['results'][-1]['state'] == CHANNEL_STATE.METAINFO_LOOKUP.value
 
     # We test out different combinations of channels' states and download progress
     # State UPDATING:
@@ -38,7 +38,7 @@ async def test_get_channels(enable_chant, enable_api, add_fake_torrents_channels
         channel.local_version = 123
 
     json_dict = await do_request(session, 'channels')
-    assert json_dict['results'][0]['progress'] == 0.5
+    assert json_dict['results'][-1]['progress'] == 0.5
 
     # State DOWNLOADING
     with db_session:
@@ -49,7 +49,7 @@ async def test_get_channels(enable_chant, enable_api, add_fake_torrents_channels
     session.dlmgr.metainfo_requests.get = lambda _: False
     session.dlmgr.download_exists = lambda _: True
     json_dict = await do_request(session, 'channels')
-    assert json_dict['results'][0]['state'] == CHANNEL_STATE.DOWNLOADING.value
+    assert json_dict['results'][-1]['state'] == CHANNEL_STATE.DOWNLOADING.value
 
 
 @pytest.mark.asyncio

--- a/src/tribler-core/tribler_core/modules/metadata_store/restapi/tests/test_channels_endpoint.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/restapi/tests/test_channels_endpoint.py
@@ -122,7 +122,6 @@ async def test_get_channel_contents(enable_chant, enable_api, add_fake_torrents_
     with db_session:
         chan = session.mds.ChannelMetadata.select().first()
     json_dict = await do_request(session, 'channels/%s/123' % hexlify(chan.public_key), expected_code=200)
-    print(json_dict)
     assert len(json_dict['results']) == 5
     assert 'status' in json_dict['results'][0]
     assert json_dict['results'][0]['progress'] == 0.5

--- a/src/tribler-core/tribler_core/modules/metadata_store/tests/test_channel_metadata.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/tests/test_channel_metadata.py
@@ -452,50 +452,53 @@ def test_get_channels(metadata_store):
 
 @db_session
 def test_sort_by_health(metadata_store):
+    def save():
+        metadata_store._db.flush()  # pylint: disable=W0212
+
     channel = metadata_store.ChannelMetadata.create_channel('channel1')
-    metadata_store._db.flush()
+    save()
 
     torrent1 = metadata_store.TorrentMetadata(
         origin_id=channel.id_, status=NEW, infohash=random_infohash(), title='torrent1 aaa bbb'
     )
     torrent1.health.set(seeders=10, leechers=20)
-    metadata_store._db.flush()
+    save()
 
     folder1 = metadata_store.CollectionNode(origin_id=channel.id_, title='folder1 aaa ccc')
-    metadata_store._db.flush()
+    save()
 
     torrent2 = metadata_store.TorrentMetadata(
         origin_id=channel.id_, status=NEW, infohash=random_infohash(), title='torrent2 bbb ccc'
     )
     torrent2.health.set(seeders=5, leechers=10)
-    metadata_store._db.flush()
+    save()
 
     folder2 = metadata_store.CollectionNode(origin_id=channel.id_, title='folder2 aaa bbb')
-    metadata_store._db.flush()
+    save()
 
     torrent3 = metadata_store.TorrentMetadata(
         origin_id=channel.id_, status=NEW, infohash=random_infohash(), title='torrent3 ccc ddd'
     )
     torrent3.health.set(seeders=30, leechers=40)
-    metadata_store._db.flush()
+    save()
 
     folder2_1 = metadata_store.CollectionNode(
         origin_id=folder2.id_,
         title='folder2_1 aaa bbb',
     )
-    metadata_store._db.flush()
+    save()
 
     folder2_2 = metadata_store.CollectionNode(
         origin_id=folder2.id_,
         title='folder2_2 bbb ccc',
     )
-    metadata_store._db.flush()
+    save()
 
     torrent2_1 = metadata_store.TorrentMetadata(
         origin_id=folder2.id_, status=NEW, infohash=random_infohash(), title='torrent2_1 aaa ccc'
     )
     torrent2_1.health.set(seeders=20, leechers=10)
-    metadata_store._db.flush()
+    save()
 
     # Without FTS search
 

--- a/src/tribler-core/tribler_core/modules/metadata_store/tests/test_torrent_metadata.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/tests/test_torrent_metadata.py
@@ -225,7 +225,7 @@ def test_get_entries(metadata_store):
 
     args = dict(channel_pk=channel_pk, hide_xxx=True, exclude_deleted=True, metadata_type=REGULAR_TORRENT)
     torrents = metadata_store.TorrentMetadata.get_entries_query(**args)[:]
-    assert tlist[-5:-2] == list(torrents)
+    assert tlist[-5:-2] == list(torrents)[::-1]
 
     count = metadata_store.TorrentMetadata.get_entries_count(**args)
     assert count == 3


### PR DESCRIPTION
This PR fixes a problem when folders are not displayed in the channel content view after sorting by "health".

The essence of the fix is in replacing INNER JOIN to LEFT JOIN in SQL query, so ChannelNode objects without TorrentState corresponding objects are still returned by the query. 

Also, in this PR I add default ordering by `rowid` to all queries which return ChannelNode objects, to have guaranteed stable sorting order in tests.

Some tests are marked with FIXME as they are not returning totally correct results. Namely, full-text search queries don't return more than one folder. This is a separate bug in full-text search queries and will be fixed in a separate PR.