### PR TITLE
Add tracking of peers subscribed to channels

### DIFF
--- a/src/tribler-core/tribler_core/modules/metadata_store/community/gigachannel_community.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/community/gigachannel_community.py
@@ -1,7 +1,6 @@
-import time as unixtime
 import uuid
 from binascii import unhexlify
-from collections import defaultdict, deque
+from collections import defaultdict
 from dataclasses import dataclass
 from random import sample
 
@@ -25,12 +24,12 @@ maximum_payload_size = 1024
 max_entries = maximum_payload_size // minimal_blob_size
 max_search_peers = 5
 
+
 MAGIC_GIGACHAN_VERSION_MARK = b'\x01'
 
 
 @dataclass
-class PeerEntry:
-    peer: Peer
+class ChannelEntry:
     timestamp: float
     channel_version: int
 
@@ -38,19 +37,42 @@ class PeerEntry:
 class ChannelsPeersMapping:
     def __init__(self, max_peers_per_channel=10):
         self.max_peers_per_channel = max_peers_per_channel
-        self.channels_dict = defaultdict(deque)
+        self._channels_dict = defaultdict(set)
+        # Reverse mapping from peers to channels
+        self._peers_channels = defaultdict(set)
 
-    def add(self, peer, channel_pk, channel_id, channel_version):
+    def add(self, peer: Peer, channel_pk: bytes, channel_id: int):
         id_tuple = (channel_pk, channel_id)
-        channel_entry = self.channels_dict[id_tuple]
-        channel_entry.append(PeerEntry(peer, unixtime.time(), channel_version))
-        if len(channel_entry) > self.max_peers_per_channel:
-            channel_entry.popleft()
+        channel_peers = self._channels_dict[id_tuple]
+
+        channel_peers.add(peer)
+        self._peers_channels[peer].add(id_tuple)
+
+        if len(channel_peers) > self.max_peers_per_channel:
+            removed_peer = min(channel_peers, key=lambda x: x.last_response)
+            channel_peers.remove(removed_peer)
+            # Maintain the reverse mapping
+            self._peers_channels[removed_peer].remove(id_tuple)
+            if not self._peers_channels[removed_peer]:
+                self._peers_channels.pop(removed_peer)
+
+    def remove_peer(self, peer):
+        for id_tuple in self._peers_channels[peer]:
+            self._channels_dict.pop(id_tuple, None)
+        self._peers_channels.pop(peer)
+
+    def get_last_seen_peers_for_channel(self, channel_pk: bytes, channel_id: int, limit=None):
+        id_tuple = (channel_pk, channel_id)
+        channel_peers = self._channels_dict.get(id_tuple, [])
+        return sorted(channel_peers, key=lambda x: x.last_response, reverse=True)[0:limit]
 
 
 @dataclass
 class GigaChannelCommunitySettings(RemoteQueryCommunitySettings):
     queried_peers_limit: int = 1000
+    # The maximum number of peers that we got from channels to peers mapping,
+    # that must be queried in addition to randomly queried peers
+    max_mapped_query_peers = 3
 
 
 class GigaChannelCommunity(RemoteQueryCommunity):
@@ -106,7 +128,7 @@ class GigaChannelCommunity(RemoteQueryCommunity):
             with db_session:
                 for c in (r.md_obj for r in processing_results if r.md_obj.metadata_type == CHANNEL_TORRENT):
                     self.mds.vote_bump(c.public_key, c.id_, peer.public_key.key_to_bin()[10:])
-                    self.channels_peers.add(peer, c.public_key, c.id_, c.timestamp)
+                    self.channels_peers.add(peer, c.public_key, c.id_)
 
             # Notify GUI about the new channels
             results = [
@@ -142,10 +164,31 @@ class GigaChannelCommunity(RemoteQueryCommunity):
             if self.notifier and results:
                 self.notifier.notify(NTFY.REMOTE_QUERY_RESULTS, {"results": results, "uuid": str(request_uuid)})
 
-        for p in self.get_random_peers(self.settings.max_query_peers):
+        # Try sending the request to at least some peers that we know have it
+        if "channel_pk" in kwargs and "origin_id" in kwargs:
+            peers_to_query = self.get_known_subscribed_peers_for_node(
+                unhexlify(kwargs["channel_pk"]), kwargs["origin_id"], self.settings.max_mapped_query_peers
+            )
+        else:
+            peers_to_query = self.get_random_peers(self.settings.max_query_peers)
+
+        for p in peers_to_query:
             self.send_remote_select(p, **kwargs, processing_callback=notify_gui)
 
         return request_uuid
+
+    def get_known_subscribed_peers_for_node(self, node_pk, node_id, limit=None):
+        # Determine the toplevel parent channel
+        with db_session:
+            node = self.mds.ChannelNode.get(public_key=node_pk, id_=node_id)
+            root_id = next((value for value in node.get_parents_ids() if value != 0), node_id) if node else node_id
+
+        return self.channels_peers.get_last_seen_peers_for_channel(node_pk, root_id, limit)
+
+    def _on_query_timeout(self, request_cache):
+        if not request_cache.peer_responded:
+            self.channels_peers.remove_peer(request_cache.peer)
+        super()._on_query_timeout(request_cache)
 
 
 class GigaChannelTestnetCommunity(GigaChannelCommunity):

--- a/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/channel_metadata.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/channel_metadata.py
@@ -1,4 +1,5 @@
 import os
+from binascii import unhexlify
 from datetime import datetime
 from pathlib import Path
 
@@ -34,6 +35,8 @@ CHANNEL_DIR_NAME_ID_LENGTH = 16  # Zero-padded long int in hex form
 CHANNEL_DIR_NAME_LENGTH = CHANNEL_DIR_NAME_PK_LENGTH + CHANNEL_DIR_NAME_ID_LENGTH
 BLOB_EXTENSION = '.mdblob'
 LZ4_END_MARK_SIZE = 4  # in bytes, from original specification. We don't use CRC
+
+LZ4_EMPTY_ARCHIVE = unhexlify("04224d184040c000000000")
 
 
 def chunks(l, n):

--- a/src/tribler-core/tribler_core/modules/metadata_store/restapi/tests/test_remote_query_endpoint.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/restapi/tests/test_remote_query_endpoint.py
@@ -1,9 +1,19 @@
 import uuid
 from unittest.mock import Mock
 
+from ipv8.keyvault.crypto import default_eccrypto
+from ipv8.peer import Peer
+
+from pony.orm import db_session
+
 import pytest
 
+from tribler_core.modules.metadata_store.community.gigachannel_community import ChannelsPeersMapping
 from tribler_core.restapi.base_api_test import do_request
+from tribler_core.utilities.random_utils import random_infohash
+from tribler_core.utilities.unicode import hexlify
+
+# pylint: disable=unused-argument
 
 
 @pytest.mark.asyncio
@@ -38,3 +48,33 @@ async def test_create_remote_search_request(enable_chant, enable_api, session):
         session, f'remote_query?channel_pk={channel_pk}&metadata_type=torrent', request_type="PUT", expected_code=200
     )
     assert sent['channel_pk'] == channel_pk
+
+
+@pytest.mark.asyncio
+async def test_get_channels_peers(enable_chant, enable_api, session):
+    """
+    Test getting debug info about the state of channels to peers mapping
+    """
+
+    session.gigachannel_community = Mock()
+    mapping = session.gigachannel_community.channels_peers = ChannelsPeersMapping()
+
+    peer_key = default_eccrypto.generate_key("curve25519")
+    chan_key = default_eccrypto.generate_key("curve25519")
+    with db_session:
+        chan = session.mds.ChannelMetadata(sign_with=chan_key, name="bla", infohash=random_infohash())
+
+    peer = Peer(peer_key, ("1.2.3.4", 5))
+    mapping.add(peer, chan.public_key, chan.id_, chan.timestamp)
+
+    result = await do_request(
+        session,
+        'remote_query/channels_peers',
+        request_type="GET",
+        expected_code=200,
+    )
+    first_result = result["channels_list"][0]
+    assert first_result["channel_name"] == chan.title
+    assert first_result["channel_pk"] == hexlify(chan.public_key)
+    assert first_result["channel_id"] == chan.id_
+    assert first_result["peers"][0][0] == hexlify(peer.mid)

--- a/src/tribler-core/tribler_core/modules/metadata_store/restapi/tests/test_remote_query_endpoint.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/restapi/tests/test_remote_query_endpoint.py
@@ -65,7 +65,7 @@ async def test_get_channels_peers(enable_chant, enable_api, session):
         chan = session.mds.ChannelMetadata(sign_with=chan_key, name="bla", infohash=random_infohash())
 
     peer = Peer(peer_key, ("1.2.3.4", 5))
-    mapping.add(peer, chan.public_key, chan.id_, chan.timestamp)
+    mapping.add(peer, chan.public_key, chan.id_)
 
     result = await do_request(
         session,

--- a/src/tribler-gui/tribler_gui/qt_resources/debugwindow.ui
+++ b/src/tribler-gui/tribler_gui/qt_resources/debugwindow.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>873</width>
+    <width>1012</width>
     <height>695</height>
    </rect>
   </property>
@@ -21,7 +21,7 @@
     <item>
      <widget class="QTabWidget" name="debug_tab_widget">
       <property name="currentIndex">
-       <number>7</number>
+       <number>10</number>
       </property>
       <widget class="QWidget" name="tab">
        <attribute name="title">
@@ -177,7 +177,7 @@
         <item>
          <widget class="QTabWidget" name="ipv8_tab_widget">
           <property name="currentIndex">
-           <number>1</number>
+           <number>3</number>
           </property>
           <widget class="QWidget" name="tab_6">
            <attribute name="title">
@@ -414,7 +414,7 @@
         <item>
          <widget class="QTabWidget" name="tunnel_tab_widget">
           <property name="currentIndex">
-           <number>1</number>
+           <number>4</number>
           </property>
           <widget class="QWidget" name="tab_6">
            <attribute name="title">
@@ -748,7 +748,7 @@
         <item>
          <widget class="QTabWidget" name="dht_tab_widget">
           <property name="currentIndex">
-           <number>0</number>
+           <number>1</number>
           </property>
           <widget class="QWidget" name="tab_3">
            <attribute name="title">
@@ -921,7 +921,7 @@
         <item>
          <widget class="QTabWidget" name="system_tab_widget">
           <property name="currentIndex">
-           <number>3</number>
+           <number>0</number>
           </property>
           <widget class="QWidget" name="tab_9">
            <attribute name="title">
@@ -1581,7 +1581,7 @@
         <item>
          <widget class="QTabWidget" name="log_tab_widget">
           <property name="currentIndex">
-           <number>0</number>
+           <number>1</number>
           </property>
           <widget class="QWidget" name="tab_6">
            <attribute name="title">
@@ -1692,6 +1692,117 @@
                <bool>true</bool>
               </property>
              </widget>
+            </item>
+           </layout>
+          </widget>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+      <widget class="QWidget" name="tab_channels">
+       <attribute name="title">
+        <string>Channels</string>
+       </attribute>
+       <layout class="QVBoxLayout" name="verticalLayout">
+        <property name="spacing">
+         <number>0</number>
+        </property>
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="QTabWidget" name="channels_tab_widget">
+          <property name="currentIndex">
+           <number>0</number>
+          </property>
+          <widget class="QWidget" name="tab_3">
+           <attribute name="title">
+            <string>Channels peers</string>
+           </attribute>
+           <layout class="QVBoxLayout" name="verticalLayout_2">
+            <property name="spacing">
+             <number>0</number>
+            </property>
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
+             <number>0</number>
+            </property>
+            <item>
+             <widget class="QTreeWidget" name="channels_peers_tree_widget">
+              <property name="sortingEnabled">
+               <bool>true</bool>
+              </property>
+              <attribute name="headerDefaultSectionSize">
+               <number>200</number>
+              </attribute>
+              <column>
+               <property name="text">
+                <string>Channel name</string>
+               </property>
+              </column>
+              <column>
+               <property name="text">
+                <string>Public key</string>
+               </property>
+              </column>
+              <column>
+               <property name="text">
+                <string>Id</string>
+               </property>
+              </column>
+              <column>
+               <property name="text">
+                <string>Peer count</string>
+               </property>
+              </column>
+              <column>
+               <property name="text">
+                <string>Peer age (seconds)</string>
+               </property>
+              </column>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+          <widget class="QWidget" name="tab_10">
+           <attribute name="title">
+            <string>Stub</string>
+           </attribute>
+           <layout class="QVBoxLayout" name="verticalLayout">
+            <property name="spacing">
+             <number>0</number>
+            </property>
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
+             <number>0</number>
+            </property>
+            <item>
+             <widget class="QWidget" name="stub" native="true"/>
             </item>
            </layout>
           </widget>


### PR DESCRIPTION
This PR adds tracking of the last 10 peers who introduced us to a channel, for each channel. If a peer does not respond to our queries, it is dropped. Also, it adds a convenient debug endpoint and a corresponding Channels debug tab.

This is another step towards live previews in Channels 2.5

![изображение](https://user-images.githubusercontent.com/2509103/112657515-cc3dd980-8e52-11eb-8b17-42a39a46fa09.png)
