### PR TITLE
Feature/improve sentry event

### DIFF
--- a/src/tribler-common/tribler_common/sentry_reporter/sentry_reporter.py
+++ b/src/tribler-common/tribler_common/sentry_reporter/sentry_reporter.py
@@ -192,7 +192,11 @@ class SentryReporter:
 
         context['browser'] = {'version': version, 'name': 'Tribler'}
 
-        reporter[STACKTRACE] = parse_stacktrace(get_value(post_data, 'stack'))
+        stacktrace_parts = parse_stacktrace(get_value(post_data, 'stack'))
+        reporter[STACKTRACE] = next(stacktrace_parts, [])
+        reporter[f'{STACKTRACE}_long'] = next(stacktrace_parts, [])
+        reporter[f'{STACKTRACE}_context'] = next(stacktrace_parts, [])
+
         reporter['comments'] = get_value(post_data, 'comments')
 
         reporter[OS_ENVIRON] = parse_os_environ(get_value(sys_info, OS_ENVIRON))

--- a/src/tribler-common/tribler_common/sentry_reporter/sentry_reporter.py
+++ b/src/tribler-common/tribler_common/sentry_reporter/sentry_reporter.py
@@ -198,7 +198,7 @@ class SentryReporter:
 
         stacktrace_parts = parse_stacktrace(get_value(post_data, 'stack'))
         reporter[STACKTRACE] = next(stacktrace_parts, [])
-        reporter[f'{STACKTRACE}_long'] = next(stacktrace_parts, [])
+        reporter[f'{STACKTRACE}_extra'] = next(stacktrace_parts, [])
         reporter[f'{STACKTRACE}_context'] = next(stacktrace_parts, [])
 
         reporter['comments'] = get_value(post_data, 'comments')

--- a/src/tribler-common/tribler_common/sentry_reporter/sentry_tools.py
+++ b/src/tribler-common/tribler_common/sentry_reporter/sentry_tools.py
@@ -83,6 +83,14 @@ def get_value(d, key, default=None):
     return d.get(key, default) if d else default
 
 
+def extract_dict(d, regex_key_pattern):
+    if not d or not regex_key_pattern:
+        return dict()
+
+    matched_keys = [key for key in d if re.match(regex_key_pattern, key)]
+    return {key: d[key] for key in matched_keys}
+
+
 def modify_value(d, key, function):
     if not d or not key or not function:
         return d

--- a/src/tribler-common/tribler_common/sentry_reporter/sentry_tools.py
+++ b/src/tribler-common/tribler_common/sentry_reporter/sentry_tools.py
@@ -30,21 +30,36 @@ def parse_os_environ(array):
     return result
 
 
-def parse_stacktrace(stacktrace):
+def parse_stacktrace(stacktrace, delimiters=None):
     """Parse stacktrace field.
 
+    Example of stacktrace:
+        Traceback (most recent call last):,
+              File "src\run_tribler.py", line 179, in <module>,
+            RuntimeError: ('\'utf-8\' codec can\'t decode byte 0xcd in position 0: invalid continuation byte,
+        --LONG TEXT--,
+            Traceback (most recent call last):,
+              File "<user>\\asyncio\\events.py", line 81, in _run,
+            UnicodeDecodeError: \'utf-8\' codec can\'t decode byte 0xcd in position 0: invalid continuation byte,
+        --CONTEXT--,
+            {\'message\': "Exception in callback'
     Args:
-        stacktrace: a string with '\n' delimiter.
-            Example: "line1\nline2"
+        stacktrace: the string that represents stacktrace.
+
+        delimiters: hi-level delimiters of the stacktrace.
+            ['--LONG TEXT--', '--CONTEXT--'] by default.
 
     Returns:
-        The list of strings made from the given string.
-            Example: ["line1", "line2"]
+        The generator of stacktrace parts.
     """
-    if not stacktrace:
-        return []
+    if delimiters is None:
+        delimiters = ['--LONG TEXT--', '--CONTEXT--']
 
-    return [line for line in re.split(r'\\n|\n', stacktrace) if line]
+    if not stacktrace:
+        return None
+
+    for part in re.split('|'.join(delimiters), stacktrace):
+        yield [line for line in re.split(r'\\n|\n', part) if line]
 
 
 def get_first_item(items, default=None):

--- a/src/tribler-common/tribler_common/sentry_reporter/sentry_tools.py
+++ b/src/tribler-common/tribler_common/sentry_reporter/sentry_tools.py
@@ -56,7 +56,7 @@ def parse_stacktrace(stacktrace, delimiters=None):
         delimiters = ['--LONG TEXT--', '--CONTEXT--']
 
     if not stacktrace:
-        return None
+        return
 
     for part in re.split('|'.join(delimiters), stacktrace):
         yield [line for line in re.split(r'\\n|\n', part) if line]

--- a/src/tribler-common/tribler_common/sentry_reporter/sentry_tools.py
+++ b/src/tribler-common/tribler_common/sentry_reporter/sentry_tools.py
@@ -1,6 +1,7 @@
 """ This a collection of tools for SentryReporter and SentryScrubber aimed to
 simplify work with several data structures.
 """
+import re
 
 
 def parse_os_environ(array):
@@ -43,7 +44,7 @@ def parse_stacktrace(stacktrace):
     if not stacktrace:
         return []
 
-    return [line for line in stacktrace.split('\n') if line]
+    return [line for line in re.split(r'\\n|\n', stacktrace) if line]
 
 
 def get_first_item(items, default=None):

--- a/src/tribler-common/tribler_common/sentry_reporter/tests/test_sentry_reporter.py
+++ b/src/tribler-common/tribler_common/sentry_reporter/tests/test_sentry_reporter.py
@@ -51,7 +51,7 @@ def test_send():
             'reporter': {
                 '_stacktrace': [],
                 '_stacktrace_context': [],
-                '_stacktrace_long': [],
+                '_stacktrace_extra': [],
                 'comments': None,
                 OS_ENVIRON: {},
                 'sysinfo': {},
@@ -79,7 +79,7 @@ def test_send():
             'reporter': {
                 '_stacktrace': ['l1', 'l2'],
                 '_stacktrace_context': [],
-                '_stacktrace_long': ['l3', 'l4'],
+                '_stacktrace_extra': ['l3', 'l4'],
                 'comments': 'comment',
                 'os.environ': {},
                 'sysinfo': {},
@@ -104,7 +104,7 @@ def test_send():
             'reporter': {
                 '_stacktrace': [],
                 '_stacktrace_context': [],
-                '_stacktrace_long': [],
+                '_stacktrace_extra': [],
                 'comments': None,
                 OS_ENVIRON: {'KEY': 'VALUE', 'KEY1': 'VALUE1'},
                 'sysinfo': {'platform': ['darwin'], 'platform.details': ['details']},

--- a/src/tribler-common/tribler_common/sentry_reporter/tests/test_sentry_reporter.py
+++ b/src/tribler-common/tribler_common/sentry_reporter/tests/test_sentry_reporter.py
@@ -48,7 +48,14 @@ def test_send():
     assert SentryReporter.send_event({}, None, None) == {
         'contexts': {
             'browser': {'name': 'Tribler', 'version': None},
-            'reporter': {'_stacktrace': [], 'comments': None, OS_ENVIRON: {}, 'sysinfo': None},
+            'reporter': {
+                '_stacktrace': [],
+                '_stacktrace_context': [],
+                '_stacktrace_long': [],
+                'comments': None,
+                OS_ENVIRON: {},
+                'sysinfo': None,
+            },
         },
         'tags': {'machine': None, 'os': None, 'platform': None, PLATFORM_DETAILS: None, 'version': None},
     }
@@ -61,14 +68,21 @@ def test_send():
         "timestamp": 42,
         "sysinfo": '',
         "comments": 'comment',
-        "stack": 'some\nstack',
+        "stack": 'l1\nl2--LONG TEXT--l3\nl4',
     }
 
     assert SentryReporter.send_event({'a': 'b'}, post_data, None) == {
         'a': 'b',
         'contexts': {
             'browser': {'name': 'Tribler', 'version': '0.0.0'},
-            'reporter': {'_stacktrace': ['some', 'stack'], 'comments': 'comment', 'os.environ': {}, 'sysinfo': None},
+            'reporter': {
+                '_stacktrace': ['l1', 'l2'],
+                '_stacktrace_context': [],
+                '_stacktrace_long': ['l3', 'l4'],
+                'comments': 'comment',
+                'os.environ': {},
+                'sysinfo': None,
+            },
         },
         'tags': {'machine': 'x86_64', 'os': 'posix', 'platform': None, 'platform.details': None, 'version': '0.0.0'},
     }
@@ -79,7 +93,14 @@ def test_send():
     assert SentryReporter.send_event({}, post_data, None) == {
         'contexts': {
             'browser': {'name': 'Tribler', 'version': None},
-            'reporter': {'_stacktrace': [], 'comments': None, 'os.environ': {}, 'sysinfo': None},
+            'reporter': {
+                '_stacktrace': [],
+                '_stacktrace_context': [],
+                '_stacktrace_long': [],
+                'comments': None,
+                'os.environ': {},
+                'sysinfo': None,
+            },
         },
         'tags': {'machine': None, 'os': None, 'platform': None, 'platform.details': None, 'version': None},
     }
@@ -90,6 +111,8 @@ def test_send():
             'browser': {'name': 'Tribler', 'version': None},
             'reporter': {
                 '_stacktrace': [],
+                '_stacktrace_context': [],
+                '_stacktrace_long': [],
                 'comments': None,
                 'os.environ': {'KEY': 'VALUE', 'KEY1': 'VALUE1'},
                 'sysinfo': sys_info,

--- a/src/tribler-common/tribler_common/sentry_reporter/tests/test_sentry_reporter.py
+++ b/src/tribler-common/tribler_common/sentry_reporter/tests/test_sentry_reporter.py
@@ -54,7 +54,8 @@ def test_send():
                 '_stacktrace_long': [],
                 'comments': None,
                 OS_ENVIRON: {},
-                'sysinfo': None,
+                'sysinfo': {},
+                'events': {},
             },
         },
         'tags': {'machine': None, 'os': None, 'platform': None, PLATFORM_DETAILS: None, 'version': None},
@@ -81,31 +82,22 @@ def test_send():
                 '_stacktrace_long': ['l3', 'l4'],
                 'comments': 'comment',
                 'os.environ': {},
-                'sysinfo': None,
+                'sysinfo': {},
+                'events': {},
             },
         },
         'tags': {'machine': 'x86_64', 'os': 'posix', 'platform': None, 'platform.details': None, 'version': '0.0.0'},
     }
 
-    # test sys_info
-    post_data = {"sysinfo": 'key\tvalue\nkey1\tvalue1\n'}
-
-    assert SentryReporter.send_event({}, post_data, None) == {
-        'contexts': {
-            'browser': {'name': 'Tribler', 'version': None},
-            'reporter': {
-                '_stacktrace': [],
-                '_stacktrace_context': [],
-                '_stacktrace_long': [],
-                'comments': None,
-                'os.environ': {},
-                'sysinfo': None,
-            },
-        },
-        'tags': {'machine': None, 'os': None, 'platform': None, 'platform.details': None, 'version': None},
+    sys_info = {
+        'platform': ['darwin'],
+        'platform.details': ['details'],
+        OS_ENVIRON: ['KEY:VALUE', 'KEY1:VALUE1'],
+        'event_1': [{'type': ''}],
+        'request_1': [{}],
+        'event_2': [],
+        'request_2': [],
     }
-
-    sys_info = {'platform': ['darwin'], 'platform.details': ['details'], OS_ENVIRON: ['KEY:VALUE', 'KEY1:VALUE1']}
     assert SentryReporter.send_event({}, None, sys_info) == {
         'contexts': {
             'browser': {'name': 'Tribler', 'version': None},
@@ -114,8 +106,9 @@ def test_send():
                 '_stacktrace_context': [],
                 '_stacktrace_long': [],
                 'comments': None,
-                'os.environ': {'KEY': 'VALUE', 'KEY1': 'VALUE1'},
-                'sysinfo': sys_info,
+                OS_ENVIRON: {'KEY': 'VALUE', 'KEY1': 'VALUE1'},
+                'sysinfo': {'platform': ['darwin'], 'platform.details': ['details']},
+                'events': {'event_1': [{'type': ''}], 'request_1': [{}], 'event_2': [], 'request_2': []},
             },
         },
         'tags': {'machine': None, 'os': None, 'platform': 'darwin', 'platform.details': 'details', 'version': None},

--- a/src/tribler-common/tribler_common/sentry_reporter/tests/test_sentry_tools.py
+++ b/src/tribler-common/tribler_common/sentry_reporter/tests/test_sentry_tools.py
@@ -63,11 +63,24 @@ def test_parse_os_environ():
 
 
 def test_parse_stacktrace():
-    assert parse_stacktrace(None) == []
-    assert parse_stacktrace('') == []
-    assert parse_stacktrace('\n') == []
-    assert parse_stacktrace('\n\n') == []
-    assert parse_stacktrace('line1\n\nline2\\nline3') == ['line1', 'line2', 'line3']
+    assert list(parse_stacktrace(None)) == []
+    assert list(parse_stacktrace('')) == []
+    assert list(parse_stacktrace('\n')) == [[]]
+    assert list(parse_stacktrace('\n\n')) == [[]]
+    assert list(parse_stacktrace('line1\n\nline2\\nline3')) == [['line1', 'line2', 'line3']]
+
+    # split --LONG TEXT-- and --CONTEXT-- parts
+    assert list(parse_stacktrace('l1\nl2--LONG TEXT--l3\nl4--CONTEXT--l5\nl6')) == [
+        ['l1', 'l2'],
+        ['l3', 'l4'],
+        ['l5', 'l6'],
+    ]
+
+    # split custom parts
+    assert list(parse_stacktrace('l1\nl2customl3\nl4', delimiters=['custom'])) == [
+        ['l1', 'l2'],
+        ['l3', 'l4'],
+    ]
 
 
 def test_modify():

--- a/src/tribler-common/tribler_common/sentry_reporter/tests/test_sentry_tools.py
+++ b/src/tribler-common/tribler_common/sentry_reporter/tests/test_sentry_tools.py
@@ -1,6 +1,7 @@
 from tribler_common.sentry_reporter.sentry_tools import (
     delete_item,
     distinct_by,
+    extract_dict,
     format_version,
     get_first_item,
     get_last_item,
@@ -131,3 +132,10 @@ def test_skip_dev_version():
     # experimental versions
     assert format_version('7.7.1-exp1-1-abcd ') == '7.7.1-exp1'
     assert format_version('7.7.1-someresearchtopic-7-abcd ') == '7.7.1-someresearchtopic'
+
+
+def test_extract_dict():
+    assert not extract_dict(None, None)
+
+    assert extract_dict({}, '') == {}
+    assert extract_dict({'k': 'v', 'k1': 'v1'}, r'\w$') == {'k': 'v'}

--- a/src/tribler-common/tribler_common/sentry_reporter/tests/test_sentry_tools.py
+++ b/src/tribler-common/tribler_common/sentry_reporter/tests/test_sentry_tools.py
@@ -67,7 +67,7 @@ def test_parse_stacktrace():
     assert parse_stacktrace('') == []
     assert parse_stacktrace('\n') == []
     assert parse_stacktrace('\n\n') == []
-    assert parse_stacktrace('some\n\nvalue') == ['some', 'value']
+    assert parse_stacktrace('line1\n\nline2\\nline3') == ['line1', 'line2', 'line3']
 
 
 def test_modify():


### PR DESCRIPTION
This PR improves sentry events view and should fix https://github.com/Tribler/tribler/issues/5781:
1. Better `stacktrace` formatting (long text and context were extracted)
2. Better `sysinfo` formatting (events were extracted)

Examples:
* The event before formatting: https://sentry.tribler.org/organizations/tribler/issues/475
* The event after formatting: https://sentry.tribler.org/organizations/tribler/issues/478