### PR TITLE
READY: Add GUI options to minimize to tray

### DIFF
--- a/src/tribler-gui/tribler_gui/defs.py
+++ b/src/tribler-gui/tribler_gui/defs.py
@@ -1,6 +1,7 @@
 """
 This file contains various definitions used by the Tribler GUI.
 """
+import sys
 from collections import namedtuple
 
 DEFAULT_API_PROTOCOL = "http"
@@ -222,3 +223,6 @@ MB = 1024 * KB
 GB = 1024 * MB
 TB = 1024 * GB
 PB = 1024 * TB
+
+DARWIN = sys.platform == 'darwin'
+WINDOWS = sys.platform == 'win32'

--- a/src/tribler-gui/tribler_gui/dialogs/startdownloaddialog.py
+++ b/src/tribler-gui/tribler_gui/dialogs/startdownloaddialog.py
@@ -16,7 +16,6 @@ from tribler_gui.tribler_request_manager import TriblerNetworkRequest
 from tribler_gui.utilities import (
     connect,
     format_size,
-    get_checkbox_style,
     get_gui_setting,
     get_image_path,
     get_ui_file_path,
@@ -86,15 +85,6 @@ class StartDownloadDialog(DialogContainer):
         """
             % get_image_path('down_arrow_input.png')
         )
-
-        # self.dialog_widget.add_to_channel_checkbox.setStyleSheet(get_checkbox_style())
-        checkbox_style = get_checkbox_style()
-        for checkbox in [
-            self.dialog_widget.add_to_channel_checkbox,
-            self.dialog_widget.safe_seed_checkbox,
-            self.dialog_widget.anon_download_checkbox,
-        ]:
-            checkbox.setStyleSheet(checkbox_style)
 
         if self.window().tribler_settings:
             # Set the most recent download locations in the QComboBox

--- a/src/tribler-gui/tribler_gui/qt_resources/mainwindow.ui
+++ b/src/tribler-gui/tribler_gui/qt_resources/mainwindow.ui
@@ -99,7 +99,10 @@ qproperty-defaultAlignment: AlignLeft;
 }
 QListView {
 color:#B5B5B5;
-}</string>
+}
+
+QCheckBox { color:#B5B5B5; }
+QCheckBox::indicator:unchecked {border: 1px solid #555;}</string>
   </property>
   <widget class="QWidget" name="central_widget">
    <property name="styleSheet">

--- a/src/tribler-gui/tribler_gui/qt_resources/mainwindow.ui
+++ b/src/tribler-gui/tribler_gui/qt_resources/mainwindow.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>1058</width>
-    <height>882</height>
+    <height>867</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -1482,7 +1482,7 @@ border-top: 1px solid #555;
                <x>0</x>
                <y>0</y>
                <width>854</width>
-               <height>712</height>
+               <height>697</height>
               </rect>
              </property>
              <layout class="QVBoxLayout" name="verticalLayout_22">
@@ -1908,28 +1908,28 @@ color: white;</string>
 color: white;</string>
                     </property>
                     <property name="text">
-                     <string>Monochrome tray icon</string>
+                     <string>Tray Icon</string>
                     </property>
                    </widget>
                   </item>
-                  <item row="13" column="0">
+                  <item row="14" column="0">
                    <widget class="QLabel" name="label_32">
                     <property name="text">
                      <string>Use monochrome icon?</string>
                     </property>
                    </widget>
                   </item>
-                  <item row="13" column="1">
+                  <item row="14" column="1">
                    <widget class="QCheckBox" name="use_monochrome_icon_checkbox">
                     <property name="styleSheet">
                      <string notr="true">margin-top: 2px;</string>
                     </property>
                     <property name="text">
-                     <string/>
+                     <string notr="true"/>
                     </property>
                    </widget>
                   </item>
-                  <item row="14" column="0">
+                  <item row="15" column="0">
                    <widget class="QLabel" name="label_42">
                     <property name="styleSheet">
                      <string notr="true">font-weight: bold;
@@ -1940,7 +1940,7 @@ color: white;</string>
                     </property>
                    </widget>
                   </item>
-                  <item row="15" column="0">
+                  <item row="16" column="0">
                    <widget class="QLabel" name="label_43">
                     <property name="text">
                      <string>Commit changes automatically
@@ -1948,10 +1948,27 @@ color: white;</string>
                     </property>
                    </widget>
                   </item>
-                  <item row="15" column="1">
+                  <item row="16" column="1">
                    <widget class="QCheckBox" name="channel_autocommit_checkbox">
                     <property name="text">
                      <string/>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="13" column="0">
+                   <widget class="QLabel" name="label_3">
+                    <property name="text">
+                     <string>Minimize to system tray?</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="13" column="1">
+                   <widget class="QCheckBox" name="minimize_to_tray_checkbox">
+                    <property name="styleSheet">
+                     <string notr="true">margin-top: 2px;</string>
+                    </property>
+                    <property name="text">
+                     <string notr="true"/>
                     </property>
                    </widget>
                   </item>
@@ -3980,8 +3997,8 @@ color: white</string>
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>856</width>
-                       <height>388</height>
+                       <width>321</width>
+                       <height>259</height>
                       </rect>
                      </property>
                      <layout class="QFormLayout" name="formLayout_4">

--- a/src/tribler-gui/tribler_gui/utilities.py
+++ b/src/tribler-gui/tribler_gui/utilities.py
@@ -306,15 +306,6 @@ def html_label(text, background="#e4e4e4", color="#222222", bold=True):
     return f"<label style='{style}'>&nbsp;{text}&nbsp;</label>"
 
 
-def get_checkbox_style(color="#B5B5B5"):
-    return (
-        """QCheckBox { color: %s; }
-                QCheckBox::indicator:unchecked {border: 1px solid #555;}
-                """
-        % color
-    )
-
-
 def votes_count(votes=0.0):
     votes = float(votes)
     # FIXME: this is a temp fix to cap the normalized value to 1.

--- a/src/tribler-gui/tribler_gui/widgets/settingspage.py
+++ b/src/tribler-gui/tribler_gui/widgets/settingspage.py
@@ -25,7 +25,6 @@ from tribler_gui.tribler_request_manager import TriblerNetworkRequest, TriblerRe
 from tribler_gui.utilities import (
     connect,
     format_size,
-    get_checkbox_style,
     get_gui_setting,
     is_dir_writable,
     seconds_to_hhmm_string,
@@ -63,25 +62,6 @@ class SettingsPage(AddBreadcrumbOnShowMixin, QWidget):
         connect(self.window().download_settings_anon_checkbox.stateChanged, self.on_anon_download_state_changed)
         connect(self.window().log_location_chooser_button.clicked, self.on_choose_log_dir_clicked)
         connect(self.window().btn_remove_old_state_dir.clicked, self.on_remove_version_dirs)
-
-        checkbox_style = get_checkbox_style()
-        for checkbox in [
-            self.window().family_filter_checkbox,
-            self.window().channel_autocommit_checkbox,
-            self.window().always_ask_location_checkbox,
-            self.window().developer_mode_enabled_checkbox,
-            self.window().use_monochrome_icon_checkbox,
-            self.window().download_settings_anon_checkbox,
-            self.window().download_settings_anon_seeding_checkbox,
-            self.window().lt_utp_checkbox,
-            self.window().watchfolder_enabled_checkbox,
-            self.window().allow_exit_node_checkbox,
-            self.window().developer_mode_enabled_checkbox,
-            self.window().checkbox_enable_network_statistics,
-            self.window().checkbox_enable_resource_log,
-            self.window().download_settings_add_to_channel_checkbox,
-        ]:
-            checkbox.setStyleSheet(checkbox_style)
 
         self.update_stacked_widget_height()
 

--- a/src/tribler-gui/tribler_gui/widgets/settingspage.py
+++ b/src/tribler-gui/tribler_gui/widgets/settingspage.py
@@ -9,6 +9,7 @@ from tribler_core.utilities.osutils import get_root_state_directory
 
 from tribler_gui.defs import (
     BUTTON_TYPE_NORMAL,
+    DARWIN,
     DEFAULT_API_PORT,
     PAGE_SETTINGS_ANONYMITY,
     PAGE_SETTINGS_BANDWIDTH,
@@ -44,6 +45,9 @@ class SettingsPage(AddBreadcrumbOnShowMixin, QWidget):
         self.version_history = VersionHistory(get_root_state_directory())
 
     def initialize_settings_page(self):
+        if DARWIN:
+            self.window().minimize_to_tray_checkbox.setHidden(True)
+            self.window().label_3.setHidden(True)
         self.window().settings_tab.initialize()
         connect(self.window().settings_tab.clicked_tab_button, self.clicked_tab_button)
         connect(self.window().settings_save_button.clicked, self.save_settings)
@@ -55,6 +59,7 @@ class SettingsPage(AddBreadcrumbOnShowMixin, QWidget):
         connect(self.window().family_filter_checkbox.stateChanged, self.on_family_filter_checkbox_changed)
         connect(self.window().developer_mode_enabled_checkbox.stateChanged, self.on_developer_mode_checkbox_changed)
         connect(self.window().use_monochrome_icon_checkbox.stateChanged, self.on_use_monochrome_icon_checkbox_changed)
+        connect(self.window().minimize_to_tray_checkbox.stateChanged, self.on_minimize_to_tray_changed)
         connect(self.window().download_settings_anon_checkbox.stateChanged, self.on_anon_download_state_changed)
         connect(self.window().log_location_chooser_button.clicked, self.on_choose_log_dir_clicked)
         connect(self.window().btn_remove_old_state_dir.clicked, self.on_remove_version_dirs)
@@ -94,6 +99,10 @@ class SettingsPage(AddBreadcrumbOnShowMixin, QWidget):
         use_monochrome_icon = self.window().use_monochrome_icon_checkbox.isChecked()
         self.window().gui_settings.setValue("use_monochrome_icon", use_monochrome_icon)
         self.window().update_tray_icon(use_monochrome_icon)
+
+    def on_minimize_to_tray_changed(self, _):
+        minimize_to_tray = self.window().minimize_to_tray_checkbox.isChecked()
+        self.window().gui_settings.setValue("minimize_to_tray", minimize_to_tray)
 
     def on_anon_download_state_changed(self, _):
         if self.window().download_settings_anon_checkbox.isChecked():
@@ -157,6 +166,9 @@ class SettingsPage(AddBreadcrumbOnShowMixin, QWidget):
         )
         self.window().use_monochrome_icon_checkbox.setChecked(
             get_gui_setting(gui_settings, "use_monochrome_icon", False, is_bool=True)
+        )
+        self.window().minimize_to_tray_checkbox.setChecked(
+            get_gui_setting(gui_settings, "minimize_to_tray", False, is_bool=True)
         )
         self.window().download_location_input.setText(settings['download_defaults']['saveas'])
         self.window().always_ask_location_checkbox.setChecked(
@@ -539,6 +551,7 @@ class SettingsPage(AddBreadcrumbOnShowMixin, QWidget):
         self.window().gui_settings.setValue(
             "use_monochrome_icon", self.window().use_monochrome_icon_checkbox.isChecked()
         )
+        self.window().gui_settings.setValue("minimize_to_tray", self.window().minimize_to_tray_checkbox.isChecked())
 
         self.saved_dialog = ConfirmationDialog(
             TriblerRequestManager.window,

--- a/src/tribler-gui/tribler_gui/widgets/tablecontentdelegate.py
+++ b/src/tribler-gui/tribler_gui/widgets/tablecontentdelegate.py
@@ -1,4 +1,3 @@
-import sys
 from math import floor
 
 from PyQt5.QtCore import QEvent, QModelIndex, QObject, QRect, QRectF, QSize, Qt, pyqtSignal
@@ -15,12 +14,14 @@ from tribler_gui.defs import (
     COMMIT_STATUS_TODELETE,
     COMMIT_STATUS_UPDATED,
     ContentCategories,
+    DARWIN,
     HEALTH_CHECKING,
     HEALTH_DEAD,
     HEALTH_ERROR,
     HEALTH_GOOD,
     HEALTH_MOOT,
     HEALTH_UNCHECKED,
+    WINDOWS,
 )
 from tribler_gui.utilities import format_votes, get_health, get_image_path
 from tribler_gui.widgets.tablecontentmodel import Column
@@ -32,9 +33,6 @@ TRIBLER_NEUTRAL = QColor("#B5B5B5")
 TRIBLER_ORANGE = QColor("#e67300")
 TRIBLER_PALETTE = QPalette()
 TRIBLER_PALETTE.setColor(QPalette.Highlight, TRIBLER_ORANGE)
-
-DARWIN = sys.platform == 'darwin'
-WINDOWS = sys.platform == 'win32'
 
 
 def draw_text(


### PR DESCRIPTION
This adds an option in Settings to minimize Tribler GUI to system tray. Users asked for it repeatedly over the years:
fixes #3631
fixes #1054 

related to #5972 

recent [forum post](https://forum.tribler.org/t/minimize-to-system-tray/5047/7)


p.s.
for some reason the newly adde checkbox looks different than the older checkboxes. I looked basically everywhere, but AFAICT there is no difference in definition of the new and old checkboxes :face_with_head_bandage: 

@devos50 , @xoriole , maybe you guys know something about this checkbox mystery?

Also, dear Mac :apple: users, could you please test it out? I only tested it on Windows and on Linux, works as expected.

[Qt reference for TrayIcon](https://doc.qt.io/qt-5/qsystemtrayicon.html#details)


EDIT:
I guess it [makes not sense](https://stackoverflow.com/questions/44286102/minimize-to-tray-on-macosx) to talk about minimizing to tray on Mac.


EDIT:
Checkboxes mystery solved (after about an hour of experiments with .ui files)! The problem was that https://github.com/Tribler/tribler/commit/f5a8474a2de6d0ef54b36b9bd2c2803580a60f94 was setting checkboxes' style sheets _individually_ by a list of widgets.

Guys, please! There are three "don'ts" in QT design:
1. **Don't set CSS in the code**, set it in the widget `.ui`-file
2. **Don't set it on individual widgets**, set it on the highest parent widget, which is the main Tribler window in our case. CSS will do the rest
3.  Don't copy-paste the stylesheets, try to move as much stuff as possible to the highest possible parent widget and subclass the widgets in Qt Creator.