### PR TITLE
Fix test_get_first_free_port

### DIFF
--- a/src/tribler-core/tribler_core/tests/test_network_utils.py
+++ b/src/tribler-core/tribler_core/tests/test_network_utils.py
@@ -52,13 +52,14 @@ def test_autodetect_socket_style():
 
 def test_get_first_free_port():
     # target port is free
-    assert get_first_free_port(start=50000) == 50000
+    port = random.randint(50000, 60000)
+    assert get_first_free_port(start=port) == port
 
     # target port is locked
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        sock.bind(('', 50000))
-        assert get_first_free_port(start=50000) == 50001
+        sock.bind(('', port))
+        assert get_first_free_port(start=port) == port + 1
 
     # no free ports found
     with pytest.raises(FreePortNotFoundError):
-        get_first_free_port(start=50000, limit=0)
+        get_first_free_port(start=port, limit=0)


### PR DESCRIPTION
This PR fixes #6042.

I was not able to reproduce the actual issue.
My guess is the cause of the issue was simultaneously running tests. 

The fix is simple: to use a randomly picked port instead of a fixed one.