### PR TITLE
Fix/5547

### DIFF
--- a/doc/restapi/introduction.rst
+++ b/doc/restapi/introduction.rst
@@ -16,9 +16,11 @@ Some requests require one or more parameters. These parameters are passed using 
 
 .. code-block:: none
 
-    curl -X PUT -H "X-Api-Key: <YOUR API KEY>" http://localhost:8085/mychannel/rssfeeds/http%3A%2F%2Frssfeed.com%2Frss.xml
+    curl -X PUT -H "X-Api-Key: <YOUR API KEY>" http://localhost:52194/mychannel/rssfeeds/http%3A%2F%2Frssfeed.com%2Frss.xml
 
-Alternatively, requests can be made using Swagger UI by starting Tribler and opening `http://localhost:8085/docs` in a browser.
+Alternatively, requests can be made using Swagger UI by starting Tribler and opening `http://localhost:52194/docs` in a browser.
+
+Note: 52194 is a default port value. It can be changed by setting up "CORE_API_PORT" environment variable.
 
 Error handling
 ==============

--- a/src/tribler-core/run_bandwidth_crawler.py
+++ b/src/tribler-core/run_bandwidth_crawler.py
@@ -51,7 +51,7 @@ async def start_crawler(tribler_config):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=('Start a crawler in the bandwidth accounting community'))
     parser.add_argument('--statedir', '-s', default='bw_crawler', type=str, help='Use an alternate statedir')
-    parser.add_argument('--restapi', '-p', default=8085, type=str, help='Use an alternate port for the REST API',
+    parser.add_argument('--restapi', '-p', default=52194, type=str, help='Use an alternate port for the REST API',
                         action=PortAction, metavar='{0..65535}')
     args = parser.parse_args(sys.argv[1:])
 

--- a/src/tribler-core/run_tunnel_helper.py
+++ b/src/tribler-core/run_tunnel_helper.py
@@ -177,7 +177,7 @@ def main(argv):
     parser.add_argument('--ipv8_port', '-d', default=-1, type=int, help='IPv8 port', action=PortAction, metavar='{0..65535}')
     parser.add_argument('--ipv8_address', '-i', default='0.0.0.0', type=str, help='IPv8 listening address', action=IPAction)
     parser.add_argument('--ipv8_bootstrap_override', '-b', default=None, type=str, help='Force the usage of specific IPv8 bootstrap server (ip:port)', action=IPPortAction)
-    parser.add_argument('--restapi', '-p', default=8085, type=str, help='Use an alternate port for the REST API', action=PortAction, metavar='{0..65535}')
+    parser.add_argument('--restapi', '-p', default=52194, type=str, help='Use an alternate port for the REST API', action=PortAction, metavar='{0..65535}')
     parser.add_argument('--cert-file', '-e', help='Path to combined certificate/key file. If not given HTTP is used.')
     parser.add_argument('--api-key', '-k', help='API key to use. If not given API key protection is disabled.')
     parser.add_argument('--random_slots', '-r', default=10, type=int, help='Specifies the number of random slots')

--- a/src/tribler-core/run_tunnel_helper.py
+++ b/src/tribler-core/run_tunnel_helper.py
@@ -72,7 +72,7 @@ class TunnelHelperService(TaskManager):
 
     def tribler_started(self):
         async def signal_handler(sig):
-            print(f"Received shut down signal {sig}")
+            print(f"Received shut down signal {sig}")  # noqa: T001
             if not self._stopping:
                 self._stopping = True
                 await self.session.shutdown()
@@ -176,8 +176,10 @@ def main(argv):
     parser.add_argument('--help', '-h', action='help', default=argparse.SUPPRESS, help='Show this help message and exit')
     parser.add_argument('--ipv8_port', '-d', default=-1, type=int, help='IPv8 port', action=PortAction, metavar='{0..65535}')
     parser.add_argument('--ipv8_address', '-i', default='0.0.0.0', type=str, help='IPv8 listening address', action=IPAction)
-    parser.add_argument('--ipv8_bootstrap_override', '-b', default=None, type=str, help='Force the usage of specific IPv8 bootstrap server (ip:port)', action=IPPortAction)
-    parser.add_argument('--restapi', '-p', default=52194, type=str, help='Use an alternate port for the REST API', action=PortAction, metavar='{0..65535}')
+    parser.add_argument('--ipv8_bootstrap_override', '-b', default=None, type=str,
+                        help='Force the usage of specific IPv8 bootstrap server (ip:port)', action=IPPortAction)
+    parser.add_argument('--restapi', '-p', default=52194, type=str,
+                        help='Use an alternate port for the REST API', action=PortAction, metavar='{0..65535}')
     parser.add_argument('--cert-file', '-e', help='Path to combined certificate/key file. If not given HTTP is used.')
     parser.add_argument('--api-key', '-k', help='API key to use. If not given API key protection is disabled.')
     parser.add_argument('--random_slots', '-r', default=10, type=int, help='Specifies the number of random slots')

--- a/src/tribler-core/tribler_core/config/tribler_config.py
+++ b/src/tribler-core/tribler_core/config/tribler_config.py
@@ -10,13 +10,13 @@ from configobj import ConfigObj, ParseError
 
 from validate import Validator
 
+from tribler_common.network_utils import get_random_port
 from tribler_common.simpledefs import MAX_LIBTORRENT_RATE_LIMIT
 
 from tribler_core.exceptions import InvalidConfigException
 from tribler_core.modules.libtorrent.download_config import get_default_dest_dir
 from tribler_core.utilities import path_util
 from tribler_core.utilities.install_dir import get_lib_path
-from tribler_core.utilities.network_utils import get_random_port
 from tribler_core.utilities.path_util import Path
 
 CONFIG_FILENAME = 'triblerd.conf'

--- a/src/tribler-core/tribler_core/conftest.py
+++ b/src/tribler-core/tribler_core/conftest.py
@@ -10,6 +10,7 @@ from ipv8.util import succeed
 
 import pytest
 
+from tribler_common.network_utils import get_random_port
 from tribler_common.simpledefs import DLSTATUS_SEEDING
 
 from tribler_core.config.tribler_config import TriblerConfig
@@ -21,7 +22,6 @@ from tribler_core.session import Session
 from tribler_core.tests.tools.common import TESTS_DATA_DIR, TESTS_DIR
 from tribler_core.tests.tools.tracker.udp_tracker import UDPTracker
 from tribler_core.upgrade.db72_to_pony import DispersyToPonyMigration
-from tribler_core.utilities.network_utils import get_random_port
 from tribler_core.utilities.unicode import hexlify
 
 

--- a/src/tribler-core/tribler_core/modules/tunnel/tests/test_triblertunnel_community.py
+++ b/src/tribler-core/tribler_core/modules/tunnel/tests/test_triblertunnel_community.py
@@ -19,12 +19,13 @@ from ipv8.test.mocking.exit_socket import MockTunnelExitSocket
 from ipv8.test.mocking.ipv8 import MockIPv8
 from ipv8.util import succeed
 
+from tribler_common.network_utils import get_random_port
+
 from tribler_core.modules.bandwidth_accounting.community import BandwidthAccountingCommunity
 from tribler_core.modules.tunnel.community.payload import BandwidthTransactionPayload
 from tribler_core.modules.tunnel.community.triblertunnel_community import PEER_FLAG_EXIT_HTTP, TriblerTunnelCommunity
 from tribler_core.tests.tools.base_test import MockObject
 from tribler_core.tests.tools.tracker.http_tracker import HTTPTracker
-from tribler_core.utilities.network_utils import get_random_port
 from tribler_core.utilities.path_util import mkdtemp
 
 

--- a/src/tribler-core/tribler_core/restapi/events_endpoint.py
+++ b/src/tribler-core/tribler_core/restapi/events_endpoint.py
@@ -145,7 +145,7 @@ class EventsEndpoint(RESTEndpoint, TaskManager):
 
                 .. sourcecode:: none
 
-                    curl -X GET http://localhost:8085/events
+                    curl -X GET http://localhost:52194/events
         """
 
         # Setting content-type to text/event-stream to ensure browsers will handle the content properly

--- a/src/tribler-core/tribler_core/tests/test_network_utils.py
+++ b/src/tribler-core/tribler_core/tests/test_network_utils.py
@@ -3,7 +3,12 @@ import socket
 
 import pytest
 
-from tribler_core.utilities.network_utils import autodetect_socket_style, get_random_port
+from tribler_common.network_utils import (
+    FreePortNotFoundError,
+    autodetect_socket_style,
+    get_first_free_port,
+    get_random_port,
+)
 
 
 def test_get_random_port():
@@ -43,3 +48,17 @@ def test_get_random_port_invalid_type():
 def test_autodetect_socket_style():
     style = autodetect_socket_style()
     assert style == 0 or autodetect_socket_style() == 1
+
+
+def test_get_first_free_port():
+    # target port is free
+    assert get_first_free_port(start=50000) == 50000
+
+    # target port is locked
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(('', 50000))
+        assert get_first_free_port(start=50000) == 50001
+
+    # no free ports found
+    with pytest.raises(FreePortNotFoundError):
+        get_first_free_port(start=50000, limit=0)

--- a/src/tribler-gui/tribler_gui/core_manager.py
+++ b/src/tribler-gui/tribler_gui/core_manager.py
@@ -84,7 +84,7 @@ class CoreManager(QObject):
 
     def start(self, core_args=None, core_env=None):
         """
-        First test whether we already have a Tribler process listening on port 8085. If so, use that one and don't
+        First test whether we already have a Tribler process listening on port <CORE_API_PORT>. If so, use that one and don't
         start a new, fresh session.
         """
 

--- a/src/tribler-gui/tribler_gui/core_manager.py
+++ b/src/tribler-gui/tribler_gui/core_manager.py
@@ -60,7 +60,7 @@ class CoreManager(QObject):
         if b'Traceback' in raw_output:
             self.core_traceback = decoded_output
             self.core_traceback_timestamp = int(round(time.time() * 1000))
-        print(decoded_output.strip())
+        print(decoded_output.strip())  # noqa: T001
 
     def on_core_finished(self, exit_code, exit_status):
         if self.shutting_down and self.should_stop_on_shutdown:
@@ -84,8 +84,8 @@ class CoreManager(QObject):
 
     def start(self, core_args=None, core_env=None):
         """
-        First test whether we already have a Tribler process listening on port <CORE_API_PORT>. If so, use that one and don't
-        start a new, fresh session.
+        First test whether we already have a Tribler process listening on port <CORE_API_PORT>.
+        If so, use that one and don't start a new, fresh session.
         """
 
         def on_request_error(_):

--- a/src/tribler-gui/tribler_gui/defs.py
+++ b/src/tribler-gui/tribler_gui/defs.py
@@ -5,7 +5,7 @@ from collections import namedtuple
 
 DEFAULT_API_PROTOCOL = "http"
 DEFAULT_API_HOST = "localhost"
-DEFAULT_API_PORT = 8085
+DEFAULT_API_PORT = 52194
 
 # Define stacked widget page indices
 PAGE_SEARCH_RESULTS = 0

--- a/src/tribler-gui/tribler_gui/i18n/pt_BR.ts
+++ b/src/tribler-gui/tribler_gui/i18n/pt_BR.ts
@@ -1238,8 +1238,8 @@ per download</source>
     </message>
     <message>
         <location filename="../qt_resources/mainwindow.ui" line="2356"/>
-        <source>Port (defaults to 8085)</source>
-        <translation>Porta (padrão é 8085)</translation>
+        <source>Port (defaults to 52194)</source>
+        <translation>Porta (padrão é 52194)</translation>
     </message>
     <message>
         <location filename="../qt_resources/mainwindow.ui" line="2394"/>

--- a/src/tribler-gui/tribler_gui/qt_resources/mainwindow.ui
+++ b/src/tribler-gui/tribler_gui/qt_resources/mainwindow.ui
@@ -2218,7 +2218,7 @@ color: white;</string>
                   <item row="13" column="0">
                    <widget class="QLabel" name="label_62">
                     <property name="text">
-                     <string>Port (defaults to 8085)</string>
+                     <string>Port (defaults to 52194)</string>
                     </property>
                    </widget>
                   </item>

--- a/src/tribler-gui/tribler_gui/tests/test_gui.py
+++ b/src/tribler-gui/tribler_gui/tests/test_gui.py
@@ -9,8 +9,9 @@ from PyQt5.QtWidgets import QApplication, QListWidget, QTableView, QTextEdit, QT
 
 import pytest
 
+from tribler_common.network_utils import get_random_port
+
 from tribler_core.tests.tools.common import TORRENT_UBUNTU_FILE
-from tribler_core.utilities.network_utils import get_random_port
 
 import tribler_gui
 import tribler_gui.core_manager as core_manager
@@ -63,7 +64,7 @@ def tribler_api(api_port, tmpdir_factory):
     def on_core_read_ready():
         raw_output = bytes(core_process.readAll())
         decoded_output = raw_output.decode(errors="replace")
-        print(decoded_output.strip())
+        print(decoded_output.strip())  # noqa: T001
 
     core_process.setProcessEnvironment(core_env)
     core_process.setReadChannel(QProcess.StandardOutput)

--- a/src/tribler-gui/tribler_gui/tribler_window.py
+++ b/src/tribler-gui/tribler_gui/tribler_window.py
@@ -37,6 +37,8 @@ from PyQt5.QtWidgets import (
     QTreeWidget,
 )
 
+from tribler_common.network_utils import get_first_free_port
+
 from tribler_core.modules.process_checker import ProcessChecker
 from tribler_core.utilities.unicode import hexlify
 from tribler_core.version import version_id
@@ -112,6 +114,8 @@ class TriblerWindow(QMainWindow):
         api_port = api_port or int(get_gui_setting(self.gui_settings, "api_port", DEFAULT_API_PORT))
         api_key = api_key or get_gui_setting(self.gui_settings, "api_key", hexlify(os.urandom(16)).encode('utf-8'))
         self.gui_settings.setValue("api_key", api_key)
+
+        api_port = get_first_free_port(start=api_port, limit=100)
         request_manager.port, request_manager.key = api_port, api_key
 
         self.tribler_started = False

--- a/src/tribler-gui/tribler_gui/tribler_window.py
+++ b/src/tribler-gui/tribler_gui/tribler_window.py
@@ -108,7 +108,7 @@ class TriblerWindow(QMainWindow):
 
         self.setWindowIcon(QIcon(QPixmap(get_image_path('tribler.png'))))
 
-        self.gui_settings = QSettings()
+        self.gui_settings = QSettings('nl.tudelft.tribler')
         api_port = api_port or int(get_gui_setting(self.gui_settings, "api_port", DEFAULT_API_PORT))
         api_key = api_key or get_gui_setting(self.gui_settings, "api_key", hexlify(os.urandom(16)).encode('utf-8'))
         self.gui_settings.setValue("api_key", api_key)


### PR DESCRIPTION
This PR partially fixes #5547 by:
1. Changing default API port number from `8085` to `52194`
2. Setting up an organization for `QSettings`. It should decrease an overlap with other QT applications
3. Adding a `get_first_free_port` function to ensure that we use a free port for core-gui interaction

There is another probable root case for #5547. 
If the previous attempt to run Tribler's did not kill the core process properly, then it can cause the given issue (ref @xoriole) 
This particular situation will be addressed in the next PR.