### PR TITLE
Binary data transfer protocol over ipv8.

### DIFF
--- a/src/tribler-core/tribler_core/modules/metadata_store/community/eva_protocol.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/community/eva_protocol.py
@@ -1,0 +1,564 @@
+# EVA protocol: a protocol for transferring big binary data over ipv8.
+#
+# Limitations and other useful information described in the corresponding class.
+# Example of use:
+#
+# class MyCommunity(EVAProtocolMixin, Community):
+#     community_id = os.urandom(20)
+#
+#     def __init__(self, *args, **kwargs):
+#         super().__init__(*args, **kwargs)
+#         self.eva_init()
+#
+#         self.eva_register_receive_callback(self.on_receive)
+#         self.eva_register_send_complete_callback(self.on_send_complete)
+#         self.eva_register_error_callback(self.on_error)
+#
+#     def my_function(self, peer):
+#         self.eva_send_message(peer, b'info1', b'data1')
+#         self.eva_send_message(peer, b'info2', b'data2')
+#         self.eva_send_message(peer, b'info3', b'data3')
+#
+#     def on_receive(self, peer, binary_info, binary_data, nonce):
+#         logger.info(f'Data has been received: {binary_info}')
+#
+#     def on_send_complete(self, peer, binary_info, binary_data, nonce):
+#         logger.info(f'Transfer has been completed: {binary_info}')
+#
+#     def on_error(self, peer, exception):
+#         logger.error(f'Error has been occurred: {exception}')
+
+import logging
+import math
+import time
+from collections import defaultdict, deque
+from enum import Enum, auto
+from types import SimpleNamespace
+
+from ipv8.lazy_community import lazy_wrapper
+from ipv8.messaging.lazy_payload import VariablePayload, vp_compile
+
+logger = logging.getLogger('EVA')
+
+
+# fmt: off
+
+@vp_compile
+class WriteRequest(VariablePayload):
+    format_list = ['I', 'I', 'raw']
+    names = ['data_size', 'nonce', 'info_binary']
+
+
+@vp_compile
+class Acknowledgement(VariablePayload):
+    format_list = ['I', 'I', 'I']
+    names = ['number', 'window_size', 'nonce']
+
+
+@vp_compile
+class Data(VariablePayload):
+    format_list = ['I', 'I', 'raw']
+    names = ['block_number', 'nonce', 'data_binary']
+
+
+@vp_compile
+class Error(VariablePayload):
+    format_list = ['raw']
+    names = ['message']
+
+
+class TransferException(Exception):
+    def __init__(self, transfer_type, info_binary, nonce, message):
+        super().__init__(message)
+        self.transfer_type = transfer_type
+        self.info_binary = info_binary
+        self.nonce = nonce
+
+
+class SizeLimitException(TransferException):
+    pass
+
+
+class TimeoutException(TransferException):
+    pass
+
+
+class EVAProtocolMixin:
+    """This mixin makes it possible to transfer big binary data over ipv8.
+
+    The protocol based on TFTP with windowsize (RFC 7440).
+    Features:
+        * timeout
+        * retransmit
+        * dynamic window size
+
+    The maximum data size that can be transferred through the protocol can be
+    calculated as "block_size * 4294967295" where 4294967295 is the max segment
+    number (4B unsigned int).
+    """
+
+    def eva_init(  # pylint: disable=too-many-arguments
+            self,
+            block_size=1000,
+            window_size_in_blocks=16,
+            start_message_id=186,
+            retransmit_interval_in_sec=3,
+            retransmit_attempt_count=3,
+            timeout_interval_in_sec=10,
+            binary_size_limit=1024 * 1024 * 1024,
+    ):
+        """Init should be called manually within his parent class.
+
+        Args:
+            block_size: a single block size in bytes. Please keep in mind that
+                ipv8 adds approx. 177 bytes to each packet.
+            window_size_in_blocks: size of consecutive blocks to send
+            start_message_id: a started id that will be used to assigning
+                protocol's messages ids
+            retransmit_interval_in_sec: an interval until the next attempt
+                to retransmit will be made
+            retransmit_attempt_count: a limit for retransmit attempts
+            timeout_interval_in_sec: an interval after which the transfer will
+                be considered as "dead" and will be terminated
+            binary_size_limit: limit for binary data size. If this limit will be
+                exceeded, the exception will be returned through a registered
+                error handler
+        """
+        self.last_message_id = start_message_id
+        self.eva_messages = dict()
+
+        self.eva_protocol = EVAProtocol(
+            community=self,
+            block_size=block_size,
+            window_size_in_blocks=window_size_in_blocks,
+            retransmit_interval_in_sec=retransmit_interval_in_sec,
+            retransmit_attempt_count=retransmit_attempt_count,
+            scheduled_send_interval_in_sec=5,
+            timeout_interval_in_sec=timeout_interval_in_sec,
+            binary_size_limit=binary_size_limit,
+        )
+
+        # note:
+        # The order in which _eva_register_message_handler is called defines
+        # the message wire format. Do not change it.
+        self._eva_register_message_handler(WriteRequest, self.on_eva_write_request)
+        self._eva_register_message_handler(Acknowledgement, self.on_eva_acknowledgement)
+        self._eva_register_message_handler(Data, self.on_eva_data)
+        self._eva_register_message_handler(Error, self.on_eva_error)
+
+    def eva_send_binary(self, peer, info_binary, data_binary, nonce=None):
+        """Send a big binary data.
+
+        Due to ipv8 specifics, we can use only one socket port per one peer.
+        Therefore, at one point in time, the protocol can only transmit one particular
+        piece of data for one particular peer.
+
+        In case "eva_send_binary" is invoked multiply times for a single peer, the data
+        transfer will be scheduled and performed when the current sending session is finished.
+
+        An example:
+
+        self.eva_send_binary(peer, b'binary_data0', b'binary_info0')
+        self.eva_send_binary(peer, b'binary_data1', b'binary_info1')
+        self.eva_send_binary(peer, b'binary_data2', b'binary_info2')
+
+        Args:
+            peer: the target peer
+            info_binary: a binary info, limited by <block_size> bytes
+            data_binary: binary data that will be sent to the target.
+                It is limited by several GB, but the protocol is slow by design, so
+                try to send less rather than more.
+            nonce: a uniq number for identifying the session. If not specified,
+                then `self.nonce + 1` will be used
+        """
+        self.eva_protocol.send_binary(peer, info_binary, data_binary, nonce)
+
+    def eva_register_receive_callback(self, callback):
+        """Register callback that will be invoked when a data receiving is complete.
+
+        An example:
+
+        def on_receive(peer, info, data, nonce):
+            pass
+
+        self.eva_register_receive_callback(on_receive)
+        """
+        self.eva_protocol.receive_callbacks.add(callback)
+
+    def eva_register_send_complete_callback(self, callback):
+        """Register callback that will be invoked when a data sending is complete.
+
+        An example:
+
+        def on_send_complete(peer, info, data, nonce):
+            pass
+
+        self.eva_register_send_complete_callback(on_receive)
+        """
+        self.eva_protocol.send_complete_callbacks.add(callback)
+
+    def eva_register_error_callback(self, callback):
+        """Register callback that will be invoked in case of an error.
+
+        An example:
+
+        def on_error(self, peer, exception):
+            pass
+
+        self.eva_register_error_callback(on_error)
+        """
+        self.eva_protocol.error_callbacks.add(callback)
+
+    def eva_send_message(self, peer, message):
+        self.endpoint.send(peer.address, self.ezr_pack(self.eva_messages[type(message)], message))
+
+    @lazy_wrapper(WriteRequest)
+    async def on_eva_write_request(self, peer, payload):
+        await self.eva_protocol.on_write_request(peer, payload)
+
+    @lazy_wrapper(Acknowledgement)
+    async def on_eva_acknowledgement(self, peer, payload):
+        await self.eva_protocol.on_acknowledgement(peer, payload)
+
+    @lazy_wrapper(Data)
+    async def on_eva_data(self, peer, payload):
+        await self.eva_protocol.on_data(peer, payload)
+
+    @lazy_wrapper(Error)
+    async def on_eva_error(self, peer, payload):
+        await self.eva_protocol.on_error(peer, payload)
+
+    def _eva_register_message_handler(self, message_class, handler):
+        self.add_message_handler(self.last_message_id, handler)
+        self.eva_messages[message_class] = self.last_message_id
+        self.last_message_id += 1
+
+
+class TransferType(Enum):
+    INCOMING = auto()
+    OUTGOING = auto()
+
+
+class Transfer:  # pylint: disable=too-many-instance-attributes
+    """The class describes an incoming or an outgoing transfer"""
+
+    NONE = -1
+
+    def __init__(self, transfer_type, info_binary, data_binary, nonce):
+        self.type = transfer_type
+        self.info_binary = info_binary
+        self.data_binary = data_binary
+        self.block_number = Transfer.NONE
+        self.block_count = 0
+        self.attempt = 0
+        self.nonce = nonce
+        self.window_size = 0
+        self.acknowledgement_number = 0
+        self.updated = time.time()
+        self.released = False
+
+    def release(self):
+        self.info_binary = None
+        self.data_binary = None
+        self.released = True
+
+    def __str__(self):
+        return (
+            f'Type: {self.type}. Info: {self.info_binary}. Block: {self.block_number}({self.block_count}). '
+            f'Window size: {self.window_size}. Updated: {self.updated}'
+        )
+
+
+class EVAProtocol:  # pylint: disable=too-many-instance-attributes
+    def __init__(  # pylint: disable=too-many-arguments
+            self,
+            community,
+            block_size=1000,
+            window_size_in_blocks=16,
+            start_message_id=186,
+            retransmit_interval_in_sec=3,
+            retransmit_attempt_count=3,
+            scheduled_send_interval_in_sec=5,
+            timeout_interval_in_sec=10,
+            binary_size_limit=1024 * 1024 * 1024,
+    ):
+        self.community = community
+
+        self.scheduled = defaultdict(deque)
+        self.block_size = block_size
+        self.window_size = window_size_in_blocks
+        self.retransmit_interval_in_sec = retransmit_interval_in_sec
+        self.retransmit_attempt_count = retransmit_attempt_count
+        self.timeout_interval_in_sec = timeout_interval_in_sec
+        self.scheduled_send_interval_in_sec = scheduled_send_interval_in_sec
+        self.binary_size_limit = binary_size_limit
+
+        self.send_complete_callbacks = set()
+        self.receive_callbacks = set()
+        self.error_callbacks = set()
+
+        self.incoming = dict()
+        self.outgoing = dict()
+
+        self.retransmit_enabled = True
+        self.terminate_by_timeout_enabled = True
+
+        self.nonce = 0
+
+        # register tasks
+        community.register_task('scheduled send', self.send_scheduled, interval=scheduled_send_interval_in_sec)
+
+        logger.info(
+            f'Initialized. Block size: {block_size}. Window size: {window_size_in_blocks}. '
+            f'Start message id: {start_message_id}. Retransmit interval: {retransmit_interval_in_sec}sec. '
+            f'Max retransmit attempts: {retransmit_attempt_count}. Timeout: {timeout_interval_in_sec}sec. '
+            f'Scheduled send interval: {scheduled_send_interval_in_sec}sec. '
+            f'Binary size limit: {binary_size_limit}.'
+        )
+
+    def send_binary(self, peer, info_binary, data_binary, nonce=None):
+        if not data_binary:
+            return
+
+        if peer == self.community.my_peer:
+            return
+
+        if nonce is None:
+            self.nonce += 1
+
+        nonce = nonce or self.nonce
+
+        if peer in self.outgoing:
+            scheduled_transfer = SimpleNamespace(info_binary=info_binary, data_binary=data_binary, nonce=nonce)
+            self.scheduled[peer].append(scheduled_transfer)
+            return
+
+        self.start_outgoing_transfer(peer, info_binary, data_binary, nonce)
+
+    def start_outgoing_transfer(self, peer, info_binary, data_binary, nonce):
+        transfer = Transfer(TransferType.OUTGOING, info_binary, b'', nonce)
+
+        data_size = len(data_binary)
+        if data_size > self.binary_size_limit:
+            message = f'Current data size limit({self.binary_size_limit}) has been exceeded'
+            self._notify_error(peer, SizeLimitException(transfer.type, transfer.info_binary, transfer.nonce, message))
+            return
+
+        transfer.block_count = math.ceil(data_size / self.block_size)
+        transfer.data_binary = data_binary
+
+        self.outgoing[peer] = transfer
+
+        self._schedule_terminate(self.outgoing, peer, transfer)
+
+        logger.info(f'Write Request. Peer hash: {hash(peer)}. Transfer: {transfer}')
+        self.community.eva_send_message(peer, WriteRequest(data_size, nonce, info_binary))
+
+    async def on_write_request(self, peer, payload):
+        logger.info(f'On write request. Peer hash: {hash(peer)}. Info: {payload.info_binary}. '
+                    f'Size: {payload.data_size}')
+
+        transfer = Transfer(TransferType.INCOMING, payload.info_binary, b'', payload.nonce)
+        transfer.window_size = self.window_size
+        transfer.attempt = 0
+
+        if payload.data_size > self.binary_size_limit:
+            self._incoming_error_size_limit_exceeded(peer, transfer)
+            return
+
+        self.incoming[peer] = transfer
+
+        self._schedule_terminate(self.incoming, peer, transfer)
+        self._schedule_resend_acknowledge(peer, transfer)
+
+        self.send_acknowledgement(peer, transfer)
+
+    async def on_acknowledgement(self, peer, payload):
+        logger.debug(f'On acknowledgement({payload.number}). Window size: {payload.window_size}. '
+                     f'Peer hash: {hash(peer)}.')
+
+        transfer = self.outgoing.get(peer, None)
+        if not transfer:
+            return
+
+        can_be_handled = transfer.block_number <= payload.number
+        if not can_be_handled or transfer.nonce != payload.nonce:
+            return
+
+        transfer.block_number = payload.number
+        if transfer.block_number > transfer.block_count:
+            self.finish_outgoing_transfer(peer, transfer)
+            return
+
+        transfer.window_size = payload.window_size
+        transfer.updated = time.time()
+
+        for block_number in range(transfer.block_number, transfer.block_number + transfer.window_size):
+            start_position = block_number * self.block_size
+            stop_position = start_position + self.block_size
+            data = transfer.data_binary[start_position:stop_position]
+            logger.debug(f'Transmit({block_number}). Peer hash: {hash(peer)}.')
+            self.community.eva_send_message(peer, Data(block_number, transfer.nonce, data))
+            if len(data) == 0:
+                break
+
+    async def on_data(self, peer, payload):
+        logger.debug(
+            f'On data({payload.block_number}). Peer hash: {hash(peer)}. Data hash: {hash(payload.data_binary)}')
+        transfer = self.incoming.get(peer, None)
+        if not transfer:
+            return
+
+        can_be_handled = transfer.block_number == payload.block_number - 1
+        if not can_be_handled or transfer.nonce != payload.nonce:
+            return
+
+        transfer.block_number = payload.block_number
+
+        is_final_data_packet = len(payload.data_binary) == 0
+        if is_final_data_packet:
+            self.send_acknowledgement(peer, transfer)
+            self.finish_incoming_transfer(peer, transfer)
+            return
+
+        data_size = len(transfer.data_binary) + len(payload.data_binary)
+        if data_size > self.binary_size_limit:
+            self._incoming_error_size_limit_exceeded(peer, transfer)
+            return
+
+        transfer.data_binary += payload.data_binary
+        transfer.attempt = 0
+        transfer.updated = time.time()
+
+        time_to_acknowledge = transfer.acknowledgement_number + transfer.window_size <= transfer.block_number + 1
+        if time_to_acknowledge:
+            self.send_acknowledgement(peer, transfer)
+
+    def send_acknowledgement(self, peer, transfer):
+        transfer.acknowledgement_number = transfer.block_number + 1
+
+        logger.debug(f'Acknowledgement ({transfer.acknowledgement_number}). Window size: {transfer.window_size}. '
+                     f'Peer hash: {hash(peer)}')
+
+        acknowledgement = Acknowledgement(transfer.acknowledgement_number, transfer.window_size, transfer.nonce)
+        self.community.eva_send_message(peer, acknowledgement)
+
+    async def on_error(self, peer, payload):
+        message = payload.message.decode('utf-8')
+        logger.info(f'On error. Peer hash: {hash(peer)}. Message: "{message}"')
+        transfer = self.outgoing.get(peer, None)
+        if not transfer:
+            return
+
+        EVAProtocol.terminate(self.outgoing, peer, transfer)
+
+        self._notify_error(peer, TransferException(transfer.type, transfer.info_binary, transfer.nonce, message))
+        self.send_scheduled()
+
+    def finish_incoming_transfer(self, peer, transfer):
+        data = transfer.data_binary
+        info = transfer.info_binary
+        nonce = transfer.nonce
+
+        EVAProtocol.terminate(self.incoming, peer, transfer)
+
+        for callback in self.receive_callbacks:
+            callback(peer, info, data, nonce)
+
+    def finish_outgoing_transfer(self, peer, transfer):
+        data = transfer.data_binary
+        info = transfer.info_binary
+        nonce = transfer.nonce
+
+        EVAProtocol.terminate(self.outgoing, peer, transfer)
+
+        for callback in self.send_complete_callbacks:
+            callback(peer, info, data, nonce)
+
+        self.send_scheduled()
+
+    def send_scheduled(self):
+        logger.debug('Looking for scheduled transfers for send...')
+
+        free_peers = [peer for peer in self.scheduled if peer not in self.outgoing]
+
+        for peer in free_peers:
+            if not self.scheduled[peer]:
+                self.scheduled.pop(peer, None)
+                continue
+
+            transfer = self.scheduled[peer].popleft()
+
+            logger.info(f'Scheduled send: {transfer.info_binary}')
+            self.start_outgoing_transfer(peer, transfer.info_binary, transfer.data_binary, transfer.nonce)
+
+    @staticmethod
+    def terminate(container, peer, transfer):
+        logger.info(f'Finish. Peer hash: {hash(peer)}. Transfer: {transfer}')
+
+        transfer.release()
+        container.pop(peer, None)
+
+    def _incoming_error_size_limit_exceeded(self, peer, transfer):
+        EVAProtocol.terminate(self.incoming, peer, transfer)
+
+        message = f'Current data size limit({self.binary_size_limit}) has been exceeded'
+        self.community.eva_send_message(peer, Error(message.encode('utf-8')))
+        self._notify_error(peer, SizeLimitException(transfer.type, transfer.info_binary, transfer.nonce, message))
+
+    def _notify_error(self, peer, exception):
+        logger.warning(f'Exception.Peer hash {hash(peer)}: "{exception}"')
+
+        for callback in self.error_callbacks:
+            callback(peer, exception)
+
+    def _schedule_terminate(self, container, peer, transfer):
+        if not self.terminate_by_timeout_enabled:
+            return
+
+        self.community.register_anonymous_task('eva_terminate_by_timeout', self._terminate_by_timout_task, container,
+                                               peer, transfer, delay=self.timeout_interval_in_sec, )
+
+    def _terminate_by_timout_task(self, container, peer, transfer):
+        if transfer.released or not self.terminate_by_timeout_enabled:
+            return
+
+        timeout = self.timeout_interval_in_sec
+        remaining_time = timeout - (time.time() - transfer.updated)
+
+        if remaining_time > 0:
+            self.community.register_anonymous_task('eva_terminate_by_timeout', self._terminate_by_timout_task,
+                                                   container, peer, transfer, delay=remaining_time, )
+            return
+
+        EVAProtocol.terminate(container, peer, transfer)
+        message = f'Terminated by timeout. Timeout is: {timeout} sec'
+        self._notify_error(peer, TimeoutException(transfer.type, transfer.info_binary, transfer.nonce, message))
+
+    def _schedule_resend_acknowledge(self, peer, transfer):
+        if not self.retransmit_enabled:
+            return
+
+        self.community.register_anonymous_task('eva_resend_acknowledge', self._resend_acknowledge_task,
+                                               peer, transfer, delay=self.retransmit_interval_in_sec, )
+
+    def _resend_acknowledge_task(self, peer, transfer):
+        if transfer.released or not self.retransmit_enabled:
+            return
+
+        attempts_are_over = transfer.attempt >= self.retransmit_attempt_count
+        if attempts_are_over:
+            return
+
+        resend_needed = time.time() - transfer.updated >= self.retransmit_interval_in_sec
+        if resend_needed:
+            transfer.acknowledgement_number = transfer.block_number + 1
+            transfer.attempt += 1
+
+            logger.debug(f'Re-acknowledgement({transfer.acknowledgement_number}). '
+                         f'Attempt: {transfer.attempt + 1}/{self.retransmit_attempt_count} for peer: {hash(peer)}')
+
+            self.send_acknowledgement(peer, transfer)
+
+        self.community.register_anonymous_task('eva_resend_acknowledge', self._resend_acknowledge_task, peer,
+                                               transfer, delay=self.retransmit_interval_in_sec, )

--- a/src/tribler-core/tribler_core/modules/metadata_store/community/tests/test_eva_protocol.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/community/tests/test_eva_protocol.py
@@ -1,0 +1,503 @@
+import asyncio
+import logging
+import os
+import random
+from collections import defaultdict
+from itertools import permutations
+from types import SimpleNamespace
+
+from ipv8.community import Community
+from ipv8.test.base import TestBase
+
+import pytest
+
+from tribler_core.modules.metadata_store.community.eva_protocol import (
+    EVAProtocolMixin,
+    Error,
+    SizeLimitException,
+    TimeoutException,
+    Transfer,
+    TransferException,
+    TransferType,
+)
+
+# fmt: off
+
+
+TEST_DEFAULT_TERMINATE_INTERVAL_IN_SEC = 1
+TEST_DEFAULT_RETRANSMIT_INTERVAL_IN_SEC = 0.3
+TEST_DEFAULT_SEGMENT_SIZE = 1200
+TEST_START_MESSAGE_ID = 100
+
+
+def create_transfer(time):
+    transfer = Transfer(TransferType.INCOMING, b'', b'', 0)
+    transfer.updated = time
+    return transfer
+
+
+async def drain_loop(loop):
+    """Cool asyncio magic brewed by Vadim"""
+    while True:
+        if not loop._ready or not loop._scheduled:  # pylint: disable=protected-access
+            break
+        await asyncio.sleep(0)
+
+
+class MockCommunity(EVAProtocolMixin, Community):  # pylint: disable=too-many-ancestors
+    community_id = os.urandom(20)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.received_data = defaultdict(lambda: [])
+        self.sent_data = defaultdict(lambda: [])
+
+        self.most_recent_received_data = None
+        self.most_recent_received_exception = None
+        self.most_recent_sent_data = None
+
+        self.eva_init(
+            timeout_interval_in_sec=TEST_DEFAULT_TERMINATE_INTERVAL_IN_SEC,
+            retransmit_interval_in_sec=TEST_DEFAULT_RETRANSMIT_INTERVAL_IN_SEC,
+            start_message_id=TEST_START_MESSAGE_ID,
+        )
+
+        self.eva_register_receive_callback(self.on_receive)
+        self.eva_register_send_complete_callback(self.on_send_complete)
+        self.eva_register_error_callback(self.on_error)
+
+    def on_receive(self, peer, info, data, nonce):
+        self.most_recent_received_data = info, data, nonce
+        self.received_data[peer].append(self.most_recent_received_data)
+
+    def on_send_complete(self, peer, info, data, nonce):
+        self.most_recent_sent_data = info, data, nonce
+        self.sent_data[peer].append(self.most_recent_sent_data)
+
+    def on_error(self, peer, exception):
+        self.most_recent_received_exception = exception
+
+
+class TestEVA(TestBase):
+    def setUp(self):
+        super().setUp()
+        self.initialize(MockCommunity, 3)
+
+        self.test_store = SimpleNamespace()
+
+    async def test_one_chunk_binary(self):
+        self.overlay(0).eva_send_binary(self.peer(1), b'test1', b'1234', 42)
+
+        await drain_loop(asyncio.get_event_loop())
+
+        assert self.overlay(1).most_recent_received_data == (b'test1', b'1234', 42)
+        assert len(self.overlay(0).sent_data[self.peer(1)]) == 1
+        assert len(self.overlay(1).received_data[self.peer(0)]) == 1
+
+    async def test_self_send(self):
+        self.overlay(0).eva_send_binary(self.peer(0), b'test1', b'1234')
+
+        await drain_loop(asyncio.get_event_loop())
+
+        assert not self.overlay(0).most_recent_received_data
+        assert len(self.overlay(0).sent_data[self.peer(1)]) == 0
+
+    async def test_two_chunk_binary(self):
+        data = b'test2', b'4321', 42
+        self.overlay(0).block_size = 2
+        self.overlay(0).eva_send_binary(self.peer(1), *data)
+
+        await drain_loop(asyncio.get_event_loop())
+
+        assert self.overlay(1).most_recent_received_data == data
+        assert len(self.overlay(0).sent_data[self.peer(1)]) == 1
+        assert len(self.overlay(1).received_data[self.peer(0)]) == 1
+
+    async def test_zero_transfer(self):
+        self.overlay(0).eva_send_binary(self.peer(1), b'', b'')
+
+        await drain_loop(asyncio.get_event_loop())
+
+        assert self.overlay(1).most_recent_received_data is None
+        assert len(self.overlay(0).eva_protocol.outgoing) == 0
+        assert len(self.overlay(1).eva_protocol.incoming) == 0
+
+        assert len(self.overlay(0).sent_data[self.peer(1)]) == 0
+        assert len(self.overlay(1).received_data[self.peer(0)]) == 0
+
+    @pytest.mark.timeout(15)
+    async def test_one_megabyte_transfer(self):
+        data_size = 1024 * 1024
+        data = os.urandom(1), os.urandom(data_size), random.randrange(0, 256)
+
+        self.overlay(0).eva_send_binary(self.peer(1), *data)
+
+        await drain_loop(asyncio.get_event_loop())
+
+        assert len(self.overlay(1).most_recent_received_data[1]) == data_size
+        assert self.overlay(1).most_recent_received_data == data
+
+    @pytest.mark.timeout(15)
+    async def test_termination_by_timeout(self):
+        # breaks "on_data" function in community2 to make this community silent
+
+        self.overlay(0).eva_protocol.window_size = 10
+        self.overlay(2).eva_protocol.window_size = 20
+
+        async def void(*_):
+            await asyncio.sleep(0)
+
+        self.overlay(2).eva_protocol.on_data = void
+
+        self.overlay(0).eva_send_binary(self.peer(2), b'info', b'data')
+
+        await self.deliver_messages(timeout=TEST_DEFAULT_TERMINATE_INTERVAL_IN_SEC + 1)
+
+        assert len(self.overlay(2).eva_protocol.incoming) == 0
+        assert isinstance(self.overlay(2).most_recent_received_exception, TimeoutException)
+
+        await self.deliver_messages(timeout=TEST_DEFAULT_TERMINATE_INTERVAL_IN_SEC + 1)
+
+        assert len(self.overlay(0).eva_protocol.outgoing) == 0
+        assert isinstance(self.overlay(0).most_recent_received_exception, TimeoutException)
+
+    async def test_retransmit(self):
+        attempts = 2
+
+        self.overlay(0).eva_protocol.terminate_by_timeout_enabled = False
+        self.overlay(1).eva_protocol.terminate_by_timeout_enabled = False
+        self.overlay(1).eva_protocol.retransmit_attempt_count = attempts
+
+        # breaks "acknowledgement" function in community0 to make this community silent
+        async def void(*_):
+            await asyncio.sleep(0)
+
+        self.overlay(0).eva_protocol.on_acknowledgement = void
+
+        self.overlay(0).eva_send_binary(self.peer(1), b'info', b'data')
+
+        await self.deliver_messages(timeout=(attempts + 1) * TEST_DEFAULT_RETRANSMIT_INTERVAL_IN_SEC)
+
+        assert len(self.overlay(0).eva_protocol.outgoing) == 1
+        assert len(self.overlay(1).eva_protocol.incoming) == 1
+
+        assert self.overlay(1).eva_protocol.incoming[self.peer(0)].attempt == attempts
+
+    async def test_retransmit_disabled(self):
+        self.overlay(0).eva_protocol.terminate_by_timeout_enabled = False
+        self.overlay(0).eva_protocol.retransmit_enabled = False
+        self.overlay(1).eva_protocol.terminate_by_timeout_enabled = False
+        self.overlay(1).eva_protocol.retransmit_enabled = False
+
+        # breaks "acknowledgement" function in community0 to make this community silent
+        async def void(*_):
+            await asyncio.sleep(0)
+
+        self.overlay(0).eva_protocol.on_acknowledgement = void
+
+        self.overlay(0).eva_send_binary(self.peer(1), b'info', b'data')
+
+        await self.deliver_messages(timeout=2 * TEST_DEFAULT_RETRANSMIT_INTERVAL_IN_SEC + 1)
+
+        assert len(self.overlay(0).eva_protocol.outgoing) == 1
+        assert len(self.overlay(1).eva_protocol.incoming) == 1
+
+        assert self.overlay(1).eva_protocol.incoming[self.peer(0)].attempt == 0
+
+    async def test_size_limit(self):
+        # test on a sender side
+        self.overlay(2).eva_protocol.binary_size_limit = 4
+
+        self.overlay(2).eva_send_binary(self.peer(0), b'info', b'12345')
+
+        await drain_loop(asyncio.get_event_loop())
+
+        assert isinstance(self.overlay(2).most_recent_received_exception, SizeLimitException)
+        assert not self.overlay(2).eva_protocol.outgoing
+        assert not self.overlay(0).eva_protocol.incoming
+        assert len(self.overlay(0).received_data[self.peer(1)]) == 0
+        assert len(self.overlay(2).sent_data[self.peer(1)]) == 0
+
+        # test on a receiver side
+        self.overlay(0).most_recent_received_exception = None
+        self.overlay(2).most_recent_received_exception = None
+
+        self.overlay(0).eva_send_binary(self.peer(2), b'info', b'54321')
+
+        await drain_loop(asyncio.get_event_loop())
+
+        assert isinstance(self.overlay(0).most_recent_received_exception, TransferException)
+        assert isinstance(self.overlay(2).most_recent_received_exception, SizeLimitException)
+        assert not self.overlay(2).eva_protocol.incoming
+        assert not self.overlay(2).eva_protocol.outgoing
+        assert len(self.overlay(0).sent_data[self.peer(2)]) == 0
+
+    async def test_duplex(self):
+        count = 100
+        block_size = 10
+
+        self.overlay(0).eva_protocol.block_size = block_size
+        self.overlay(1).eva_protocol.block_size = block_size
+
+        data0 = os.urandom(1), os.urandom(block_size * count), random.randrange(0, 256)
+        data1 = os.urandom(1), os.urandom(block_size * count), random.randrange(0, 256)
+
+        self.overlay(0).eva_send_binary(self.peer(1), *data0)
+        self.overlay(1).eva_send_binary(self.peer(0), *data1)
+
+        await drain_loop(asyncio.get_event_loop())
+
+        assert self.overlay(0).most_recent_received_data == data1
+        assert self.overlay(1).most_recent_received_data == data0
+
+        assert not self.overlay(0).eva_protocol.incoming
+        assert not self.overlay(0).eva_protocol.outgoing
+        assert not self.overlay(1).eva_protocol.incoming
+        assert not self.overlay(1).eva_protocol.outgoing
+        assert len(self.overlay(0).sent_data[self.peer(1)]) == 1
+        assert len(self.overlay(0).received_data[self.peer(1)]) == 1
+        assert len(self.overlay(1).sent_data[self.peer(0)]) == 1
+        assert len(self.overlay(1).received_data[self.peer(0)]) == 1
+
+    async def test_multiply_send(self):
+        data_set_count = 100
+        data_size = 1024
+
+        data_list = [(os.urandom(1), os.urandom(data_size), random.randrange(0, 256)) for _ in range(data_set_count)]
+        for data in data_list:
+            self.overlay(0).eva_send_binary(self.peer(1), *data)
+
+        await drain_loop(asyncio.get_event_loop())
+
+        assert self.overlay(1).received_data[self.peer(0)] == data_list
+        assert not self.overlay(0).eva_protocol.scheduled
+
+    async def test_multiply_duplex(self):
+        data_set_count = 10
+
+        self.overlay(0).eva_protocol.block_size = 10
+        self.overlay(1).eva_protocol.block_size = 10
+        self.overlay(2).eva_protocol.block_size = 10
+
+        # create 10 different data sets for each direction (0->1, 0->2, 1->0, 1->2, 2->0, 2->1)
+        participants = [
+            (self.peer(0), self.overlay(0)),
+            (self.peer(1), self.overlay(1)),
+            (self.peer(2), self.overlay(2)),
+        ]
+
+        data = [
+            (p, list((os.urandom(1), os.urandom(100), random.randrange(0, 256)) for _ in range(data_set_count)))
+            for p in permutations(participants, 2)
+        ]
+
+        for ((_, community), (peer, _)), data_set in data:
+            for d in data_set:
+                community.eva_send_binary(peer, *d)
+
+        await drain_loop(asyncio.get_event_loop())
+
+        assert len(self.overlay(0).received_data) == 2
+        assert len(self.overlay(1).received_data) == 2
+        assert len(self.overlay(2).received_data) == 2
+
+        data_sets_checked = 0
+        for ((peer, _), (_, community)), data_set in data:
+            assert community.received_data[peer] == data_set
+            data_sets_checked += 1
+
+        assert data_sets_checked == 6
+
+    @pytest.mark.timeout(20)
+    async def test_survive_when_multiply_packets_lost(self):
+        self.overlay(0).eva_protocol.terminate_by_timeout_enabled = False
+        self.overlay(1).eva_protocol.terminate_by_timeout_enabled = False
+
+        lost_packets_count_estimation = 5
+        data_set_count = 3
+
+        block_count = 15
+        block_size = 3
+        window_size = 10
+
+        packet_loss_probability = lost_packets_count_estimation / (block_count * data_set_count)
+
+        self.overlay(0).eva_protocol.block_size = block_size
+        self.overlay(1).eva_protocol.window_size = window_size
+
+        self.overlay(1).eva_protocol.retransmit_attempt_count = lost_packets_count_estimation
+
+        data = [(os.urandom(1), os.urandom(block_size * block_count), 0) for _ in range(data_set_count)]
+
+        real_on_data1 = self.overlay(1).eva_protocol.on_data
+
+        # store for the fake function
+        self.test_store.actual_packets_lost = 0
+        self.test_store.lost_packets_count_estimation = lost_packets_count_estimation
+        self.test_store.packet_loss_probability = packet_loss_probability
+
+        # modify "on_data" function to proxying all calls and to add a probability
+        # to a packet loss
+        async def fake_on_data1(peer, payload):
+            chance_to_fake = random.random() < self.test_store.packet_loss_probability
+            is_last_packet = len(payload.data_binary) == 0
+            max_count_reached = self.test_store.actual_packets_lost >= self.test_store.lost_packets_count_estimation
+
+            if chance_to_fake and not max_count_reached and not is_last_packet:
+                self.test_store.actual_packets_lost += 1
+                return
+
+            await real_on_data1(peer, payload)
+
+        self.overlay(1).eva_protocol.on_data = fake_on_data1
+
+        for d in data:
+            self.overlay(0).eva_send_binary(self.peer(1), *d)
+
+        timeout = 1 + lost_packets_count_estimation * TEST_DEFAULT_RETRANSMIT_INTERVAL_IN_SEC * 2
+        await self.deliver_messages(timeout=timeout)
+
+        logging.info(f'Estimated packet lost block_count/probability: '
+                     f'{lost_packets_count_estimation}/{packet_loss_probability}')
+        logging.info(f'Actual packet lost: {self.test_store.actual_packets_lost}')
+
+        assert len(self.overlay(1).received_data[self.peer(0)]) == data_set_count
+        assert self.overlay(1).received_data[self.peer(0)] == data
+
+    @pytest.mark.timeout(15)
+    async def test_dynamically_changed_window_size(self):
+        window_size = 5
+
+        self.test_store.window_size_increment = -1
+        self.test_store.actual_window_size = 0
+
+        block_size = 2
+
+        self.overlay(0).eva_protocol.block_size = block_size
+        self.overlay(1).eva_protocol.window_size = window_size
+
+        data = os.urandom(1), os.urandom(block_size * 1024), 42
+
+        real_on_acknowledgement0 = self.overlay(0).eva_protocol.on_acknowledgement
+        real_on_send_acknowledgement1 = self.overlay(1).eva_protocol.send_acknowledgement
+
+        async def fake_on_acknowledgement0(peer, payload):
+            await real_on_acknowledgement0(peer, payload)
+
+            transfer = self.overlay(0).eva_protocol.outgoing.get(peer, None)
+            if transfer:
+                # check that windows size is updated
+                assert self.test_store.actual_window_size == transfer.window_size
+
+        def fake_eva_send_acknowledgement1(peer, transfer):
+            if transfer.window_size == 1:
+                # go up
+                self.test_store.window_size_increment = 2
+
+            transfer.window_size += self.test_store.window_size_increment
+
+            self.test_store.actual_window_size = transfer.window_size
+            real_on_send_acknowledgement1(peer, transfer)
+
+        self.overlay(0).eva_protocol.on_acknowledgement = fake_on_acknowledgement0
+        self.overlay(1).eva_protocol.send_acknowledgement = fake_eva_send_acknowledgement1
+
+        self.overlay(0).eva_send_binary(self.peer(1), *data)
+        await drain_loop(asyncio.get_event_loop())
+
+        assert self.overlay(1).received_data[self.peer(0)][0] == data
+
+    async def test_cheating_send_over_size(self):
+        self.overlay(1).eva_protocol.binary_size_limit = 4
+        acknowledgement_message_id = TEST_START_MESSAGE_ID + 1
+
+        real_on_acknowledgement0 = self.overlay(0).decode_map[acknowledgement_message_id]
+
+        def fake_on_acknowledgement0(peer, payload):
+            transfer = self.overlay(0).eva_protocol.outgoing[self.peer(1)]
+            transfer.data_binary = b'1' * 100
+            transfer.count = 100
+            return real_on_acknowledgement0(peer, payload)
+
+        self.overlay(0).decode_map[acknowledgement_message_id] = fake_on_acknowledgement0
+
+        self.overlay(0).eva_send_binary(self.peer(1), b'', b'12')
+
+        await drain_loop(asyncio.get_event_loop())
+
+        assert isinstance(self.overlay(0).most_recent_received_exception, TransferException)
+        assert isinstance(self.overlay(1).most_recent_received_exception, SizeLimitException)
+
+    async def test_wrong_message_order_and_wrong_nonce(self):
+        self.overlay(0).eva_protocol.terminate_by_timeout_enabled = False
+        self.overlay(1).eva_protocol.terminate_by_timeout_enabled = False
+        self.overlay(1).eva_protocol.retransmit_attempt_count = 5
+
+        data_set_count = 1
+
+        block_count = 20
+        block_size = 3
+        window_size = 2
+
+        self.overlay(0).eva_protocol.block_size = block_size
+        self.overlay(1).eva_protocol.window_size = window_size
+
+        data = [(os.urandom(1), os.urandom(block_size * block_count), 0) for _ in range(data_set_count)]
+
+        real_on_acknowledgement = self.overlay(0).eva_protocol.on_acknowledgement
+
+        self.test_store.acknowledgement_count_before_start = 2
+        self.test_store.wrong_order_attempted = False
+        self.test_store.wrong_nonce_attempted = False
+
+        # test wrong message order and wrong nonce
+        async def fake_on_acknowledgement(peer, payload):
+            if self.test_store.acknowledgement_count_before_start > 0:
+                self.test_store.acknowledgement_count_before_start -= 1
+                await real_on_acknowledgement(peer, payload)
+            elif not self.test_store.wrong_order_attempted:
+                self.test_store.wrong_order_attempted = True
+                payload.number = 0
+                await real_on_acknowledgement(peer, payload)
+            elif not self.test_store.wrong_nonce_attempted:
+                self.test_store.wrong_nonce_attempted = True
+                payload.nonce = 100
+                await real_on_acknowledgement(peer, payload)
+            else:
+                await real_on_acknowledgement(peer, payload)
+
+        self.overlay(0).eva_protocol.on_acknowledgement = fake_on_acknowledgement
+
+        for d in data:
+            self.overlay(0).eva_send_binary(self.peer(1), *d)
+
+        await self.deliver_messages(timeout=5)
+        assert len(self.overlay(1).received_data[self.peer(0)]) == data_set_count
+        assert self.overlay(1).received_data[self.peer(0)] == data
+
+    async def test_received_packet_that_have_no_transfer(self):
+        self.overlay(0).eva_protocol.timeout_interval_in_sec = 0
+        self.overlay(1).eva_protocol.timeout_interval_in_sec = 0
+
+        # wait to new timeout will be set up
+        await self.deliver_messages(timeout=TEST_DEFAULT_TERMINATE_INTERVAL_IN_SEC * 2)
+
+        # try to send data with 0 timeout
+        # it should lead to packet's send without presented transfer
+        self.overlay(0).eva_send_binary(self.peer(1), b'', os.urandom(1000))
+        await self.deliver_messages(timeout=1)
+
+        assert len(self.overlay(0).eva_protocol.outgoing) == 0
+        assert isinstance(self.overlay(0).most_recent_received_exception, TimeoutException)
+        assert len(self.overlay(1).eva_protocol.incoming) == 0
+        assert isinstance(self.overlay(1).most_recent_received_exception, TimeoutException)
+
+        # then try to send an error message without corresponding transfer
+        self.overlay(0).most_recent_received_exception = None
+        self.overlay(1).most_recent_received_exception = None
+
+        self.overlay(0).eva_send_message(self.peer(1), Error('message'.encode('utf-8')))
+        await self.deliver_messages(timeout=0.1)
+
+        assert not self.overlay(0).most_recent_received_exception
+        assert not self.overlay(1).most_recent_received_exception


### PR DESCRIPTION
This PR makes it possible to transfer big binary data over ipv8.
Closes https://github.com/Tribler/tribler/issues/6003

The protocol based on TFTP with windowsize (RFC 7440).

Features:

 * timeout
 * retransmit
 * dynamic window size

The maximum data size that can be transferred through the protocol can be calculated as "block_size * 4294967295" where 4294967295 is the max segment number (4B unsigned int). But the protocol is slow by design, so try to send less rather than more.

### How to use:

```python
class MyCommunity(EVAProtocolMixin, Community):
    community_id = b'0' * 20

    def __init__(self, *args, **kwargs):
        super().__init__(*args, **kwargs)

        self.eva_init()

        self.eva_register_receive_callback(self.on_receive)
        self.eva_register_send_complete_callback(self.on_send_complete)
        self.eva_register_error_callback(self.on_error)

    def my_function(self, peer):
        self.eva_send_binary(peer, b'info1', b'data1', 42)
        self.eva_send_binary(peer, b'info2', b'data2', 42)
        self.eva_send_binary(peer, b'info3', b'data3', 42)

   def on_receive(self, peer, binary_info, binary_data, nonce):
        logger.info(f'Data has been received: {binary_info}')

   def on_send_complete(self, peer, binary_info, binary_data, nonce):
        logger.info(f'Transfer has been completed: {binary_info}')

   def on_error(self, peer, exception, nonce):
        logger.error(f'Error has been occurred: {exception}')
```


Due to ipv8 specifics, we can use only one socket port per one peer. Therefore, at one point in time, the protocol can only transmit one particular piece of data for one particular peer.

In case the `eva_send_binary` method is invoked multiply times for a single peer, the data transfer will be scheduled and performed when the current transfer session is finished.