### PR TITLE
Fixed a bug with LedgerZero timestamps

### DIFF
--- a/src/tribler-core/tribler_core/modules/bandwidth_accounting/transaction.py
+++ b/src/tribler-core/tribler_core/modules/bandwidth_accounting/transaction.py
@@ -8,7 +8,7 @@ context.
 from __future__ import annotations
 
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Dict
 
 from ipv8.keyvault.crypto import default_eccrypto
@@ -32,7 +32,7 @@ class BandwidthTransactionData:
     signature_a: bytes
     signature_b: bytes
     amount: int
-    timestamp: int = int(round(time.time() * 1000))
+    timestamp: int = field(default_factory=lambda: int(round(time.time() * 1000)))
 
     def pack(self, signature_a=True, signature_b=True) -> bytes:
         """

--- a/src/tribler-core/tribler_core/modules/tests/bandwidth_accounting/test_community.py
+++ b/src/tribler-core/tribler_core/modules/tests/bandwidth_accounting/test_community.py
@@ -1,3 +1,5 @@
+from asyncio import sleep
+
 from ipv8.test.base import TestBase
 from ipv8.test.mocking.ipv8 import MockIPv8
 
@@ -50,6 +52,15 @@ class TestBandwidthAccountingCommunity(TestBase):
         assert self.nodes[1].overlay.database.get_total_taken(pk1) == 500
         assert self.nodes[0].overlay.database.get_total_taken(pk2) == 1500
         assert self.nodes[1].overlay.database.get_total_taken(pk2) == 1500
+
+    async def test_bilateral_transaction_timestamps(self):
+        """
+        Test creating subsequent transactions and check whether the timestamps are different.
+        """
+        tx1 = await self.nodes[0].overlay.do_payout(self.nodes[1].overlay.my_peer, 500)
+        await sleep(0.1)
+        tx2 = await self.nodes[0].overlay.do_payout(self.nodes[1].overlay.my_peer, 500)
+        assert tx1.timestamp != tx2.timestamp
 
     async def test_invalid_transaction(self):
         """


### PR DESCRIPTION
We are using a dataclass for the container class BandwidthTransactionData and we were using a default value for the timestamp. However, this default value is not updated when a new dataclass is instantiated, resulting in erroneous timestamps in LedgerZero. This PR explicitly adds an __init__ method which should ensure correctness when creating new transactions.