### PR TITLE
Fix/5911

### DIFF
--- a/src/tribler-gui/tribler_gui/widgets/tablecontentmodel.py
+++ b/src/tribler-gui/tribler_gui/widgets/tablecontentmodel.py
@@ -197,7 +197,7 @@ class RemoteTableModel(QAbstractTableModel):
         :return: True, if response, False otherwise
         """
         # TODO: count remote results
-        if not response:
+        if not response or self.qt_object_destroyed:
             return False
 
         # Trigger labels update on the initial table load

--- a/src/tribler-gui/tribler_gui/widgets/tablecontentmodel.py
+++ b/src/tribler-gui/tribler_gui/widgets/tablecontentmodel.py
@@ -11,7 +11,7 @@ from tribler_core.modules.metadata_store.serialization import CHANNEL_TORRENT, C
 from tribler_gui.defs import ACTION_BUTTONS, BITTORRENT_BIRTHDAY, COMMIT_STATUS_TODELETE, HEALTH_CHECKING
 from tribler_gui.i18n import tr
 from tribler_gui.tribler_request_manager import TriblerNetworkRequest
-from tribler_gui.utilities import format_size, format_votes, get_votes_rating_description, pretty_date
+from tribler_gui.utilities import connect, format_size, format_votes, get_votes_rating_description, pretty_date
 
 
 def get_item_uid(item):
@@ -44,7 +44,9 @@ class RemoteTableModel(QAbstractTableModel):
         self.sort_desc = True
         self.saved_header_state = None
         self.saved_scroll_state = None
+        self.qt_object_destroyed = False
 
+        connect(self.destroyed, self.on_destroy)
         # Every remote query must be attributed to its specific model to avoid updating wrong models
         # on receiving a result. We achieve this by maintaining a set of in-flight remote queries.
         # Note that this only applies to results that are returned through the events notification
@@ -52,6 +54,9 @@ class RemoteTableModel(QAbstractTableModel):
         # We do not clean it up after receiving a result because we don't know if the result was the
         # last one. In a sense, the queries' UUIDs play the role of "subscription topics" for the model.
         self.remote_queries = set()
+
+    def on_destroy(self, *args):
+        self.qt_object_destroyed = True
 
     def reset(self):
         self.beginResetModel()


### PR DESCRIPTION
This PR resolves #5911.

### The solution:
1. Add a new property to `RemoteTableModel` that will indicate is QT object destroyed or not
2. Stop calling `on_query_results` callback after destructing of corresponding QT object

More info: https://github.com/Tribler/tribler/issues/5911#issuecomment-756713970