### PR TITLE
Update Popularity community

### DIFF
--- a/src/tribler-core/tribler_core/modules/ipv8_module_catalog.py
+++ b/src/tribler-core/tribler_core/modules/ipv8_module_catalog.py
@@ -178,7 +178,8 @@ class TriblerTunnelTestnetCommunityLauncher(TestnetMixIn, TriblerTunnelCommunity
 @set_in_session('popularity_community')
 @overlay(popularity_community)
 @kwargs(metadata_store='session.mds', torrent_checker='session.torrent_checker')
-@walk_strategy(random_walk)
+@walk_strategy(random_walk, target_peers=30)
+@walk_strategy(remove_peers, target_peers=INFINITE)
 class PopularityCommunityLauncher(IPv8CommunityLauncher):
     pass
 

--- a/src/tribler-core/tribler_core/modules/popularity/popularity_community.py
+++ b/src/tribler-core/tribler_core/modules/popularity/popularity_community.py
@@ -2,6 +2,8 @@ import heapq
 import random
 from binascii import unhexlify
 
+from ipv8.peerdiscovery.network import Network
+
 from ipv8.lazy_community import lazy_wrapper
 
 from pony.orm import db_session
@@ -26,10 +28,11 @@ class PopularityCommunity(RemoteQueryCommunity):
 
     community_id = unhexlify('9aca62f878969c437da9844cba29a134917e1648')
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, my_peer, endpoint, network, **kwargs):
         self.torrent_checker = kwargs.pop('torrent_checker', None)
 
-        super().__init__(*args, **kwargs)
+        # Creating a separate instance of Network for this community to find more peers
+        super().__init__(my_peer, endpoint, Network(), **kwargs)
 
         self.add_message_handler(TorrentsHealthPayload, self.on_torrents_health)
 

--- a/src/tribler-core/tribler_core/modules/popularity/popularity_community.py
+++ b/src/tribler-core/tribler_core/modules/popularity/popularity_community.py
@@ -2,9 +2,8 @@ import heapq
 import random
 from binascii import unhexlify
 
-from ipv8.peerdiscovery.network import Network
-
 from ipv8.lazy_community import lazy_wrapper
+from ipv8.peerdiscovery.network import Network
 
 from pony.orm import db_session
 
@@ -17,14 +16,16 @@ class PopularityCommunity(RemoteQueryCommunity):
     """
     Community for disseminating the content across the network.
 
-    Every 5 seconds it gossips 5 the most popular torrents and 5 random torrents to
+    Every 2 minutes it gossips 10 popular torrents and
+    every 5 seconds it gossips 10 random torrents to
     a random peer.
 
     Gossiping is for checked torrents only.
     """
-    GOSSIP_INTERVAL = 5
-    GOSSIP_POPULAR_TORRENT_COUNT = 5
-    GOSSIP_RANDOM_TORRENT_COUNT = 5
+    GOSSIP_INTERVAL_FOR_POPULAR_TORRENTS = 120  # seconds
+    GOSSIP_INTERVAL_FOR_RANDOM_TORRENTS = 5  # seconds
+    GOSSIP_POPULAR_TORRENT_COUNT = 10
+    GOSSIP_RANDOM_TORRENT_COUNT = 10
 
     community_id = unhexlify('9aca62f878969c437da9844cba29a134917e1648')
 
@@ -38,17 +39,21 @@ class PopularityCommunity(RemoteQueryCommunity):
 
         self.logger.info('Popularity Community initialized (peer mid %s)',
                          hexlify(self.my_peer.mid))
-        self.register_task("gossip", self.gossip_torrents_health,
-                           interval=PopularityCommunity.GOSSIP_INTERVAL)
+        self.register_task("gossip_popular_torrents", self.gossip_popular_torrents_health,
+                           interval=PopularityCommunity.GOSSIP_INTERVAL_FOR_POPULAR_TORRENTS)
+        self.register_task("gossip_random_torrents", self.gossip_random_torrents_health,
+                           interval=PopularityCommunity.GOSSIP_INTERVAL_FOR_RANDOM_TORRENTS)
 
     @staticmethod
-    def select_torrents_to_gossip(torrents) -> (set, set):
+    def select_torrents_to_gossip(torrents, include_popular=True, include_random=True) -> (set, set):
         """ Select torrents to gossip.
 
         Select top 5 popular torrents, and 5 random torrents.
 
         Args:
             torrents: set of tuples (infohash, seeders, leechers, last_check)
+            include_popular: If True, popular torrents based on seeder count are selected
+            include_random: If True, torrents are randomly selected
 
         Returns:
             tuple (set(popular), set(random))
@@ -60,18 +65,22 @@ class PopularityCommunity(RemoteQueryCommunity):
         if not alive:
             return {}, {}
 
-        # select 5 most popular from alive torrents, using `seeders` as a key
-        count = PopularityCommunity.GOSSIP_POPULAR_TORRENT_COUNT
-        popular = set(heapq.nlargest(count, alive, key=lambda t: t[1]))
+        popular, rand = set(), set()
 
-        # select 5 random torrents from the rest of the list
-        rest = alive - popular
-        count = min(PopularityCommunity.GOSSIP_RANDOM_TORRENT_COUNT, len(rest))
-        rand = set(random.sample(rest, count))
+        # select most popular from alive torrents, using `seeders` as a key
+        if include_popular:
+            count = PopularityCommunity.GOSSIP_POPULAR_TORRENT_COUNT
+            popular = set(heapq.nlargest(count, alive, key=lambda t: t[1]))
+
+        # select random torrents from the rest of the list
+        if include_random:
+            rest = alive - popular
+            count = min(PopularityCommunity.GOSSIP_RANDOM_TORRENT_COUNT, len(rest))
+            rand = set(random.sample(rest, count))
 
         return popular, rand
 
-    def gossip_torrents_health(self):
+    def _gossip_torrents_health(self, include_popular=True, include_random=True):
         """
         Gossip torrent health information to another peer.
         """
@@ -82,7 +91,9 @@ class PopularityCommunity(RemoteQueryCommunity):
         if not checked:
             return
 
-        popular, rand = PopularityCommunity.select_torrents_to_gossip(checked)
+        popular, rand = PopularityCommunity.select_torrents_to_gossip(checked,
+                                                                      include_popular=include_popular,
+                                                                      include_random=include_random)
         if not popular and not rand:
             self.logger.info(f'No torrents to gossip. Checked torrents count: '
                              f'{len(checked)}')
@@ -95,6 +106,18 @@ class PopularityCommunity(RemoteQueryCommunity):
             f' random torrents and {len(popular)} popular torrents')
 
         self.ez_send(random_peer, TorrentsHealthPayload.create(rand, popular))
+
+    def gossip_random_torrents_health(self):
+        """
+        Gossip random torrent health information to another peer.
+        """
+        self._gossip_torrents_health(include_popular=False, include_random=True)
+
+    def gossip_popular_torrents_health(self):
+        """
+        Gossip popular torrent health information to another peer.
+        """
+        self._gossip_torrents_health(include_popular=True, include_random=False)
 
     @lazy_wrapper(TorrentsHealthPayload)
     async def on_torrents_health(self, peer, payload):

--- a/src/tribler-core/tribler_core/modules/popularity/test_popularity_community.py
+++ b/src/tribler-core/tribler_core/modules/popularity/test_popularity_community.py
@@ -58,18 +58,18 @@ class TestPopularityCommunity(TestBase):
         Test whether torrent health information is correctly gossiped around
         """
         checked_torrent_info = (b'a' * 20, 200, 0, int(time.time()))
-        db1 = self.nodes[0].overlay.mds.TorrentState
-        db2 = self.nodes[1].overlay.mds.TorrentState
+        node0_db = self.nodes[0].overlay.mds.TorrentState
+        node1_db2 = self.nodes[1].overlay.mds.TorrentState
 
         with db_session:
-            assert db1.select().count() == 0
-            assert db2.select().count() == 0
+            assert node0_db.select().count() == 0
+            assert node1_db2.select().count() == 0
 
         await self.init_first_node_and_gossip(checked_torrent_info)
 
         # Check whether node 1 has new torrent health information
         with db_session:
-            torrent = db2.select().first()
+            torrent = node1_db2.select().first()
             assert torrent.infohash == checked_torrent_info[0]
             assert torrent.seeders == checked_torrent_info[1]
             assert torrent.leechers == checked_torrent_info[2]


### PR DESCRIPTION
Two changes:
- Popular and random torrents are gossiped separately in two different intervals (popular: 2 mins, random: 5 seconds)
- Popularity community now uses a separate Network instance