### PR TITLE
Specify timeout for the DiscoveryBooster

### DIFF
--- a/src/tribler-core/tribler_core/modules/metadata_store/community/gigachannel_community.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/community/gigachannel_community.py
@@ -74,7 +74,7 @@ class NonLegacyGigaChannelCommunity(RemoteQueryCommunity):
         # TODO: use Bloom filter here instead. We actually *want* it to be all-false-positives eventually.
         self.queried_peers = set()
 
-        self.discovery_booster = DiscoveryBooster()
+        self.discovery_booster = DiscoveryBooster(timeout_in_sec=30)
         self.discovery_booster.apply(self)
 
 


### PR DESCRIPTION
This PR set DiscoveryBooster timeout to 30 seconds as it was described in https://github.com/Tribler/tribler/issues/5828 