### PR TITLE
Cherry-pick forcing EVA transfer

### DIFF
--- a/src/tribler-core/tribler_core/modules/metadata_store/community/tests/test_remote_query_community.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/community/tests/test_remote_query_community.py
@@ -88,6 +88,13 @@ class TestRemoteQueryCommunity(TestBase):
             self.assertEqual(len(torrents0), len(torrents1))
             self.assertEqual(len(torrents0), 20)
 
+        # Test getting empty response for a query
+        kwargs_dict = {"txt_filter": "ubuntu*", "origin_id": 352127}
+        callback = Mock()
+        self.nodes[1].overlay.send_remote_select(self.nodes[0].my_peer, **kwargs_dict, processing_callback=callback)
+        await self.deliver_messages(timeout=0.5)
+        callback.assert_called()
+
     async def test_remote_select_query_back(self):
         """
         Test querying back preview contents for previously unknown channels.

--- a/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/channel_metadata.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/channel_metadata.py
@@ -1,4 +1,5 @@
 import os
+from binascii import unhexlify
 from datetime import datetime
 from pathlib import Path
 
@@ -32,6 +33,8 @@ CHANNEL_DIR_NAME_ID_LENGTH = 16  # Zero-padded long int in hex form
 CHANNEL_DIR_NAME_LENGTH = CHANNEL_DIR_NAME_PK_LENGTH + CHANNEL_DIR_NAME_ID_LENGTH
 BLOB_EXTENSION = '.mdblob'
 LZ4_END_MARK_SIZE = 4  # in bytes, from original specification. We don't use CRC
+
+LZ4_EMPTY_ARCHIVE = unhexlify("04224d184040c000000000")
 
 
 def chunks(l, n):


### PR DESCRIPTION
This PR cherry-picks from `main` to make 7.9 hosts answer to forced EVA RQC requests and respond with an empty list packet to non-matching RQC queries.
This will enable experimentation and smooth transition towards Channels 2.5 remote preview feature.

Note that these changes are completely compatible with the previous versions of RQC.