### PR TITLE
Check on 'escape_pressed' attribute

### DIFF
--- a/src/tribler-gui/tribler_gui/dialogs/confirmationdialog.py
+++ b/src/tribler-gui/tribler_gui/dialogs/confirmationdialog.py
@@ -44,8 +44,8 @@ class ConfirmationDialog(DialogContainer):
 
         hspacer_right = QSpacerItem(1, 1, QSizePolicy.Expanding, QSizePolicy.Fixed)
         self.dialog_widget.dialog_button_container.layout().addSpacerItem(hspacer_right)
-
-        connect(self.window().escape_pressed, self.close_dialog)
+        if hasattr(self.window(), 'escape_pressed'):
+            connect(self.window().escape_pressed, self.close_dialog)
         self.on_main_window_resize()
 
     @classmethod


### PR DESCRIPTION
This PR resolves #5915 by adding a check for the presence of the 'escape_pressed' attribute.

Fixes TRIBLER-5Z
Fixes SENTRY-FOR-760-21