### PR TITLE
Enable forcing EVA usage for RQC queries

### DIFF
--- a/src/tribler-core/tribler_core/modules/metadata_store/community/remote_query_community.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/community/remote_query_community.py
@@ -141,8 +141,11 @@ class RemoteQueryCommunity(Community, EVAProtocolMixin):
         self.request_cache.add(request)
 
         self.logger.info(f"Select to {hexlify(peer.mid)} with ({kwargs})")
-        payload_class = RemoteSelectPayloadEva if force_eva_response else RemoteSelectPayload
-        self.ez_send(peer, payload_class(request.number, json.dumps(kwargs).encode('utf8')))
+        args = (request.number, json.dumps(kwargs).encode('utf8'))
+        if force_eva_response:
+            self.ez_send(peer, RemoteSelectPayloadEva(*args))
+        else:
+            self.ez_send(peer, RemoteSelectPayload(*args))
 
     async def process_rpc_query(self, json_bytes: bytes):
         """

--- a/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/torrent_metadata.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/torrent_metadata.py
@@ -119,6 +119,7 @@ def define_binding(db):
             # Add the torrent as a free-for-all entry if it is unknown to GigaChannel
             return cls.from_dict(dict(ffa_dict, public_key=b'', status=COMMITTED, id_=id_))
 
+        @db_session
         def to_simple_dict(self):
             """
             Return a basic dictionary with information about the channel.


### PR DESCRIPTION
Forcing usage of EVA for RQC replies is another step towards reliable real-time previews (Channels 2.5)