### PR TITLE
Fix Pillow missing dependency

### DIFF
--- a/tribler.spec
+++ b/tribler.spec
@@ -92,6 +92,7 @@ hiddenimports = [
     'csv',
     'ecdsa',
     'pyaes',
+    'PIL',
     'scrypt', '_scrypt',
     'sqlalchemy', 'sqlalchemy.ext.baked', 'sqlalchemy.ext.declarative',
     'pkg_resources', 'pkg_resources.py2_warn', # Workaround PyInstaller & SetupTools, https://github.com/pypa/setuptools/issues/1963


### PR DESCRIPTION
Pyinstaller build is missing Pillow dependency so here the dependency is added as hidden imports. 

Fixes https://github.com/Tribler/tribler/issues/5943