### PR TITLE
READY: Add search loading page

### DIFF
--- a/src/tribler-core/tribler_core/modules/metadata_store/restapi/remote_query_endpoint.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/restapi/remote_query_endpoint.py
@@ -52,8 +52,10 @@ class RemoteQueryEndpoint(MetadataEndpointBase):
         except (ValueError, KeyError) as e:
             return RESTResponse({"error": f"Error processing request parameters: {e}"}, status=HTTP_BAD_REQUEST)
 
-        request_uuid = self.session.gigachannel_community.send_search_request(**sanitized)
-        return RESTResponse({"request_uuid": str(request_uuid)})
+        request_uuid, peers_list = self.session.gigachannel_community.send_search_request(**sanitized)
+        peers_mid_list = [hexlify(p.mid) for p in peers_list]
+
+        return RESTResponse({"request_uuid": str(request_uuid), "peers": peers_mid_list})
 
     async def get_channels_peers(self, _):
         # Get debug stats for peers serving channels

--- a/src/tribler-core/tribler_core/modules/metadata_store/restapi/tests/test_remote_query_endpoint.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/restapi/tests/test_remote_query_endpoint.py
@@ -22,11 +22,12 @@ async def test_create_remote_search_request(enable_chant, enable_api, session):
     Test that remote search call is sent on a REST API search request
     """
     sent = {}
+    peers = []
     request_uuid = uuid.uuid4()
 
     def mock_send(**kwargs):
         sent.update(kwargs)
-        return request_uuid
+        return request_uuid, peers
 
     # Test querying for keywords
     session.gigachannel_community = Mock()
@@ -37,7 +38,7 @@ async def test_create_remote_search_request(enable_chant, enable_api, session):
         f'remote_query?txt_filter={search_txt}',
         request_type="PUT",
         expected_code=200,
-        expected_json={"request_uuid": str(request_uuid)},
+        expected_json={"request_uuid": str(request_uuid), "peers": peers},
     )
     assert sent['txt_filter'] == search_txt
     sent.clear()

--- a/src/tribler-gui/tribler_gui/qt_resources/mainwindow.ui
+++ b/src/tribler-gui/tribler_gui/qt_resources/mainwindow.ui
@@ -960,6 +960,19 @@ QPushButton::menu-indicator{width:0px;}</string>
           </spacer>
          </item>
          <item>
+          <spacer name="horizontalSpacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
           <layout class="QVBoxLayout" name="verticalLayout_5">
            <item>
             <widget class="ChannelsMenuListWidget" name="channels_menu_list">
@@ -1051,7 +1064,7 @@ QListWidget::item:disabled
         <property name="currentIndex">
          <number>1</number>
         </property>
-        <widget class="ChannelContentsWidget" name="search_results_page"/>
+        <widget class="SearchResultsWidget" name="search_results_page"/>
         <widget class="SettingsPage" name="settings_page">
          <layout class="QVBoxLayout" name="verticalLayout">
           <property name="spacing">
@@ -5742,6 +5755,11 @@ margin: 10px 4px 2px 10px;</string>
    <extends>QListWidget</extends>
    <header>tribler_gui.widgets.channelsmenulistwidget.h</header>
   </customwidget>
+  <customwidget>
+   <class>SearchResultsWidget</class>
+   <extends>QWidget</extends>
+   <header>tribler_gui.widgets.searchresultswidget.h</header>
+  </customwidget>
  </customwidgets>
  <resources/>
  <connections>
@@ -5750,22 +5768,6 @@ margin: 10px 4px 2px 10px;</string>
    <signal>textChanged(QString)</signal>
    <receiver>MainWindow</receiver>
    <slot>on_search_text_change()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>308</x>
-     <y>24</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>427</x>
-     <y>317</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>top_search_bar</sender>
-   <signal>returnPressed()</signal>
-   <receiver>MainWindow</receiver>
-   <slot>on_top_search_button_click()</slot>
    <hints>
     <hint type="sourcelabel">
      <x>308</x>

--- a/src/tribler-gui/tribler_gui/qt_resources/search_results.ui
+++ b/src/tribler-gui/tribler_gui/qt_resources/search_results.ui
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>search_stacked_widget</class>
+ <widget class="QStackedWidget" name="search_stacked_widget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>657</width>
+    <height>513</height>
+   </rect>
+  </property>
+  <property name="currentIndex">
+   <number>0</number>
+  </property>
+  <widget class="QWidget" name="loading_page">
+   <layout class="QVBoxLayout" name="verticalLayout">
+    <item>
+     <widget class="TimeoutProgressBar" name="timeout_progress_bar">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>16777215</width>
+        <height>10</height>
+       </size>
+      </property>
+      <property name="value">
+       <number>0</number>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+      </property>
+      <property name="format">
+       <string notr="true"/>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QLabel" name="state_label">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>0</width>
+        <height>60</height>
+       </size>
+      </property>
+      <property name="text">
+       <string>TextLabel</string>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <layout class="QHBoxLayout" name="horizontalLayout_5">
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="EllipseButton" name="show_results_button">
+        <property name="minimumSize">
+         <size>
+          <width>100</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Show now</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </item>
+    <item>
+     <spacer name="verticalSpacer_7">
+      <property name="orientation">
+       <enum>Qt::Vertical</enum>
+      </property>
+      <property name="sizeHint" stdset="0">
+       <size>
+        <width>20</width>
+        <height>40</height>
+       </size>
+      </property>
+     </spacer>
+    </item>
+   </layout>
+  </widget>
+  <widget class="ChannelContentsWidget" name="results_page"/>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>EllipseButton</class>
+   <extends>QToolButton</extends>
+   <header>tribler_gui.widgets.ellipsebutton.h</header>
+  </customwidget>
+  <customwidget>
+   <class>ChannelContentsWidget</class>
+   <extends>QWidget</extends>
+   <header>tribler_gui.widgets.channelcontentswidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>TimeoutProgressBar</class>
+   <extends>QProgressBar</extends>
+   <header>tribler_gui.widgets.timeoutprogressbar.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/tribler-gui/tribler_gui/tests/test_gui.py
+++ b/src/tribler-gui/tribler_gui/tests/test_gui.py
@@ -358,8 +358,16 @@ def test_search_suggestions(tribler_api, window):
 def test_search(tribler_api, window):
     window.top_search_bar.setText("trib")
     QTest.keyClick(window.top_search_bar, Qt.Key_Enter)
+    wait_for_variable(window, "search_results_page.search_request")
+    screenshot(window, name="search_loading_page")
+    QTest.mouseClick(window.search_results_page.show_results_button, Qt.LeftButton)
     tst_channels_widget(
-        window, window.search_results_page, "search_results", sort_column=2, test_filter=False, test_subscribe=False
+        window,
+        window.search_results_page.results_page,
+        "search_results",
+        sort_column=2,
+        test_filter=False,
+        test_subscribe=False,
     )
 
 

--- a/src/tribler-gui/tribler_gui/utilities.py
+++ b/src/tribler-gui/tribler_gui/utilities.py
@@ -443,10 +443,6 @@ def dict_item_is_any_of(d, key, values):
     return key in d and d[key] in values
 
 
-def translate(context, key):
-    return f'{QCoreApplication.translate(context, key)}'
-
-
 def get_translator(language=None):
     system_locale = QLocale.system()
     # Remapping the language from uiLanguages is a workaround for an annoying bug in Qt,

--- a/src/tribler-gui/tribler_gui/widgets/searchresultswidget.py
+++ b/src/tribler-gui/tribler_gui/widgets/searchresultswidget.py
@@ -1,0 +1,125 @@
+import logging
+import time
+import uuid
+from dataclasses import dataclass, field
+
+from PyQt5 import uic
+from PyQt5.QtCore import pyqtSignal
+
+from tribler_common.sentry_reporter.sentry_mixin import AddBreadcrumbOnShowMixin
+
+from tribler_core.modules.metadata_store.serialization import CHANNEL_TORRENT, COLLECTION_NODE, REGULAR_TORRENT
+
+from tribler_gui.tribler_request_manager import TriblerNetworkRequest
+from tribler_gui.utilities import connect, get_ui_file_path, tr
+from tribler_gui.widgets.tablecontentmodel import SearchResultsModel
+from tribler_gui.widgets.triblertablecontrollers import to_fts_query
+
+widget_form, widget_class = uic.loadUiType(get_ui_file_path('search_results.ui'))
+
+
+def format_search_loading_label(search_request):
+    total_peers = len(search_request.peers)
+    num_complete_peers = len(search_request.peers_complete)
+    num_remote_results = len(search_request.remote_results)
+
+    return (
+        f"Remote responses: {num_complete_peers} / {total_peers}"
+        + f"\nNew remote results received: {num_remote_results}"
+    )
+
+
+@dataclass
+class SearchRequest:
+    uuid: uuid
+    query: str
+    peers: set
+    peers_complete: set = field(default_factory=set)
+    remote_results: list = field(default_factory=list)
+
+    @property
+    def complete(self):
+        return self.peers == self.peers_complete
+
+
+class SearchResultsWidget(AddBreadcrumbOnShowMixin, widget_form, widget_class):
+    received_remote_results = pyqtSignal(object)
+
+    def __init__(self, parent=None):
+        widget_class.__init__(self, parent=parent)
+
+        try:
+            self.setupUi(self)
+        except SystemError:
+            pass
+
+        self.last_search_time = None
+        self.last_search_query = None
+        self.hide_xxx = None
+        self.search_request = None
+
+    def initialize(self, hide_xxx=False):
+        self.hide_xxx = hide_xxx
+        self.results_page.initialize_content_page(hide_xxx=hide_xxx)
+        self.results_page.channel_torrents_filter_input.setHidden(True)
+        connect(self.received_remote_results, self.update_loading_page)
+        connect(self.timeout_progress_bar.timeout, self.show_results)
+        connect(self.show_results_button.clicked, self.show_results)
+
+    @property
+    def has_results(self):
+        return self.last_search_query is not None
+
+    def show_results(self, *_):
+        self.timeout_progress_bar.stop()
+        query = self.search_request.query
+        self.results_page.initialize_root_model(
+            SearchResultsModel(
+                channel_info={"name": (tr("Search results for %s") % query) if len(query) < 50 else f"{query[:50]}..."},
+                endpoint_url="search",
+                hide_xxx=self.results_page.hide_xxx,
+                text_filter=to_fts_query(query),
+                type_filter=[REGULAR_TORRENT, CHANNEL_TORRENT, COLLECTION_NODE],
+            )
+        )
+        self.setCurrentWidget(self.results_page)
+
+    def check_can_show(self, query):
+        if (
+            self.last_search_query == query
+            and self.last_search_time is not None
+            and time.time() - self.last_search_time < 1
+        ):
+            logging.info("Same search query already sent within 500ms so dropping this one")
+            return False
+        return True
+
+    def search(self, query):
+        if not self.check_can_show(query):
+            return
+
+        self.last_search_query = query
+        self.last_search_time = time.time()
+
+        # Trigger remote search
+        def register_request(response):
+            self.search_request = SearchRequest(response["request_uuid"], query, set(response["peers"]))
+            self.state_label.setText(format_search_loading_label(self.search_request))
+            self.timeout_progress_bar.start()
+            self.setCurrentWidget(self.loading_page)
+
+        params = {'txt_filter': to_fts_query(query), 'hide_xxx': self.hide_xxx}
+
+        TriblerNetworkRequest('remote_query', register_request, method="PUT", url_params=params)
+
+    def reset(self):
+        if self.currentWidget() == self.results_page:
+            self.results_page.go_back_to_level(0)
+
+    def update_loading_page(self, remote_results):
+        peer = remote_results["peer"]
+        self.search_request.peers_complete.add(peer)
+        self.search_request.remote_results.append(remote_results.get("results", []))
+        self.state_label.setText(format_search_loading_label(self.search_request))
+        if self.search_request.complete:
+            self.show_results()

--- a/src/tribler-gui/tribler_gui/widgets/settingspage.py
+++ b/src/tribler-gui/tribler_gui/widgets/settingspage.py
@@ -72,7 +72,6 @@ class SettingsPage(AddBreadcrumbOnShowMixin, QWidget):
                     self.window().language_selector.setCurrentIndex(self.lang_list.index(lang_name))
                     break
 
-        # connect(self.window().language_selector.currentIndexChanged, self.on_language_selector_changed)
         self.update_stacked_widget_height()
 
     def on_channel_autocommit_checkbox_changed(self, _):

--- a/src/tribler-gui/tribler_gui/widgets/timeoutprogressbar.py
+++ b/src/tribler-gui/tribler_gui/widgets/timeoutprogressbar.py
@@ -1,0 +1,33 @@
+from PyQt5.QtCore import QTimer, pyqtSignal
+from PyQt5.QtWidgets import QProgressBar
+
+from tribler_gui.utilities import connect
+
+
+class TimeoutProgressBar(QProgressBar):
+
+    timeout = pyqtSignal()
+
+    def __init__(self, parent=None, timeout=10000):
+        super().__init__(parent)
+        self.timeout_interval = timeout
+        self.timer = QTimer()
+        self.timer.setSingleShot(False)
+        self.timer.setInterval(100)  # update the progress bar tick
+
+        connect(self.timer.timeout, self._update)
+        self.setMaximum(self.timeout_interval)
+
+    def _update(self):
+        self.setValue(self.value() + self.timer.interval())
+        if self.value() >= self.maximum():
+            self.timer.stop()
+            self.timeout.emit()
+
+    def start(self):
+        self.setValue(0)
+        self.timer.start()
+
+    def stop(self):
+        self.setValue(0)
+        self.timer.stop()


### PR DESCRIPTION
This PR adds an intermediary "Waiting for remote search results" page.
![image](https://user-images.githubusercontent.com/2509103/116784570-40445080-aa95-11eb-886d-19162f1c3565.png)


After the user starts a remote search, "Search Loading" Page is shown now. The page contains the number of remote responses/request, the timeout progress bar and "Show now" button.
The regular Channels-based search results page is shown when at least one of the following events happen:
1. Tribler receives all (5 out of 5) remote responses
2. The timeout progress bar runs to 100% (30 seconds)
3. The user clicks the "Show now" button.

The Loading page is a separate widget now, so it will be easy to change it in the future by e.g. adding dynamic search criteria, etc.