### PR TITLE
Python random is discouraged, move to secrets

### DIFF
--- a/src/tribler-common/tribler_common/network_utils.py
+++ b/src/tribler-common/tribler_common/network_utils.py
@@ -3,6 +3,7 @@ This module contains some utility functions for networking.
 """
 import logging
 import random
+import secrets
 import socket
 import struct
 import sys
@@ -45,7 +46,7 @@ def get_random_port(socket_type="all", min_port=5000, max_port=60000):
     assert 0 < min_port <= max_port <= MAX_PORT, f"Invalid min_port and mac_port values {min_port}, {max_port}"
 
     working_port = None
-    try_port = random.randint(min_port, max_port)
+    try_port = secrets.choice(range(min_port, max_port))
     while try_port <= MAX_PORT:
         if check_random_port(try_port, socket_type):
             working_port = try_port

--- a/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/channel_node.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/channel_node.py
@@ -1,4 +1,5 @@
 import random
+import secrets
 from datetime import datetime
 
 from ipv8.database import database_blob
@@ -134,7 +135,7 @@ def define_binding(db, logger=None, key=None):
                 kwargs["timestamp"] = clock.tick()
 
             if "id_" not in kwargs:
-                kwargs["id_"] = int(random.getrandbits(63))
+                kwargs["id_"] = int(secrets.randbits(63))
 
             if not private_key_override and not skip_key_check:
                 # No key/signature given, sign with our own key.

--- a/src/tribler-core/tribler_core/modules/metadata_store/tests/gen_test_data.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/tests/gen_test_data.py
@@ -34,10 +34,10 @@ def get_random_text_string(size=200):
 
 def gen_random_entry():
     return {
-        "title": "test entry " + str(secrets.choise(range(0, 1000000))),
+        "title": "test entry " + str(secrets.choice(range(0, 1000000))),
         "infohash": str(secrets.randbits(160)),
         "torrent_date": datetime(1970, 1, 1),
-        "size": 100 + secrets.choise(range(0, 10000)),
+        "size": 100 + secrets.choice(range(0, 10000)),
         "tags": "video",
         "status": NEW,
     }

--- a/src/tribler-core/tribler_core/modules/metadata_store/tests/gen_test_data.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/tests/gen_test_data.py
@@ -1,5 +1,6 @@
 import os
 import random
+import secrets
 from datetime import datetime
 
 from ipv8.keyvault.crypto import default_eccrypto
@@ -33,10 +34,10 @@ def get_random_text_string(size=200):
 
 def gen_random_entry():
     return {
-        "title": "test entry " + str(random.randint(0, 1000000)),
-        "infohash": str(random.getrandbits(160)),
+        "title": "test entry " + str(secrets.choise(range(0, 1000000))),
+        "infohash": str(secrets.randbits(160)),
         "torrent_date": datetime(1970, 1, 1),
-        "size": 100 + random.randint(0, 10000),
+        "size": 100 + secrets.choise(range(0, 10000)),
         "tags": "video",
         "status": NEW,
     }

--- a/src/tribler-core/tribler_core/modules/metadata_store/tests/test_store.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/tests/test_store.py
@@ -1,5 +1,6 @@
 import os
 import random
+import secrets
 import string
 from binascii import unhexlify
 from datetime import datetime
@@ -96,7 +97,7 @@ def test_squash_mdblobs(metadata_store):
     chunk_size = metadata_store.ChannelMetadata._CHUNK_SIZE_LIMIT
     md_list = [
         metadata_store.TorrentMetadata(
-            title=''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(20)),
+            title=''.join(secrets.choice(string.ascii_uppercase + string.digits) for _ in range(20)),
             infohash=database_blob(random_infohash()),
             torrent_date=datetime.utcfromtimestamp(100),
         )
@@ -117,7 +118,7 @@ def test_squash_mdblobs(metadata_store):
 def test_squash_mdblobs_multiple_chunks(metadata_store):
     md_list = [
         metadata_store.TorrentMetadata(
-            title=''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(20)),
+            title=''.join(secrets.choice(string.ascii_uppercase + string.digits) for _ in range(20)),
             infohash=database_blob(random_infohash()),
             torrent_date=datetime.utcfromtimestamp(100),
         )

--- a/src/tribler-core/tribler_core/modules/popularity/popularity_community.py
+++ b/src/tribler-core/tribler_core/modules/popularity/popularity_community.py
@@ -1,6 +1,7 @@
 import asyncio
 import heapq
 import random
+import secrets
 from binascii import unhexlify
 
 from ipv8.lazy_community import lazy_wrapper
@@ -86,7 +87,7 @@ class PopularityCommunity(RemoteQueryCommunity):
                              f'{len(checked)}')
             return
 
-        random_peer = random.choice(self.get_peers())
+        random_peer = secrets.choice(self.get_peers())
 
         self.logger.info(
             f'Gossip torrent health information for {len(rand)}'

--- a/src/tribler-core/tribler_core/modules/tests/bandwidth_accounting/test_database.py
+++ b/src/tribler-core/tribler_core/modules/tests/bandwidth_accounting/test_database.py
@@ -83,8 +83,8 @@ def test_get_latest_transactions(bandwidth_db):
     assert not bandwidth_db.get_latest_transactions(pub_key_a)
 
     for pub_key in pub_keys_rest:
-        seq_number = secrets.choise(range(1, 100))
-        amount = secrets.choise(range(1, 1000))
+        seq_number = secrets.choice(range(1, 100))
+        amount = secrets.choice(range(1, 1000))
         tx = BandwidthTransactionData(seq_number, pub_key_a, pub_key, EMPTY_SIGNATURE, EMPTY_SIGNATURE, amount)
         bandwidth_db.BandwidthTransaction.insert(tx)
 

--- a/src/tribler-core/tribler_core/modules/tests/bandwidth_accounting/test_database.py
+++ b/src/tribler-core/tribler_core/modules/tests/bandwidth_accounting/test_database.py
@@ -1,4 +1,5 @@
 import random
+import secrets
 from pathlib import Path
 
 from ipv8.keyvault.crypto import default_eccrypto
@@ -82,8 +83,8 @@ def test_get_latest_transactions(bandwidth_db):
     assert not bandwidth_db.get_latest_transactions(pub_key_a)
 
     for pub_key in pub_keys_rest:
-        seq_number = random.randint(1, 100)
-        amount = random.randint(1, 1000)
+        seq_number = secrets.choise(range(1, 100))
+        amount = secrets.choise(range(1, 1000))
         tx = BandwidthTransactionData(seq_number, pub_key_a, pub_key, EMPTY_SIGNATURE, EMPTY_SIGNATURE, amount)
         bandwidth_db.BandwidthTransaction.insert(tx)
 

--- a/src/tribler-core/tribler_core/modules/tests/test_resource_monitor.py
+++ b/src/tribler-core/tribler_core/modules/tests/test_resource_monitor.py
@@ -112,8 +112,8 @@ def test_write_resource_log(resource_monitor):
 
     # 2. Try adding some random data and write resource logs
     time_now = time.time()
-    rand_memory = secrets.choise(range(1, 100))
-    rand_cpu = secrets.choise(range(1, 100))
+    rand_memory = secrets.choice(range(1, 100))
+    rand_cpu = secrets.choice(range(1, 100))
     resource_monitor.memory_data = [(time_now, rand_memory)]
     resource_monitor.cpu_data = [(time_now, rand_cpu)]
     resource_monitor.write_resource_logs()

--- a/src/tribler-core/tribler_core/modules/tests/test_resource_monitor.py
+++ b/src/tribler-core/tribler_core/modules/tests/test_resource_monitor.py
@@ -1,5 +1,6 @@
 import os
 import random
+import secrets
 import time
 from collections import deque, namedtuple
 from unittest.mock import Mock
@@ -111,8 +112,8 @@ def test_write_resource_log(resource_monitor):
 
     # 2. Try adding some random data and write resource logs
     time_now = time.time()
-    rand_memory = random.randint(1, 100)
-    rand_cpu = random.randint(1, 100)
+    rand_memory = secrets.choise(range(1, 100))
+    rand_cpu = secrets.choise(range(1, 100))
     resource_monitor.memory_data = [(time_now, rand_memory)]
     resource_monitor.cpu_data = [(time_now, rand_cpu)]
     resource_monitor.write_resource_logs()

--- a/src/tribler-core/tribler_core/modules/torrent_checker/test_torrentchecker.py
+++ b/src/tribler-core/tribler_core/modules/torrent_checker/test_torrentchecker.py
@@ -92,8 +92,8 @@ async def test_load_torrents_check_from_db(enable_chant, torrent_checker, sessio
     def save_random_torrent_state(last_checked=0, self_checked=False, count=1):
         for _ in range(count):
             session.mds.TorrentState(infohash=secrets.token_bytes(20),
-                                     seeders=random.randint(1, 100),
-                                     leechers=random.randint(1, 100),
+                                     seeders=secrets.choise(range(1, 100)),
+                                     leechers=secrets.choise(range(1, 100)),
                                      last_check=last_checked,
                                      self_checked=self_checked)
 

--- a/src/tribler-core/tribler_core/modules/torrent_checker/test_torrentchecker.py
+++ b/src/tribler-core/tribler_core/modules/torrent_checker/test_torrentchecker.py
@@ -92,8 +92,8 @@ async def test_load_torrents_check_from_db(enable_chant, torrent_checker, sessio
     def save_random_torrent_state(last_checked=0, self_checked=False, count=1):
         for _ in range(count):
             session.mds.TorrentState(infohash=secrets.token_bytes(20),
-                                     seeders=secrets.choise(range(1, 100)),
-                                     leechers=secrets.choise(range(1, 100)),
+                                     seeders=secrets.choice(range(1, 100)),
+                                     leechers=secrets.choice(range(1, 100)),
                                      last_check=last_checked,
                                      self_checked=self_checked)
 

--- a/src/tribler-core/tribler_core/modules/torrent_checker/torrentchecker_session.py
+++ b/src/tribler-core/tribler_core/modules/torrent_checker/torrentchecker_session.py
@@ -280,7 +280,7 @@ class UdpTrackerSession(TrackerSession):
         """
         while True:
             # make sure there is no duplicated transaction IDs
-            transaction_id = secrets.choise(range(0, MAX_INT32))
+            transaction_id = secrets.choice(range(0, MAX_INT32))
             if transaction_id not in UdpTrackerSession._active_session_dict.items():
                 UdpTrackerSession._active_session_dict[self] = transaction_id
                 self.transaction_id = transaction_id

--- a/src/tribler-core/tribler_core/modules/torrent_checker/torrentchecker_session.py
+++ b/src/tribler-core/tribler_core/modules/torrent_checker/torrentchecker_session.py
@@ -1,5 +1,6 @@
 import logging
 import random
+import secrets
 import socket
 import struct
 import sys
@@ -279,7 +280,7 @@ class UdpTrackerSession(TrackerSession):
         """
         while True:
             # make sure there is no duplicated transaction IDs
-            transaction_id = random.randint(0, MAX_INT32)
+            transaction_id = secrets.choise(range(0, MAX_INT32))
             if transaction_id not in UdpTrackerSession._active_session_dict.items():
                 UdpTrackerSession._active_session_dict[self] = transaction_id
                 self.transaction_id = transaction_id

--- a/src/tribler-core/tribler_core/modules/trust_calculation/graph_positioning.py
+++ b/src/tribler-core/tribler_core/modules/trust_calculation/graph_positioning.py
@@ -1,5 +1,5 @@
 import random
-
+import secrets
 import networkx as nx
 
 
@@ -45,7 +45,7 @@ class GraphPositioning:
                 # allows back compatibility with nx version 1.11
                 root = next(iter(nx.topological_sort(G)))
             else:
-                root = random.choice(list(G.nodes))
+                root = secrets.choice(list(G.nodes))
 
         def _hierarchy_pos(G, root, width=1., vert_gap=0.2, vert_loc=0, xcenter=0.5, pos=None, parent=None):
             """

--- a/src/tribler-core/tribler_core/modules/tunnel/community/dispatcher.py
+++ b/src/tribler-core/tribler_core/modules/tunnel/community/dispatcher.py
@@ -1,4 +1,5 @@
 import random
+import secrets
 from collections import defaultdict
 
 from ipv8.messaging.anonymization.tunnel import (
@@ -125,7 +126,7 @@ class TunnelDispatcher(TaskManager):
                                             self.on_socks5_udp_data(c, r) if f.result() else None)
             return None
 
-        circuit = random.choice(options)
+        circuit = secrets.choice(options)
         self.cid_to_con[circuit.circuit_id] = connection
         self.con_to_cir[connection][request.destination] = circuit
         self._logger.debug("Select circuit %d for %s", circuit.circuit_id, request.destination)

--- a/src/tribler-core/tribler_core/restapi/tests/test_trustview_endpoint.py
+++ b/src/tribler-core/tribler_core/restapi/tests/test_trustview_endpoint.py
@@ -48,8 +48,8 @@ def mock_bootstrap(session):
     session.bootstrap.shutdown = lambda: succeed(None)
 
     bootstrap_download_state = Mock()
-    bootstrap_download_state.get_total_transferred = lambda _: random.randint(0, 10000)
-    bootstrap_download_state.get_progress = lambda: random.randint(10, 100)
+    bootstrap_download_state.get_total_transferred = lambda _: secrets.choise(range(0, 10000))
+    bootstrap_download_state.get_progress = lambda: secrets.choise(range(10, 100))
 
     session.bootstrap.download.get_state = lambda: bootstrap_download_state
 
@@ -202,7 +202,7 @@ async def test_trustview_response(enable_api, mock_ipv8, session, mock_bootstrap
 def insert_node_transactions(root_key, session, node_public_key=None, count=1):
     for idx in range(count):
         counterparty = unhexlify(node_public_key if node_public_key else get_random_node_public_key())
-        amount = random.randint(10, 100)
+        amount = secrets.choise(range(10, 100))
         tx1 = BandwidthTransactionData(idx, root_key, counterparty, EMPTY_SIGNATURE, EMPTY_SIGNATURE, amount)
         session.bandwidth_community.database.BandwidthTransaction.insert(tx1)
 

--- a/src/tribler-core/tribler_core/restapi/tests/test_trustview_endpoint.py
+++ b/src/tribler-core/tribler_core/restapi/tests/test_trustview_endpoint.py
@@ -48,8 +48,8 @@ def mock_bootstrap(session):
     session.bootstrap.shutdown = lambda: succeed(None)
 
     bootstrap_download_state = Mock()
-    bootstrap_download_state.get_total_transferred = lambda _: secrets.choise(range(0, 10000))
-    bootstrap_download_state.get_progress = lambda: secrets.choise(range(10, 100))
+    bootstrap_download_state.get_total_transferred = lambda _: secrets.choice(range(0, 10000))
+    bootstrap_download_state.get_progress = lambda: secrets.choice(range(10, 100))
 
     session.bootstrap.download.get_state = lambda: bootstrap_download_state
 
@@ -202,7 +202,7 @@ async def test_trustview_response(enable_api, mock_ipv8, session, mock_bootstrap
 def insert_node_transactions(root_key, session, node_public_key=None, count=1):
     for idx in range(count):
         counterparty = unhexlify(node_public_key if node_public_key else get_random_node_public_key())
-        amount = secrets.choise(range(10, 100))
+        amount = secrets.choice(range(10, 100))
         tx1 = BandwidthTransactionData(idx, root_key, counterparty, EMPTY_SIGNATURE, EMPTY_SIGNATURE, amount)
         session.bandwidth_community.database.BandwidthTransaction.insert(tx1)
 

--- a/src/tribler-core/tribler_core/tests/test_network_utils.py
+++ b/src/tribler-core/tribler_core/tests/test_network_utils.py
@@ -1,4 +1,5 @@
 import random
+import secrets
 import socket
 
 import pytest
@@ -18,7 +19,7 @@ def test_get_random_port():
 
 
 def test_get_random_port_tcp():
-    rand_port_num = random.randint(1000, 10000)
+    rand_port_num = secrets.choise(range(1000, 10000))
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         attempts = 0
         while attempts < 20:

--- a/src/tribler-core/tribler_core/tests/test_network_utils.py
+++ b/src/tribler-core/tribler_core/tests/test_network_utils.py
@@ -19,7 +19,7 @@ def test_get_random_port():
 
 
 def test_get_random_port_tcp():
-    rand_port_num = secrets.choise(range(1000, 10000))
+    rand_port_num = secrets.choice(range(1000, 10000))
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         attempts = 0
         while attempts < 20:

--- a/src/tribler-core/tribler_core/tests/tools/tracker/udp_tracker.py
+++ b/src/tribler-core/tribler_core/tests/tools/tracker/udp_tracker.py
@@ -1,4 +1,5 @@
 import random
+import secrets
 import struct
 from asyncio import DatagramProtocol, get_event_loop
 
@@ -58,7 +59,7 @@ class UDPTrackerProtocol(DatagramProtocol):
         """
         Send a connection reply.
         """
-        self.connection_id = random.randint(0, MAX_INT32)
+        self.connection_id = secrets.choise(range(0, MAX_INT32))
         response_msg = struct.pack('!iiq', TRACKER_ACTION_CONNECT, self.transaction_id, self.connection_id)
         self.transport.sendto(response_msg, (host, port))
 

--- a/src/tribler-core/tribler_core/tests/tools/tracker/udp_tracker.py
+++ b/src/tribler-core/tribler_core/tests/tools/tracker/udp_tracker.py
@@ -59,7 +59,7 @@ class UDPTrackerProtocol(DatagramProtocol):
         """
         Send a connection reply.
         """
-        self.connection_id = secrets.choise(range(0, MAX_INT32))
+        self.connection_id = secrets.choice(range(0, MAX_INT32))
         response_msg = struct.pack('!iiq', TRACKER_ACTION_CONNECT, self.transaction_id, self.connection_id)
         self.transport.sendto(response_msg, (host, port))
 

--- a/src/tribler-core/tribler_core/utilities/random_utils.py
+++ b/src/tribler-core/tribler_core/utilities/random_utils.py
@@ -1,10 +1,11 @@
 import random
+import secrets
 import string
 
 
 def random_string(size=6, chars=string.ascii_uppercase + string.digits):
     """ Generates a random string """
-    return ''.join(random.choice(chars) for _ in range(size))
+    return ''.join(secrets.choice(chars) for _ in range(size))
 
 
 def random_infohash():
@@ -41,4 +42,4 @@ def random_utf8_string(length=6):
         for current_range in include_ranges
         for code_point in range(current_range[0], current_range[1] + 1)
     ]
-    return ''.join(random.choice(alphabet) for i in range(length))
+    return ''.join(secrets.choice(alphabet) for i in range(length))


### PR DESCRIPTION
Some of the CI/CD jobs for Tribler already warns about this:
https://github.com/Tribler/tribler/runs/1913957805
https://sonarcloud.io/project/security_hotspots?id=Tribler_tribler&hotspots=AW_DWqEXH4jiAyAXJjGK

Official python doc:
https://docs.python.org/3/library/secrets.html
https://docs.python.org/3/library/random.html

Please note: I used `secrets.choise(range(min,max))` as this is somewhat
clearer than `secrets.randbelow(n)` which treats edge different from random..
(I.e. `secrets.randbelow` would have to have "`n=max-min+1`" and then add "`min`").

And also note: I did not remove the "`import random`",
as some lines could not be translated 1:1 with the new secrets.

Feel free to edit this merge request, discard it or merge it at your will...