### PR TITLE
Update torrent progress in channels on download table polls

### DIFF
--- a/src/tribler-gui/tribler_gui/widgets/downloadspage.py
+++ b/src/tribler-gui/tribler_gui/widgets/downloadspage.py
@@ -164,6 +164,11 @@ class DownloadsPage(AddBreadcrumbOnShowMixin, QWidget):
 
         items = []
         for download in downloads["downloads"]:
+            # Update download progress information for torrents in the Channels GUI
+            self.window().core_manager.events_manager.node_info_updated.emit(
+                {"infohash": download["infohash"], "progress": download["progress"]}
+            )
+
             if download["infohash"] in self.download_widgets:
                 item = self.download_widgets[download["infohash"]]
             else:


### PR DESCRIPTION
Partially fixes #5886 

The progress will only be updated when the user clicks on the "Downloads" tab,, at the background downloads polling interval (about 15 seconds), and on special events, e.g. torrent completion.