### PR TITLE
Enriched log entry with peer info

### DIFF
--- a/src/tribler-core/tribler_core/modules/bandwidth_accounting/community.py
+++ b/src/tribler-core/tribler_core/modules/bandwidth_accounting/community.py
@@ -125,7 +125,8 @@ class BandwidthAccountingCommunity(Community):
                         self.database.BandwidthTransaction.insert(tx)
                         self.send_transaction(tx, from_peer.address, payload.request_id)
                     else:
-                        self.logger.info("Received older bandwidth transaction - sending back the latest one")
+                        self.logger.info("Received older bandwidth transaction from peer %s:%d - "
+                                         "sending back the latest one", *from_peer.address)
                         self.send_transaction(latest_tx, from_peer.address, payload.request_id)
                 else:
                     # This transaction is the first one with party A. Sign it, store it, and send it back.


### PR DESCRIPTION
Hopefully this will help to debug a bug where there is a ping-pong of bandwidth transactions between two peers.