### PR TITLE
Sentry: additional tags

### DIFF
--- a/src/tribler-common/tribler_common/sentry_reporter/sentry_reporter.py
+++ b/src/tribler-common/tribler_common/sentry_reporter/sentry_reporter.py
@@ -142,7 +142,7 @@ class SentryReporter:
         return sentry_sdk.add_breadcrumb(crumb, **kwargs)
 
     @staticmethod
-    def send_event(event, post_data=None, sys_info=None):
+    def send_event(event=None, post_data=None, sys_info=None, additional_tags=None):
         """Send the event to the Sentry server
 
         This method
@@ -161,6 +161,7 @@ class SentryReporter:
             post_data: dictionary made by the feedbackdialog.py
                 previous stages of executing.
             sys_info: dictionary made by the feedbackdialog.py
+            additional_tags: tags that will be added to the event
 
         Returns:
             Event that was sent to Sentry server
@@ -172,6 +173,7 @@ class SentryReporter:
 
         post_data = post_data or dict()
         sys_info = sys_info or dict()
+        additional_tags = additional_tags or dict()
 
         if CONTEXTS not in event:
             event[CONTEXTS] = {}
@@ -188,6 +190,7 @@ class SentryReporter:
         tags['os'] = get_value(post_data, 'os')
         tags['platform'] = get_first_item(get_value(sys_info, 'platform'))
         tags[f'{PLATFORM_DETAILS}'] = get_first_item(get_value(sys_info, PLATFORM_DETAILS))
+        tags.update(additional_tags)
 
         # context
         context = event[CONTEXTS]

--- a/src/tribler-common/tribler_common/sentry_reporter/tests/test_sentry_reporter.py
+++ b/src/tribler-common/tribler_common/sentry_reporter/tests/test_sentry_reporter.py
@@ -41,11 +41,10 @@ def test_set_user():
     }
 
 
-def test_send():
+def test_send_defaults():
     assert SentryReporter.send_event(None, None, None) is None
 
-    # test return defaults
-    assert SentryReporter.send_event({}, None, None) == {
+    assert SentryReporter.send_event(event={}) == {
         'contexts': {
             'browser': {'name': 'Tribler', 'version': None},
             'reporter': {
@@ -61,18 +60,20 @@ def test_send():
         'tags': {'machine': None, 'os': None, 'platform': None, PLATFORM_DETAILS: None, 'version': None},
     }
 
-    # test post_data
-    post_data = {
-        "version": '0.0.0',
-        "machine": 'x86_64',
-        "os": 'posix',
-        "timestamp": 42,
-        "sysinfo": '',
-        "comments": 'comment',
-        "stack": 'l1\nl2--LONG TEXT--l3\nl4',
-    }
 
-    assert SentryReporter.send_event({'a': 'b'}, post_data, None) == {
+def test_send_post_data():
+    assert SentryReporter.send_event(
+        event={'a': 'b'},
+        post_data={
+            "version": '0.0.0',
+            "machine": 'x86_64',
+            "os": 'posix',
+            "timestamp": 42,
+            "sysinfo": '',
+            "comments": 'comment',
+            "stack": 'l1\nl2--LONG TEXT--l3\nl4',
+        },
+    ) == {
         'a': 'b',
         'contexts': {
             'browser': {'name': 'Tribler', 'version': '0.0.0'},
@@ -86,19 +87,23 @@ def test_send():
                 'events': {},
             },
         },
-        'tags': {'machine': 'x86_64', 'os': 'posix', 'platform': None, 'platform.details': None, 'version': '0.0.0'},
+        'tags': {'machine': 'x86_64', 'os': 'posix', 'platform': None, PLATFORM_DETAILS: None, 'version': '0.0.0'},
     }
 
-    sys_info = {
-        'platform': ['darwin'],
-        'platform.details': ['details'],
-        OS_ENVIRON: ['KEY:VALUE', 'KEY1:VALUE1'],
-        'event_1': [{'type': ''}],
-        'request_1': [{}],
-        'event_2': [],
-        'request_2': [],
-    }
-    assert SentryReporter.send_event({}, None, sys_info) == {
+
+def test_send_sys_info():
+    assert SentryReporter.send_event(
+        event={},
+        sys_info={
+            'platform': ['darwin'],
+            PLATFORM_DETAILS: ['details'],
+            OS_ENVIRON: ['KEY:VALUE', 'KEY1:VALUE1'],
+            'event_1': [{'type': ''}],
+            'request_1': [{}],
+            'event_2': [],
+            'request_2': [],
+        },
+    ) == {
         'contexts': {
             'browser': {'name': 'Tribler', 'version': None},
             'reporter': {
@@ -107,11 +112,36 @@ def test_send():
                 '_stacktrace_extra': [],
                 'comments': None,
                 OS_ENVIRON: {'KEY': 'VALUE', 'KEY1': 'VALUE1'},
-                'sysinfo': {'platform': ['darwin'], 'platform.details': ['details']},
+                'sysinfo': {'platform': ['darwin'], PLATFORM_DETAILS: ['details']},
                 'events': {'event_1': [{'type': ''}], 'request_1': [{}], 'event_2': [], 'request_2': []},
             },
         },
         'tags': {'machine': None, 'os': None, 'platform': 'darwin', 'platform.details': 'details', 'version': None},
+    }
+
+
+def test_send_additional_tags():
+    assert SentryReporter.send_event(event={}, additional_tags={'tag_key': 'tag_value'}) == {
+        'contexts': {
+            'browser': {'name': 'Tribler', 'version': None},
+            'reporter': {
+                '_stacktrace': [],
+                '_stacktrace_context': [],
+                '_stacktrace_extra': [],
+                'comments': None,
+                OS_ENVIRON: {},
+                'sysinfo': {},
+                'events': {},
+            },
+        },
+        'tags': {
+            'machine': None,
+            'os': None,
+            'platform': None,
+            'platform.details': None,
+            'version': None,
+            'tag_key': 'tag_value',
+        },
     }
 
 

--- a/src/tribler-gui/tribler_gui/dialogs/feedbackdialog.py
+++ b/src/tribler-gui/tribler_gui/dialogs/feedbackdialog.py
@@ -32,6 +32,7 @@ class FeedbackDialog(AddBreadcrumbOnShowMixin, QDialog):
         sentry_event=None,
         error_reporting_requires_user_consent=True,
         stop_application_on_close=True,
+        additional_tags=None
     ):
         QDialog.__init__(self, parent)
 
@@ -43,6 +44,7 @@ class FeedbackDialog(AddBreadcrumbOnShowMixin, QDialog):
         self.sentry_event = sentry_event
         self.scrubber = SentryScrubber()
         self.stop_application_on_close = stop_application_on_close
+        self.additional_tags = additional_tags
 
         # Qt 5.2 does not have the setPlaceholderText property
         if hasattr(self.comments_text_edit, "setPlaceholderText"):
@@ -182,7 +184,7 @@ class FeedbackDialog(AddBreadcrumbOnShowMixin, QDialog):
             "stack": stack,
         }
 
-        SentryReporter.send_event(self.sentry_event, post_data, sys_info_dict)
+        SentryReporter.send_event(self.sentry_event, post_data, sys_info_dict, self.additional_tags)
 
         TriblerNetworkRequest(endpoint, self.on_report_sent, raw_data=tribler_urlencode(post_data), method='POST')
 

--- a/src/tribler-gui/tribler_gui/error_handler.py
+++ b/src/tribler-gui/tribler_gui/error_handler.py
@@ -43,7 +43,8 @@ class ErrorHandler:
             start_time=self.tribler_window.start_time,
             sentry_event=SentryReporter.event_from_exception(info_error),
             error_reporting_requires_user_consent=True,
-            stop_application_on_close=self._tribler_stopped
+            stop_application_on_close=self._tribler_stopped,
+            additional_tags={'source': 'gui'}
         ).show()
 
     def core_error(self, text, core_event):
@@ -61,7 +62,8 @@ class ErrorHandler:
             start_time=self.tribler_window.start_time,
             sentry_event=core_event['sentry_event'],
             error_reporting_requires_user_consent=core_event['error_reporting_requires_user_consent'],
-            stop_application_on_close=self._tribler_stopped
+            stop_application_on_close=self._tribler_stopped,
+            additional_tags={'source': 'core'}
         ).show()
 
     def _stop_tribler(self, text):


### PR DESCRIPTION
This PR adds a `source` tag for the "core" and "GUI" errors.
Also, a refactoring for `SentryReporter` tests has been made. 

![image](https://user-images.githubusercontent.com/13798583/107550537-73cbb900-6bd1-11eb-857f-eb2c6f16de11.png)

An example of a sentry report: https://sentry.tribler.org/organizations/tribler/issues/524/?project=3&query=is%3Aunresolved
