### PR TITLE
Place healthy torrents on top of search result

### DIFF
--- a/src/tribler-core/tribler_core/conftest.py
+++ b/src/tribler-core/tribler_core/conftest.py
@@ -29,23 +29,23 @@ from tribler_core.utilities.random_utils import random_infohash
 from tribler_core.utilities.unicode import hexlify
 
 
-@pytest.fixture
-def tribler_root_dir(tmpdir):
+@pytest.fixture(name="tribler_root_dir")
+def _tribler_root_dir(tmpdir):
     return Path(tmpdir)
 
 
-@pytest.fixture
-def tribler_state_dir(tribler_root_dir):
+@pytest.fixture(name="tribler_state_dir")
+def _tribler_state_dir(tribler_root_dir):
     return tribler_root_dir / "dot.Tribler"
 
 
-@pytest.fixture
-def tribler_download_dir(tribler_root_dir):
+@pytest.fixture(name="tribler_download_dir")
+def _tribler_download_dir(tribler_root_dir):
     return tribler_root_dir / "TriblerDownloads"
 
 
-@pytest.fixture
-def tribler_config(tribler_state_dir, tribler_download_dir):
+@pytest.fixture(name="tribler_config")
+def _tribler_config(tribler_state_dir, tribler_download_dir):
     config = TriblerConfig(tribler_state_dir)
     config.set_default_destination_dir(tribler_download_dir)
     config.set_torrent_checking_enabled(False)
@@ -156,8 +156,8 @@ async def channel_seeder_session(seed_config, channel_tdef):
 selected_ports = set()
 
 
-@pytest.fixture
-def free_ports():
+@pytest.fixture(name="free_ports")
+def _free_ports():
     """
     Return random, free ports.
     This is here to make sure that tests in different buckets get assigned different listen ports.
@@ -181,8 +181,8 @@ def free_ports():
     return get_ports
 
 
-@pytest.fixture
-def free_port(free_ports):
+@pytest.fixture(name="free_port")
+def _free_port(free_ports):
     return free_ports(1)[0]
 
 

--- a/src/tribler-core/tribler_core/modules/metadata_store/restapi/metadata_endpoint_base.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/restapi/metadata_endpoint_base.py
@@ -17,7 +17,7 @@ json2pony_columns = {
     'health': 'HEALTH',
 }
 
-# TODO: use the same representation for metadata nodes as in the database
+# TODO: use the same representation for metadata nodes as in the database  # pylint: disable=fixme
 metadata_type_to_search_scope = {
     '': frozenset((REGULAR_TORRENT, CHANNEL_TORRENT, COLLECTION_NODE)),
     "channel": frozenset((CHANNEL_TORRENT, COLLECTION_NODE)),
@@ -44,8 +44,6 @@ class MetadataEndpointBase(RESTEndpoint):
             "category": parameters.get('category'),
             "exclude_deleted": bool(int(parameters.get('exclude_deleted', 0)) > 0),
         }
-        if 'remote_query' in parameters:
-            sanitized["remote_query"] = (bool(int(parameters.get('remote_query', 0)) > 0),)
         if 'metadata_type' in parameters:
             mtypes = []
             for arg in parameters.getall('metadata_type'):

--- a/src/tribler-core/tribler_core/modules/metadata_store/restapi/metadata_endpoint_base.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/restapi/metadata_endpoint_base.py
@@ -17,7 +17,7 @@ json2pony_columns = {
     'health': 'HEALTH',
 }
 
-# TODO: use the same representation for metadata nodes as in the database  # pylint: disable=fixme
+# TODO: use the same representation for metadata nodes as in the database
 metadata_type_to_search_scope = {
     '': frozenset((REGULAR_TORRENT, CHANNEL_TORRENT, COLLECTION_NODE)),
     "channel": frozenset((CHANNEL_TORRENT, COLLECTION_NODE)),

--- a/src/tribler-core/tribler_core/modules/metadata_store/restapi/search_endpoint.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/restapi/search_endpoint.py
@@ -27,6 +27,13 @@ class SearchEndpoint(MetadataEndpointBase):
     def get_uuid(parameters):
         return parameters['uuid'] if 'uuid' in parameters else None
 
+    @classmethod
+    def sanitize_parameters(cls, parameters):
+        sanitized = super().sanitize_parameters(parameters)
+        if "max_rowid" in parameters:
+            sanitized["max_rowid"] = int(parameters["max_rowid"])
+        return sanitized
+
     @docs(
         tags=['Metadata'],
         summary="Perform a search for a given query.",
@@ -72,17 +79,21 @@ class SearchEndpoint(MetadataEndpointBase):
         include_total = request.query.get('include_total', '')
 
         def search_db():
-            with db_session:
-                pony_query = self.session.mds.get_entries(**sanitized)
-                total = self.session.mds.get_total_count(**sanitized) if include_total else None
-                search_results = [r.to_simple_dict() for r in pony_query]
-            self.session.mds._db.disconnect()  # DB must be disconnected explicitly if run on a thread
-            return search_results, total
+            try:
+                with db_session:
+                    pony_query = self.session.mds.get_entries(**sanitized)
+                    total = self.session.mds.get_total_count(**sanitized) if include_total else None
+                    max_rowid = self.session.mds.get_max_rowid() if include_total else None
+                    search_results = [r.to_simple_dict() for r in pony_query]
+            finally:
+                # DB must be disconnected explicitly if run on a thread
+                self.session.mds._db.disconnect()  # pylint: disable=protected-access
+            return search_results, total, max_rowid
 
         try:
-            search_results, total = await asyncio.get_event_loop().run_in_executor(None, search_db)
-        except Exception as e:
-            self._logger.error("Error while performing DB search: %s", e)
+            search_results, total, max_rowid = await asyncio.get_event_loop().run_in_executor(None, search_db)
+        except Exception as e:  # pylint: disable=broad-except;  # pragma: no cover
+            self._logger.error("Error while performing DB search: %s: %s", type(e).__name__, e)
             return RESTResponse(status=HTTP_BAD_REQUEST)
 
         response_dict = {
@@ -94,6 +105,8 @@ class SearchEndpoint(MetadataEndpointBase):
         }
         if total is not None:
             response_dict.update({"total": total})
+            if max_rowid is not None:
+                response_dict["max_rowid"] = max_rowid
 
         return RESTResponse(response_dict)
 
@@ -118,6 +131,6 @@ class SearchEndpoint(MetadataEndpointBase):
             return RESTResponse({"error": "query parameter missing"}, status=HTTP_BAD_REQUEST)
 
         keywords = args['q'].strip().lower()
-        # TODO: add XXX filtering for completion terms
+        # TODO: add XXX filtering for completion terms  # pylint: disable=fixme
         results = self.session.mds.get_auto_complete_terms(keywords, max_terms=5)
         return RESTResponse({"completions": results})

--- a/src/tribler-core/tribler_core/modules/metadata_store/restapi/search_endpoint.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/restapi/search_endpoint.py
@@ -131,6 +131,6 @@ class SearchEndpoint(MetadataEndpointBase):
             return RESTResponse({"error": "query parameter missing"}, status=HTTP_BAD_REQUEST)
 
         keywords = args['q'].strip().lower()
-        # TODO: add XXX filtering for completion terms  # pylint: disable=fixme
+        # TODO: add XXX filtering for completion terms
         results = self.session.mds.get_auto_complete_terms(keywords, max_terms=5)
         return RESTResponse({"completions": results})

--- a/src/tribler-core/tribler_core/modules/metadata_store/restapi/tests/test_search_endpoint.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/restapi/tests/test_search_endpoint.py
@@ -39,9 +39,20 @@ async def test_search(enable_chant, enable_api, session):
 
     parsed = await do_request(session, 'search?txt_filter=needle', expected_code=200)
     assert len(parsed["results"]) == 1
+    assert "max_rowid" not in parsed
+
+    parsed = await do_request(session, 'search?txt_filter=needle&include_total=1', expected_code=200)
+    assert len(parsed["results"]) == 1
+    assert parsed["max_rowid"] == 103
 
     parsed = await do_request(session, 'search?txt_filter=hay', expected_code=200)
     assert len(parsed["results"]) == 50
+
+    parsed = await do_request(session, 'search?txt_filter=hay&max_rowid=0', expected_code=200)
+    assert len(parsed["results"]) == 0
+
+    parsed = await do_request(session, 'search?txt_filter=hay&max_rowid=20', expected_code=200)
+    assert len(parsed["results"]) == 19
 
     parsed = await do_request(session, 'search?txt_filter=test&type=channel', expected_code=200)
     assert len(parsed["results"]) == 1
@@ -50,6 +61,12 @@ async def test_search(enable_chant, enable_api, session):
     assert parsed["results"][0]['name'] == 'needle'
 
     parsed = await do_request(session, 'search?txt_filter=needle&sort_by=name', expected_code=200)
+    assert len(parsed["results"]) == 1
+
+    parsed = await do_request(session, 'search?txt_filter=needle&sort_by=name&max_rowid=20',  expected_code=200)
+    assert len(parsed["results"]) == 0
+
+    parsed = await do_request(session, 'search?txt_filter=needle&sort_by=name&max_rowid=200', expected_code=200)
     assert len(parsed["results"]) == 1
 
     parsed = await do_request(session, 'search?txt_filter=needle%2A&sort_by=name&sort_desc=1', expected_code=200)

--- a/src/tribler-gui/tribler_gui/widgets/triblertablecontrollers.py
+++ b/src/tribler-gui/tribler_gui/widgets/triblertablecontrollers.py
@@ -68,6 +68,7 @@ class TriblerTableViewController(QObject):
         if (
             self.table_view.verticalScrollBar().value() == self.table_view.verticalScrollBar().maximum()
             and self.model.data_items
+            and not self.model.all_local_entries_loaded
         ):  # workaround for duplicate calls to _on_list_scroll on view creation
             self.model.perform_query()
 


### PR DESCRIPTION
This PR places healthy torrents on top of the search result list. Previously, remote results with unknown health were constantly adding to the top of the search result list, obstructing the view and making it harder to see healthy torrents.

Currently, only local results contain health information. After #6053 become merged, it would be possible to add remote results with good health at the top of the search result list as well.