### PR TITLE
Remove hard-coded peer limits from DebugWindow

### DIFF
--- a/src/tribler-core/tribler_core/modules/ipv8_module_catalog.py
+++ b/src/tribler-core/tribler_core/modules/ipv8_module_catalog.py
@@ -109,6 +109,7 @@ def remove_peers():
 
 @precondition('session.config.get_discovery_community_enabled()')
 @overlay(discovery_community)
+@kwargs(max_peers='100')
 @walk_strategy(random_churn, target_peers=INFINITE)
 @walk_strategy(random_walk)
 @walk_strategy(periodic_similarity, target_peers=INFINITE)
@@ -134,6 +135,7 @@ class BandwidthTestnetCommunityLauncher(TestnetMixIn, BandwidthCommunityLauncher
 @precondition('session.config.get_dht_enabled()')
 @set_in_session('dht_community')
 @overlay(dht_discovery_community)
+@kwargs(max_peers='60')
 @walk_strategy(ping_churn, target_peers=INFINITE)
 @walk_strategy(random_walk)
 class DHTCommunityLauncher(IPv8CommunityLauncher):
@@ -186,7 +188,7 @@ class PopularityCommunityLauncher(IPv8CommunityLauncher):
 @precondition('not session.config.get_chant_testnet()')
 @set_in_session('gigachannel_community')
 @overlay(giga_channel_community)
-@kwargs(metadata_store='session.mds', notifier='session.notifier')
+@kwargs(metadata_store='session.mds', notifier='session.notifier', max_peers='50')
 # GigaChannelCommunity remote search feature works better with higher amount of connected peers
 @walk_strategy(random_walk, target_peers=30)
 @walk_strategy(remove_peers, target_peers=INFINITE)

--- a/src/tribler-core/tribler_core/modules/metadata_store/community/remote_query_community.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/community/remote_query_community.py
@@ -95,8 +95,8 @@ class RemoteQueryCommunity(Community):
     Community for general purpose SELECT-like queries into remote Channels database
     """
 
-    def __init__(self, my_peer, endpoint, network, metadata_store, settings=None):
-        super().__init__(my_peer, endpoint, network=network)
+    def __init__(self, my_peer, endpoint, network, metadata_store, settings=None, **kwargs):
+        super().__init__(my_peer, endpoint, network=network, **kwargs)
 
         self.settings = settings or RemoteQueryCommunitySettings()
         self.mds = metadata_store

--- a/src/tribler-gui/tribler_gui/debug_window.py
+++ b/src/tribler-gui/tribler_gui/debug_window.py
@@ -329,15 +329,8 @@ class DebugWindow(QMainWindow):
     def load_ipv8_communities_tab(self):
         TriblerNetworkRequest("ipv8/overlays", self.on_ipv8_community_stats)
 
-    def _colored_peer_count(self, peer_count, overlay_count, overlay_name):
-        if overlay_name == 'DiscoveryCommunity':
-            limits = [20, overlay_count * 30 + 1]
-        elif overlay_name == 'DHTDiscoveryCommunity':
-            limits = [20, 61]
-        elif overlay_name == 'RemoteQueryCommunity':
-            limits = [20, 51]
-        else:
-            limits = [20, 31]
+    def _colored_peer_count(self, peer_count, max_peers):
+        limits = [20, max_peers + 1]
         color = 0xF4D03F if peer_count < limits[0] else (0x56F129 if peer_count < limits[1] else 0xF12929)
         return QBrush(QColor(color))
 
@@ -352,7 +345,7 @@ class DebugWindow(QMainWindow):
             item.setText(2, overlay["my_peer"][-12:])
             peer_count = len(overlay["peers"])
             item.setText(3, f"{peer_count}")
-            item.setForeground(3, self._colored_peer_count(peer_count, len(data["overlays"]), overlay["overlay_name"]))
+            item.setForeground(3, self._colored_peer_count(peer_count, overlay["max_peers"]))
 
             if "statistics" in overlay and overlay["statistics"]:
                 statistics = overlay["statistics"]


### PR DESCRIPTION
Note that this needs to go to devel since we didn't want to move the IPv8 pointer too far (https://github.com/Tribler/tribler/pull/5955#issuecomment-768202925)