### PR TITLE
Replace "comments" field by "what were you doing before" question.

### DIFF
--- a/src/tribler-gui/tribler_gui/dialogs/feedbackdialog.py
+++ b/src/tribler-gui/tribler_gui/dialogs/feedbackdialog.py
@@ -42,7 +42,9 @@ class FeedbackDialog(AddBreadcrumbOnShowMixin, QDialog):
 
         # Qt 5.2 does not have the setPlaceholderText property
         if hasattr(self.comments_text_edit, "setPlaceholderText"):
-            self.comments_text_edit.setPlaceholderText("Comments (optional)")
+            placeholder = "What were you doing before this crash happened? " \
+                          "This information will help Tribler developers to figure out and fix the issue quickly."
+            self.comments_text_edit.setPlaceholderText(placeholder)
 
         def add_item_to_info_widget(key, value):
             item = QTreeWidgetItem(self.env_variables_list)

--- a/src/tribler-gui/tribler_gui/qt_resources/feedback_dialog.ui
+++ b/src/tribler-gui/tribler_gui/qt_resources/feedback_dialog.ui
@@ -250,7 +250,7 @@ background-color: #303030;
          </size>
         </property>
         <property name="text">
-         <string>Comments (optional):</string>
+         <string>Additional information:</string>
         </property>
         <property name="wordWrap">
          <bool>true</bool>


### PR DESCRIPTION
This PR starts to solve https://github.com/Tribler/tribler/discussions/5938 by changing the meaning of additional information, provided by a user.

Instead of asking "comment", we explicitly ask "what were you doing before this crash happened?"

<img src="https://user-images.githubusercontent.com/13798583/104742097-52022200-574a-11eb-97c7-e7dec213cb4d.png" width="600">

