### PR TITLE
Fix kill Tribler on restart mechanism

### DIFF
--- a/src/tribler-core/tribler_core/check_os.py
+++ b/src/tribler-core/tribler_core/check_os.py
@@ -49,7 +49,7 @@ def check_environment():
 
 def check_free_space():
     try:
-        free_space = psutil.disk_usage(".").free/(1024 * 1024.0)
+        free_space = psutil.disk_usage(".").free / (1024 * 1024.0)
         if free_space < 100:
             error_and_exit("Insufficient disk space",
                            "You have less than 100MB of usable disk space. " +
@@ -104,26 +104,25 @@ def should_kill_other_tribler_instances():
             sys.exit(0)
 
 
+def is_tribler_process(name):
+    """
+    Checks if the given name is of a Tribler processs. It checks a few potential keywords that
+    could be present in a Tribler process name across different platforms.
+    :param name: Process name
+    :return: True if pid is a Tribler process else False
+    """
+    name = name.lower()
+    keywords = ['tribler', 'python']
+
+    return any(keyword in name for keyword in keywords)
+
+
 def kill_tribler_process(process):
     """
     Kills the given process if it is a Tribler process.
     :param process: psutil.Process
     :return: None
     """
-    def is_tribler_process(name):
-        """
-        Checks if the given name is of a Tribler processs. It checks a few potential keywords that
-        could be present in a Tribler process name across different platforms.
-        :param name: Process name
-        :return: True if pid is a Tribler process else False
-        """
-        name = name.lower()
-        process_keywords = ['usr/bin/python', 'run_tribler.py', 'tribler.exe', 'tribler.sh',
-                            'Contents/MacOS/tribler', 'usr/bin/tribler']
-        for keyword in process_keywords:
-            if keyword.lower() in name:
-                return True
-        return False
 
     try:
         if not is_tribler_process(process.exe()):

--- a/src/tribler-core/tribler_core/tests/test_osutils.py
+++ b/src/tribler-core/tribler_core/tests/test_osutils.py
@@ -2,6 +2,7 @@ import os
 import sys
 from pathlib import Path
 
+from tribler_core.check_os import is_tribler_process
 from tribler_core.utilities.osutils import (
     dir_copy,
     fix_filebasename,
@@ -23,37 +24,37 @@ def test_fix_filebasename():
     default_name = '_'
     win_name_table = {
         'abcdef': 'abcdef',
-      '.': default_name,
-      '..': default_name,
-      '': default_name,
-      ' ': default_name,
-      '   ': default_name,
-      os.path.join('a', 'b'): 'a_b',
-      '\x5c\x61': '_a',    # \x5c = '\\'
-      '\x92\x97': '\x92\x97',
-      '\x5c\x5c': '__',
-      '\x5c\x61\x5c': '_a_',
-      '\x2f\x61': '_a',    # \x2f = '/'
-      '\x2f\x2f': '__',
-      '\x2f\x61\x2f': '_a_',
-      'a' * 300: 'a' * 255
+        '.': default_name,
+        '..': default_name,
+        '': default_name,
+        ' ': default_name,
+        '   ': default_name,
+        os.path.join('a', 'b'): 'a_b',
+        '\x5c\x61': '_a',  # \x5c = '\\'
+        '\x92\x97': '\x92\x97',
+        '\x5c\x5c': '__',
+        '\x5c\x61\x5c': '_a_',
+        '\x2f\x61': '_a',  # \x2f = '/'
+        '\x2f\x2f': '__',
+        '\x2f\x61\x2f': '_a_',
+        'a' * 300: 'a' * 255
     }
     for c in '"*/:<>?\\|':
         win_name_table[c] = default_name
 
     linux_name_table = {
         'abcdef': 'abcdef',
-      '.': default_name,
-      '..': default_name,
-      '': default_name,
-      ' ': default_name,
-      '   ': default_name,
-      os.path.join('a', 'b'): 'a_b',
-      '\x2f\x61': '_a',    # \x2f = '/'
-      '\x92\x97': '\x92\x97',
-      '\x2f\x2f': '__',
-      '\x2f\x61\x2f': '_a_',
-      'a' * 300: 'a' * 255
+        '.': default_name,
+        '..': default_name,
+        '': default_name,
+        ' ': default_name,
+        '   ': default_name,
+        os.path.join('a', 'b'): 'a_b',
+        '\x2f\x61': '_a',  # \x2f = '/'
+        '\x92\x97': '\x92\x97',
+        '\x2f\x2f': '__',
+        '\x2f\x61\x2f': '_a_',
+        'a' * 300: 'a' * 255
     }
 
     if sys.platform.startswith('win'):
@@ -130,3 +131,15 @@ def test_dir_copy(tmpdir):
     dir_copy(src_dir, dest_dir2, merge_if_exists=True)
     assert len(os.listdir(src_dir)) == len(os.listdir(dest_dir2))
     assert Path(dest_dir2, dummy_file).read_text() == "source: hello world"
+
+
+def test_is_tribler_process():
+    assert is_tribler_process('python.exe')
+    assert is_tribler_process('run_tribler.py')
+    assert is_tribler_process('usr/bin/python')
+    assert is_tribler_process('usr/bin/tribler')
+    assert is_tribler_process('Tribler.exe')
+    assert is_tribler_process('Tribler.sh')
+    assert is_tribler_process('Contents/MacOS/tribler')
+
+    assert not is_tribler_process('any other string')


### PR DESCRIPTION
This PR linked with #5547 and fixes an issue with the "killing Tribler on restart" mechanism.

<img src="https://user-images.githubusercontent.com/13798583/106499933-83f0e380-64c1-11eb-8a59-b777f03aa97b.png" width=300>

The problem was in keywords. They can't handle processes named "Python".