### PR TITLE
Fix for DHTHealthManager returning incorrect results

### DIFF
--- a/src/tribler-core/tribler_core/modules/tests/test_dht_health_manager.py
+++ b/src/tribler-core/tribler_core/modules/tests/test_dht_health_manager.py
@@ -74,14 +74,16 @@ async def test_receive_bloomfilters(dht_health_manager):
     Test whether the right operations happen when receiving a bloom filter
     """
     infohash = b'a' * 20
-    dht_health_manager.received_bloomfilters(infohash)  # It should not do anything
+    transaction_id = '1'
+    dht_health_manager.received_bloomfilters(transaction_id)  # It should not do anything
     assert not dht_health_manager.bf_seeders
     assert not dht_health_manager.bf_peers
 
     dht_health_manager.lookup_futures[infohash] = Future()
     dht_health_manager.bf_seeders[infohash] = bytearray(256)
     dht_health_manager.bf_peers[infohash] = bytearray(256)
-    dht_health_manager.received_bloomfilters(b'b' * 20,
+    dht_health_manager.requesting_bloomfilters(transaction_id, infohash)
+    dht_health_manager.received_bloomfilters(transaction_id,
                                              bf_seeds=bytearray(b'\xee' * 256),
                                              bf_peers=bytearray(b'\xff' * 256))
     assert dht_health_manager.bf_seeders[infohash] == bytearray(b'\xee' * 256)

--- a/src/tribler-core/tribler_core/modules/torrent_checker/torrentchecker_session.py
+++ b/src/tribler-core/tribler_core/modules/torrent_checker/torrentchecker_session.py
@@ -479,7 +479,6 @@ class FakeBep33DHTSession(FakeDHTSession):
         :return: A deferred that fires with the health information.
         """
         try:
-            async with async_timeout.timeout(self.timeout):
-                return await self._session.dlmgr.dht_health_manager.get_health(self.infohash)
+            return await self._session.dlmgr.dht_health_manager.get_health(self.infohash, timeout=self.timeout)
         except TimeoutError:
             self.failed(msg='request timed out')


### PR DESCRIPTION
This PR fixes an issue with increased peer counts being returned by the `DHTHealthManager`. The problem is that when we send BEP33 responses for active downloads, they are picked up by the `DHTHealthManager` and added to the nearest infohash. A similar issue could present when we receive BEP33 responses for active downloads.

To fix the issue we keep track of transaction_id -> infohash. Unfortunately, this means that we have to process all incoming and outgoing DHT messages. Note that I'm assuming that transaction_ids for in-flight requests are unique.