### PR TITLE
Return from "on_received_metainfo" if the dialog closed

### DIFF
--- a/src/tribler-gui/tribler_gui/dialogs/startdownloaddialog.py
+++ b/src/tribler-gui/tribler_gui/dialogs/startdownloaddialog.py
@@ -185,7 +185,7 @@ class StartDownloadDialog(DialogContainer):
             self.metainfo_retries += 1
 
     def on_received_metainfo(self, response):
-        if not response or not self:
+        if not response or not self or self.closed:
             return
 
         if 'error' in response:


### PR DESCRIPTION
This PR resolves #5843

The cause of the bug very close to https://github.com/Tribler/tribler/pull/5888