### PR TITLE
Fix incorrectly updating channel progress from downloads

### DIFF
--- a/src/tribler-gui/tribler_gui/widgets/downloadspage.py
+++ b/src/tribler-gui/tribler_gui/widgets/downloadspage.py
@@ -162,10 +162,13 @@ class DownloadsPage(AddBreadcrumbOnShowMixin, QWidget):
 
         items = []
         for download in downloads["downloads"]:
-            # Update download progress information for torrents in the Channels GUI
-            self.window().core_manager.events_manager.node_info_updated.emit(
-                {"infohash": download["infohash"], "progress": download["progress"]}
-            )
+            # Update download progress information for torrents in the Channels GUI.
+            # We skip updating progress information for ChannelTorrents because otherwise it interferes
+            # with channel processing progress updates
+            if not download["channel_download"]:
+                self.window().core_manager.events_manager.node_info_updated.emit(
+                    {"infohash": download["infohash"], "progress": download["progress"]}
+                )
 
             if download["infohash"] in self.download_widgets:
                 item = self.download_widgets[download["infohash"]]


### PR DESCRIPTION
Fix channel processing progress bar incorrectly updating to 100% from the corresponding download.