### PR TITLE
Fix incorrect log line when exitnode mode is enabled

### DIFF
--- a/src/tribler-core/tribler_core/modules/tunnel/community/triblertunnel_community.py
+++ b/src/tribler-core/tribler_core/modules/tunnel/community/triblertunnel_community.py
@@ -10,7 +10,7 @@ from distutils.version import LooseVersion
 import async_timeout
 
 from ipv8.messaging.anonymization.caches import CreateRequestCache
-from ipv8.messaging.anonymization.community import unpack_cell
+from ipv8.messaging.anonymization.community import TunnelSettings, unpack_cell
 from ipv8.messaging.anonymization.hidden_services import HiddenTunnelCommunity
 from ipv8.messaging.anonymization.payload import EstablishIntroPayload, NO_CRYPTO_PACKETS
 from ipv8.messaging.anonymization.tunnel import (
@@ -74,19 +74,21 @@ class TriblerTunnelCommunity(HiddenTunnelCommunity):
         socks_listen_ports = kwargs.pop('socks_listen_ports', None)
         state_path = self.tribler_session.config.get_state_dir() if self.tribler_session else path_util.Path()
         self.exitnode_cache = kwargs.pop('exitnode_cache', state_path / 'exitnode_cache.dat')
-        super().__init__(*args, **kwargs)
-        self._use_main_thread = True
 
+        settings = kwargs.pop('settings', TunnelSettings())
         if self.tribler_session:
             if self.tribler_session.config.get_tunnel_community_exitnode_enabled():
-                self.settings.peer_flags.add(PEER_FLAG_EXIT_BT)
-                self.settings.peer_flags.add(PEER_FLAG_EXIT_IPV8)
-                self.settings.peer_flags.add(PEER_FLAG_EXIT_HTTP)
+                settings.peer_flags.add(PEER_FLAG_EXIT_BT)
+                settings.peer_flags.add(PEER_FLAG_EXIT_IPV8)
+                settings.peer_flags.add(PEER_FLAG_EXIT_HTTP)
 
             if not socks_listen_ports:
                 socks_listen_ports = self.tribler_session.config.get_tunnel_community_socks5_listen_ports()
         elif socks_listen_ports is None:
             socks_listen_ports = range(1080, 1085)
+
+        super().__init__(*args, settings=settings, **kwargs)
+        self._use_main_thread = True
 
         self.bittorrent_peers = {}
         self.dispatcher = TunnelDispatcher(self)


### PR DESCRIPTION
When `run_tunnel_helper.py` script is started with `--exit` argument, it erroneously writes to logs:

```
INFO:TriblerTunnelTestnetCommunity:Exit settings: BT=False, IPv8=False
```

It may be dangerous, as a user will have a false impression that the exit node mode was not enabled. The reason for the bug is that the log message is emitted in the base constructor of `TunnelCommunity`, while the relevant flags are set up later in the constructor of the `TriblerTunnelCommunity` class.

In this fix, I process exit node flags earlier, so the `TunnelCommunity` class receives correct settings and log them correctly. With this fix, when running with the `--exit` argument, it writes:

```
INFO:TriblerTunnelTestnetCommunity:Exit settings: BT=True, IPv8=True
```