### PR TITLE
Change on_files_included/excluded signature

### DIFF
--- a/src/tribler-gui/tribler_gui/widgets/downloadsdetailstabwidget.py
+++ b/src/tribler-gui/tribler_gui/widgets/downloadsdetailstabwidget.py
@@ -20,6 +20,7 @@ class DownloadsDetailsTabWidget(QTabWidget):
         QTabWidget.__init__(self, parent)
         self.current_download = None
         self.files_widgets = {}  # dict of file name -> widget
+        self.selected_files_info = []
 
     def initialize_details_widget(self):
         connect(self.window().download_files_list.customContextMenuRequested, self.on_right_click_file_item)
@@ -152,7 +153,7 @@ class DownloadsDetailsTabWidget(QTabWidget):
             return
 
         item_infos = []  # Array of (item, included, is_selected)
-        selected_files_info = []
+        self.selected_files_info = []
 
         for i in range(self.window().download_files_list.topLevelItemCount()):
             item = self.window().download_files_list.topLevelItem(i)
@@ -160,7 +161,7 @@ class DownloadsDetailsTabWidget(QTabWidget):
             item_infos.append((item, item.file_info["included"], is_selected))
 
             if is_selected:
-                selected_files_info.append(item.file_info)
+                self.selected_files_info.append(item.file_info)
 
         item_clicked = self.window().download_files_list.itemAt(pos)
         if not item_clicked or not item_clicked in self.window().download_files_list.selectedItems():
@@ -180,9 +181,9 @@ class DownloadsDetailsTabWidget(QTabWidget):
         include_action = QAction('Include file' + ('(s)' if num_selected > 1 else ''), self)
         exclude_action = QAction('Exclude file' + ('(s)' if num_selected > 1 else ''), self)
 
-        connect(include_action.triggered, lambda: self.on_files_included(selected_files_info))
+        connect(include_action.triggered, self.on_files_included)
         include_action.setEnabled(True)
-        connect(exclude_action.triggered, lambda: self.on_files_excluded(selected_files_info))
+        connect(exclude_action.triggered, self.on_files_excluded)
         exclude_action.setEnabled(not (num_excludes + num_includes_selected == len(item_infos)))
 
         menu.addAction(include_action)
@@ -193,17 +194,17 @@ class DownloadsDetailsTabWidget(QTabWidget):
     def get_included_file_list(self):
         return [file_info["index"] for file_info in self.current_download["files"] if file_info["included"]]
 
-    def on_files_included(self, files_data):
+    def on_files_included(self, *args):
         included_list = self.get_included_file_list()
-        for file_data in files_data:
+        for file_data in self.selected_files_info:
             if not file_data["index"] in included_list:
                 included_list.append(file_data["index"])
 
         self.set_included_files(included_list)
 
-    def on_files_excluded(self, files_data):
+    def on_files_excluded(self, *args):
         included_list = self.get_included_file_list()
-        for file_data in files_data:
+        for file_data in self.selected_files_info:
             if file_data["index"] in included_list:
                 included_list.remove(file_data["index"])
 


### PR DESCRIPTION
This PR fixes #5901 by changing signatures of

```python
    def on_files_included(self, *args):
```

```python
    def on_files_excluded(self, *args):
```

Because they are called with a Boolean argument.
 