### PR TITLE
Change mocked config to corrupted source file

### DIFF
--- a/src/tribler-core/tribler_core/upgrade/tests/test_config_upgrade_to_75.py
+++ b/src/tribler-core/tribler_core/upgrade/tests/test_config_upgrade_to_75.py
@@ -14,19 +14,7 @@ from tribler_core.upgrade.config_converter import convert_config_to_tribler75
 
 CONFIG_PATH = TESTS_DATA_DIR / "config_files"
 
-
-@pytest.fixture(name='faulty_download_config_parser')
-async def fixture_faulty_download_config_parser():
-    def load_config_with_parse_error(filename):
-        raise ConfigObjParseError(f"Error parsing config file {filename}")
-
-    original_load_config = DownloadConfig.load
-    DownloadConfig.load = load_config_with_parse_error
-    yield DownloadConfig
-    DownloadConfig.load = original_load_config
-
-
-def test_convert_state_file_to_conf75_with_parse_error(tmpdir, faulty_download_config_parser):
+def test_convert_state_file_to_conf75_with_parse_error(tmpdir):
     """
     Tests conversion of the conf files (7.4.0) files to .conf files (7.5) when there is parsing error.
     ParseError happens for some users for some unknown reason. We simply remove the files that we cannot
@@ -36,7 +24,7 @@ def test_convert_state_file_to_conf75_with_parse_error(tmpdir, faulty_download_c
     os.makedirs(state_dir / STATEDIR_CHECKPOINT_DIR)
 
     # Copy Ubuntu conf file with corrupted metainfo data
-    src_path = CONFIG_PATH / "13a25451c761b1482d3e85432f07c4be05ca8a56.conf"
+    src_path = CONFIG_PATH / "corrupt_download_config.conf"
     dest_path = state_dir / STATEDIR_CHECKPOINT_DIR / "ubuntu_corrupted.conf"
     shutil.copyfile(src_path, dest_path)
 


### PR DESCRIPTION
### Problem
Sometimes we see this error in window's tests console output:

```
_________________________ test_download_load_corrupt __________________________
[gw6] win32 -- Python 3.8.4 c:\users\tribler\appdata\local\programs\python\python38\python.exe
download_config = <tribler_core.modules.libtorrent.download_config.DownloadConfig object at 0x00000000294F2A90>
    def test_download_load_corrupt(download_config):
        with pytest.raises(ConfigObjError):
>           download_config.load(CONFIG_FILES_DIR / "corrupt_download_config.conf")
E           TypeError: load() takes from 0 to 1 positional arguments but 2 were given

```

The example: https://jenkins-ci.tribler.org/job/GH_Tribler_PR_Tests/job/PR_win64_pytest/793/console

### The root cause

This fixture overrides `DownloadConfig.load` method:
https://github.com/Tribler/tribler/blob/5af797b65bf626c6963c99d7b8e567a437d2f318/src/tribler-core/tribler_core/upgrade/tests/test_config_upgrade_to_75.py#L18-L26

That's why sometimes other tests (and particular `test_download_load_corrupt`) crashes suddenly with TypeError.

(thanks @qstokkink  for investigation)

### Solution
The solution is: remove the fixture and use a conf file that leads to a native crash.