### PR TITLE
Fix profiler functionality of the Debug Pane

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -20,4 +20,5 @@ Faker
 Pillow
 netifaces
 pyqtgraph
+yappi
 

--- a/src/tribler-core/tribler_core/modules/resource_monitor/core.py
+++ b/src/tribler-core/tribler_core/modules/resource_monitor/core.py
@@ -9,6 +9,7 @@ import psutil
 from tribler_common.simpledefs import NTFY
 
 from tribler_core.modules.resource_monitor.base import ResourceMonitor
+from tribler_core.modules.resource_monitor.profiler import YappiProfiler
 
 FREE_DISK_THRESHOLD = 100 * (1024 * 1024)  # 100MB
 DEFAULT_RESOURCE_FILENAME = "resources.log"
@@ -31,6 +32,9 @@ class CoreResourceMonitor(ResourceMonitor, TaskManager):
         self.state_dir = session.config.get_state_dir()
         self.resource_log_file = session.config.get_log_dir() / DEFAULT_RESOURCE_FILENAME
         self.resource_log_enabled = session.config.get_resource_monitor_enabled()
+
+        # Setup yappi profiler
+        self.profiler = YappiProfiler(self.session)
 
     def start(self):
         """

--- a/src/tribler-core/tribler_core/modules/resource_monitor/profiler.py
+++ b/src/tribler-core/tribler_core/modules/resource_monitor/profiler.py
@@ -1,0 +1,51 @@
+import os
+import time
+
+import yappi
+
+
+class YappiProfiler:
+
+    def __init__(self, session):
+        self.session = session
+
+        self._start_time = None
+        self._is_running = False
+
+    def is_running(self):
+        return self._is_running
+
+    def start(self):
+        """
+        Start the Yappi profiler if it is not already running.
+        """
+        if self._is_running:
+            raise RuntimeError("Profiler is already running")
+
+        yappi.start(builtins=True)
+        self._start_time = int(time.time())
+        self._is_running = True
+
+    def stop(self):
+        """
+        Stop Yappi and write the stats to the output directory.
+        Return the path of the statistics file.
+        """
+        if not self._is_running:
+            raise RuntimeError("Profiler is not running")
+
+        yappi.stop()
+
+        yappi_stats = yappi.get_func_stats()
+        yappi_stats.sort("tsub")
+
+        log_dir = self.session.config.get_state_dir() / 'logs'
+        file_path = log_dir / f"yappi_{self._start_time}.stats"
+        # Make the log directory if it does not exist
+        if not log_dir.exists():
+            os.makedirs(log_dir)
+
+        yappi_stats.save(file_path, type='callgrind')
+        yappi.clear_stats()
+        self._is_running = False
+        return file_path

--- a/src/tribler-core/tribler_core/modules/resource_monitor/profiler.py
+++ b/src/tribler-core/tribler_core/modules/resource_monitor/profiler.py
@@ -37,7 +37,7 @@ class YappiProfiler:
         yappi.stop()
 
         yappi_stats = yappi.get_func_stats()
-        yappi_stats.sort("tsub")
+        yappi_stats.sort('tsub', sort_order="desc")
 
         log_dir = self.session.config.get_state_dir() / 'logs'
         file_path = log_dir / f"yappi_{self._start_time}.stats"

--- a/src/tribler-core/tribler_core/modules/tests/test_resource_monitor.py
+++ b/src/tribler-core/tribler_core/modules/tests/test_resource_monitor.py
@@ -134,3 +134,24 @@ def test_enable_resource_log(resource_monitor):
 def test_reset_resource_log(resource_monitor):
     resource_monitor.reset_resource_logs()
     assert not resource_monitor.resource_log_file.exists()
+
+
+def test_profiler(resource_monitor):
+    """
+    Test the profiler start(), stop() methods.
+    """
+    profiler = resource_monitor.profiler
+    assert not profiler.is_running()
+
+    profiler.start()
+    assert profiler.is_running()
+
+    with pytest.raises(RuntimeError):
+        profiler.start()
+
+    stats_file = profiler.stop()
+    assert os.path.exists(stats_file)
+    assert not profiler.is_running()
+
+    with pytest.raises(RuntimeError):
+        profiler.stop()

--- a/src/tribler-core/tribler_core/restapi/debug_endpoint.py
+++ b/src/tribler-core/tribler_core/restapi/debug_endpoint.py
@@ -314,9 +314,9 @@ class DebugEndpoint(RESTEndpoint):
             }
         }
     )
-    async def get_profiler_state(self, request):
+    async def get_profiler_state(self, _):
         monitor_enabled = self.session.config.get_resource_monitor_enabled()
-        state = "STARTED" if (monitor_enabled and self.session.resource_monitor.profiler_running) else "STOPPED"
+        state = "STARTED" if (monitor_enabled and self.session.resource_monitor.profiler.is_running()) else "STOPPED"
         return RESTResponse({"state": state})
 
     @docs(
@@ -330,8 +330,8 @@ class DebugEndpoint(RESTEndpoint):
             }
         }
     )
-    async def start_profiler(self, request):
-        self.session.resource_monitor.start_profiler()
+    async def start_profiler(self, _):
+        self.session.resource_monitor.profiler.start()
         return RESTResponse({"success": True})
 
     @docs(
@@ -345,6 +345,6 @@ class DebugEndpoint(RESTEndpoint):
             }
         }
     )
-    async def stop_profiler(self, request):
-        file_path = self.session.resource_monitor.stop_profiler()
+    async def stop_profiler(self, _):
+        file_path = self.session.resource_monitor.profiler.stop()
         return RESTResponse({"success": True, "profiler_file": str(file_path)})

--- a/src/tribler-core/tribler_core/restapi/tests/test_debug_endpoint.py
+++ b/src/tribler-core/tribler_core/restapi/tests/test_debug_endpoint.py
@@ -210,16 +210,16 @@ async def test_start_stop_profiler(enable_api, enable_resource_monitor, session)
     tests.
     """
     def mocked_start_profiler():
-        session.resource_monitor.profiler_running = True
+        session.resource_monitor.profiler._is_running = True
 
     def mocked_stop_profiler():
-        session.resource_monitor.profiler_running = False
-        return 'a'
+        session.resource_monitor.profiler._is_running = False
+        return 'yappi_1611750286.stats'
 
-    session.resource_monitor.start_profiler = mocked_start_profiler
-    session.resource_monitor.stop_profiler = mocked_stop_profiler
+    session.resource_monitor.profiler.start = mocked_start_profiler
+    session.resource_monitor.profiler.stop = mocked_stop_profiler
 
     await do_request(session, 'debug/profiler', expected_code=200, request_type='PUT')
-    assert session.resource_monitor.profiler_running
+    assert session.resource_monitor.profiler.is_running()
     await do_request(session, 'debug/profiler', expected_code=200, request_type='DELETE')
-    assert not session.resource_monitor.profiler_running
+    assert not session.resource_monitor.profiler.is_running()

--- a/src/tribler-gui/tribler_gui/debug_window.py
+++ b/src/tribler-gui/tribler_gui/debug_window.py
@@ -722,7 +722,7 @@ class DebugWindow(QMainWindow):
         self.window().toggle_profiler_button.setEnabled(True)
         self.window().toggle_profiler_button.setText(f"{'Stop' if self.profiler_enabled else 'Start'} profiler")
 
-    def on_toggle_profiler_button_clicked(self, checked):
+    def on_toggle_profiler_button_clicked(self, checked=False):
         if self.toggling_profiler:
             return
 


### PR DESCRIPTION
Fixes system/profiler in the Debug Pane. Also, makes Yappi a pip dependency so availability need not be checked anymore since it should be bundled by PyInstaller.

 
![profiler](https://user-images.githubusercontent.com/1442867/105992602-a049e600-60a5-11eb-88e3-64b2d949784a.png)
