### PR TITLE
READY: Add live channel preview feature

### DIFF
--- a/src/tribler-core/tribler_core/modules/metadata_store/community/remote_query_community.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/community/remote_query_community.py
@@ -1,5 +1,6 @@
 import json
 import struct
+from asyncio import Future
 from binascii import unhexlify
 from dataclasses import dataclass
 
@@ -14,6 +15,7 @@ from tribler_core.modules.metadata_store.community.eva_protocol import EVAProtoc
 from tribler_core.modules.metadata_store.orm_bindings.channel_metadata import LZ4_EMPTY_ARCHIVE, entries_to_chunk
 from tribler_core.modules.metadata_store.serialization import CHANNEL_TORRENT, COLLECTION_NODE, REGULAR_TORRENT
 from tribler_core.modules.metadata_store.store import MetadataStore, ObjState
+from tribler_core.modules.metadata_store.utils import RequestTimeoutException
 from tribler_core.utilities.unicode import hexlify
 
 BINARY_FIELDS = ("infohash", "channel_pk")
@@ -37,6 +39,23 @@ def sanitize_query(query_dict, cap=100):
             sanitized_dict[field] = unhexlify(value)
 
     return sanitized_dict
+
+
+def convert_to_json(parameters):
+    sanitized = dict(parameters)
+    # Convert frozenset to string
+    if "metadata_type" in sanitized:
+        sanitized["metadata_type"] = [int(mt) for mt in sanitized["metadata_type"] if mt]
+
+    for field in BINARY_FIELDS:
+        value = parameters.get(field)
+        if value is not None:
+            sanitized[field] = hexlify(value)
+
+    if "origin_id" in parameters:
+        sanitized["origin_id"] = int(parameters["origin_id"])
+
+    return json.dumps(sanitized)
 
 
 @vp_compile
@@ -77,6 +96,17 @@ class SelectRequest(RandomNumberCache):
     def on_timeout(self):
         if self.timeout_callback is not None:
             self.timeout_callback(self)
+
+
+class EvaSelectRequest(SelectRequest):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # For EVA transfer it is meaningless to send more than one message
+        self.packets_limit = 1
+
+        self.processing_results = Future()
+        self.register_future(self.processing_results, on_timeout=RequestTimeoutException())
 
 
 class PushbackWindow(NumberCache):
@@ -144,7 +174,8 @@ class RemoteQueryCommunity(Community, EVAProtocolMixin):
         self.logger.warning(f"EVA transfer error: peer {hexlify(peer.mid)}, exception: {exception}")
 
     def send_remote_select(self, peer, processing_callback=None, force_eva_response=False, **kwargs):
-        request = SelectRequest(
+        request_class = EvaSelectRequest if force_eva_response else SelectRequest
+        request = request_class(
             self.request_cache,
             hexlify(peer.mid),
             kwargs,
@@ -155,11 +186,12 @@ class RemoteQueryCommunity(Community, EVAProtocolMixin):
         self.request_cache.add(request)
 
         self.logger.info(f"Select to {hexlify(peer.mid)} with ({kwargs})")
-        args = (request.number, json.dumps(kwargs).encode('utf8'))
+        args = (request.number, convert_to_json(kwargs).encode('utf8'))
         if force_eva_response:
             self.ez_send(peer, RemoteSelectPayloadEva(*args))
         else:
             self.ez_send(peer, RemoteSelectPayload(*args))
+        return request
 
     async def process_rpc_query(self, json_bytes: bytes):
         """
@@ -227,10 +259,6 @@ class RemoteQueryCommunity(Community, EVAProtocolMixin):
         if request is None:
             return
 
-        # Remember that at least a single packet was received was received from the queried peer.
-        if isinstance(request, SelectRequest):
-            request.peer_responded = True
-
         # Check for limit on the number of packets per request
         if request.packets_limit > 1:
             request.packets_limit -= 1
@@ -239,6 +267,9 @@ class RemoteQueryCommunity(Community, EVAProtocolMixin):
 
         processing_results = await self.mds.process_compressed_mdblob_threaded(response_payload.raw_blob)
         self.logger.info(f"Response result: {processing_results}")
+
+        if isinstance(request, EvaSelectRequest) and not request.processing_results.done():
+            request.processing_results.set_result(processing_results)
 
         # If we know about updated versions of the received stuff, push the updates back
         if isinstance(request, SelectRequest) and self.settings.push_updates_back_enabled:
@@ -256,7 +287,7 @@ class RemoteQueryCommunity(Community, EVAProtocolMixin):
                 ):
                     request_dict = {
                         "metadata_type": [COLLECTION_NODE, REGULAR_TORRENT],
-                        "channel_pk": hexlify(result.md_obj.public_key),
+                        "channel_pk": result.md_obj.public_key,
                         "origin_id": result.md_obj.id_,
                         "first": 0,
                         "last": self.settings.max_channel_query_back,
@@ -272,6 +303,10 @@ class RemoteQueryCommunity(Community, EVAProtocolMixin):
 
         if isinstance(request, SelectRequest) and request.processing_callback:
             request.processing_callback(request, processing_results)
+
+        # Remember that at least a single packet was received was received from the queried peer.
+        if isinstance(request, SelectRequest):
+            request.peer_responded = True
 
     def _on_query_timeout(self, request_cache):
         if not request_cache.peer_responded:

--- a/src/tribler-core/tribler_core/modules/metadata_store/community/tests/test_gigachannel_community.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/community/tests/test_gigachannel_community.py
@@ -16,16 +16,19 @@ from tribler_core.modules.metadata_store.community.gigachannel_community import 
     ChannelsPeersMapping,
     GigaChannelCommunity,
     MAGIC_GIGACHAN_VERSION_MARK,
+    NoChannelSourcesException,
 )
+from tribler_core.modules.metadata_store.community.remote_query_community import RequestTimeoutException
 from tribler_core.modules.metadata_store.store import MetadataStore
 from tribler_core.notifier import Notifier
 from tribler_core.utilities.path_util import Path
 from tribler_core.utilities.random_utils import random_infohash
-from tribler_core.utilities.unicode import hexlify
 
 EMPTY_BLOB = database_blob(b"")
 
 # pylint:disable=protected-access
+
+BASE_PATH = 'tribler_core.modules.metadata_store.community.remote_query_community'
 
 
 class TestGigaChannelUnits(TestBase):
@@ -53,6 +56,25 @@ class TestGigaChannelUnits(TestBase):
 
     def torrent_metadata(self, i):
         return self.nodes[i].overlay.mds.TorrentMetadata
+
+    def generate_torrents(self, overlay):
+        key = default_eccrypto.generate_key("curve25519")
+        channel_pk = key.pub().key_to_bin()[10:]
+        channel_id = 123
+        kwargs = {"channel_pk": channel_pk, "origin_id": channel_id}
+        with db_session:
+            for m in range(0, 50):
+                overlay.mds.TorrentMetadata(
+                    title=f"bla-{m}", origin_id=channel_id, infohash=random_infohash(), sign_with=key
+                )
+        return kwargs
+
+    def client_server_request_setup(self):
+        client = self.overlay(0)
+        server = self.overlay(2)
+        kwargs = self.generate_torrents(server)
+        client.get_known_subscribed_peers_for_node = lambda *_: [server.my_peer]
+        return client, server, kwargs
 
     async def test_gigachannel_search(self):
         """
@@ -233,7 +255,6 @@ class TestGigaChannelUnits(TestBase):
         assert len(mapping._peers_channels) == 0
         assert len(mapping._channels_dict) == 0
 
-    @pytest.mark.timeout(0)
     async def test_remote_search_mapped_peers(self):
         """
         Test using mapped peers for channel queries.
@@ -241,7 +262,7 @@ class TestGigaChannelUnits(TestBase):
         key = default_eccrypto.generate_key("curve25519")
         channel_pk = key.pub().key_to_bin()[10:]
         channel_id = 123
-        kwargs = {"channel_pk": f"{hexlify(channel_pk)}", "origin_id": channel_id}
+        kwargs = {"channel_pk": channel_pk, "origin_id": channel_id}
 
         await self.introduce_nodes()
 
@@ -259,24 +280,16 @@ class TestGigaChannelUnits(TestBase):
         # The peer must have queried at least one peer
         self.nodes[2].overlay.send_remote_select.assert_called()
 
-    @pytest.mark.timeout(5)
     async def test_drop_silent_peer_from_channels_map(self):
-
         # We do not want the query back mechanism to interfere with this test
         self.nodes[1].overlay.settings.max_channel_query_back = 0
-
         kwargs_dict = {"txt_filter": "ubuntu*"}
-
-        basic_path = 'tribler_core.modules.metadata_store.community'
-
-        with patch(
-            basic_path + '.remote_query_community.SelectRequest.timeout_delay', new_callable=PropertyMock
-        ) as delay_mock:
+        with patch(f'{BASE_PATH}.SelectRequest.timeout_delay', new_callable=PropertyMock) as delay_mock:
             # Change query timeout to a really low value
             delay_mock.return_value = 0.3
 
             # Stop peer 0 from responding
-            with patch(basic_path + '.remote_query_community.RemoteQueryCommunity._on_remote_select_basic'):
+            with patch(f'{BASE_PATH}.RemoteQueryCommunity._on_remote_select_basic'):
                 self.nodes[1].overlay.channels_peers.remove_peer = Mock()
                 self.nodes[1].overlay.send_remote_select(self.nodes[0].my_peer, **kwargs_dict)
 
@@ -289,3 +302,35 @@ class TestGigaChannelUnits(TestBase):
             self.nodes[1].overlay.send_remote_select(self.nodes[0].my_peer, **kwargs_dict)
             await self.deliver_messages(timeout=1)
             self.nodes[1].overlay.channels_peers.remove_peer.assert_not_called()
+
+    async def test_remote_select_channel_contents(self):
+        """
+        Test awaiting for response from remote peer
+        """
+        client, server, kwargs = self.client_server_request_setup()
+        with db_session:
+            results = [p.to_simple_dict() for p in server.mds.get_entries(**kwargs)]
+        assert results == await client.remote_select_channel_contents(**kwargs)
+        assert len(results) == 50
+
+    async def test_remote_select_channel_contents_empty(self):
+        """
+        Test awaiting for response from remote peer and getting empty results
+        """
+        client, _, kwargs = self.client_server_request_setup()
+        kwargs["origin_id"] = 333
+        assert [] == await client.remote_select_channel_contents(**kwargs)
+
+    async def test_remote_select_channel_timeout(self):
+        client, server, kwargs = self.client_server_request_setup()
+        server.send_db_results = Mock()
+        with patch(f'{BASE_PATH}.EvaSelectRequest.timeout_delay', new_callable=PropertyMock) as zz:
+            zz.return_value = 2.0
+            with pytest.raises(RequestTimeoutException):
+                await client.remote_select_channel_contents(**kwargs)
+
+    async def test_remote_select_channel_no_peers(self):
+        client, _, kwargs = self.client_server_request_setup()
+        client.get_known_subscribed_peers_for_node = lambda *_: []
+        with pytest.raises(NoChannelSourcesException):
+            await client.remote_select_channel_contents(**kwargs)

--- a/src/tribler-core/tribler_core/modules/metadata_store/community/tests/test_remote_query_community.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/community/tests/test_remote_query_community.py
@@ -207,7 +207,7 @@ class TestRemoteQueryCommunity(TestBase):
             processing_results.extend(results)
 
         self.nodes[1].overlay.send_remote_select(
-            peer, metadata_type=REGULAR_TORRENT, infohash=hexlify(torrent_infohash), processing_callback=callback
+            peer, metadata_type=[REGULAR_TORRENT], infohash=torrent_infohash, processing_callback=callback
         )
         await self.deliver_messages()
 
@@ -225,7 +225,7 @@ class TestRemoteQueryCommunity(TestBase):
 
         processing_results = []
         self.nodes[1].overlay.send_remote_select(
-            peer, metadata_type=REGULAR_TORRENT, infohash=hexlify(torrent_infohash), processing_callback=callback
+            peer, metadata_type=[REGULAR_TORRENT], infohash=torrent_infohash, processing_callback=callback
         )
         await self.deliver_messages()
 
@@ -293,7 +293,7 @@ class TestRemoteQueryCommunity(TestBase):
         await self.deliver_messages(timeout=0.1)
 
         # mixed: the old and a new attribute
-        rqc_node2.send_remote_select(rqc_node1.my_peer, **{'infohash': hexlify(b'0' * 20), 'foo': 'bar'})
+        rqc_node2.send_remote_select(rqc_node1.my_peer, **{'infohash': b'0' * 20, 'foo': 'bar'})
         await self.deliver_messages(timeout=0.1)
 
     async def test_process_rpc_query_match_many(self):

--- a/src/tribler-core/tribler_core/modules/metadata_store/restapi/metadata_endpoint_base.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/restapi/metadata_endpoint_base.py
@@ -44,6 +44,8 @@ class MetadataEndpointBase(RESTEndpoint):
             "category": parameters.get('category'),
             "exclude_deleted": bool(int(parameters.get('exclude_deleted', 0)) > 0),
         }
+        if "remote" in parameters:
+            sanitized["remote"] = (bool(int(parameters.get('remote', 0)) > 0),)
         if 'metadata_type' in parameters:
             mtypes = []
             for arg in parameters.getall('metadata_type'):

--- a/src/tribler-core/tribler_core/modules/metadata_store/restapi/remote_query_endpoint.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/restapi/remote_query_endpoint.py
@@ -1,4 +1,5 @@
 import time
+from binascii import unhexlify
 
 from aiohttp import web
 
@@ -28,11 +29,8 @@ class RemoteQueryEndpoint(MetadataEndpointBase):
     def sanitize_parameters(self, parameters):
         sanitized = super().sanitize_parameters(parameters)
 
-        # Convert frozenset to string
-        if "metadata_type" in sanitized:
-            sanitized["metadata_type"] = [str(mt) for mt in sanitized["metadata_type"] if mt]
         if "channel_pk" in parameters:
-            sanitized["channel_pk"] = parameters["channel_pk"]
+            sanitized["channel_pk"] = unhexlify(parameters["channel_pk"])
         if "origin_id" in parameters:
             sanitized["origin_id"] = int(parameters["origin_id"])
 

--- a/src/tribler-core/tribler_core/modules/metadata_store/restapi/tests/test_remote_query_endpoint.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/restapi/tests/test_remote_query_endpoint.py
@@ -48,7 +48,7 @@ async def test_create_remote_search_request(enable_chant, enable_api, session):
     await do_request(
         session, f'remote_query?channel_pk={channel_pk}&metadata_type=torrent', request_type="PUT", expected_code=200
     )
-    assert sent['channel_pk'] == channel_pk
+    assert hexlify(sent['channel_pk']) == channel_pk
 
 
 @pytest.mark.asyncio

--- a/src/tribler-core/tribler_core/modules/metadata_store/store.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/store.py
@@ -662,7 +662,7 @@ class MetadataStore:
                 ).first()
                 request_dict = {
                     "metadata_type": [dep_type],
-                    "channel_pk": hexlify(node.public_key),
+                    "channel_pk": node.public_key,
                     "origin_id": node.id_,
                     "first": 0,
                     "last": 1,

--- a/src/tribler-core/tribler_core/modules/metadata_store/utils.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/utils.py
@@ -6,6 +6,14 @@ from tribler_core.tests.tools.common import PNG_FILE
 from tribler_core.utilities.random_utils import random_infohash, random_utf8_string
 
 
+class RequestTimeoutException(Exception):
+    pass
+
+
+class NoChannelSourcesException(Exception):
+    pass
+
+
 @db_session
 def generate_torrent(metadata_store, parent):
     metadata_store.TorrentMetadata(title=random_utf8_string(50), infohash=random_infohash(), origin_id=parent.id_)

--- a/src/tribler-core/tribler_core/modules/popularity/popularity_community.py
+++ b/src/tribler-core/tribler_core/modules/popularity/popularity_community.py
@@ -103,7 +103,7 @@ class PopularityCommunity(RemoteQueryCommunity):
 
         for infohash in await self.mds.run_threaded(self.process_torrents_health, torrents):
             # Get a single result per infohash to avoid duplicates
-            self.send_remote_select(peer=peer, infohash=hexlify(infohash), last=1)
+            self.send_remote_select(peer=peer, infohash=infohash, last=1)
 
     @db_session
     def process_torrents_health(self, torrent_healths):

--- a/src/tribler-gui/tribler_gui/qt_resources/torrents_list.ui
+++ b/src/tribler-gui/tribler_gui/qt_resources/torrents_list.ui
@@ -244,60 +244,6 @@ color: #B5B5B5;</string>
        </widget>
       </item>
       <item>
-       <spacer name="horizontalSpacer_60">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeType">
-         <enum>QSizePolicy::Fixed</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>10</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="QToolButton" name="channel_preview_button">
-        <property name="minimumSize">
-         <size>
-          <width>28</width>
-          <height>28</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>28</width>
-          <height>28</height>
-         </size>
-        </property>
-        <property name="cursor">
-         <cursorShape>PointingHandCursor</cursorShape>
-        </property>
-        <property name="styleSheet">
-         <string notr="true">QToolButton {
-border: none;
-background-color: transparent;
-}</string>
-        </property>
-        <property name="text">
-         <string notr="true">REFRESH</string>
-        </property>
-        <property name="icon">
-         <iconset>
-          <normaloff>../images/refresh.png</normaloff>../images/refresh.png</iconset>
-        </property>
-        <property name="iconSize">
-         <size>
-          <width>18</width>
-          <height>18</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item>
        <spacer name="horizontalSpacer_16">
         <property name="orientation">
          <enum>Qt::Horizontal</enum>

--- a/src/tribler-gui/tribler_gui/widgets/channelcontentswidget.py
+++ b/src/tribler-gui/tribler_gui/widgets/channelcontentswidget.py
@@ -52,8 +52,6 @@ class ChannelContentsWidget(AddBreadcrumbOnShowMixin, widget_form, widget_class)
         # detecting paths to external resources used in .ui files. Therefore,
         # for each external resource (e.g. image/icon), we must reload it manually here.
         self.channel_options_button.setIcon(QIcon(get_image_path('ellipsis.png')))
-        self.channel_preview_button.setIcon(QIcon(get_image_path('refresh.png')))
-        self.channel_preview_button.setToolTip(tr("Click to load preview contents"))
 
         self.default_channel_model = ChannelContentModel
 
@@ -97,7 +95,6 @@ class ChannelContentsWidget(AddBreadcrumbOnShowMixin, widget_form, widget_class)
     def hide_all_labels(self):
         self.edit_channel_contents_top_bar.setHidden(True)
         self.subscription_widget.setHidden(True)
-        self.channel_preview_button.setHidden(True)
         self.channel_num_torrents_label.setHidden(True)
         self.channel_state_label.setHidden(True)
 
@@ -143,9 +140,6 @@ class ChannelContentsWidget(AddBreadcrumbOnShowMixin, widget_form, widget_class)
         self.commit_control_bar.setHidden(True)
 
         self.controller = controller_class(self.content_table, filter_input=self.channel_torrents_filter_input)
-
-        # To reload the preview
-        connect(self.channel_preview_button.clicked, self.preview_clicked)
 
         # Hide channel description on scroll
         connect(self.controller.table_view.verticalScrollBar().valueChanged, self._on_table_scroll)
@@ -382,8 +376,6 @@ class ChannelContentsWidget(AddBreadcrumbOnShowMixin, widget_form, widget_class)
         personal = self.model.channel_info.get("state", None) == CHANNEL_STATE.PERSONAL.value
         root = len(self.channels_stack) == 1
         legacy = self.model.channel_info.get("state", None) == CHANNEL_STATE.LEGACY.value
-        complete = self.model.channel_info.get("state", None) == CHANNEL_STATE.COMPLETE.value
-        search = isinstance(self.model, SearchResultsModel)
         discovered = isinstance(self.model, DiscoveredChannelsModel)
         personal_model = isinstance(self.model, PersonalChannelsModel)
         is_a_channel = self.model.channel_info.get("type", None) == CHANNEL_TORRENT
@@ -446,9 +438,6 @@ class ChannelContentsWidget(AddBreadcrumbOnShowMixin, widget_form, widget_class)
         if not self.subscription_widget.isHidden():
             self.subscription_widget.update_subscribe_button(self.model.channel_info)
 
-        self.channel_preview_button.setHidden(
-            (root and not search and not is_a_channel) or personal or legacy or complete
-        )
         self.channel_state_label.setHidden((root and not is_a_channel) or personal)
 
         self.commit_control_bar.setHidden(self.autocommit_enabled or not dirty or not personal)

--- a/src/tribler-gui/tribler_gui/widgets/channelcontentswidget.py
+++ b/src/tribler-gui/tribler_gui/widgets/channelcontentswidget.py
@@ -20,6 +20,7 @@ from tribler_gui.tribler_request_manager import TriblerNetworkRequest
 from tribler_gui.utilities import connect, disconnect, get_image_path, get_ui_file_path, tr
 from tribler_gui.widgets.tablecontentmodel import (
     ChannelContentModel,
+    ChannelPreviewModel,
     DiscoveredChannelsModel,
     PersonalChannelsModel,
     SearchResultsModel,
@@ -366,7 +367,10 @@ class ChannelContentsWidget(AddBreadcrumbOnShowMixin, widget_form, widget_class)
         # Hide the edit controls by default, to prevent the user clicking the buttons prematurely
         self.hide_all_labels()
         # Turn off sorting by default to speed up SQL queries
-        self.push_channels_stack(self.default_channel_model(channel_info=channel_info))
+        if channel_info.get("state") == CHANNEL_STATE.PREVIEW.value:
+            self.push_channels_stack(ChannelPreviewModel(channel_info=channel_info))
+        else:
+            self.push_channels_stack(self.default_channel_model(channel_info=channel_info))
         self.controller.set_model(self.model)
         self.controller.table_view.resizeEvent(None)
 
@@ -375,10 +379,10 @@ class ChannelContentsWidget(AddBreadcrumbOnShowMixin, widget_form, widget_class)
     def update_labels(self, dirty=False):
 
         folder = self.model.channel_info.get("type", None) == COLLECTION_NODE
-        personal = self.model.channel_info.get("state", None) == "Personal"
+        personal = self.model.channel_info.get("state", None) == CHANNEL_STATE.PERSONAL.value
         root = len(self.channels_stack) == 1
-        legacy = self.model.channel_info.get("state", None) == "Legacy"
-        complete = self.model.channel_info.get("state", None) == "Complete"
+        legacy = self.model.channel_info.get("state", None) == CHANNEL_STATE.LEGACY.value
+        complete = self.model.channel_info.get("state", None) == CHANNEL_STATE.COMPLETE.value
         search = isinstance(self.model, SearchResultsModel)
         discovered = isinstance(self.model, DiscoveredChannelsModel)
         personal_model = isinstance(self.model, PersonalChannelsModel)

--- a/src/tribler-gui/tribler_gui/widgets/searchresultswidget.py
+++ b/src/tribler-gui/tribler_gui/widgets/searchresultswidget.py
@@ -117,6 +117,8 @@ class SearchResultsWidget(AddBreadcrumbOnShowMixin, widget_form, widget_class):
             self.results_page.go_back_to_level(0)
 
     def update_loading_page(self, remote_results):
+        if not self.search_request or remote_results.get("uuid") != self.search_request.uuid:
+            return
         peer = remote_results["peer"]
         self.search_request.peers_complete.add(peer)
         self.search_request.remote_results.append(remote_results.get("results", []))

--- a/src/tribler-gui/tribler_gui/widgets/tablecontentmodel.py
+++ b/src/tribler-gui/tribler_gui/widgets/tablecontentmodel.py
@@ -511,6 +511,12 @@ class ChannelContentModel(RemoteTableModel):
         self.on_query_results(response, remote=True)
 
 
+class ChannelPreviewModel(ChannelContentModel):
+    def perform_query(self, **kwargs):
+        kwargs["remote"] = True
+        super().perform_query(**kwargs)
+
+
 class SearchResultsModel(ChannelContentModel):
     pass
 


### PR DESCRIPTION
This change affects how non-subscribed channels are shown to the user. Now _all_ the results are shown from a remote peer that is known to host the channel.