### PR TITLE
Fix/5903

### DIFF
--- a/src/tribler-gui/tribler_gui/dialogs/startdownloaddialog.py
+++ b/src/tribler-gui/tribler_gui/dialogs/startdownloaddialog.py
@@ -235,7 +235,7 @@ class StartDownloadDialog(DialogContainer):
 
         self.received_metainfo.emit(metainfo)
 
-    def on_reload_torrent_info(self):
+    def on_reload_torrent_info(self, *args):
         """
         This method is called when user clicks the QLabel text showing loading or error message. Here, we reset
         the number of retries to fetch the metainfo. Note color of QLabel is also reset to white.


### PR DESCRIPTION
This PR fixes #5903 

`*args` is used because the following function can be called with one and with two arguments.

```python
    def on_reload_torrent_info(self, *args):
```