### PR TITLE
Skip all the versions produced by the deployment tester

### DIFF
--- a/src/tribler-common/tribler_common/sentry_reporter/sentry_scrubber.py
+++ b/src/tribler-common/tribler_common/sentry_reporter/sentry_scrubber.py
@@ -12,7 +12,7 @@ from tribler_common.sentry_reporter.sentry_reporter import (
     SYSINFO,
     VALUES,
 )
-from tribler_common.sentry_reporter.sentry_tools import delete_item, distinct_by, modify_value, skip_dev_version
+from tribler_common.sentry_reporter.sentry_tools import delete_item, distinct_by, format_version, modify_value
 
 
 class SentryScrubber:
@@ -88,7 +88,7 @@ class SentryScrubber:
         modify_value(event, BREADCRUMBS, _remove_duplicates_from_breadcrumbs)
 
         # skip dev version
-        modify_value(event, RELEASE, skip_dev_version)
+        modify_value(event, RELEASE, format_version)
 
         # remove sensitive information
         modify_value(event, EXTRA, self.scrub_entity_recursively)

--- a/src/tribler-common/tribler_common/sentry_reporter/sentry_tools.py
+++ b/src/tribler-common/tribler_common/sentry_reporter/sentry_tools.py
@@ -112,21 +112,23 @@ def distinct_by(list_of_dict, key):
     return result
 
 
-def skip_dev_version(version):
-    """
-    For the release version let's ignore all "developers" versions
-    to keep the meaning of the `latest` keyword:
-    See Also:https://docs.sentry.io/product/sentry-basics/search/
-    Args:
-        version: version string
-
-    Returns: version if it is not a dev version, and Null otherwise
-
-    """
+def format_version(version):
     if not version:
         return version
 
+    # For the release version let's ignore all "developers" versions
+    # to keep the meaning of the `latest` keyword:
+    # See Also:https://docs.sentry.io/product/sentry-basics/search/
     if 'GIT' in version:
         return None
 
-    return version
+    parts = version.split('-', maxsplit=2)
+    if len(parts) < 2:
+        return version
+
+    # if version has been produced by deployment tester, then
+    if parts[1].isdigit():
+        return parts[0]
+
+    # for all other cases keep <version>-<first_part>
+    return f"{parts[0]}-{parts[1]}"

--- a/src/tribler-common/tribler_common/sentry_reporter/tests/test_sentry_tools.py
+++ b/src/tribler-common/tribler_common/sentry_reporter/tests/test_sentry_tools.py
@@ -1,13 +1,13 @@
 from tribler_common.sentry_reporter.sentry_tools import (
     delete_item,
     distinct_by,
+    format_version,
     get_first_item,
     get_last_item,
     get_value,
     modify_value,
     parse_os_environ,
     parse_stacktrace,
-    skip_dev_version,
 )
 
 
@@ -104,7 +104,17 @@ def test_distinct():
 
 
 def test_skip_dev_version():
-    assert skip_dev_version(None) is None
-    assert skip_dev_version('') == ''
-    assert skip_dev_version('7.6.0') == '7.6.0'
-    assert skip_dev_version('7.6.0-GIT') is None
+    assert format_version(None) is None
+    assert format_version('') == ''
+    assert format_version('7.6.0') == '7.6.0'
+    assert format_version('7.6.0-GIT') is None
+
+    # version from deployment tester
+    assert format_version('7.7.1-17-gcb73f7baa') == '7.7.1'
+
+    # release candidate
+    assert format_version('7.7.1-RC1-10-abcd') == '7.7.1-RC1'
+
+    # experimental versions
+    assert format_version('7.7.1-exp1-1-abcd ') == '7.7.1-exp1'
+    assert format_version('7.7.1-someresearchtopic-7-abcd ') == '7.7.1-someresearchtopic'


### PR DESCRIPTION
This PR fixes the issue of unnecessary multiplication of "release version" during a deployment test:

<img src="https://user-images.githubusercontent.com/13798583/104910142-2e78ea80-5989-11eb-810a-cd532fb8ab56.png" width=300>

https://sentry.tribler.org/organizations/tribler/releases/?project=7