### PR TITLE
Fix "UnicodeDecodeError: invalid continuation byte" issue

### DIFF
--- a/src/tribler-core/tribler_core/modules/libtorrent/download.py
+++ b/src/tribler-core/tribler_core/modules/libtorrent/download.py
@@ -297,24 +297,23 @@ class Download(TaskManager):
 
     def on_tracker_error_alert(self, alert):
         # try-except block here is a workaround and has been added to solve
-        # https://github.com/Tribler/tribler/issues/5740
+        # the issue: "UnicodeDecodeError: invalid continuation byte"
         try:
             url = alert.url
+            peers = self.tracker_status[url][0] if url in self.tracker_status else 0
+            if alert.msg:
+                status = 'Error: ' + alert.msg
+            elif alert.status_code > 0:
+                status = 'HTTP status code %d' % alert.status_code
+            elif alert.status_code == 0:
+                status = 'Timeout'
+            else:
+                status = 'Not working'
+
+            self.tracker_status[url] = [peers, status]
         except UnicodeDecodeError as e:
             self._logger.exception(e)
             return
-
-        peers = self.tracker_status[url][0] if url in self.tracker_status else 0
-        if alert.msg:
-            status = 'Error: ' + alert.msg
-        elif alert.status_code > 0:
-            status = 'HTTP status code %d' % alert.status_code
-        elif alert.status_code == 0:
-            status = 'Timeout'
-        else:
-            status = 'Not working'
-
-        self.tracker_status[url] = [peers, status]
 
     def on_tracker_warning_alert(self, alert):
         peers = self.tracker_status[alert.url][0] if alert.url in self.tracker_status else 0


### PR DESCRIPTION
This PR resolves #6008 by extending the try-except block from a single line to the whole function.