### PR TITLE
Add second pass of scrubbing

### DIFF
--- a/src/tribler-common/tribler_common/sentry_reporter/sentry_scrubber.py
+++ b/src/tribler-common/tribler_common/sentry_reporter/sentry_scrubber.py
@@ -91,19 +91,13 @@ class SentryScrubber:
         modify_value(event, RELEASE, format_version)
 
         # remove sensitive information
-        modify_value(event, EXTRA, self.scrub_entity_recursively)
-        modify_value(event, LOGENTRY, self.scrub_entity_recursively)
-        modify_value(event, BREADCRUMBS, self.scrub_entity_recursively)
+        scrubbed_event = self.scrub_entity_recursively(event)
 
-        reporter = event.get(CONTEXTS, {}).get(REPORTER, None)
-        if not reporter:
-            return event
+        # this second call is necessary for complete the entities scrubbing
+        # which were found at the end of the previous call
+        scrubbed_event = self.scrub_entity_recursively(scrubbed_event)
 
-        modify_value(reporter, OS_ENVIRON, self.scrub_entity_recursively)
-        modify_value(reporter, STACKTRACE, self.scrub_entity_recursively)
-        modify_value(reporter, SYSINFO, self.scrub_entity_recursively)
-
-        return event
+        return scrubbed_event
 
     def scrub_text(self, text):
         """Replace all sensitive information from `text` by corresponding

--- a/src/tribler-common/tribler_common/sentry_reporter/tests/test_sentry_scrubber.py
+++ b/src/tribler-common/tribler_common/sentry_reporter/tests/test_sentry_scrubber.py
@@ -137,6 +137,7 @@ def test_scrub_simple_event(scrubber):
 
 def test_scrub_event(scrubber):
     event = {
+        'the very first item': 'username',
         CONTEXTS: {
             REPORTER: {
                 OS_ENVIRON: {
@@ -164,6 +165,7 @@ def test_scrub_event(scrubber):
     }
 
     assert scrubber.scrub_event(event) == {
+        'the very first item': scrubber.placeholder_user,
         CONTEXTS: {
             REPORTER: {
                 OS_ENVIRON: {


### PR DESCRIPTION
This PR should improve scrubbing of sensitive information by adding a second pass of scrubbing.

It needs in rare cases, where sensitive information is unexpectedly formatted and located in the first parts of the event.

See the test as an example: https://github.com/Tribler/tribler/pull/6060/files#diff-26702280a5708819383ad8010a8557895b16c41a59a3f31add3451aa0b3d90dfR140
