### PR TITLE
Add auto-disconnecting mixin for QObject

### DIFF
--- a/src/tribler-gui/tribler_gui/dialogs/addtopersonalchanneldialog.py
+++ b/src/tribler-gui/tribler_gui/dialogs/addtopersonalchanneldialog.py
@@ -9,7 +9,7 @@ from tribler_core.modules.metadata_store.serialization import CHANNEL_TORRENT, C
 from tribler_gui.dialogs.dialogcontainer import DialogContainer
 from tribler_gui.dialogs.new_channel_dialog import NewChannelDialog
 from tribler_gui.tribler_request_manager import TriblerNetworkRequest
-from tribler_gui.utilities import connect, get_ui_file_path
+from tribler_gui.utilities import get_ui_file_path
 
 
 class DownloadFileTreeWidgetItem(QTreeWidgetItem):
@@ -29,10 +29,10 @@ class AddToChannelDialog(DialogContainer):
     def __init__(self, parent):
         DialogContainer.__init__(self, parent)
         uic.loadUi(get_ui_file_path('addtochanneldialog.ui'), self.dialog_widget)
-        connect(self.dialog_widget.btn_cancel.clicked, self.close_dialog)
-        connect(self.dialog_widget.btn_confirm.clicked, self.on_confirm_clicked)
-        connect(self.dialog_widget.btn_new_channel.clicked, self.on_create_new_channel_clicked)
-        connect(self.dialog_widget.btn_new_folder.clicked, self.on_create_new_folder_clicked)
+        self.connect_signal(self.dialog_widget.btn_cancel.clicked, self.close_dialog)
+        self.connect_signal(self.dialog_widget.btn_confirm.clicked, self.on_confirm_clicked)
+        self.connect_signal(self.dialog_widget.btn_new_channel.clicked, self.on_create_new_channel_clicked)
+        self.connect_signal(self.dialog_widget.btn_new_folder.clicked, self.on_create_new_folder_clicked)
 
         self.confirm_clicked_callback = None
 
@@ -40,7 +40,7 @@ class AddToChannelDialog(DialogContainer):
 
         self.channels_tree = {}
         self.id2wt_mapping = {0: self.dialog_widget.channels_tree_wt}
-        connect(self.dialog_widget.channels_tree_wt.itemExpanded, self.on_item_expanded)
+        self.connect_signal(self.dialog_widget.channels_tree_wt.itemExpanded, self.on_item_expanded)
 
         self.dialog_widget.channels_tree_wt.setHeaderLabels(['Name'])
         self.on_main_window_resize()

--- a/src/tribler-gui/tribler_gui/dialogs/auto_disconnecting_mixin.py
+++ b/src/tribler-gui/tribler_gui/dialogs/auto_disconnecting_mixin.py
@@ -1,0 +1,78 @@
+import logging
+from collections import defaultdict
+from threading import RLock
+
+from PyQt5.QtCore import pyqtBoundSignal
+
+from tribler_gui.utilities import connect, disconnect
+
+lock = RLock()
+logger = logging.getLogger('QAutoDisconnectingMixin')
+
+
+class QAutoDisconnectingMixin:
+    enabled = False
+
+    def lazy_init(self):
+        if not QAutoDisconnectingMixin.enabled:
+            return
+
+        with lock:
+            # abbreviation "adm" here is the attempt to avoid naming conflicts
+            if hasattr(self, 'adm_inited'):
+                return
+
+            self.adm_inited = True
+            self.adm_destroyed_callback_connected = False
+            self.adm_connected_signals = {}
+            self.adm_connected_callbacks = defaultdict(set)
+
+            if hasattr(self, 'destroyed') and isinstance(self.destroyed, pyqtBoundSignal):
+                connect(self.destroyed, self.on_adm_destroy)
+
+                self.adm_destroyed_callback_connected = True
+
+                logger.info(f'Initialized: {self.__class__.__name__}')
+
+    def connect_signal(self, signal, callback):
+        if not callback:
+            return
+
+        if not QAutoDisconnectingMixin.enabled:
+            connect(signal, callback)
+            return
+
+        self.lazy_init()
+
+        with lock:
+            signal_id = id(signal)
+
+            # prevent double connect for a signal-callback pair
+            if callback not in self.adm_connected_callbacks[signal_id]:
+                connect(signal, callback)
+
+            if self.adm_destroyed_callback_connected:
+                self.adm_connected_signals[signal_id] = signal
+                self.adm_connected_callbacks[signal_id].add(callback)
+
+            logger.info(f'Connected: {self.__class__.__name__}-{signal_id}')
+
+    def on_adm_destroy(self, *args):
+        if not QAutoDisconnectingMixin.enabled:
+            return
+
+        with lock:
+            if not self.adm_connected_signals:
+                return
+
+            for signal_id, signal in self.adm_connected_signals.items():
+                for callback in self.adm_connected_callbacks[signal_id]:
+                    try:
+                        disconnect(signal, callback)
+
+                        logger.info(f'Disconnected: {self.__class__.__name__}-{signal_id}')
+                    except Exception as e:
+                        logger.error(f'Error while disconnect {self.__class__.__name__}-{signal_id}: {e}')
+
+            self.adm_connected_signals = None
+            self.adm_connected_callbacks = None

--- a/src/tribler-gui/tribler_gui/dialogs/confirmationdialog.py
+++ b/src/tribler-gui/tribler_gui/dialogs/confirmationdialog.py
@@ -5,7 +5,7 @@ from PyQt5.QtWidgets import QSizePolicy, QSpacerItem
 
 from tribler_gui.defs import BUTTON_TYPE_NORMAL
 from tribler_gui.dialogs.dialogcontainer import DialogContainer
-from tribler_gui.utilities import connect, get_ui_file_path
+from tribler_gui.utilities import get_ui_file_path
 from tribler_gui.widgets.ellipsebutton import EllipseButton
 
 
@@ -28,7 +28,7 @@ class ConfirmationDialog(DialogContainer):
         if not show_input:
             self.dialog_widget.dialog_input.setHidden(True)
         else:
-            connect(self.dialog_widget.dialog_input.returnPressed, lambda: self.button_clicked.emit(0))
+            self.connect_signal(self.dialog_widget.dialog_input.returnPressed, lambda: self.button_clicked.emit(0))
 
         if not checkbox_text:
             self.dialog_widget.checkbox.setHidden(True)
@@ -45,7 +45,7 @@ class ConfirmationDialog(DialogContainer):
         hspacer_right = QSpacerItem(1, 1, QSizePolicy.Expanding, QSizePolicy.Fixed)
         self.dialog_widget.dialog_button_container.layout().addSpacerItem(hspacer_right)
         if hasattr(self.window(), 'escape_pressed'):
-            connect(self.window().escape_pressed, self.close_dialog)
+            self.connect_signal(self.window().escape_pressed, self.close_dialog)
         self.on_main_window_resize()
 
     @classmethod
@@ -55,7 +55,7 @@ class ConfirmationDialog(DialogContainer):
         def on_close(checked):
             error_dialog.close_dialog()
 
-        connect(error_dialog.button_clicked, on_close)
+        error_dialog.connect_signal(error_dialog.button_clicked, on_close)
         error_dialog.show()
         return error_dialog
 
@@ -66,7 +66,7 @@ class ConfirmationDialog(DialogContainer):
         def on_close(checked):
             error_dialog.close_dialog()
 
-        connect(error_dialog.button_clicked, on_close)
+        error_dialog.connect_signal(error_dialog.button_clicked, on_close)
         error_dialog.show()
         return error_dialog
 
@@ -95,4 +95,4 @@ class ConfirmationDialog(DialogContainer):
         )
 
         self.dialog_widget.dialog_button_container.layout().addWidget(button)
-        connect(button.clicked, lambda _: self.button_clicked.emit(index))
+        self.connect_signal(button.clicked, lambda _: self.button_clicked.emit(index))

--- a/src/tribler-gui/tribler_gui/dialogs/createtorrentdialog.py
+++ b/src/tribler-gui/tribler_gui/dialogs/createtorrentdialog.py
@@ -5,13 +5,12 @@ from PyQt5.QtCore import QDir, pyqtSignal
 from PyQt5.QtWidgets import QAction, QFileDialog, QSizePolicy, QTreeWidgetItem
 
 from tribler_core.utilities.unicode import ensure_unicode
-
 from tribler_gui.defs import BUTTON_TYPE_NORMAL
 from tribler_gui.dialogs.confirmationdialog import ConfirmationDialog
 from tribler_gui.dialogs.dialogcontainer import DialogContainer
 from tribler_gui.tribler_action_menu import TriblerActionMenu
 from tribler_gui.tribler_request_manager import TriblerNetworkRequest
-from tribler_gui.utilities import connect, get_ui_file_path, is_dir_writable
+from tribler_gui.utilities import get_ui_file_path, is_dir_writable
 
 
 class DownloadFileTreeWidgetItem(QTreeWidgetItem):
@@ -20,7 +19,6 @@ class DownloadFileTreeWidgetItem(QTreeWidgetItem):
 
 
 class CreateTorrentDialog(DialogContainer):
-
     create_torrent_notification = pyqtSignal(dict)
 
     def __init__(self, parent):
@@ -29,13 +27,13 @@ class CreateTorrentDialog(DialogContainer):
         uic.loadUi(get_ui_file_path('createtorrentdialog.ui'), self.dialog_widget)
 
         self.dialog_widget.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Expanding)
-        connect(self.dialog_widget.btn_cancel.clicked, self.close_dialog)
-        connect(self.dialog_widget.create_torrent_choose_files_button.clicked, self.on_choose_files_clicked)
-        connect(self.dialog_widget.create_torrent_choose_dir_button.clicked, self.on_choose_dir_clicked)
-        connect(self.dialog_widget.btn_create.clicked, self.on_create_clicked)
-        connect(self.dialog_widget.create_torrent_files_list.customContextMenuRequested, self.on_right_click_file_item)
+        self.connect_signal(self.dialog_widget.btn_cancel.clicked, self.close_dialog)
+        self.connect_signal(self.dialog_widget.create_torrent_choose_files_button.clicked, self.on_choose_files_clicked)
+        self.connect_signal(self.dialog_widget.create_torrent_choose_dir_button.clicked, self.on_choose_dir_clicked)
+        self.connect_signal(self.dialog_widget.btn_create.clicked, self.on_create_clicked)
+        self.connect_signal(self.dialog_widget.create_torrent_files_list.customContextMenuRequested, self.on_right_click_file_item)
         self.dialog_widget.create_torrent_files_list.clear()
-        connect(self.dialog_widget.save_directory_chooser.clicked, self.on_select_save_directory)
+        self.connect_signal(self.dialog_widget.save_directory_chooser.clicked, self.on_select_save_directory)
         self.dialog_widget.edit_channel_create_torrent_progress_label.setText("")
         self.dialog_widget.file_export_dir.setText(os.path.expanduser("~"))
         self.dialog_widget.adjustSize()
@@ -86,7 +84,7 @@ class CreateTorrentDialog(DialogContainer):
                 [('CLOSE', BUTTON_TYPE_NORMAL)],
             )
 
-            connect(dialog.button_clicked, dialog.close_dialog)
+            self.connect_signal(dialog.button_clicked, dialog.close_dialog)
             dialog.show()
             return
 
@@ -165,7 +163,7 @@ class CreateTorrentDialog(DialogContainer):
         selected_item_index = self.dialog_widget.create_torrent_files_list.row(item_clicked)
 
         remove_action = QAction('Remove file', self)
-        connect(remove_action.triggered, lambda index=selected_item_index: self.on_remove_entry(index))
+        self.connect_signal(remove_action.triggered, lambda index=selected_item_index: self.on_remove_entry(index))
 
         menu = TriblerActionMenu(self)
         menu.addAction(remove_action)

--- a/src/tribler-gui/tribler_gui/dialogs/dialogcontainer.py
+++ b/src/tribler-gui/tribler_gui/dialogs/dialogcontainer.py
@@ -3,18 +3,19 @@ from PyQt5.QtGui import QPainter
 from PyQt5.QtWidgets import QStyle, QStyleOption, QWidget
 
 from tribler_common.sentry_reporter.sentry_mixin import AddBreadcrumbOnShowMixin
+from tribler_gui.dialogs.auto_disconnecting_mixin import QAutoDisconnectingMixin
 
 from tribler_gui.utilities import connect
 
 
-class DialogContainer(AddBreadcrumbOnShowMixin, QWidget):
+class DialogContainer(AddBreadcrumbOnShowMixin, QAutoDisconnectingMixin, QWidget):
     def __init__(self, parent):
         QWidget.__init__(self, parent)
         self.setStyleSheet("background-color: rgba(30, 30, 30, 0.75);")
 
         self.dialog_widget = QWidget(self)
         self.closed = False
-        connect(self.window().resize_event, self.on_main_window_resize)
+        self.connect_signal(self.window().resize_event, self.on_main_window_resize)
 
     def paintEvent(self, _):
         opt = QStyleOption()

--- a/src/tribler-gui/tribler_gui/dialogs/feedbackdialog.py
+++ b/src/tribler-gui/tribler_gui/dialogs/feedbackdialog.py
@@ -10,6 +10,7 @@ from PyQt5.QtWidgets import QAction, QApplication, QDialog, QMessageBox, QTreeWi
 
 from tribler_common.sentry_reporter.sentry_mixin import AddBreadcrumbOnShowMixin
 from tribler_common.sentry_reporter.sentry_reporter import SentryReporter
+from tribler_gui.dialogs.auto_disconnecting_mixin import QAutoDisconnectingMixin
 
 from tribler_gui.event_request_manager import received_events
 from tribler_gui.tribler_action_menu import TriblerActionMenu
@@ -18,10 +19,10 @@ from tribler_gui.tribler_request_manager import (
     performed_requests as tribler_performed_requests,
     tribler_urlencode,
 )
-from tribler_gui.utilities import connect, get_ui_file_path
+from tribler_gui.utilities import get_ui_file_path
 
 
-class FeedbackDialog(AddBreadcrumbOnShowMixin, QDialog):
+class FeedbackDialog(AddBreadcrumbOnShowMixin, QAutoDisconnectingMixin, QDialog):
     def __init__(  # pylint: disable=too-many-arguments, too-many-locals
         self,
         parent,
@@ -53,8 +54,8 @@ class FeedbackDialog(AddBreadcrumbOnShowMixin, QDialog):
 
         self.error_text_edit.setPlainText(exception_text.rstrip())
 
-        connect(self.cancel_button.clicked, self.on_cancel_clicked)
-        connect(self.send_report_button.clicked, self.on_send_clicked)
+        self.connect_signal(self.cancel_button.clicked, self.on_cancel_clicked)
+        self.connect_signal(self.send_report_button.clicked, self.on_send_clicked)
 
         # Add machine information to the tree widget
         add_item_to_info_widget('os.getcwd', f'{os.getcwd()}')
@@ -94,7 +95,7 @@ class FeedbackDialog(AddBreadcrumbOnShowMixin, QDialog):
             events_ind += 1
 
         # Users can remove specific lines in the report
-        connect(self.env_variables_list.customContextMenuRequested, self.on_right_click_item)
+        self.connect_signal(self.env_variables_list.customContextMenuRequested, self.on_right_click_item)
 
         self.send_automatically = FeedbackDialog.can_send_automatically(error_reporting_requires_user_consent)
         if self.send_automatically:
@@ -118,7 +119,7 @@ class FeedbackDialog(AddBreadcrumbOnShowMixin, QDialog):
         menu = TriblerActionMenu(self)
 
         remove_action = QAction('Remove entry', self)
-        connect(remove_action.triggered, self.on_remove_entry)
+        self.connect_signal(remove_action.triggered, self.on_remove_entry)
         menu.addAction(remove_action)
         menu.exec_(self.env_variables_list.mapToGlobal(pos))
 

--- a/src/tribler-gui/tribler_gui/dialogs/new_channel_dialog.py
+++ b/src/tribler-gui/tribler_gui/dialogs/new_channel_dialog.py
@@ -1,6 +1,5 @@
 from tribler_gui.defs import BUTTON_TYPE_CONFIRM, BUTTON_TYPE_NORMAL
 from tribler_gui.dialogs.confirmationdialog import ConfirmationDialog
-from tribler_gui.utilities import connect
 
 
 class NewChannelDialog(ConfirmationDialog):
@@ -20,7 +19,7 @@ class NewChannelDialog(ConfirmationDialog):
         self.create_channel_callback = create_channel_callback
         self.dialog_widget.dialog_input.setPlaceholderText('Channel name')
         self.dialog_widget.dialog_input.setFocus()
-        connect(self.button_clicked, self.on_channel_name_dialog_done)
+        self.connect_signal(self.button_clicked, self.on_channel_name_dialog_done)
         self.show()
 
     def on_channel_name_dialog_done(self, action):

--- a/src/tribler-gui/tribler_gui/dialogs/startdownloaddialog.py
+++ b/src/tribler-gui/tribler_gui/dialogs/startdownloaddialog.py
@@ -13,7 +13,6 @@ from tribler_gui.dialogs.confirmationdialog import ConfirmationDialog
 from tribler_gui.dialogs.dialogcontainer import DialogContainer
 from tribler_gui.tribler_request_manager import TriblerNetworkRequest
 from tribler_gui.utilities import (
-    connect,
     format_size,
     get_checkbox_style,
     get_gui_setting,
@@ -52,13 +51,13 @@ class StartDownloadDialog(DialogContainer):
 
         self.dialog_widget.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Expanding)
 
-        connect(self.dialog_widget.browse_dir_button.clicked, self.on_browse_dir_clicked)
-        connect(self.dialog_widget.cancel_button.clicked, lambda _: self.button_clicked.emit(0))
-        connect(self.dialog_widget.download_button.clicked, self.on_download_clicked)
-        connect(self.dialog_widget.select_all_files_button.clicked, self.on_all_files_selected_clicked)
-        connect(self.dialog_widget.deselect_all_files_button.clicked, self.on_all_files_deselected_clicked)
-        connect(self.dialog_widget.loading_files_label.clicked, self.on_reload_torrent_info)
-        connect(self.dialog_widget.anon_download_checkbox.clicked, self.on_reload_torrent_info)
+        self.connect_signal(self.dialog_widget.browse_dir_button.clicked, self.on_browse_dir_clicked)
+        self.connect_signal(self.dialog_widget.cancel_button.clicked, lambda _: self.button_clicked.emit(0))
+        self.connect_signal(self.dialog_widget.download_button.clicked, self.on_download_clicked)
+        self.connect_signal(self.dialog_widget.select_all_files_button.clicked, self.on_all_files_selected_clicked)
+        self.connect_signal(self.dialog_widget.deselect_all_files_button.clicked, self.on_all_files_deselected_clicked)
+        self.connect_signal(self.dialog_widget.loading_files_label.clicked, self.on_reload_torrent_info)
+        self.connect_signal(self.dialog_widget.anon_download_checkbox.clicked, self.on_reload_torrent_info)
 
         self.dialog_widget.destination_input.setStyleSheet(
             """
@@ -108,7 +107,7 @@ class StartDownloadDialog(DialogContainer):
 
         self.dialog_widget.torrent_name_label.setText(torrent_name)
 
-        connect(self.dialog_widget.anon_download_checkbox.stateChanged, self.on_anon_download_state_changed)
+        self.connect_signal(self.dialog_widget.anon_download_checkbox.stateChanged, self.on_anon_download_state_changed)
         self.dialog_widget.anon_download_checkbox.setChecked(
             self.window().tribler_settings['download_defaults']['anonymity_enabled']
         )
@@ -178,7 +177,7 @@ class StartDownloadDialog(DialogContainer):
                 loading_message if not self.metainfo_retries else timeout_message
             )
             self.metainfo_fetch_timer = QTimer()
-            connect(self.metainfo_fetch_timer.timeout, self.perform_files_request)
+            self.connect_signal(self.metainfo_fetch_timer.timeout, self.perform_files_request)
             self.metainfo_fetch_timer.setSingleShot(True)
             self.metainfo_fetch_timer.start(METAINFO_TIMEOUT)
 

--- a/src/tribler-gui/tribler_gui/dialogs/trustexplanationdialog.py
+++ b/src/tribler-gui/tribler_gui/dialogs/trustexplanationdialog.py
@@ -2,7 +2,7 @@ from PyQt5 import uic
 from PyQt5.QtWidgets import QSizePolicy
 
 from tribler_gui.dialogs.dialogcontainer import DialogContainer
-from tribler_gui.utilities import connect, get_ui_file_path
+from tribler_gui.utilities import get_ui_file_path
 
 
 class TrustExplanationDialog(DialogContainer):
@@ -12,7 +12,7 @@ class TrustExplanationDialog(DialogContainer):
         uic.loadUi(get_ui_file_path('trustexplanation.ui'), self.dialog_widget)
 
         self.dialog_widget.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Expanding)
-        connect(self.dialog_widget.close_button.clicked, self.close_dialog)
+        self.connect_signal(self.dialog_widget.close_button.clicked, self.close_dialog)
 
         self.update_window()
 

--- a/src/tribler-gui/tribler_gui/single_application.py
+++ b/src/tribler-gui/tribler_gui/single_application.py
@@ -7,12 +7,13 @@ from PyQt5.QtCore import QTextStream, Qt, pyqtSignal
 from PyQt5.QtNetwork import QLocalServer, QLocalSocket
 from PyQt5.QtWidgets import QApplication
 
+from tribler_gui.dialogs.auto_disconnecting_mixin import QAutoDisconnectingMixin
 from tribler_gui.utilities import connect, disconnect
 
 LOGVARSTR = "%25s = '%s'"
 
 
-class QtSingleApplication(QApplication):
+class QtSingleApplication(QAutoDisconnectingMixin, QApplication):
     """
     This class makes sure that we can only start one Tribler application.
     When a user tries to open a second Tribler instance, the current active one will be brought to front.
@@ -57,7 +58,7 @@ class QtSingleApplication(QApplication):
             self._outSocket = None
             self._server = QLocalServer()
             self._server.listen(self._id)
-            connect(self._server.newConnection, self._on_new_connection)
+            self.connect_signal(self._server.newConnection, self._on_new_connection)
 
         logfunc(sys._getframe().f_code.co_name + '(): returning')
 
@@ -106,7 +107,7 @@ class QtSingleApplication(QApplication):
             return
         self._inStream = QTextStream(self._inSocket)
         self._inStream.setCodec('UTF-8')
-        connect(self._inSocket.readyRead, self._on_ready_read)
+        self.connect_signal(self._inSocket.readyRead, self._on_ready_read)
         if self._activate_on_message:
             self.activate_window()
 

--- a/src/tribler-gui/tribler_gui/tribler_app.py
+++ b/src/tribler-gui/tribler_gui/tribler_app.py
@@ -24,7 +24,7 @@ class TriblerApplication(QtSingleApplication):
     def __init__(self, app_name, args):
         QtSingleApplication.__init__(self, app_name, args)
         self.code_executor = None
-        connect(self.messageReceived, self.on_app_message)
+        self.connect_signal(self.messageReceived, self.on_app_message)
         self.translator = get_default_system_translator()
 
     def on_app_message(self, msg):
@@ -48,7 +48,7 @@ class TriblerApplication(QtSingleApplication):
             variables.update(locals())
             variables['window'] = self.activation_window()
             self.code_executor = CodeExecutor(5500, shell_variables=variables)
-            connect(self.activation_window().tribler_crashed, self.code_executor.on_crash)
+            self.connect_signal(self.activation_window().tribler_crashed, self.code_executor.on_crash)
 
         if '--testnet' in sys.argv[1:]:
             os.environ['TESTNET'] = "YES"

--- a/src/tribler-gui/tribler_gui/widgets/channelsmenulistwidget.py
+++ b/src/tribler-gui/tribler_gui/widgets/channelsmenulistwidget.py
@@ -7,10 +7,11 @@ from PyQt5.QtWidgets import QAbstractItemView, QAction, QListWidget, QListWidget
 from tribler_common.simpledefs import CHANNEL_STATE
 
 from tribler_core.modules.metadata_store.serialization import CHANNEL_TORRENT
+from tribler_gui.dialogs.auto_disconnecting_mixin import QAutoDisconnectingMixin
 
 from tribler_gui.tribler_action_menu import TriblerActionMenu
 from tribler_gui.tribler_request_manager import TriblerNetworkRequest
-from tribler_gui.utilities import connect, get_image_path
+from tribler_gui.utilities import get_image_path
 
 
 def entry_to_tuple(entry):
@@ -43,7 +44,7 @@ class ChannelListItem(QListWidgetItem):
         return super().setData(role, new_value)
 
 
-class ChannelsMenuListWidget(QListWidget):
+class ChannelsMenuListWidget(QAutoDisconnectingMixin, QListWidget):
     def __init__(self, parent=None):
         QListWidget.__init__(self, parent=parent)
         self.base_url = "channels"
@@ -72,18 +73,18 @@ class ChannelsMenuListWidget(QListWidget):
     def create_foreign_menu(self):
         menu = TriblerActionMenu(self)
         unsubscribe_action = QAction('Unsubscribe', self)
-        connect(unsubscribe_action.triggered, self._on_unsubscribe_action)
+        self.connect_signal(unsubscribe_action.triggered, self._on_unsubscribe_action)
         menu.addAction(unsubscribe_action)
         return menu
 
     def create_personal_menu(self):
         menu = TriblerActionMenu(self)
         delete_action = QAction('Delete channel', self)
-        connect(delete_action.triggered, self._on_delete_action)
+        self.connect_signal(delete_action.triggered, self._on_delete_action)
         menu.addAction(delete_action)
 
         rename_action = QAction('Rename channel', self)
-        connect(rename_action.triggered, self._trigger_name_editor)
+        self.connect_signal(rename_action.triggered, self._trigger_name_editor)
         menu.addAction(rename_action)
         return menu
 

--- a/src/tribler-gui/tribler_gui/widgets/createtorrentpage.py
+++ b/src/tribler-gui/tribler_gui/widgets/createtorrentpage.py
@@ -7,13 +7,14 @@ from PyQt5.QtWidgets import QAction, QFileDialog, QWidget
 from tribler_common.sentry_reporter.sentry_mixin import AddBreadcrumbOnShowMixin
 
 from tribler_gui.defs import BUTTON_TYPE_NORMAL, PAGE_EDIT_CHANNEL_TORRENTS
+from tribler_gui.dialogs.auto_disconnecting_mixin import QAutoDisconnectingMixin
 from tribler_gui.dialogs.confirmationdialog import ConfirmationDialog
 from tribler_gui.tribler_action_menu import TriblerActionMenu
 from tribler_gui.tribler_request_manager import TriblerNetworkRequest
-from tribler_gui.utilities import connect, get_image_path
+from tribler_gui.utilities import get_image_path
 
 
-class CreateTorrentPage(AddBreadcrumbOnShowMixin, QWidget):
+class CreateTorrentPage(AddBreadcrumbOnShowMixin, QAutoDisconnectingMixin, QWidget):
     """
     The CreateTorrentPage is the page where users can create torrent files so they can be added to their channel.
     """
@@ -36,12 +37,12 @@ class CreateTorrentPage(AddBreadcrumbOnShowMixin, QWidget):
         if not self.initialized:
             self.window().manage_channel_create_torrent_back.setIcon(QIcon(get_image_path('page_back.png')))
 
-            connect(self.window().create_torrent_files_list.customContextMenuRequested, self.on_right_click_file_item)
-            connect(self.window().manage_channel_create_torrent_back.clicked,
-                    self.on_create_torrent_manage_back_clicked)
-            connect(self.window().create_torrent_choose_files_button.clicked, self.on_choose_files_clicked)
-            connect(self.window().create_torrent_choose_dir_button.clicked, self.on_choose_dir_clicked)
-            connect(self.window().edit_channel_create_torrent_button.clicked, self.on_create_clicked)
+            self.connect_signal(self.window().create_torrent_files_list.customContextMenuRequested, self.on_right_click_file_item)
+            self.connect_signal(self.window().manage_channel_create_torrent_back.clicked,
+                                self.on_create_torrent_manage_back_clicked)
+            self.connect_signal(self.window().create_torrent_choose_files_button.clicked, self.on_choose_files_clicked)
+            self.connect_signal(self.window().create_torrent_choose_dir_button.clicked, self.on_choose_dir_clicked)
+            self.connect_signal(self.window().edit_channel_create_torrent_button.clicked, self.on_create_clicked)
 
             self.initialized = True
 
@@ -76,7 +77,7 @@ class CreateTorrentPage(AddBreadcrumbOnShowMixin, QWidget):
             self.dialog = ConfirmationDialog(
                 self, "Notice", "You should add at least one file to your torrent.", [('CLOSE', BUTTON_TYPE_NORMAL)]
             )
-            connect(self.dialog.button_clicked, self.on_dialog_ok_clicked)
+            self.connect_signal(self.dialog.button_clicked, self.on_dialog_ok_clicked)
             self.dialog.show()
             return
 
@@ -132,6 +133,6 @@ class CreateTorrentPage(AddBreadcrumbOnShowMixin, QWidget):
         menu = TriblerActionMenu(self)
 
         remove_action = QAction('Remove file', self)
-        connect(remove_action.triggered, self.on_remove_entry)
+        self.connect_signal(remove_action.triggered, self.on_remove_entry)
         menu.addAction(remove_action)
         menu.exec_(self.window().create_torrent_files_list.mapToGlobal(pos))

--- a/src/tribler-gui/tribler_gui/widgets/discoveringpage.py
+++ b/src/tribler-gui/tribler_gui/widgets/discoveringpage.py
@@ -2,11 +2,12 @@ from PyQt5.QtSvg import QGraphicsSvgItem, QSvgRenderer
 from PyQt5.QtWidgets import QGraphicsScene, QWidget
 
 from tribler_common.sentry_reporter.sentry_mixin import AddBreadcrumbOnShowMixin
+from tribler_gui.dialogs.auto_disconnecting_mixin import QAutoDisconnectingMixin
 
 from tribler_gui.utilities import connect, get_image_path
 
 
-class DiscoveringPage(AddBreadcrumbOnShowMixin, QWidget):
+class DiscoveringPage(AddBreadcrumbOnShowMixin, QAutoDisconnectingMixin, QWidget):
     """
     The DiscoveringPage is shown when users are starting Tribler for the first time. It hides when there are at least
     five discovered channels.
@@ -22,13 +23,13 @@ class DiscoveringPage(AddBreadcrumbOnShowMixin, QWidget):
         svg_item = QGraphicsSvgItem()
 
         svg = QSvgRenderer(get_image_path("loading_animation.svg"))
-        connect(svg.repaintNeeded, svg_item.update)
+        self.connect_signal(svg.repaintNeeded, svg_item.update)
         svg_item.setSharedRenderer(svg)
         svg_container.addItem(svg_item)
 
         self.window().discovering_svg_view.setScene(svg_container)
 
-        connect(self.window().core_manager.events_manager.discovered_channel, self.on_discovered_channel)
+        self.connect_signal(self.window().core_manager.events_manager.discovered_channel, self.on_discovered_channel)
 
     def on_discovered_channel(self, _):
         self.found_channels += 1

--- a/src/tribler-gui/tribler_gui/widgets/downloadsdetailstabwidget.py
+++ b/src/tribler-gui/tribler_gui/widgets/downloadsdetailstabwidget.py
@@ -4,13 +4,14 @@ from PyQt5.QtWidgets import QAction, QTabWidget, QTreeWidgetItem
 from tribler_common.simpledefs import dlstatus_strings
 
 from tribler_gui.defs import *
+from tribler_gui.dialogs.auto_disconnecting_mixin import QAutoDisconnectingMixin
 from tribler_gui.tribler_action_menu import TriblerActionMenu
 from tribler_gui.tribler_request_manager import TriblerNetworkRequest
 from tribler_gui.utilities import compose_magnetlink, connect, copy_to_clipboard, format_size, format_speed
 from tribler_gui.widgets.downloadfilewidgetitem import DownloadFileWidgetItem
 
 
-class DownloadsDetailsTabWidget(QTabWidget):
+class DownloadsDetailsTabWidget(QAutoDisconnectingMixin, QTabWidget):
     """
     The DownloadDetailsTab is the tab that provides details about a specific selected download. This information
     includes the connected peers, tracker status and file information.
@@ -23,14 +24,14 @@ class DownloadsDetailsTabWidget(QTabWidget):
         self.selected_files_info = []
 
     def initialize_details_widget(self):
-        connect(self.window().download_files_list.customContextMenuRequested, self.on_right_click_file_item)
+        self.connect_signal(self.window().download_files_list.customContextMenuRequested, self.on_right_click_file_item)
         self.window().download_files_list.header().resizeSection(0, 220)
         self.setCurrentIndex(0)
         # make name, infohash and download destination selectable to copy
         self.window().download_detail_infohash_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
         self.window().download_detail_name_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
         self.window().download_detail_destination_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
-        connect(self.window().download_detail_copy_magnet_button.clicked, self.on_copy_magnet_clicked)
+        self.connect_signal(self.window().download_detail_copy_magnet_button.clicked, self.on_copy_magnet_clicked)
 
     def update_with_download(self, download):
         did_change = self.current_download != download
@@ -181,9 +182,9 @@ class DownloadsDetailsTabWidget(QTabWidget):
         include_action = QAction('Include file' + ('(s)' if num_selected > 1 else ''), self)
         exclude_action = QAction('Exclude file' + ('(s)' if num_selected > 1 else ''), self)
 
-        connect(include_action.triggered, self.on_files_included)
+        self.connect_signal(include_action.triggered, self.on_files_included)
         include_action.setEnabled(True)
-        connect(exclude_action.triggered, self.on_files_excluded)
+        self.connect_signal(exclude_action.triggered, self.on_files_excluded)
         exclude_action.setEnabled(not (num_excludes + num_includes_selected == len(item_infos)))
 
         menu.addAction(include_action)

--- a/src/tribler-gui/tribler_gui/widgets/downloadspage.py
+++ b/src/tribler-gui/tribler_gui/widgets/downloadspage.py
@@ -26,6 +26,7 @@ from tribler_gui.defs import (
     DOWNLOADS_FILTER_DOWNLOADING,
     DOWNLOADS_FILTER_INACTIVE,
 )
+from tribler_gui.dialogs.auto_disconnecting_mixin import QAutoDisconnectingMixin
 from tribler_gui.dialogs.confirmationdialog import ConfirmationDialog
 from tribler_gui.tribler_action_menu import TriblerActionMenu
 from tribler_gui.tribler_request_manager import TriblerFileDownloadRequest, TriblerNetworkRequest
@@ -43,7 +44,7 @@ button_name2filter = {
 }
 
 # pylint: disable=too-many-instance-attributes, too-many-public-methods
-class DownloadsPage(AddBreadcrumbOnShowMixin, QWidget):
+class DownloadsPage(AddBreadcrumbOnShowMixin, QAutoDisconnectingMixin, QWidget):
     """
     This class is responsible for managing all items on the downloads page.
     The downloads page shows all downloads and specific details about a download.
@@ -78,28 +79,28 @@ class DownloadsPage(AddBreadcrumbOnShowMixin, QWidget):
 
     def initialize_downloads_page(self):
         self.window().downloads_tab.initialize()
-        connect(self.window().downloads_tab.clicked_tab_button, self.on_downloads_tab_button_clicked)
+        self.connect_signal(self.window().downloads_tab.clicked_tab_button, self.on_downloads_tab_button_clicked)
 
-        connect(self.window().start_download_button.clicked, self.on_start_download_clicked)
-        connect(self.window().stop_download_button.clicked, self.on_stop_download_clicked)
-        connect(self.window().remove_download_button.clicked, self.on_remove_download_clicked)
+        self.connect_signal(self.window().start_download_button.clicked, self.on_start_download_clicked)
+        self.connect_signal(self.window().stop_download_button.clicked, self.on_stop_download_clicked)
+        self.connect_signal(self.window().remove_download_button.clicked, self.on_remove_download_clicked)
 
-        connect(self.window().downloads_list.itemSelectionChanged, self.on_download_item_clicked)
+        self.connect_signal(self.window().downloads_list.itemSelectionChanged, self.on_download_item_clicked)
 
-        connect(self.window().downloads_list.customContextMenuRequested, self.on_right_click_item)
+        self.connect_signal(self.window().downloads_list.customContextMenuRequested, self.on_right_click_item)
 
         self.window().download_details_widget.initialize_details_widget()
         self.window().download_details_widget.hide()
 
-        connect(self.window().downloads_filter_input.textChanged, self.on_filter_text_changed)
+        self.connect_signal(self.window().downloads_filter_input.textChanged, self.on_filter_text_changed)
 
         self.window().downloads_list.header().setSortIndicator(12, Qt.AscendingOrder)
         self.window().downloads_list.header().resizeSection(12, 146)
 
         self.downloads_timeout_timer.setSingleShot(True)
         self.downloads_timer.setSingleShot(True)
-        connect(self.downloads_timer.timeout, self.load_downloads)
-        connect(self.downloads_timeout_timer.timeout, self.on_downloads_request_timeout)
+        self.connect_signal(self.downloads_timer.timeout, self.load_downloads)
+        self.connect_signal(self.downloads_timeout_timer.timeout, self.on_downloads_request_timeout)
 
     def on_filter_text_changed(self, text):
         self.window().downloads_list.clearSelection()
@@ -323,7 +324,7 @@ class DownloadsPage(AddBreadcrumbOnShowMixin, QWidget):
                 ('cancel', BUTTON_TYPE_CONFIRM),
             ],
         )
-        connect(self.dialog.button_clicked, self.on_remove_download_dialog)
+        self.connect_signal(self.dialog.button_clicked, self.on_remove_download_dialog)
         self.dialog.show()
 
     def on_remove_download_dialog(self, action):
@@ -424,7 +425,7 @@ class DownloadsPage(AddBreadcrumbOnShowMixin, QWidget):
             self.dialog.dialog_widget.dialog_input.setPlaceholderText('Torrent file name')
             self.dialog.dialog_widget.dialog_input.setText(f"{torrent_name}.torrent")
             self.dialog.dialog_widget.dialog_input.setFocus()
-            connect(self.dialog.button_clicked, self.on_export_download_dialog_done)
+            self.connect_signal(self.dialog.button_clicked, self.on_export_download_dialog_done)
             self.dialog.show()
 
     def on_export_download_dialog_done(self, action):
@@ -492,22 +493,22 @@ class DownloadsPage(AddBreadcrumbOnShowMixin, QWidget):
         two_hop_anon_action = QAction('Two hops', self)
         three_hop_anon_action = QAction('Three hops', self)
 
-        connect(start_action.triggered, self.on_start_download_clicked)
+        self.connect_signal(start_action.triggered, self.on_start_download_clicked)
         start_action.setEnabled(DownloadsPage.start_download_enabled(self.selected_items))
-        connect(stop_action.triggered, self.on_stop_download_clicked)
+        self.connect_signal(stop_action.triggered, self.on_stop_download_clicked)
         stop_action.setEnabled(DownloadsPage.stop_download_enabled(self.selected_items))
-        connect(add_to_channel_action.triggered, self.on_add_to_channel)
-        connect(remove_download_action.triggered, self.on_remove_download_clicked)
-        connect(force_recheck_action.triggered, self.on_force_recheck_download)
+        self.connect_signal(add_to_channel_action.triggered, self.on_add_to_channel)
+        self.connect_signal(remove_download_action.triggered, self.on_remove_download_clicked)
+        self.connect_signal(force_recheck_action.triggered, self.on_force_recheck_download)
         force_recheck_action.setEnabled(DownloadsPage.force_recheck_download_enabled(self.selected_items))
-        connect(export_download_action.triggered, self.on_export_download)
-        connect(explore_files_action.triggered, self.on_explore_files)
-        connect(move_files_action.triggered, self.on_move_files)
+        self.connect_signal(export_download_action.triggered, self.on_export_download)
+        self.connect_signal(explore_files_action.triggered, self.on_explore_files)
+        self.connect_signal(move_files_action.triggered, self.on_move_files)
 
-        connect(no_anon_action.triggered, lambda _: self.change_anonymity(0))
-        connect(one_hop_anon_action.triggered, lambda _: self.change_anonymity(1))
-        connect(two_hop_anon_action.triggered, lambda _: self.change_anonymity(2))
-        connect(three_hop_anon_action.triggered, lambda _: self.change_anonymity(3))
+        self.connect_signal(no_anon_action.triggered, lambda _: self.change_anonymity(0))
+        self.connect_signal(one_hop_anon_action.triggered, lambda _: self.change_anonymity(1))
+        self.connect_signal(two_hop_anon_action.triggered, lambda _: self.change_anonymity(2))
+        self.connect_signal(three_hop_anon_action.triggered, lambda _: self.change_anonymity(3))
 
         menu.addAction(start_action)
         menu.addAction(stop_action)

--- a/src/tribler-gui/tribler_gui/widgets/ipv8health.py
+++ b/src/tribler-gui/tribler_gui/widgets/ipv8health.py
@@ -7,11 +7,12 @@ from PyQt5.QtGui import QPainter
 from PyQt5.QtWidgets import QWidget
 
 from tribler_common.sentry_reporter.sentry_mixin import AddBreadcrumbOnShowMixin
+from tribler_gui.dialogs.auto_disconnecting_mixin import QAutoDisconnectingMixin
 
 from tribler_gui.utilities import connect
 
 
-class MonitorWidget(AddBreadcrumbOnShowMixin, QWidget):
+class MonitorWidget(AddBreadcrumbOnShowMixin, QAutoDisconnectingMixin,  QWidget):
     """
     An "ECG" plot of the IPv8 core update frequency.
 
@@ -38,7 +39,7 @@ class MonitorWidget(AddBreadcrumbOnShowMixin, QWidget):
         self.walk_interval_target = "?"
 
         self.timer = QTimer()
-        connect(self.timer.timeout, self.repaint)
+        self.connect_signal(self.timer.timeout, self.repaint)
         self.timer.start(33)
 
         self.backup_size = None

--- a/src/tribler-gui/tribler_gui/widgets/lazytableview.py
+++ b/src/tribler-gui/tribler_gui/widgets/lazytableview.py
@@ -5,11 +5,12 @@ from PyQt5.QtWidgets import QAbstractItemView, QTableView
 from tribler_core.modules.metadata_store.serialization import CHANNEL_TORRENT, COLLECTION_NODE, REGULAR_TORRENT
 
 from tribler_gui.defs import ACTION_BUTTONS, COMMIT_STATUS_COMMITTED
+from tribler_gui.dialogs.auto_disconnecting_mixin import QAutoDisconnectingMixin
 from tribler_gui.utilities import connect, data_item2uri, index2uri
 from tribler_gui.widgets.tablecontentdelegate import TriblerContentDelegate
 
 
-class TriblerContentTableView(QTableView):
+class TriblerContentTableView(QAutoDisconnectingMixin, QTableView):
     """
     This table view is designed to support lazy loading.
     When the user reached the end of the table, it will ask the model for more items, and load them dynamically.
@@ -30,16 +31,16 @@ class TriblerContentTableView(QTableView):
         self.delegate = TriblerContentDelegate()
 
         self.setItemDelegate(self.delegate)
-        connect(self.mouse_moved, self.delegate.on_mouse_moved)
-        connect(self.delegate.redraw_required, self.redraw)
+        self.connect_signal(self.mouse_moved, self.delegate.on_mouse_moved)
+        self.connect_signal(self.delegate.redraw_required, self.redraw)
 
         # Stop triggering editor events on doubleclick, because we already use doubleclick to start downloads.
         # Editing should be started manually, from drop-down menu instead.
         self.setEditTriggers(QAbstractItemView.NoEditTriggers)
 
         # Mix-in connects
-        connect(self.clicked, self.on_table_item_clicked)
-        connect(self.doubleClicked, lambda item: self.on_table_item_clicked(item, doubleclick=True))
+        self.connect_signal(self.clicked, self.on_table_item_clicked)
+        self.connect_signal(self.doubleClicked, lambda item: self.on_table_item_clicked(item, doubleclick=True))
 
     def mouseMoveEvent(self, event):
         index = QModelIndex(self.indexAt(event.pos()))

--- a/src/tribler-gui/tribler_gui/widgets/loadingpage.py
+++ b/src/tribler-gui/tribler_gui/widgets/loadingpage.py
@@ -2,11 +2,12 @@ from PyQt5.QtSvg import QGraphicsSvgItem, QSvgRenderer
 from PyQt5.QtWidgets import QGraphicsScene, QWidget
 
 from tribler_common.sentry_reporter.sentry_mixin import AddBreadcrumbOnShowMixin
+from tribler_gui.dialogs.auto_disconnecting_mixin import QAutoDisconnectingMixin
 
 from tribler_gui.utilities import connect, get_image_path
 
 
-class LoadingPage(AddBreadcrumbOnShowMixin, QWidget):
+class LoadingPage(AddBreadcrumbOnShowMixin, QAutoDisconnectingMixin,  QWidget):
     """
     This page is presented when Tribler is starting.
     """
@@ -21,14 +22,14 @@ class LoadingPage(AddBreadcrumbOnShowMixin, QWidget):
         svg_item = QGraphicsSvgItem()
 
         svg = QSvgRenderer(get_image_path("loading_animation.svg"))
-        connect(svg.repaintNeeded, svg_item.update)
+        self.connect_signal(svg.repaintNeeded, svg_item.update)
         svg_item.setSharedRenderer(svg)
         svg_container.addItem(svg_item)
 
         self.window().loading_svg_view.setScene(svg_container)
-        connect(self.window().core_manager.events_manager.upgrader_tick, self.on_upgrader_tick)
-        connect(self.window().core_manager.events_manager.upgrader_finished, self.upgrader_finished)
-        connect(self.window().core_manager.events_manager.change_loading_text, self.change_loading_text)
+        self.connect_signal(self.window().core_manager.events_manager.upgrader_tick, self.on_upgrader_tick)
+        self.connect_signal(self.window().core_manager.events_manager.upgrader_finished, self.upgrader_finished)
+        self.connect_signal(self.window().core_manager.events_manager.change_loading_text, self.change_loading_text)
         self.window().skip_conversion_btn.hide()
 
         # Hide the force shutdown button initially. Should be triggered by shutdown timer from main window.

--- a/src/tribler-gui/tribler_gui/widgets/settingspage.py
+++ b/src/tribler-gui/tribler_gui/widgets/settingspage.py
@@ -15,6 +15,7 @@ from tribler_gui.defs import (
     PAGE_SETTINGS_GENERAL,
     PAGE_SETTINGS_SEEDING,
 )
+from tribler_gui.dialogs.auto_disconnecting_mixin import QAutoDisconnectingMixin
 from tribler_gui.dialogs.confirmationdialog import ConfirmationDialog
 from tribler_gui.tribler_request_manager import TriblerNetworkRequest, TriblerRequestManager
 from tribler_gui.utilities import (
@@ -27,7 +28,7 @@ from tribler_gui.utilities import (
 )
 
 
-class SettingsPage(AddBreadcrumbOnShowMixin, QWidget):
+class SettingsPage(AddBreadcrumbOnShowMixin, QAutoDisconnectingMixin, QWidget):
     """
     This class is responsible for displaying and adjusting the settings present in Tribler.
     """
@@ -39,18 +40,18 @@ class SettingsPage(AddBreadcrumbOnShowMixin, QWidget):
 
     def initialize_settings_page(self):
         self.window().settings_tab.initialize()
-        connect(self.window().settings_tab.clicked_tab_button, self.clicked_tab_button)
-        connect(self.window().settings_save_button.clicked, self.save_settings)
+        self.connect_signal(self.window().settings_tab.clicked_tab_button, self.clicked_tab_button)
+        self.connect_signal(self.window().settings_save_button.clicked, self.save_settings)
 
-        connect(self.window().download_location_chooser_button.clicked, self.on_choose_download_dir_clicked)
-        connect(self.window().watch_folder_chooser_button.clicked, self.on_choose_watch_dir_clicked)
+        self.connect_signal(self.window().download_location_chooser_button.clicked, self.on_choose_download_dir_clicked)
+        self.connect_signal(self.window().watch_folder_chooser_button.clicked, self.on_choose_watch_dir_clicked)
 
-        connect(self.window().channel_autocommit_checkbox.stateChanged, self.on_channel_autocommit_checkbox_changed)
-        connect(self.window().family_filter_checkbox.stateChanged, self.on_family_filter_checkbox_changed)
-        connect(self.window().developer_mode_enabled_checkbox.stateChanged, self.on_developer_mode_checkbox_changed)
-        connect(self.window().use_monochrome_icon_checkbox.stateChanged, self.on_use_monochrome_icon_checkbox_changed)
-        connect(self.window().download_settings_anon_checkbox.stateChanged, self.on_anon_download_state_changed)
-        connect(self.window().log_location_chooser_button.clicked, self.on_choose_log_dir_clicked)
+        self.connect_signal(self.window().channel_autocommit_checkbox.stateChanged, self.on_channel_autocommit_checkbox_changed)
+        self.connect_signal(self.window().family_filter_checkbox.stateChanged, self.on_family_filter_checkbox_changed)
+        self.connect_signal(self.window().developer_mode_enabled_checkbox.stateChanged, self.on_developer_mode_checkbox_changed)
+        self.connect_signal(self.window().use_monochrome_icon_checkbox.stateChanged, self.on_use_monochrome_icon_checkbox_changed)
+        self.connect_signal(self.window().download_settings_anon_checkbox.stateChanged, self.on_anon_download_state_changed)
+        self.connect_signal(self.window().log_location_chooser_button.clicked, self.on_choose_log_dir_clicked)
 
         checkbox_style = get_checkbox_style()
         for checkbox in [
@@ -206,7 +207,7 @@ class SettingsPage(AddBreadcrumbOnShowMixin, QWidget):
         # Anonymity settings
         self.window().allow_exit_node_checkbox.setChecked(settings['tunnel_community']['exitnode_enabled'])
         self.window().number_hops_slider.setValue(int(settings['download_defaults']['number_hops']))
-        connect(self.window().number_hops_slider.valueChanged, self.update_anonymity_cost_label)
+        self.connect_signal(self.window().number_hops_slider.valueChanged, self.update_anonymity_cost_label)
         self.update_anonymity_cost_label(int(settings['download_defaults']['number_hops']))
 
         # Debug
@@ -220,7 +221,7 @@ class SettingsPage(AddBreadcrumbOnShowMixin, QWidget):
             cpu_priority = int(settings['resource_monitor']['cpu_priority'])
         self.window().slider_cpu_level.setValue(cpu_priority)
         self.window().cpu_priority_value.setText(f"Current Priority = {cpu_priority}")
-        connect(self.window().slider_cpu_level.valueChanged, self.show_updated_cpu_priority)
+        self.connect_signal(self.window().slider_cpu_level.valueChanged, self.show_updated_cpu_priority)
         self.window().checkbox_enable_network_statistics.setChecked(settings['ipv8']['statistics'])
 
     def update_anonymity_cost_label(self, value):
@@ -446,7 +447,7 @@ class SettingsPage(AddBreadcrumbOnShowMixin, QWidget):
             "Your settings have been saved.",
             [('CLOSE', BUTTON_TYPE_NORMAL)],
         )
-        connect(self.saved_dialog.button_clicked, self.on_dialog_cancel_clicked)
+        self.connect_signal(self.saved_dialog.button_clicked, self.on_dialog_cancel_clicked)
         self.saved_dialog.show()
         self.window().fetch_settings()
 

--- a/src/tribler-gui/tribler_gui/widgets/subscriptionswidget.py
+++ b/src/tribler-gui/tribler_gui/widgets/subscriptionswidget.py
@@ -4,11 +4,12 @@ from PyQt5.QtWidgets import QLabel, QWidget
 
 from tribler_common.sentry_reporter.sentry_mixin import AddBreadcrumbOnShowMixin
 
-from tribler_gui.utilities import connect, format_votes_rich_text, get_votes_rating_description
+from tribler_gui.dialogs.auto_disconnecting_mixin import QAutoDisconnectingMixin
+from tribler_gui.utilities import format_votes_rich_text, get_votes_rating_description
 from tribler_gui.widgets.tablecontentdelegate import DARWIN, WINDOWS
 
 
-class SubscriptionsWidget(AddBreadcrumbOnShowMixin, QWidget):
+class SubscriptionsWidget(AddBreadcrumbOnShowMixin, QAutoDisconnectingMixin, QWidget):
     """
     This widget shows a favorite button and the number of subscriptions that a specific channel has.
     """
@@ -30,9 +31,9 @@ class SubscriptionsWidget(AddBreadcrumbOnShowMixin, QWidget):
             self.channel_rating_label = self.findChild(QLabel, "channel_rating_label")
             self.channel_rating_label.setTextFormat(Qt.RichText)
 
-            connect(self.subscribe_button.clicked, self.on_subscribe_button_click)
+            self.connect_signal(self.subscribe_button.clicked, self.on_subscribe_button_click)
             self.subscribe_button.setToolTip('Click to subscribe/unsubscribe')
-            connect(self.subscribe_button.toggled, self._adjust_tooltip)
+            self.connect_signal(self.subscribe_button.toggled, self._adjust_tooltip)
             self.initialized = True
 
     def _adjust_tooltip(self, toggled):

--- a/src/tribler-gui/tribler_gui/widgets/tabbuttonpanel.py
+++ b/src/tribler-gui/tribler_gui/widgets/tabbuttonpanel.py
@@ -2,11 +2,12 @@ from PyQt5.QtCore import pyqtSignal
 from PyQt5.QtWidgets import QWidget
 
 from tribler_common.sentry_reporter.sentry_reporter import SentryReporter
+from tribler_gui.dialogs.auto_disconnecting_mixin import QAutoDisconnectingMixin
 
 from tribler_gui.utilities import connect
 
 
-class TabButtonPanel(QWidget):
+class TabButtonPanel(QWidget, QAutoDisconnectingMixin):
     """
     This class manages the tab button panels that can often be found above pages.
     """
@@ -20,7 +21,7 @@ class TabButtonPanel(QWidget):
     def initialize(self):
         for button in self.findChildren(QWidget):
             self.buttons.append(button)
-            connect(button.clicked_tab_button, self.on_tab_button_click)
+            self.connect_signal(button.clicked_tab_button, self.on_tab_button_click)
 
     def on_tab_button_click(self, clicked_button):
         SentryReporter.add_breadcrumb(message=f'{clicked_button.objectName()}.Click', category='UI', level='info')

--- a/src/tribler-gui/tribler_gui/widgets/tablecontentmodel.py
+++ b/src/tribler-gui/tribler_gui/widgets/tablecontentmodel.py
@@ -9,6 +9,7 @@ from tribler_core.modules.metadata_store.orm_bindings.channel_node import NEW
 from tribler_core.modules.metadata_store.serialization import CHANNEL_TORRENT, COLLECTION_NODE
 
 from tribler_gui.defs import ACTION_BUTTONS, BITTORRENT_BIRTHDAY, COMMIT_STATUS_TODELETE, HEALTH_CHECKING
+from tribler_gui.dialogs.auto_disconnecting_mixin import QAutoDisconnectingMixin
 from tribler_gui.i18n import tr
 from tribler_gui.tribler_request_manager import TriblerNetworkRequest
 from tribler_gui.utilities import connect, format_size, format_votes, get_votes_rating_description, pretty_date
@@ -20,7 +21,7 @@ def get_item_uid(item):
     return item['infohash']
 
 
-class RemoteTableModel(QAbstractTableModel):
+class RemoteTableModel(QAutoDisconnectingMixin, QAbstractTableModel):
     info_changed = pyqtSignal(list)
     """
     The base model for the tables in the Tribler GUI.
@@ -46,7 +47,7 @@ class RemoteTableModel(QAbstractTableModel):
         self.saved_scroll_state = None
         self.qt_object_destroyed = False
 
-        connect(self.destroyed, self.on_destroy)
+        self.connect_signal(self.destroyed, self.on_destroy)
         # Every remote query must be attributed to its specific model to avoid updating wrong models
         # on receiving a result. We achieve this by maintaining a set of in-flight remote queries.
         # Note that this only applies to results that are returned through the events notification

--- a/src/tribler-gui/tribler_gui/widgets/trustgraphpage.py
+++ b/src/tribler-gui/tribler_gui/widgets/trustgraphpage.py
@@ -21,11 +21,12 @@ from tribler_gui.defs import (
     TB,
     TRUST_GRAPH_PEER_LEGENDS,
 )
+from tribler_gui.dialogs.auto_disconnecting_mixin import QAutoDisconnectingMixin
 from tribler_gui.tribler_request_manager import TriblerNetworkRequest
 from tribler_gui.utilities import connect, format_size, html_label
 
 
-class TrustGraph(pg.GraphItem):
+class TrustGraph(QAutoDisconnectingMixin, pg.GraphItem):
     def __init__(self):
         pg.GraphItem.__init__(self)
         self.data = None
@@ -35,7 +36,7 @@ class TrustGraph(pg.GraphItem):
         self.dragOffset = None
 
     def set_node_selection_listener(self, listener):
-        connect(self.scatter.sigClicked, listener)
+        self.connect_signal(self.scatter.sigClicked, listener)
 
     def setData(self, **data):
         self.data = data
@@ -80,7 +81,7 @@ class TrustGraph(pg.GraphItem):
         event.accept()
 
 
-class TrustGraphPage(AddBreadcrumbOnShowMixin, QWidget):
+class TrustGraphPage(AddBreadcrumbOnShowMixin, QAutoDisconnectingMixin, QWidget):
     def __init__(self):
         QWidget.__init__(self)
 
@@ -119,7 +120,7 @@ class TrustGraphPage(AddBreadcrumbOnShowMixin, QWidget):
         self.graph_view.addItem(pg.TextItem(text='YOU'))
         self.window().trust_graph_plot_widget.layout().addWidget(graph_layout)
 
-        connect(self.window().tr_control_refresh_btn.clicked, self.fetch_graph_data)
+        self.connect_signal(self.window().tr_control_refresh_btn.clicked, self.fetch_graph_data)
 
         self.window().tr_selected_node_pub_key.setHidden(True)
         self.window().tr_selected_node_stats.setHidden(True)

--- a/src/tribler-gui/tribler_gui/widgets/trustpage.py
+++ b/src/tribler-gui/tribler_gui/widgets/trustpage.py
@@ -5,6 +5,7 @@ from PyQt5.QtWidgets import QWidget
 from tribler_common.sentry_reporter.sentry_mixin import AddBreadcrumbOnShowMixin
 
 from tribler_gui.defs import GB, TB
+from tribler_gui.dialogs.auto_disconnecting_mixin import QAutoDisconnectingMixin
 from tribler_gui.dialogs.trustexplanationdialog import TrustExplanationDialog
 from tribler_gui.tribler_request_manager import TriblerNetworkRequest
 from tribler_gui.utilities import connect
@@ -21,7 +22,7 @@ class TrustSeriesPlot(TimeSeriesPlot):
         self.setLimits(yMin=-GB, yMax=TB)
 
 
-class TrustPage(AddBreadcrumbOnShowMixin, QWidget):
+class TrustPage(AddBreadcrumbOnShowMixin, QAutoDisconnectingMixin, QWidget):
     """
     This page shows various trust statistics.
     """
@@ -39,7 +40,7 @@ class TrustPage(AddBreadcrumbOnShowMixin, QWidget):
             self.trust_plot = TrustSeriesPlot(self.window().plot_widget)
             vlayout.addWidget(self.trust_plot)
 
-        connect(self.window().trust_explain_button.clicked, self.on_info_button_clicked)
+        self.connect_signal(self.window().trust_explain_button.clicked, self.on_info_button_clicked)
 
     def on_info_button_clicked(self, checked):
         self.dialog = TrustExplanationDialog(self.window())


### PR DESCRIPTION
This PR adds a Mixin that can disconnect QR signals automatically.

Based on the discussoin https://github.com/Tribler/tribler/pull/5949 and regarding @ichorid experience, it is necessary to manually disconnect a QT signal. This should help for avoiding memory leaks like https://github.com/Tribler/tribler/issues/5934

The current version of the Mixin is working with no errors (at least for me).


### The pitfalls

During developing this Mixin I saw a lot of "strange" bugs when python crashed with the following error: "Process finished with exit code 139 (interrupted by signal 11: SIGSEGV)". 

They occurred, for example, when trying to log some of the signals:

```python
                logger.info(f'Signal: {signal}')
```

And when trying to use (some) of the signals as a key in a dictionary:

```python
                self.connected_signals[signal] += 1
```

Another case. Some signals lead to a python crash if you try to disconnect all callbacks at once:
```python
                signal.disconenct()
```

Therefore:
* `id(signal)` is using for logging and as a key for a dictionary
* a full disconnect is performed by calling callback-by-callback disconnect.


### Conclusion

The Mixing is working for me with no errors, but I consider the QT disconnect mechanism is fragile.

Unfortunately, I see more risks for merging this PR rather than benefits.

What do you think about that?