### PR TITLE
Show GUI settings in Debug Panel

### DIFF
--- a/src/tribler-gui/tribler_gui/debug_window.py
+++ b/src/tribler-gui/tribler_gui/debug_window.py
@@ -3,6 +3,7 @@ import logging
 import os
 import socket
 import sys
+from binascii import unhexlify
 from time import localtime, strftime, time
 from typing import Dict
 
@@ -59,7 +60,7 @@ class DebugWindow(QMainWindow):
 
     resize_event = pyqtSignal()
 
-    def __init__(self, settings, tribler_version):
+    def __init__(self, settings, gui_settings, tribler_version):
         self._logger = logging.getLogger(self.__class__.__name__)
         QMainWindow.__init__(self)
 
@@ -132,6 +133,9 @@ class DebugWindow(QMainWindow):
         # GUI resource monitor
         self.resource_monitor = GuiResourceMonitor()
         self.resource_monitor.start()
+
+        # QT settings
+        self.gui_settings = gui_settings
 
     def hideEvent(self, hide_event):
         self.stop_timer()
@@ -282,6 +286,38 @@ class DebugWindow(QMainWindow):
         self.create_and_add_widget_item(
             "Free disk space", format_size(disk_usage.free), self.window().general_tree_widget
         )
+
+        # Show GUI settings
+        self.show_gui_settings()
+
+    def show_gui_settings(self):
+        # Empty line at the beginning
+        self.create_and_add_widget_item("", "", self.window().general_tree_widget)
+        # Heading: GUI Settings
+        self.create_and_add_widget_item("GUI Settings:", "", self.window().general_tree_widget)
+        # Location of the settings file
+        self.create_and_add_widget_item(
+            "Qt file", self.gui_settings.fileName(), self.window().general_tree_widget
+        )
+
+        selected_settings = {"api_key": lambda val: val.decode('utf-8'),
+                             "api_port": lambda val: val,
+                             "pos": lambda val: f"(x : {val.x()} px,  y : {val.y()} px)",
+                             "size": lambda val: f"(width : {val.width()} px,  height : {val.height()} px)",
+                             "ask_download_settings": lambda val: val,
+                             "autocommit_enabled": lambda val: val,
+                             "debug": lambda val: val,
+                             "family_filter": lambda val: val,
+                             "first_discover": lambda val: val,
+                             "use_monochrome_icon": lambda val: val,
+                             "recent_download_locations": lambda val: [unhexlify(url).decode('utf-8')
+                                                                       for url in val.split(",")]}
+
+        # List only selected gui settings
+        for key in self.gui_settings.allKeys():
+            if key in selected_settings:
+                value = selected_settings[key](self.gui_settings.value(key, 'N/A'))
+                self.create_and_add_widget_item(key, value, self.window().general_tree_widget)
 
     def load_requests_tab(self):
         self.window().requests_tree_widget.clear()

--- a/src/tribler-gui/tribler_gui/tribler_window.py
+++ b/src/tribler-gui/tribler_gui/tribler_window.py
@@ -995,7 +995,7 @@ class TriblerWindow(QMainWindow):
 
     def clicked_menu_button_debug(self, index=False):
         if not self.debug_window:
-            self.debug_window = DebugWindow(self.tribler_settings, self.tribler_version)
+            self.debug_window = DebugWindow(self.tribler_settings, self.gui_settings, self.tribler_version)
         self.debug_window.show()
 
     def resizeEvent(self, _):


### PR DESCRIPTION
With this PR the Debug Pane -> General tab now shows information about the GUI Qt settings.

MacOS
<img width="1012" alt="Screenshot 2021-04-14 at 15 18 23" src="https://user-images.githubusercontent.com/1442867/114717572-7499dc00-9d35-11eb-9d8b-a545d0672a4f.png">

Windows
<img width="1014" alt="Screenshot 2021-04-14 at 15 56 28" src="https://user-images.githubusercontent.com/1442867/114722420-158a9600-9d3a-11eb-954a-a64b735c7a97.png">

Linux
<img width="601" alt="Screenshot 2021-04-14 at 15 58 50" src="https://user-images.githubusercontent.com/1442867/114722825-6a2e1100-9d3a-11eb-9a13-10c8cd6b956e.png">
