### PR TITLE
Add ability to send exceptions automatically in case `TEST_SENTRY_URL` is defined

### DIFF
--- a/src/run_tribler.py
+++ b/src/run_tribler.py
@@ -65,7 +65,7 @@ def start_tribler_core(base_path, api_port, api_key, root_state_dir, core_test_m
 
         config = TriblerConfig(state_dir, config_file=state_dir / CONFIG_FILENAME)
 
-        if not config.get_error_reporting_requires_user_consent():
+        if not config.get_core_error_reporting_requires_user_consent():
             SentryReporter.global_strategy = SentryStrategy.SEND_ALLOWED
 
         config.set_api_http_port(int(api_port))

--- a/src/tribler-core/tribler_core/config/test_tribler_config.py
+++ b/src/tribler-core/tribler_core/config/test_tribler_config.py
@@ -308,4 +308,4 @@ def test_get_set_discovery_community_enabled(tribler_config):
 
 
 def test_get_error_handling(tribler_config):
-    assert tribler_config.get_error_reporting_requires_user_consent()
+    assert tribler_config.get_core_error_reporting_requires_user_consent()

--- a/src/tribler-core/tribler_core/config/tribler_config.py
+++ b/src/tribler-core/tribler_core/config/tribler_config.py
@@ -627,5 +627,5 @@ class TriblerConfig(object):
     def get_resource_monitor_history_size(self):
         return self.config['resource_monitor']['history_size']
 
-    def get_error_reporting_requires_user_consent(self):
-        return self.config['error_handling']['error_reporting_requires_user_consent']
+    def get_core_error_reporting_requires_user_consent(self):
+        return self.config['error_handling']['core_error_reporting_requires_user_consent']

--- a/src/tribler-core/tribler_core/config/tribler_config.spec
+++ b/src/tribler-core/tribler_core/config/tribler_config.spec
@@ -108,4 +108,4 @@ enabled = boolean(default=True)
 cache_dir = string(default=health_cache)
 
 [error_handling]
-error_reporting_requires_user_consent=boolean(default=True)
+core_error_reporting_requires_user_consent=boolean(default=True)

--- a/src/tribler-core/tribler_core/session.py
+++ b/src/tribler-core/tribler_core/session.py
@@ -256,7 +256,7 @@ class Session(TaskManager):
             events = self.api_manager.get_endpoint('events')
             events.on_tribler_exception(text_long,
                                         sentry_event,
-                                        self.config.get_error_reporting_requires_user_consent())
+                                        self.config.get_core_error_reporting_requires_user_consent())
 
             state = self.api_manager.get_endpoint('state')
             state.on_tribler_exception(text_long, sentry_event)

--- a/src/tribler-gui/tribler_gui/dialogs/feedbackdialog.py
+++ b/src/tribler-gui/tribler_gui/dialogs/feedbackdialog.py
@@ -94,9 +94,14 @@ class FeedbackDialog(AddBreadcrumbOnShowMixin, QDialog):
         # Users can remove specific lines in the report
         connect(self.env_variables_list.customContextMenuRequested, self.on_right_click_item)
 
-        self.error_reporting_requires_user_consent = error_reporting_requires_user_consent
-        if not error_reporting_requires_user_consent:
+        self.send_automatically = FeedbackDialog.can_send_automatically(error_reporting_requires_user_consent)
+        if self.send_automatically:
             self.on_send_clicked(True)
+
+    @staticmethod
+    def can_send_automatically(error_reporting_requires_user_consent):
+        test_sentry_url_is_defined = os.environ.get('TEST_SENTRY_URL', None) is not None
+        return test_sentry_url_is_defined and not error_reporting_requires_user_consent
 
     def on_remove_entry(self):
         self.env_variables_list.takeTopLevelItem(self.selected_item_index)
@@ -121,7 +126,7 @@ class FeedbackDialog(AddBreadcrumbOnShowMixin, QDialog):
     def on_report_sent(self, response):
         if not response:
             return
-        if not self.error_reporting_requires_user_consent:
+        if self.send_automatically:
             QApplication.quit()
 
         sent = response[u'sent']


### PR DESCRIPTION
This PR adds an ability to send handled exceptions to the reporter automatically in case `TEST_SENTRY_URL` is defined.

Requested by @xoriole for using in 24/7 Tribler instance tester.