### PR TITLE
Stop crash an application when GUI raise an exception

### DIFF
--- a/src/tribler-gui/tribler_gui/core_manager.py
+++ b/src/tribler-gui/tribler_gui/core_manager.py
@@ -58,7 +58,7 @@ class CoreManager(QObject):
         if b'Traceback' in raw_output:
             self.core_traceback = decoded_output
             self.core_traceback_timestamp = int(round(time.time() * 1000))
-        self._logger.debug(decoded_output.strip())
+        print(decoded_output.strip())
 
     def on_core_finished(self, exit_code, exit_status):
         if self.shutting_down and self.should_stop_on_shutdown:

--- a/src/tribler-gui/tribler_gui/error_handler.py
+++ b/src/tribler-gui/tribler_gui/error_handler.py
@@ -1,0 +1,87 @@
+import logging
+import os
+import traceback
+
+from tribler_common.sentry_reporter.sentry_reporter import SentryReporter
+
+from tribler_gui.dialogs.feedbackdialog import FeedbackDialog
+from tribler_gui.event_request_manager import CoreConnectTimeoutError
+
+
+class ErrorHandler:
+    def __init__(self, tribler_windows):
+        logger_name = self.__class__.__name__
+        self._logger = logging.getLogger(logger_name)
+        SentryReporter.ignore_logger(logger_name)
+
+        self.tribler_windows = tribler_windows
+
+        self._handled_exceptions = set()
+        self._tribler_stopped = False
+
+    def gui_error(self, *exc_info):
+        if self._tribler_stopped:
+            return
+
+        info_type, info_error, tb = exc_info
+        if info_type in self._handled_exceptions:
+            return
+        self._handled_exceptions.add(info_type)
+
+        text = "".join(traceback.format_exception(info_type, info_error, tb))
+
+        if info_type is CoreConnectTimeoutError:
+            text = text + self.tribler_windows.core_manager.core_traceback
+            self._stop_tribler(text)
+
+        self._logger.error(text)
+
+        FeedbackDialog(
+            self.tribler_windows,
+            text,
+            self.tribler_windows.tribler_version,
+            self.tribler_windows.start_time,
+            SentryReporter.event_from_exception(info_error),
+            True,
+            self._tribler_stopped
+        ).show()
+
+    def core_error(self, text, core_event):
+        if self._tribler_stopped:
+            return
+
+        self._logger.error(text)
+
+        self._stop_tribler(text)
+
+        FeedbackDialog(
+            self.tribler_windows,
+            text,
+            self.tribler_windows.tribler_version,
+            self.tribler_windows.start_time,
+            core_event['sentry_event'],
+            core_event['error_reporting_requires_user_consent'],
+            self._tribler_stopped
+        ).show()
+
+    def _stop_tribler(self, text):
+        if self._tribler_stopped:
+            return
+
+        self._tribler_stopped = True
+
+        self.tribler_windows.tribler_crashed.emit(text)
+        self.tribler_windows.delete_tray_icon()
+
+        # Stop the download loop
+        self.tribler_windows.downloads_page.stop_loading_downloads()
+
+        # Add info about whether we are stopping Tribler or not
+        os.environ['TRIBLER_SHUTTING_DOWN'] = str(self.tribler_windows.core_manager.shutting_down)
+        if not self.tribler_windows.core_manager.shutting_down:
+            self.tribler_windows.core_manager.stop(stop_app_on_shutdown=False)
+
+        self.tribler_windows.setHidden(True)
+
+        if self.tribler_windows.debug_window:
+            self.tribler_windows.debug_window.setHidden(True)

--- a/src/tribler-gui/tribler_gui/error_handler.py
+++ b/src/tribler-gui/tribler_gui/error_handler.py
@@ -9,12 +9,12 @@ from tribler_gui.event_request_manager import CoreConnectTimeoutError
 
 
 class ErrorHandler:
-    def __init__(self, tribler_windows):
+    def __init__(self, tribler_window):
         logger_name = self.__class__.__name__
         self._logger = logging.getLogger(logger_name)
         SentryReporter.ignore_logger(logger_name)
 
-        self.tribler_windows = tribler_windows
+        self.tribler_window = tribler_window
 
         self._handled_exceptions = set()
         self._tribler_stopped = False
@@ -31,16 +31,16 @@ class ErrorHandler:
         text = "".join(traceback.format_exception(info_type, info_error, tb))
 
         if info_type is CoreConnectTimeoutError:
-            text = text + self.tribler_windows.core_manager.core_traceback
+            text = text + self.tribler_window.core_manager.core_traceback
             self._stop_tribler(text)
 
         self._logger.error(text)
 
         FeedbackDialog(
-            parent=self.tribler_windows,
+            parent=self.tribler_window,
             exception_text=text,
-            tribler_version=self.tribler_windows.tribler_version,
-            start_time=self.tribler_windows.start_time,
+            tribler_version=self.tribler_window.tribler_version,
+            start_time=self.tribler_window.start_time,
             sentry_event=SentryReporter.event_from_exception(info_error),
             error_reporting_requires_user_consent=True,
             stop_application_on_close=self._tribler_stopped
@@ -55,10 +55,10 @@ class ErrorHandler:
         self._stop_tribler(text)
 
         FeedbackDialog(
-            parent=self.tribler_windows,
+            parent=self.tribler_window,
             exception_text=text,
-            tribler_version=self.tribler_windows.tribler_version,
-            start_time=self.tribler_windows.start_time,
+            tribler_version=self.tribler_window.tribler_version,
+            start_time=self.tribler_window.start_time,
             sentry_event=core_event['sentry_event'],
             error_reporting_requires_user_consent=core_event['error_reporting_requires_user_consent'],
             stop_application_on_close=self._tribler_stopped
@@ -70,18 +70,18 @@ class ErrorHandler:
 
         self._tribler_stopped = True
 
-        self.tribler_windows.tribler_crashed.emit(text)
-        self.tribler_windows.delete_tray_icon()
+        self.tribler_window.tribler_crashed.emit(text)
+        self.tribler_window.delete_tray_icon()
 
         # Stop the download loop
-        self.tribler_windows.downloads_page.stop_loading_downloads()
+        self.tribler_window.downloads_page.stop_loading_downloads()
 
         # Add info about whether we are stopping Tribler or not
-        os.environ['TRIBLER_SHUTTING_DOWN'] = str(self.tribler_windows.core_manager.shutting_down)
-        if not self.tribler_windows.core_manager.shutting_down:
-            self.tribler_windows.core_manager.stop(stop_app_on_shutdown=False)
+        os.environ['TRIBLER_SHUTTING_DOWN'] = str(self.tribler_window.core_manager.shutting_down).upper()
+        if not self.tribler_window.core_manager.shutting_down:
+            self.tribler_window.core_manager.stop(stop_app_on_shutdown=False)
 
-        self.tribler_windows.setHidden(True)
+        self.tribler_window.setHidden(True)
 
-        if self.tribler_windows.debug_window:
-            self.tribler_windows.debug_window.setHidden(True)
+        if self.tribler_window.debug_window:
+            self.tribler_window.debug_window.setHidden(True)

--- a/src/tribler-gui/tribler_gui/error_handler.py
+++ b/src/tribler-gui/tribler_gui/error_handler.py
@@ -37,13 +37,13 @@ class ErrorHandler:
         self._logger.error(text)
 
         FeedbackDialog(
-            self.tribler_windows,
-            text,
-            self.tribler_windows.tribler_version,
-            self.tribler_windows.start_time,
-            SentryReporter.event_from_exception(info_error),
-            True,
-            self._tribler_stopped
+            parent=self.tribler_windows,
+            exception_text=text,
+            tribler_version=self.tribler_windows.tribler_version,
+            start_time=self.tribler_windows.start_time,
+            sentry_event=SentryReporter.event_from_exception(info_error),
+            error_reporting_requires_user_consent=True,
+            stop_application_on_close=self._tribler_stopped
         ).show()
 
     def core_error(self, text, core_event):
@@ -55,13 +55,13 @@ class ErrorHandler:
         self._stop_tribler(text)
 
         FeedbackDialog(
-            self.tribler_windows,
-            text,
-            self.tribler_windows.tribler_version,
-            self.tribler_windows.start_time,
-            core_event['sentry_event'],
-            core_event['error_reporting_requires_user_consent'],
-            self._tribler_stopped
+            parent=self.tribler_windows,
+            exception_text=text,
+            tribler_version=self.tribler_windows.tribler_version,
+            start_time=self.tribler_windows.start_time,
+            sentry_event=core_event['sentry_event'],
+            error_reporting_requires_user_consent=core_event['error_reporting_requires_user_consent'],
+            stop_application_on_close=self._tribler_stopped
         ).show()
 
     def _stop_tribler(self, text):


### PR DESCRIPTION
This PR addresses _problem1_ from https://github.com/Tribler/tribler/discussions/5938 and starts to solve it.

In this PR refactoring was made to explicitly split GUI errors and Core errors.

* In the case of Core errors, we always kill the application.
* In the case of GUI errors, we only kill the application when `CoreConnectTimeoutError` will occur.

Tribler will report only the first occurred GUI exception (filtered by Type).
Repetitive exceptions will be ignored.