### PR TITLE
Fix full-text search query

### DIFF
--- a/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/metadata_node.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/metadata_node.py
@@ -46,11 +46,10 @@ def define_binding(db):
             if not query or query == "*":
                 return []
 
-            # !!! FIXME !!! Fix GROUP BY for entries without infohash !!!
             # TODO: optimize this query by removing unnecessary select nests (including Pony-manages selects)
             fts_ids = raw_sql(
                 """SELECT rowid FROM ChannelNode WHERE rowid IN (SELECT rowid FROM FtsIndex WHERE FtsIndex MATCH $query
-                ORDER BY bm25(FtsIndex) LIMIT $lim) GROUP BY infohash"""
+                ORDER BY bm25(FtsIndex) LIMIT $lim) GROUP BY coalesce(infohash, rowid)"""
             )
             return left_join(g for g in cls if g.rowid in fts_ids)  # pylint: disable=E1135
 

--- a/src/tribler-core/tribler_core/modules/metadata_store/tests/test_channel_metadata.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/tests/test_channel_metadata.py
@@ -548,15 +548,13 @@ def test_sort_by_health(metadata_store):
         channel_pk=channel.public_key, txt_filter='aaa', sort_by='HEALTH', sort_desc=True
     )
     titles = [obj.title.partition(' ')[0] for obj in objects]
-    # FIXME: does not return folder2 and folder2_1 due to a bug in a full text search query
-    assert titles == ['torrent2_1', 'torrent1', 'folder1']
+    assert titles == ['torrent2_1', 'torrent1', 'folder2_1', 'folder2', 'folder1']
 
     objects = metadata_store.MetadataNode.get_entries(
         channel_pk=channel.public_key, txt_filter='aaa', sort_by='HEALTH', sort_desc=False
     )
     titles = [obj.title.partition(' ')[0] for obj in objects]
-    # FIXME: does not return folder2 and folder2_1 due to a bug in a full text search query
-    assert titles == ['folder1', 'torrent1', 'torrent2_1']
+    assert titles == ['folder1', 'folder2', 'folder2_1', 'torrent1', 'torrent2_1']
 
     objects = metadata_store.MetadataNode.get_entries(
         origin_id=channel.id_,
@@ -565,15 +563,13 @@ def test_sort_by_health(metadata_store):
         sort_desc=True,
     )
     titles = [obj.title.partition(' ')[0] for obj in objects]
-    # FIXME: does not return folder2 due to a bug in a full text search query
-    assert titles == ['torrent1', 'folder1']
+    assert titles == ['torrent1', 'folder2', 'folder1']
 
     objects = metadata_store.MetadataNode.get_entries(
         origin_id=channel.id_, txt_filter='aaa', sort_by='HEALTH', sort_desc=False
     )
     titles = [obj.title.partition(' ')[0] for obj in objects]
-    # FIXME: does not return folder2 due to a bug in a full text search query
-    assert titles == ['folder1', 'torrent1']
+    assert titles == ['folder1', 'folder2', 'torrent1']
 
 
 @db_session


### PR DESCRIPTION
This PR fixes a bug in full-text search queries where FTS query could not return more than one object without infohash (for example, no more than one folder in a channel).