### PR TITLE
Fix/5842

### DIFF
--- a/src/tribler-gui/tribler_gui/dialogs/dialogcontainer.py
+++ b/src/tribler-gui/tribler_gui/dialogs/dialogcontainer.py
@@ -13,7 +13,7 @@ class DialogContainer(AddBreadcrumbOnShowMixin, QWidget):
         self.setStyleSheet("background-color: rgba(30, 30, 30, 0.75);")
 
         self.dialog_widget = QWidget(self)
-
+        self.closed = False
         connect(self.window().resize_event, self.on_main_window_resize)
 
     def paintEvent(self, _):
@@ -26,6 +26,7 @@ class DialogContainer(AddBreadcrumbOnShowMixin, QWidget):
         try:
             self.setParent(None)
             self.deleteLater()
+            self.closed = True
         except RuntimeError:
             pass
 

--- a/src/tribler-gui/tribler_gui/dialogs/startdownloaddialog.py
+++ b/src/tribler-gui/tribler_gui/dialogs/startdownloaddialog.py
@@ -155,6 +155,9 @@ class StartDownloadDialog(DialogContainer):
         return included_files
 
     def perform_files_request(self):
+        if self.closed:
+            return
+
         direct = not self.dialog_widget.anon_download_checkbox.isChecked()
         request = f"torrentinfo?uri={quote_plus_unicode(self.download_uri)}"
         if direct is True:

--- a/src/tribler-gui/tribler_gui/dialogs/startdownloaddialog.py
+++ b/src/tribler-gui/tribler_gui/dialogs/startdownloaddialog.py
@@ -135,6 +135,9 @@ class StartDownloadDialog(DialogContainer):
         if self.rest_request:
             self.rest_request.cancel_request()
 
+        if self.metainfo_fetch_timer:
+            self.metainfo_fetch_timer.stop()
+
         # Loading files label is a clickable label with pyqtsignal which could leak,
         # so delete the widget while closing the dialog.
         if self.dialog_widget and self.dialog_widget.loading_files_label:


### PR DESCRIPTION
This PR resolves #5842 by stopping invoke StartDownloadDialog's method when the dialog is closed.

This PR also introduces the new property of DialogContainer: "closed".