### PR TITLE
Replace "devel" by "main"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,13 +24,13 @@ Just click `here <https://github.com/Tribler/tribler/releases/latest>`__ and dow
 Obtaining support
 =================
 
-If you found a bug or have a feature request, please make sure you read `our contributing page <http://tribler.readthedocs.io/en/devel/contributing.html>`_ and then `open an issue <https://github.com/Tribler/tribler/issues/new>`_. We will have a look at it ASAP.
+If you found a bug or have a feature request, please make sure you read `our contributing page <http://tribler.readthedocs.io/en/main/contributing.html>`_ and then `open an issue <https://github.com/Tribler/tribler/issues/new>`_. We will have a look at it ASAP.
 
 Contributing
 ============
 
 Contributions are very welcome!
-If you are interested in contributing code or otherwise, please have a look at `our contributing page <http://tribler.readthedocs.io/en/devel/contributing.html>`_.
+If you are interested in contributing code or otherwise, please have a look at `our contributing page <http://tribler.readthedocs.io/en/main/contributing.html>`_.
 Have a look at the `issue tracker <https://github.com/Tribler/tribler/issues>`_ if you are looking for inspiration :).
 
 
@@ -52,9 +52,9 @@ We support development on Linux, macOS and Windows. We have written
 documentation that guides you through installing the required packages when
 setting up a Tribler development environment.
 
-* `Linux <http://tribler.readthedocs.io/en/devel/development/development_on_linux.html>`_
-* `Windows <http://tribler.readthedocs.io/en/devel/development/development_on_windows.html>`_
-* `macOS <http://tribler.readthedocs.io/en/devel/development/development_on_osx.html>`_
+* `Linux <http://tribler.readthedocs.io/en/main/development/development_on_linux.html>`_
+* `Windows <http://tribler.readthedocs.io/en/main/development/development_on_windows.html>`_
+* `macOS <http://tribler.readthedocs.io/en/main/development/development_on_osx.html>`_
 
 
 Running
@@ -75,7 +75,7 @@ On Windows, you can use the following command to run Tribler:
 Packaging Tribler
 =================
 
-We have written guides on how to package Tribler for distribution on various systems. Please take a look `here <http://tribler.readthedocs.io/en/devel/building/building.html>`_.
+We have written guides on how to package Tribler for distribution on various systems. Please take a look `here <http://tribler.readthedocs.io/en/main/building/building.html>`_.
 
 Submodule notes
 ===============
@@ -85,8 +85,8 @@ Submodule notes
 - Take care of not accidentally committing a submodule revision change with ``git commit -a``.
 - Do not commit a submodule update without running all the tests first and making sure the new code is not breaking Tribler.
 
-.. |jenkins_build| image:: http://jenkins-ci.tribler.org/job/Test_tribler_devel/badge/icon
-    :target: http://jenkins-ci.tribler.org/job/Test_tribler_devel/
+.. |jenkins_build| image:: http://jenkins-ci.tribler.org/job/Test_tribler_main/badge/icon
+    :target: http://jenkins-ci.tribler.org/job/Test_tribler_main/
     :alt: Build status on Jenkins
 
 .. |pr_closed| image:: https://img.shields.io/github/issues-pr-closed/tribler/tribler.svg?style=flat
@@ -132,6 +132,6 @@ Submodule notes
     :target: https://zenodo.org/badge/latestdoi/8411137
     :alt: DOI number
 
-.. |docs| image:: https://readthedocs.org/projects/tribler/badge/?version=devel
-    :target: https://tribler.readthedocs.io/en/devel/?badge=devel
+.. |docs| image:: https://readthedocs.org/projects/tribler/badge/?version=main
+    :target: https://tribler.readthedocs.io/en/main/?badge=main
     :alt: Documentation Status

--- a/build/debian/snap/snapcraft.yaml
+++ b/build/debian/snap/snapcraft.yaml
@@ -3,7 +3,7 @@ version: __VERSION__
 summary: Tribler
 description: >
   Peer-to-peer Bittorrent client with enhanced privacy. Search and download torrents with less worries or censorship.
-grade: devel
+grade: main
 confinement: devmode
 base: core20
 

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -7,7 +7,7 @@ How to contribute to the Tribler project?
 Checking out the Stabilization Branch
 =====================================
 
-The stabilization branch ``release-X.Y.Z`` contains the most up to date bugfixes. If your issue cannot be reproduced there, it is most likely already fixed.
+The stabilization branch ``release-X.Y`` contains the most up to date bugfixes. If your issue cannot be reproduced there, it is most likely already fixed.
 
 To backup your Tribler installation and checkout the latest version of the stabilization branch, please perform the following steps.
 * Copy the ``.Tribler`` folder to a safe location on your system (for instance the desktop) Make sure to leave the original folder on its original location. This folder is located at ``~/.Tribler/`` (Linux/OS X) or ``%APPDATA\.Tribler`` (Windows).
@@ -35,9 +35,9 @@ Pull requests
 =============
 
 When creating a new Pull request, please take note of the following:
-  * New features always go to ``devel``.
-  * If there is an unreleased ``release-X.Y.Z`` branch, fixes go there.
-  * Otherwise, fixes go to ``devel``.
+  * New features always go to ``main``.
+  * If there is an unreleased ``release-X.Y`` branch, fixes go there.
+  * Otherwise, fixes go to ``main``.
   * Before starting to work on a feature or fix, check that nobody else is
     working on it by assigning yourself the corresponding issue. Create one if it
     doesn't exist. This is also useful to get feedback about if a given feature

--- a/doc/development_methodology.rst
+++ b/doc/development_methodology.rst
@@ -14,8 +14,7 @@ Our branching model follows the GitFlow model described at length in `Vincent Dr
 
 Our main repository contains 2 permanent branches:
 
-- **devel**: The main development branch; all new features and fixes for them belong here. Every time a new release cycle is started, a new **release-X.Y.Z(-abc)** branch is forked from it. 
-- **master**: Contains the code of the latest stable release. It gets updated from **release-** after every release.
+- **main**: The main development branch; all new features and fixes for them belong here. Every time a new release cycle is started, a new **release/X.Y(-abc)** branch is forked from it.
 
 Release lifecycle
 -----------------
@@ -33,12 +32,12 @@ Example: "release/7.8"
 
 The release lifecycle:
 
-1. A release branch forks from `devel`.
+1. A release branch forks from `main`.
 2. The release branch is checked by running the application-tester
 3. In case no errors, a release candidate (RC) is published as pre-release in Github and published to the forum as release post.
 4. After a while (1-2 weeks), if there are no critical bugs, the release candidate is considered stable and ready for stable release.
 5. A stable release tag is created and the release is published in Github. A forum post is created to inform the users in the forum.
-6. The release branch is merged to `devel`
+6. The release branch is merged to `main`
 
 
 In case of an error that needs to be fixed asap in the published stable release:
@@ -46,14 +45,14 @@ In case of an error that needs to be fixed asap in the published stable release:
 1. A fix is committed to the corresponding release branch
 2. The release branch is checked by running the application-tester
 3. The fixed release is delivered to users
-4. The release branch is merged to `devel`
+4. The release branch is merged to `main`
 
 
-A release is started by forking from the top of **devel**.
+A release is started by forking from the top of **main**.
 From that moment, all the bugfixes relevant to the current release must be merged into the corresponding release branch.
 No new features could be added to it.
 
-When the release is ready for publishing, it is merged back to **devel** to integrate the bugfixes.
+When the release is ready for publishing, it is merged back to **main** to integrate the bugfixes.
 
 Tags
 ----
@@ -89,13 +88,13 @@ Working on new features or fixes
 
 .. code-block:: none
 
-   git fetch --all && git checkout upstream/devel -b fix_2344_my_new_feature
+   git fetch --all && git checkout upstream/main -b fix/2344_my_new_feature
 
 For bug fixes:
 
 .. code-block:: none
 
-   git fetch --all && git checkout upstream/release-X.Y.Z -b fix_2344_my_new_bugfix
+   git fetch --all && git checkout upstream/release/X.Y -b fix/2344_my_new_bugfix
 
 2344 would be the issue number this branch is dealing with. This makes it trivial to identify the purpose of a branch if one hasn't had been able to work on it for a while and can't remember right away.
 
@@ -107,18 +106,18 @@ When creating a PR, always prepend the PR title with **WIP** until it's ready fo
 
 **Notes:**
 
-- Always fork directly from upstream's remote branches as opposed to your own (remote or local) **devel** or **release-** branches. Those are useless as they will quickly get out of date, so kill them with fire:
+- Always fork directly from upstream's remote branches as opposed to your own (remote or local) **main** or **release/** branches. Those are useless as they will quickly get out of date, so kill them with fire:
 
 .. code-block:: none
 
-  git branch -d release-X.Y.Z 
-  git branch -d devel
+  git branch -d release/X.Y
+  git branch -d main
 
 - Once one of your branches has been merged upstream try to always delete them from your remote to avoid cluttering other people's remote listings (I've got around 15 remotes on my local Tribler repos and it can become annoying to look for a particular branch among dozens and dozens of other people's stale branches). This can be done either from github's PR web interface by clicking on the "delete branch" button after the merge has been done or with:
 
 .. code-block:: none
 
-  git push MrStudent :fix_2344_my_new_bugfix
+  git push MrStudent :fix/2344_my_new_bugfix
 
 Getting your changes merged upstream
 ------------------------------------
@@ -138,7 +137,7 @@ Misc guidelines
 
 - **Keep an eye on the PRs you've reviewed**
     You will probably learn something from other reviewers and find out what you missed out during yours.
-- **Don't send PR from your remote's ~devel~ branch**
+- **Don't send PR from your remote's ~main~ branch**
     Use proper names for your branches. It will be more informative and they become part of the merge commit message.
 - **Keep it small**
     The smaller the PRs are, the less review cycles will be needed and the quicker they will get merged.
@@ -157,7 +156,7 @@ Misc guidelines
 - **Don't rename a file and modify it on the same commit**
     If you need to rename and modify a file on the same PR, do so in two commits. This way git will always know what's going on and it will be easier to track changes across file renames.
 - **Don't send pull requests with merge commits on them**
-    Always rebase or cherry pick. If a commit on **devel** introduces merge conflicts in your branch, fix your commits by rebasing not by back merging and creating a conflict resolution commit.
+    Always rebase or cherry pick. If a commit on **main** introduces merge conflicts in your branch, fix your commits by rebasing not by back merging and creating a conflict resolution commit.
 - **If one of your commits fixes an issue, mention it**
     Add a "Closes #1234" line to the comment's body section (from line 3 onwards). This way a reference to this particular commit will be created on the issue itself and once the commit hits the target branch the issue will be closed automatically. If a whole PR is needed to close a particular issue, add the "Closes" comment on the PR body.
 - **Capitalize the commit's subject**

--- a/doc/trustchain.rst
+++ b/doc/trustchain.rst
@@ -15,6 +15,6 @@ Assuming that the transaction counterparty is online and the block is valid, the
 Using TrustChain in your project
 --------------------------------
 
-To use TrustChain in your own projects, one can create a subclass of ``TrustChainCommunity`` or use the ``TrustChainCommunity`` directly. This should be enough for basic usage. For more information about communities, we reference the reader to `a Dispersy tutorial <http://dispersy.readthedocs.io/en/devel/usage.html#community>`_.
+To use TrustChain in your own projects, one can create a subclass of ``TrustChainCommunity`` or use the ``TrustChainCommunity`` directly. This should be enough for basic usage. For more information about communities, we reference the reader to `a Dispersy tutorial <http://dispersy.readthedocs.io/en/main/usage.html#community>`_.
 
 In order to implement custom transaction validation rules, a subclass of ``TrustChainBlock`` should be made and the ``BLOCK_CLASS`` variable in the ``TrustChainCommunity`` should be updated accordingly. By overriding the ``validate_transaction`` method, you can add your own custom validation rules.


### PR DESCRIPTION
This PR updates documentation regarding "devel"->"main" renaming.

Closes https://github.com/Tribler/tribler/issues/5569 