### PR TITLE
Replace "main" by "latest" for all readthedocs.io links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,13 +24,13 @@ Just click `here <https://github.com/Tribler/tribler/releases/latest>`__ and dow
 Obtaining support
 =================
 
-If you found a bug or have a feature request, please make sure you read `our contributing page <http://tribler.readthedocs.io/en/main/contributing.html>`_ and then `open an issue <https://github.com/Tribler/tribler/issues/new>`_. We will have a look at it ASAP.
+If you found a bug or have a feature request, please make sure you read `our contributing page <http://tribler.readthedocs.io/en/latest/contributing.html>`_ and then `open an issue <https://github.com/Tribler/tribler/issues/new>`_. We will have a look at it ASAP.
 
 Contributing
 ============
 
 Contributions are very welcome!
-If you are interested in contributing code or otherwise, please have a look at `our contributing page <http://tribler.readthedocs.io/en/main/contributing.html>`_.
+If you are interested in contributing code or otherwise, please have a look at `our contributing page <http://tribler.readthedocs.io/en/latest/contributing.html>`_.
 Have a look at the `issue tracker <https://github.com/Tribler/tribler/issues>`_ if you are looking for inspiration :).
 
 
@@ -52,9 +52,9 @@ We support development on Linux, macOS and Windows. We have written
 documentation that guides you through installing the required packages when
 setting up a Tribler development environment.
 
-* `Linux <http://tribler.readthedocs.io/en/main/development/development_on_linux.html>`_
-* `Windows <http://tribler.readthedocs.io/en/main/development/development_on_windows.html>`_
-* `macOS <http://tribler.readthedocs.io/en/main/development/development_on_osx.html>`_
+* `Linux <http://tribler.readthedocs.io/en/latest/development/development_on_linux.html>`_
+* `Windows <http://tribler.readthedocs.io/en/latest/development/development_on_windows.html>`_
+* `macOS <http://tribler.readthedocs.io/en/latest/development/development_on_osx.html>`_
 
 
 Running
@@ -75,7 +75,7 @@ On Windows, you can use the following command to run Tribler:
 Packaging Tribler
 =================
 
-We have written guides on how to package Tribler for distribution on various systems. Please take a look `here <http://tribler.readthedocs.io/en/main/building/building.html>`_.
+We have written guides on how to package Tribler for distribution on various systems. Please take a look `here <http://tribler.readthedocs.io/en/latest/building/building.html>`_.
 
 Submodule notes
 ===============
@@ -133,5 +133,5 @@ Submodule notes
     :alt: DOI number
 
 .. |docs| image:: https://readthedocs.org/projects/tribler/badge/?version=main
-    :target: https://tribler.readthedocs.io/en/main/?badge=main
+    :target: https://tribler.readthedocs.io/en/latest/?badge=main
     :alt: Documentation Status

--- a/doc/trustchain.rst
+++ b/doc/trustchain.rst
@@ -15,6 +15,6 @@ Assuming that the transaction counterparty is online and the block is valid, the
 Using TrustChain in your project
 --------------------------------
 
-To use TrustChain in your own projects, one can create a subclass of ``TrustChainCommunity`` or use the ``TrustChainCommunity`` directly. This should be enough for basic usage. For more information about communities, we reference the reader to `a Dispersy tutorial <http://dispersy.readthedocs.io/en/main/usage.html#community>`_.
+To use TrustChain in your own projects, one can create a subclass of ``TrustChainCommunity`` or use the ``TrustChainCommunity`` directly. This should be enough for basic usage. For more information about communities, we reference the reader to `a Dispersy tutorial <http://dispersy.readthedocs.io/en/latest/usage.html#community>`_.
 
 In order to implement custom transaction validation rules, a subclass of ``TrustChainBlock`` should be made and the ``BLOCK_CLASS`` variable in the ``TrustChainCommunity`` should be updated accordingly. By overriding the ``validate_transaction`` method, you can add your own custom validation rules.


### PR DESCRIPTION
This PR fixes #6007 by replacing all "main" occurrences for readthedocs links.