### PR TITLE
Replace logfunc() by self.logger.info()

### DIFF
--- a/src/tribler-gui/tribler_gui/single_application.py
+++ b/src/tribler-gui/tribler_gui/single_application.py
@@ -9,8 +9,6 @@ from PyQt5.QtWidgets import QApplication
 
 from tribler_gui.utilities import connect, disconnect
 
-LOGVARSTR = "%25s = '%s'"
-
 
 class QtSingleApplication(QApplication):
     """
@@ -24,8 +22,6 @@ class QtSingleApplication(QApplication):
         self.logger = logging.getLogger(self.__class__.__name__)
         self.logger.info(f'Start Tribler application. Win id: "{win_id}". '
                          f'Sys argv: "{sys.argv}"')
-
-        self.logger.info(sys._getframe().f_code.co_name + '()')
 
         QApplication.__init__(self, *argv)
 
@@ -45,15 +41,16 @@ class QtSingleApplication(QApplication):
 
         if self._isRunning:
             # Yes, there is.
+            self.logger.info('Another instance is running')
             self._outStream = QTextStream(self._outSocket)
             self._outStream.setCodec('UTF-8')
         else:
             # No, there isn't, at least not properly.
             # Cleanup any past, crashed server.
             error = self._outSocket.error()
-            self.logger.info(LOGVARSTR % ('self._outSocket.error()', error))
+            self.logger.info(f'No running instances (socket error: {error})')
             if error == QLocalSocket.ConnectionRefusedError:
-                self.logger.warning('received QLocalSocket.ConnectionRefusedError; removing server.')
+                self.logger.info('Received QLocalSocket.ConnectionRefusedError; removing server.')
                 self.close()
                 QLocalServer.removeServer(self._id)
             self._outSocket = None
@@ -61,18 +58,15 @@ class QtSingleApplication(QApplication):
             self._server.listen(self._id)
             connect(self._server.newConnection, self._on_new_connection)
 
-        self.logger.info(sys._getframe().f_code.co_name + '(): returning')
-
     def close(self):
-        logfunc = logging.info
-        logfunc(sys._getframe().f_code.co_name + '()')
+        self.logger.info('Closing...')
         if self._inSocket:
             self._inSocket.disconnectFromServer()
         if self._outSocket:
             self._outSocket.disconnectFromServer()
         if self._server:
             self._server.close()
-        logfunc(sys._getframe().f_code.co_name + '(): returning')
+        self.logger.info('Closed')
 
     def is_running(self):
         return self._isRunning

--- a/src/tribler-gui/tribler_gui/single_application.py
+++ b/src/tribler-gui/tribler_gui/single_application.py
@@ -25,8 +25,7 @@ class QtSingleApplication(QApplication):
         self.logger.info(f'Start Tribler application. Win id: "{win_id}". '
                          f'Sys argv: "{sys.argv}"')
 
-        logfunc = logging.info
-        logfunc(sys._getframe().f_code.co_name + '()')
+        self.logger.info(sys._getframe().f_code.co_name + '()')
 
         QApplication.__init__(self, *argv)
 
@@ -52,9 +51,9 @@ class QtSingleApplication(QApplication):
             # No, there isn't, at least not properly.
             # Cleanup any past, crashed server.
             error = self._outSocket.error()
-            logfunc(LOGVARSTR % ('self._outSocket.error()', error))
+            self.logger.info(LOGVARSTR % ('self._outSocket.error()', error))
             if error == QLocalSocket.ConnectionRefusedError:
-                logfunc('received QLocalSocket.ConnectionRefusedError; removing server.')
+                self.logger.warning('received QLocalSocket.ConnectionRefusedError; removing server.')
                 self.close()
                 QLocalServer.removeServer(self._id)
             self._outSocket = None
@@ -62,7 +61,7 @@ class QtSingleApplication(QApplication):
             self._server.listen(self._id)
             connect(self._server.newConnection, self._on_new_connection)
 
-        logfunc(sys._getframe().f_code.co_name + '(): returning')
+        self.logger.info(sys._getframe().f_code.co_name + '(): returning')
 
     def close(self):
         logfunc = logging.info


### PR DESCRIPTION
This PR replaced the abstract invocation of `logfunc()` to explicit invocation of `self.logger.info()`.
Also, it removes some unnecessary logging.

It will change logs outputs from:

```
[PID:18411] 2021-02-10 16:20:13,900- INFO - TriblerApplication(23) - Start Tribler application. Win id: "triblerapp". Sys argv: "['/Users/<user>/Projects/github.com/Tribler/tribler/src/run_tribler.py']"
[PID:18411] 2021-02-10 16:20:13,906 - INFO - root(29) - __init__()
[PID:18411] 2021-02-10 16:20:13,998 - INFO - root(55) -   self._outSocket.error() = '2'
[PID:18411] 2021-02-10 16:20:14,373 - INFO - root(65) - __init__(): returning
```

to:

```
[PID:18868] 2021-02-10 16:34:07,740 - INFO - TriblerApplication(23) - Start Tribler application. Win id: "triblerapp". Sys argv: "['/Users/<user>/Projects/github.com/Tribler/tribler/src/run_tribler.py']"
[PID:18868] 2021-02-10 16:34:07,832 - INFO - TriblerApplication(51) - No running instances (socket error: 2)
```

Linked to #5938