### PR TITLE
Allow exitnodes to run without libtorrent installed

### DIFF
--- a/src/tribler-core/tribler_core/modules/dht_health_manager.py
+++ b/src/tribler-core/tribler_core/modules/dht_health_manager.py
@@ -4,8 +4,7 @@ from asyncio import Future
 from ipv8.dht.routing import distance
 from ipv8.taskmanager import TaskManager
 
-import libtorrent as lt
-
+from tribler_core.utilities.libtorrent_helper import libtorrent as lt
 from tribler_core.utilities.unicode import hexlify
 
 

--- a/src/tribler-core/tribler_core/modules/libtorrent/download.py
+++ b/src/tribler-core/tribler_core/modules/libtorrent/download.py
@@ -12,9 +12,6 @@ from pathlib import Path
 from ipv8.taskmanager import TaskManager, task
 from ipv8.util import int2byte, succeed
 
-import libtorrent as lt
-from libtorrent import create_torrent
-
 from tribler_common.simpledefs import DLSTATUS_SEEDING, DLSTATUS_STOPPED, DOWNLOAD, NTFY
 
 from tribler_core.exceptions import SaveResumeDataError
@@ -24,6 +21,7 @@ from tribler_core.modules.libtorrent.download_state import DownloadState
 from tribler_core.modules.libtorrent.stream import Stream
 from tribler_core.modules.libtorrent.torrentdef import TorrentDef, TorrentDefNoMetainfo
 from tribler_core.utilities import path_util
+from tribler_core.utilities.libtorrent_helper import libtorrent as lt
 from tribler_core.utilities.osutils import fix_filebasename
 from tribler_core.utilities.torrent_utils import get_info_from_handle
 from tribler_core.utilities.unicode import ensure_unicode, hexlify
@@ -98,7 +96,7 @@ class Download(TaskManager):
             return None
 
         torrent_info = get_info_from_handle(self.handle)
-        t = create_torrent(torrent_info)
+        t = lt.create_torrent(torrent_info)
         return t.generate()
 
     def register_alert_handler(self, alert_type, handler):

--- a/src/tribler-core/tribler_core/modules/libtorrent/download_config.py
+++ b/src/tribler-core/tribler_core/modules/libtorrent/download_config.py
@@ -3,13 +3,12 @@ from pathlib import Path
 
 from configobj import ConfigObj
 
-import libtorrent as lt
-
 from validate import Validator
 
 from tribler_core.exceptions import InvalidConfigException
 from tribler_core.utilities import path_util
 from tribler_core.utilities.install_dir import get_lib_path
+from tribler_core.utilities.libtorrent_helper import libtorrent as lt
 from tribler_core.utilities.osutils import get_home_dir
 from tribler_core.utilities.path_util import str_path
 from tribler_core.utilities.utilities import bdecode_compat

--- a/src/tribler-core/tribler_core/modules/libtorrent/download_manager.py
+++ b/src/tribler-core/tribler_core/modules/libtorrent/download_manager.py
@@ -16,8 +16,6 @@ from urllib.request import url2pathname
 
 from ipv8.taskmanager import TaskManager, task
 
-import libtorrent as lt
-
 from tribler_common.simpledefs import DLSTATUS_SEEDING, STATEDIR_CHECKPOINT_DIR
 
 from tribler_core.modules.dht_health_manager import DHTHealthManager
@@ -25,6 +23,7 @@ from tribler_core.modules.libtorrent.download import Download
 from tribler_core.modules.libtorrent.download_config import DownloadConfig
 from tribler_core.modules.libtorrent.torrentdef import TorrentDef, TorrentDefNoMetainfo
 from tribler_core.utilities import path_util, torrent_utils
+from tribler_core.utilities.libtorrent_helper import libtorrent as lt
 from tribler_core.utilities.path_util import mkdtemp
 from tribler_core.utilities.unicode import hexlify
 from tribler_core.utilities.utilities import bdecode_compat, has_bep33_support, parse_magnetlink

--- a/src/tribler-core/tribler_core/modules/libtorrent/restapi/downloads_endpoint.py
+++ b/src/tribler-core/tribler_core/modules/libtorrent/restapi/downloads_endpoint.py
@@ -11,8 +11,6 @@ from aiohttp_apispec import docs, json_schema
 from ipv8.REST.schema import schema
 from ipv8.messaging.anonymization.tunnel import CIRCUIT_ID_PORT
 
-from libtorrent import bencode
-
 from marshmallow.fields import Boolean, Float, Integer, List, String
 
 from tribler_common.simpledefs import DOWNLOAD, UPLOAD, dlstatus_strings
@@ -28,6 +26,7 @@ from tribler_core.restapi.rest_endpoint import (
     RESTStreamResponse,
 )
 from tribler_core.restapi.util import return_handled_exception
+from tribler_core.utilities.libtorrent_helper import libtorrent as lt
 from tribler_core.utilities.path_util import Path
 from tribler_core.utilities.unicode import ensure_unicode, hexlify
 
@@ -511,7 +510,7 @@ class DownloadsEndpoint(RESTEndpoint):
         if not torrent:
             return DownloadsEndpoint.return_404(request)
 
-        return RESTResponse(bencode(torrent), headers={'content-type': 'application/x-bittorrent',
+        return RESTResponse(lt.bencode(torrent), headers={'content-type': 'application/x-bittorrent',
                                                        'Content-Disposition': 'attachment; filename=%s.torrent'
                                                                               % hexlify(infohash).encode('utf-8')})
 

--- a/src/tribler-core/tribler_core/modules/libtorrent/restapi/torrentinfo_endpoint.py
+++ b/src/tribler-core/tribler_core/modules/libtorrent/restapi/torrentinfo_endpoint.py
@@ -9,14 +9,13 @@ from aiohttp_apispec import docs
 
 from ipv8.REST.schema import schema
 
-from libtorrent import bencode
-
 from marshmallow.fields import String
 
 import tribler_core.utilities.json_util as json
 from tribler_core.modules.libtorrent.torrentdef import TorrentDef
 from tribler_core.modules.metadata_store.orm_bindings.torrent_metadata import tdef_to_metadata_dict
 from tribler_core.restapi.rest_endpoint import HTTP_BAD_REQUEST, HTTP_INTERNAL_SERVER_ERROR, RESTEndpoint, RESTResponse
+from tribler_core.utilities.libtorrent_helper import libtorrent as lt
 from tribler_core.utilities.unicode import hexlify, recursive_unicode
 from tribler_core.utilities.utilities import bdecode_compat, parse_magnetlink
 
@@ -104,7 +103,7 @@ class TorrentInfoEndpoint(RESTEndpoint):
 
         # TODO(Martijn): store the stuff in a database!!!
         # TODO(Vadim): this means cache the downloaded torrent in a binary storage, like LevelDB
-        infohash = hashlib.sha1(bencode(metainfo[b'info'])).digest()
+        infohash = hashlib.sha1(lt.bencode(metainfo[b'info'])).digest()
 
         download = self.session.dlmgr.downloads.get(infohash)
         metainfo_request = self.session.dlmgr.metainfo_requests.get(infohash, [None])[0]

--- a/src/tribler-core/tribler_core/modules/libtorrent/torrentdef.py
+++ b/src/tribler-core/tribler_core/modules/libtorrent/torrentdef.py
@@ -6,12 +6,10 @@ from hashlib import sha1
 
 import aiohttp
 
-import libtorrent as lt
-from libtorrent import bencode
-
 from tribler_common.simpledefs import INFOHASH_LENGTH
 
 from tribler_core.utilities import maketorrent, path_util
+from tribler_core.utilities.libtorrent_helper import libtorrent as lt
 from tribler_core.utilities.torrent_utils import create_torrent_file
 from tribler_core.utilities.unicode import ensure_unicode
 from tribler_core.utilities.utilities import bdecode_compat, is_valid_url, parse_magnetlink
@@ -67,7 +65,7 @@ class TorrentDef:
                 except RuntimeError as exc:
                     raise ValueError(str(exc))
             self.metainfo = metainfo
-            self.infohash = sha1(bencode(self.metainfo[b'info'])).digest()
+            self.infohash = sha1(lt.bencode(self.metainfo[b'info'])).digest()
             self.copy_metainfo_to_torrent_parameters()
 
         elif torrent_parameters:

--- a/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/channel_metadata.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/channel_metadata.py
@@ -4,8 +4,6 @@ from pathlib import Path
 
 from ipv8.database import database_blob
 
-from libtorrent import add_files, bencode, create_torrent, file_storage, set_piece_hashes, torrent_info
-
 import lz4.frame
 
 from pony import orm
@@ -24,6 +22,7 @@ from tribler_core.modules.metadata_store.orm_bindings.channel_node import (
 )
 from tribler_core.modules.metadata_store.serialization import CHANNEL_TORRENT, ChannelMetadataPayload
 from tribler_core.utilities import path_util
+from tribler_core.utilities.libtorrent_helper import libtorrent as lt
 from tribler_core.utilities.path_util import str_path
 from tribler_core.utilities.random_utils import random_infohash
 from tribler_core.utilities.unicode import hexlify
@@ -42,17 +41,17 @@ def chunks(l, n):
 
 
 def create_torrent_from_dir(directory, torrent_filename):
-    fs = file_storage()
-    add_files(fs, str(directory))
-    t = create_torrent(fs)
+    fs = lt.file_storage()
+    lt.add_files(fs, str(directory))
+    t = lt.create_torrent(fs)
     # t = create_torrent(fs, flags=17) # piece alignment
     t.set_priv(False)
-    set_piece_hashes(t, str(directory.parent))
+    lt.set_piece_hashes(t, str(directory.parent))
     torrent = t.generate()
     with open(torrent_filename, 'wb') as f:
-        f.write(bencode(torrent))
+        f.write(lt.bencode(torrent))
 
-    infohash = torrent_info(torrent).info_hash().to_bytes()
+    infohash = lt.torrent_info(torrent).info_hash().to_bytes()
     return torrent, infohash
 
 

--- a/src/tribler-core/tribler_core/modules/tunnel/community/triblertunnel_community.py
+++ b/src/tribler-core/tribler_core/modules/tunnel/community/triblertunnel_community.py
@@ -48,7 +48,7 @@ from tribler_core.modules.tunnel.community.payload import (
 )
 from tribler_core.modules.tunnel.socks5.server import Socks5Server
 from tribler_core.utilities import path_util
-from tribler_core.utilities.libtorrent_helper import libtorrent as lt
+from tribler_core.utilities.bencodecheck import is_bencoded
 from tribler_core.utilities.unicode import hexlify
 
 DESTROY_REASON_BALANCE = 65535
@@ -612,14 +612,8 @@ class TriblerTunnelCommunity(HiddenTunnelCommunity):
 
         if not response.startswith(b'HTTP/1.1 307'):
             _, _, bencoded_data = response.partition(b'\r\n\r\n')
-            # Note that, depending on the libtorrent version, bdecode does not always raise
-            # an exception, sometimes it returns None instead.
-            try:
-                response_decoded = lt.bdecode(bencoded_data)
-            except RuntimeError:
-                response_decoded = None
 
-            if response_decoded is None:
+            if not is_bencoded(bencoded_data):
                 self.logger.warning('Tunnel HTTP request not allowed')
                 return
 

--- a/src/tribler-core/tribler_core/upgrade/config_converter.py
+++ b/src/tribler-core/tribler_core/upgrade/config_converter.py
@@ -7,13 +7,12 @@ from lib2to3.pgen2.parse import ParseError
 
 from configobj import ConfigObj, ParseError as ConfigObjParseError
 
-import libtorrent as lt
-
 from tribler_common.simpledefs import STATEDIR_CHECKPOINT_DIR
 
 from tribler_core.modules.libtorrent.download_config import DownloadConfig
 from tribler_core.modules.libtorrent.torrentdef import TorrentDef
 from tribler_core.utilities.configparser import CallbackConfigParser
+from tribler_core.utilities.libtorrent_helper import libtorrent as lt
 from tribler_core.utilities.unicode import recursive_ungarble_metainfo
 
 logger = logging.getLogger(__name__)

--- a/src/tribler-core/tribler_core/utilities/bencodecheck.py
+++ b/src/tribler-core/tribler_core/utilities/bencodecheck.py
@@ -9,7 +9,7 @@ def is_bencoded(x: bytes) -> bool:
     return default_checker.check(x)
 
 
-class BencodeChecker(object):
+class BencodeChecker:
     def __init__(self):
         self.check_func = {
             ord('l'): self.check_list,

--- a/src/tribler-core/tribler_core/utilities/bencodecheck.py
+++ b/src/tribler-core/tribler_core/utilities/bencodecheck.py
@@ -1,0 +1,93 @@
+
+
+def is_bencoded(x: bytes) -> bool:
+    """
+    Returns True is x appears to be valid bencoded byte string.
+
+    For better performance does not check that strings are in valid encoding.
+    """
+    return default_checker.check(x)
+
+
+class BencodeChecker(object):
+    def __init__(self):
+        self.check_func = {
+            ord('l'): self.check_list,
+            ord('i'): self.check_int,
+            ord('0'): self.check_string,
+            ord('1'): self.check_string,
+            ord('2'): self.check_string,
+            ord('3'): self.check_string,
+            ord('4'): self.check_string,
+            ord('5'): self.check_string,
+            ord('6'): self.check_string,
+            ord('7'): self.check_string,
+            ord('8'): self.check_string,
+            ord('9'): self.check_string,
+            ord('d'): self.check_dict,
+        }
+
+    def check(self, x: bytes) -> bool:
+        if not isinstance(x, bytes):
+            raise ValueError('Value should be of bytes type. Got: %s'
+                             % type(x).__name__)
+
+        try:
+            prefix = x[0]
+            pos = self.check_func[prefix](x, 0)
+        except (IndexError, KeyError, TypeError, ValueError):
+            return False
+
+        if pos != len(x):
+            # truncated string or bytes after the end of bencoded string
+            return False
+
+        return True
+
+    @staticmethod
+    def check_int(x: bytes, pos: int,
+                  ZERO=ord('0'), MINUS=ord('-')) -> int:
+        pos += 1
+        end = x.index(b'e', pos)
+
+        if x[pos] == MINUS:
+            if x[pos + 1] == ZERO:
+                raise ValueError
+        elif x[pos] == ZERO and end != pos + 1:
+            raise ValueError
+
+        return end + 1
+
+    @staticmethod
+    def check_string(x: bytes, pos: int,
+                     ZERO=ord('0')) -> int:
+        colon = x.index(b':', pos)
+        if x[pos] == ZERO and colon != pos + 1:
+            raise ValueError
+
+        n = int(x[pos:colon])
+        return colon + 1 + n
+
+    def check_list(self, x: bytes, pos: int,
+                   END=ord('e')) -> int:
+        pos += 1
+
+        while x[pos] != END:
+            prefix = x[pos]
+            pos = self.check_func[prefix](x, pos)
+
+        return pos + 1
+
+    def check_dict(self, x: bytes, pos: int,
+                   END=ord('e')) -> int:
+        pos += 1
+
+        while x[pos] != END:
+            pos = self.check_string(x, pos)
+            prefix = x[pos]
+            pos = self.check_func[prefix](x, pos)
+
+        return pos + 1
+
+
+default_checker = BencodeChecker()

--- a/src/tribler-core/tribler_core/utilities/libtorrent_helper.py
+++ b/src/tribler-core/tribler_core/utilities/libtorrent_helper.py
@@ -2,9 +2,17 @@ __all__ = ['libtorrent']
 
 
 class LibtorrentFallback:
+    """
+    Used as a fallback replacement for libtorrent library if it was not possible to import it.
+
+    Any attempt to access any member raises ImportError.
+    """
     def __getattr__(self, item):
-        # Cannot use RuntimeError here, as libtorrent functions like bdecode
-        # raise RuntimeError as well, and we need to distinct these exceptions.
+        """
+        Raises ImportError on any attempt to access a member of the class that is not explicitly defined.
+        """
+        # Cannot use RuntimeError here, as libtorrent functions like bdecode raise RuntimeError as well,
+        # and we need to distinguish these exceptions.
         raise ImportError('libtorrent library is not installed')
 
 

--- a/src/tribler-core/tribler_core/utilities/libtorrent_helper.py
+++ b/src/tribler-core/tribler_core/utilities/libtorrent_helper.py
@@ -1,0 +1,14 @@
+__all__ = ['libtorrent']
+
+
+class LibtorrentFallback:
+    def __getattr__(self, item):
+        # Cannot use RuntimeError here, as libtorrent functions like bdecode
+        # raise RuntimeError as well, and we need to distinct these exceptions.
+        raise ImportError('libtorrent library is not installed')
+
+
+try:
+    import libtorrent
+except ImportError:
+    libtorrent = LibtorrentFallback()

--- a/src/tribler-core/tribler_core/utilities/tests/test_bencodecheck.py
+++ b/src/tribler-core/tribler_core/utilities/tests/test_bencodecheck.py
@@ -3,109 +3,83 @@ import pytest
 from tribler_core.utilities.bencodecheck import is_bencoded
 
 
-def test_bcheck_nobytes():
+def test_bencode_checker():
     # only bytes is valid argument type
     with pytest.raises(ValueError, match='^Value should be of bytes type. Got: str$'):
         is_bencoded('3:abc')
 
-def test_bcheck_empty():
+    # empty encoded string
     assert not is_bencoded(b'')
 
-def test_bcheck_excess_data1():
-    # excess data after the end of encoded string
+    # excess data after the end of encoded data
     assert not is_bencoded(b'3:abc3:abc')
 
-def test_bcheck_excess_data2():
-    # excess end marker after the end of encoded string
+    # excess end marker after the end of the encoded data
     assert not is_bencoded(b'3:abce')
 
-def test_bcheck_str1():
     # empty string
     assert is_bencoded(b'0:')
 
-def test_bcheck_str2():
     # normal string with 'abc' value
     assert is_bencoded(b'3:abc')
 
-def test_bcheck_str3():
-    # the leading zeroes are not allowed in string length
+    # the leading zeroes are not allowed in string length specification
     assert not is_bencoded(b'03:abc')
 
-def test_bcheck_str4():
     # string value is too short
     assert not is_bencoded(b'4:abc')
 
-def test_bcheck_str5():
-    # semicolon is not present
+    # colon is not present in string encoded data
     assert not is_bencoded(b'3abc')
 
-def test_bcheck_int1():
     # zero int value
     assert is_bencoded(b'i0e')
 
-def test_bcheck_int2():
-    # positive value
+    # positive int value
     assert is_bencoded(b'i123e')
 
-def test_bcheck_int3():
-    # negative value
+    # negative int value
     assert is_bencoded(b'i-123e')
 
-def test_bcheck_int4():
     # leading zeroes are not allowed in int value
     assert not is_bencoded(b'i0123e')
     assert not is_bencoded(b'i00e')
 
-def test_bcheck_int5():
     # -0 is not allowed as int value
     assert not is_bencoded(b'i-0e')
     assert not is_bencoded(b'i-00e')
     assert not is_bencoded(b'i-0123e')
 
-def test_bcheck_dict1():
     # test for empty dict
     assert is_bencoded(b'de')
 
-def test_bcheck_dict2():
     # test for a normal dict {'abc': 'def'}
     assert is_bencoded(b'd3:abc3:defe')
 
-def test_bcheck_dict3():
     # dict key without a dict value
     assert not is_bencoded(b'd3:abce')
 
-def test_bcheck_dict4():
     # dict without end marker
     assert not is_bencoded(b'd3:abc3:def')
 
-def test_bcheck_dict5():
     # non-string key
     assert not is_bencoded(b'di123e3:defe')
 
-def test_bcheck_dict6():
     # nested dicts
     assert is_bencoded(b'd3:abcd3:foo3:baree')
 
-def test_bcheck_list1():
     # empty list
     assert is_bencoded(b'le')
 
-def test_bcheck_list2():
     # a normal list with four elements
     assert is_bencoded(b'li123e3:abcd3:foo3:barelee')
 
-def test_bcheck_list3():
     # nested lists
     assert is_bencoded(b'lli123e3:abceli456e3:defee')
 
-def test_bcheck_list4():
-    # no end marker
+    # no end marker for list
     assert not is_bencoded(b'l3:abc')
 
-def test_bcheck_garbage1():
     # invalid data
     assert not is_bencoded(b'hello')
-
-def test_bcheck_garbage2():
-    # invalid data
     assert not is_bencoded(b'<?=#.')

--- a/src/tribler-core/tribler_core/utilities/tests/test_bencodecheck.py
+++ b/src/tribler-core/tribler_core/utilities/tests/test_bencodecheck.py
@@ -1,0 +1,111 @@
+import pytest
+
+from tribler_core.utilities.bencodecheck import is_bencoded
+
+
+def test_bcheck_nobytes():
+    # only bytes is valid argument type
+    with pytest.raises(ValueError, match='^Value should be of bytes type. Got: str$'):
+        is_bencoded('3:abc')
+
+def test_bcheck_empty():
+    assert not is_bencoded(b'')
+
+def test_bcheck_excess_data1():
+    # excess data after the end of encoded string
+    assert not is_bencoded(b'3:abc3:abc')
+
+def test_bcheck_excess_data2():
+    # excess end marker after the end of encoded string
+    assert not is_bencoded(b'3:abce')
+
+def test_bcheck_str1():
+    # empty string
+    assert is_bencoded(b'0:')
+
+def test_bcheck_str2():
+    # normal string with 'abc' value
+    assert is_bencoded(b'3:abc')
+
+def test_bcheck_str3():
+    # the leading zeroes are not allowed in string length
+    assert not is_bencoded(b'03:abc')
+
+def test_bcheck_str4():
+    # string value is too short
+    assert not is_bencoded(b'4:abc')
+
+def test_bcheck_str5():
+    # semicolon is not present
+    assert not is_bencoded(b'3abc')
+
+def test_bcheck_int1():
+    # zero int value
+    assert is_bencoded(b'i0e')
+
+def test_bcheck_int2():
+    # positive value
+    assert is_bencoded(b'i123e')
+
+def test_bcheck_int3():
+    # negative value
+    assert is_bencoded(b'i-123e')
+
+def test_bcheck_int4():
+    # leading zeroes are not allowed in int value
+    assert not is_bencoded(b'i0123e')
+    assert not is_bencoded(b'i00e')
+
+def test_bcheck_int5():
+    # -0 is not allowed as int value
+    assert not is_bencoded(b'i-0e')
+    assert not is_bencoded(b'i-00e')
+    assert not is_bencoded(b'i-0123e')
+
+def test_bcheck_dict1():
+    # test for empty dict
+    assert is_bencoded(b'de')
+
+def test_bcheck_dict2():
+    # test for a normal dict {'abc': 'def'}
+    assert is_bencoded(b'd3:abc3:defe')
+
+def test_bcheck_dict3():
+    # dict key without a dict value
+    assert not is_bencoded(b'd3:abce')
+
+def test_bcheck_dict4():
+    # dict without end marker
+    assert not is_bencoded(b'd3:abc3:def')
+
+def test_bcheck_dict5():
+    # non-string key
+    assert not is_bencoded(b'di123e3:defe')
+
+def test_bcheck_dict6():
+    # nested dicts
+    assert is_bencoded(b'd3:abcd3:foo3:baree')
+
+def test_bcheck_list1():
+    # empty list
+    assert is_bencoded(b'le')
+
+def test_bcheck_list2():
+    # a normal list with four elements
+    assert is_bencoded(b'li123e3:abcd3:foo3:barelee')
+
+def test_bcheck_list3():
+    # nested lists
+    assert is_bencoded(b'lli123e3:abceli456e3:defee')
+
+def test_bcheck_list4():
+    # no end marker
+    assert not is_bencoded(b'l3:abc')
+
+def test_bcheck_garbage1():
+    # invalid data
+    assert not is_bencoded(b'hello')
+
+def test_bcheck_garbage2():
+    # invalid data
+    assert not is_bencoded(b'<?=#.')

--- a/src/tribler-core/tribler_core/utilities/utilities.py
+++ b/src/tribler-core/tribler_core/utilities/utilities.py
@@ -9,8 +9,7 @@ import re
 from base64 import b32decode
 from urllib.parse import parse_qsl, urlsplit
 
-import libtorrent
-from libtorrent import bdecode
+from tribler_core.utilities.libtorrent_helper import libtorrent as lt
 
 logger = logging.getLogger(__name__)
 
@@ -148,7 +147,7 @@ def has_bep33_support():
     Return whether our libtorrent version has support for BEP33 (DHT health lookups).
     Also see https://github.com/devos50/libtorrent/tree/bep33_support
     """
-    return 'dht_pkt_alert' in dir(libtorrent)
+    return 'dht_pkt_alert' in dir(lt)
 
 
 def is_infohash(infohash):
@@ -173,6 +172,6 @@ def bdecode_compat(packet_buffer):
     We should change this when Libtorrent wrapper is refactored.
     """
     try:
-        return bdecode(packet_buffer)
+        return lt.bdecode(packet_buffer)
     except RuntimeError:
         return None


### PR DESCRIPTION
This PR allows running the `run_tunnel_helper.py` script without libtorrent installing.

Currently, many modules import `libtorrent` even if it is not necessary. `run_tunnel_helper.py` script even [sets `libtorrent_enabled` option to `False`](https://github.com/Tribler/tribler/blob/devel/src/tribler-core/run_tunnel_helper.py#L124), but still imports `libtorrent` library. As installing libtorrent from sources may be a non-trivial task, it is better to allow running `run_tunnel_helper.py` without `libtorrent` installed.

This PR does two things:

1. Refactor imports to import libtorrent not directly, but from `tribler_core.utils.libtorrent_helper`. When `libtorrent` is not installed, the `libtorrent_helper` module returns a fallback object instead, which raises `ImportError` on any attempt to access `libtorrent` module members. The `ImportError` exception was chosen as it provides a clear explanation for the reason for the error. It is possible to use another exception instead. Still, it should not be `RuntimeError`, as the `libtorrent` module itself uses `RuntimeError` (in the `bdecode` function, for example). Tribler code may erroneously catch the exception and assume that the reason for the error is incorrect data for the `bdecode` function.

2. Add `is_bencoded(x)` pure-python function, which checks that the data appears to be a valid bencoded string. This function is used in `TriblerTunnelCommunity` instead of `libtorrent.bdecode` call. It is not necessary to actually perform `bdecode` in `TriblerTunnelCommunity`, as the purpose is just to check that the data is not something unrelated to libtorrrent.

Later, it will be easy to add a pure-python implementation of the `bencode` and `bdecode` functions to the `LibtorrentFallback` class if the need arises, but right now, there are no such use-cases where it may be helpful.