### PR TITLE
Remove max_peers from DiscoveryBooster

### DIFF
--- a/src/tribler-core/tribler_core/modules/metadata_store/community/discovery_booster.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/community/discovery_booster.py
@@ -8,25 +8,23 @@ class DiscoveryBooster:
 
     It can be applied to any community.
     """
-    def __init__(self, timeout_in_sec=10.0, max_peers=200, take_step_interval_in_sec=0.05, walker=None):
+
+    def __init__(self, timeout_in_sec=10.0, take_step_interval_in_sec=0.05, walker=None):
         """
 
         Args:
             timeout_in_sec: DiscoveryBooster work timeout. When this timeout will be reached,
                 `finish` function will be called.
-            max_peers: Temporary value of max peers that will be set to the community during DiscoveryBooster work.
             take_step_interval_in_sec: Сall frequency of walker's `take_step` function.
             walker: walker that will be used during boost period.
         """
         self.logger = logging.getLogger(self.__class__.__name__)
 
         self.timeout_in_sec = timeout_in_sec
-        self.max_peers = max_peers
         self.take_step_interval_in_sec = take_step_interval_in_sec
         self.walker = walker
 
         self.community = None
-        self.saved_max_peers = None
 
         self._take_step_task_name = 'take step'
 
@@ -42,15 +40,10 @@ class DiscoveryBooster:
             return
 
         self.logger.info(
-            f'Apply. Timeout: {self.timeout_in_sec}s, '
-            f'Max peers: {self.max_peers}, '
-            f'Take step interval: {self.take_step_interval_in_sec}s'
+            f'Apply. Timeout: {self.timeout_in_sec}s, ' f'Take step interval: {self.take_step_interval_in_sec}s'
         )
 
         self.community = community
-        self.saved_max_peers = community.max_peers
-
-        community.max_peers = self.max_peers
 
         if not self.walker:
             # values for neighborhood_size and edge_length were found empirically to
@@ -69,10 +62,7 @@ class DiscoveryBooster:
 
         Returns: None
         """
-        self.logger.info(
-            f'Finish. Set self.max_peers={self.saved_max_peers}. Cancel pending task: {self._take_step_task_name}'
-        )
-        self.community.max_peers = self.saved_max_peers
+        self.logger.info(f'Finish. Cancel pending task: {self._take_step_task_name}')
         self.community.cancel_pending_task(self._take_step_task_name)
 
     def take_step(self):

--- a/src/tribler-core/tribler_core/modules/metadata_store/community/tests/test_discovery_booster.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/community/tests/test_discovery_booster.py
@@ -2,11 +2,8 @@ import pytest
 
 from tribler_core.modules.metadata_store.community.discovery_booster import DiscoveryBooster
 
-TEST_BOOSTER_MAX_PEERS = 100
 TEST_BOOSTER_TIMEOUT_IN_SEC = 10
 TEST_BOOSTER_TAKE_STEP_INTERVAL_IN_SEC = 1
-
-TEST_COMMUNITY_MAX_PEERS = 30
 
 
 @pytest.fixture(name="booster")  # this workaround implemented only for pylint
@@ -20,7 +17,6 @@ def fixture_booster():
 
     return DiscoveryBooster(
         timeout_in_sec=TEST_BOOSTER_TIMEOUT_IN_SEC,
-        max_peers=TEST_BOOSTER_MAX_PEERS,
         take_step_interval_in_sec=TEST_BOOSTER_TAKE_STEP_INTERVAL_IN_SEC,
         walker=MockWalker(),
     )
@@ -30,7 +26,6 @@ def fixture_booster():
 def fixture_community():
     class MockCommunity:
         def __init__(self):
-            self.max_peers = TEST_COMMUNITY_MAX_PEERS
             self.tasks = []
 
         def register_task(
@@ -45,12 +40,10 @@ def fixture_community():
 
 
 def test_init(booster):
-    assert booster.max_peers == TEST_BOOSTER_MAX_PEERS
     assert booster.timeout_in_sec == TEST_BOOSTER_TIMEOUT_IN_SEC
     assert booster.take_step_interval_in_sec == TEST_BOOSTER_TAKE_STEP_INTERVAL_IN_SEC
 
     assert booster.community is None
-    assert booster.saved_max_peers is None
     assert booster.walker is not None
 
 
@@ -60,17 +53,14 @@ def test_apply(booster, community):
 
     booster.apply(community)
     assert booster.community == community
-    assert booster.saved_max_peers == TEST_COMMUNITY_MAX_PEERS
     assert booster.walker is not None
 
-    assert community.max_peers == booster.max_peers
     assert len(community.tasks) == 2
 
 
 def test_finish(booster, community):
     booster.apply(community)
     booster.finish()
-    assert community.max_peers == TEST_COMMUNITY_MAX_PEERS
     assert len(community.tasks) == 1
 
 


### PR DESCRIPTION
This PR removes the `max_peers` argument from `DiscoveryBooster` because it has no effect on discovery boosting.

Linked to the dev morning meeting. 