### PR TITLE
Updated ipv8 pointer

### DIFF
--- a/src/tribler-core/tribler_core/modules/ipv8_module_catalog.py
+++ b/src/tribler-core/tribler_core/modules/ipv8_module_catalog.py
@@ -16,6 +16,14 @@ class IPv8CommunityLauncher(CommunityLauncher):
         return (Peer(session.trustchain_testnet_keypair) if session.config.get_trustchain_testnet()
                 else Peer(session.trustchain_keypair))
 
+    def get_bootstrappers(self, session):
+        from ipv8.bootstrapping.dispersy.bootstrapper import DispersyBootstrapper
+        from ipv8.configuration import DISPERSY_BOOTSTRAPPER
+        if session.config.get_ipv8_bootstrap_override():
+            return [(DispersyBootstrapper, {"ip_addresses": [session.config.get_ipv8_bootstrap_override()],
+                                            "dns_addresses": []})]
+        return [(DispersyBootstrapper, DISPERSY_BOOTSTRAPPER['init'])]
+
 
 class TestnetMixIn:
     def should_launch(self, session):
@@ -105,9 +113,7 @@ def remove_peers():
 @walk_strategy(random_walk)
 @walk_strategy(periodic_similarity, target_peers=INFINITE)
 class IPv8DiscoveryCommunityLauncher(IPv8CommunityLauncher):
-    def finalize(self, ipv8, session, community):
-        community.resolve_dns_bootstrap_addresses()
-        return super()
+    pass
 
 
 @overlay(bandwidth_accounting_community)

--- a/src/tribler-core/tribler_core/modules/tests/test_ipv8_module_catalog.py
+++ b/src/tribler-core/tribler_core/modules/tests/test_ipv8_module_catalog.py
@@ -1,4 +1,6 @@
-from tribler_core.modules.ipv8_module_catalog import get_hiddenimports
+from unittest.mock import Mock
+
+from tribler_core.modules.ipv8_module_catalog import IPv8DiscoveryCommunityLauncher, get_hiddenimports
 
 
 def test_hiddenimports():
@@ -6,3 +8,19 @@ def test_hiddenimports():
     Check if all hidden imports are detected
     """
     assert not get_hiddenimports()
+
+
+def test_bootstrap_override():
+    """
+    Check that the DiscoveryCommunityLauncher respects the bootstrap override.
+    """
+    session = Mock()
+    session.config = Mock()
+    session.config.get_ipv8_bootstrap_override = Mock(return_value=("1.2.3.4", 5))
+
+    bootstrappers = IPv8DiscoveryCommunityLauncher().get_bootstrappers(session)
+
+    assert len(bootstrappers) == 1
+    assert len(bootstrappers[0][1]['dns_addresses']) == 0
+    assert len(bootstrappers[0][1]['ip_addresses']) == 1
+    assert ("1.2.3.4", 5) in bootstrappers[0][1]['ip_addresses']

--- a/src/tribler-core/tribler_core/session.py
+++ b/src/tribler-core/tribler_core/session.py
@@ -334,11 +334,6 @@ class Session(TaskManager):
                                    .set_working_directory(str(self.config.get_state_dir()))
                                    .set_walker_interval(self.config.get_ipv8_walk_interval()))
 
-            if self.config.get_ipv8_bootstrap_override():
-                import ipv8.community as community_file
-                community_file._DEFAULT_ADDRESSES = [self.config.get_ipv8_bootstrap_override()]
-                community_file._DNS_ADDRESSES = []
-
             if self.core_test_mode:
                 endpoint = DispatcherEndpoint([])
             else:


### PR DESCRIPTION
This PR:

 - Updates the IPv8 pointer.
 - Updates the `IPv8CommunityLauncher` base class to load the usual bootstrapping servers for each overlay.
 - Refactors the `get_ipv8_bootstrap_override` check in `Session` to the `IPv8CommunityLauncher` to reduce clutter.

Gumby will have to be changed after this PR.