### PR TITLE
Rearrange left menu

### DIFF
--- a/src/tribler-gui/tribler_gui/qt_resources/mainwindow.ui
+++ b/src/tribler-gui/tribler_gui/qt_resources/mainwindow.ui
@@ -170,340 +170,6 @@ padding: 4px;
     <property name="verticalSpacing">
      <number>0</number>
     </property>
-    <item row="0" column="0">
-     <widget class="QWidget" name="top_bar" native="true">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>0</width>
-        <height>50</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>16777215</width>
-        <height>50</height>
-       </size>
-      </property>
-      <property name="styleSheet">
-       <string notr="true">QWidget {
-background-color: #282828;
-border-bottom: 1px solid #242424;
-}
-
-CircleButton {
-border: 2px solid white;
-}</string>
-      </property>
-      <layout class="QHBoxLayout" name="horizontalLayout">
-       <property name="spacing">
-        <number>0</number>
-       </property>
-       <property name="leftMargin">
-        <number>0</number>
-       </property>
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <property name="rightMargin">
-        <number>0</number>
-       </property>
-       <property name="bottomMargin">
-        <number>0</number>
-       </property>
-       <item>
-        <spacer name="horizontalSpacer_3">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>10</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <widget class="QToolButton" name="top_menu_button">
-         <property name="minimumSize">
-          <size>
-           <width>16</width>
-           <height>18</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>16</width>
-           <height>18</height>
-          </size>
-         </property>
-         <property name="cursor">
-          <cursorShape>PointingHandCursor</cursorShape>
-         </property>
-         <property name="styleSheet">
-          <string notr="true">border: none; 
-</string>
-         </property>
-         <property name="text">
-          <string notr="true"/>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="horizontalSpacer_7">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>10</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <widget class="QLabel" name="tribler_name">
-         <property name="styleSheet">
-          <string notr="true">color: #e67300;
-font-size: 28px;
-font-weight: bold;
-font-family: &quot;Arial&quot;;</string>
-         </property>
-         <property name="text">
-          <string notr="true">Tribler</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="horizontalSpacer_4">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>12</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <widget class="ClickableLineEdit" name="top_search_bar">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>350</width>
-           <height>28</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>350</width>
-           <height>28</height>
-          </size>
-         </property>
-         <property name="styleSheet">
-          <string notr="true">QLineEdit {
-background-color: #eee;
-border: none;
-padding-left: 5px;
-border-radius: 14px;
-color: black;
-}</string>
-         </property>
-         <property name="placeholderText">
-          <string>Search for your favorite content</string>
-         </property>
-         <property name="clearButtonEnabled">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="horizontalSpacer_2">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Expanding</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <widget class="QWidget" name="token_balance_widget" native="true">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>92</width>
-           <height>34</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>92</width>
-           <height>34</height>
-          </size>
-         </property>
-         <property name="cursor">
-          <cursorShape>PointingHandCursor</cursorShape>
-         </property>
-         <property name="styleSheet">
-          <string notr="true">QWidget { background-color: #4c4c4c; border-radius: 4px; }</string>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_6">
-          <property name="spacing">
-           <number>0</number>
-          </property>
-          <property name="leftMargin">
-           <number>0</number>
-          </property>
-          <property name="topMargin">
-           <number>2</number>
-          </property>
-          <property name="rightMargin">
-           <number>0</number>
-          </property>
-          <property name="bottomMargin">
-           <number>2</number>
-          </property>
-          <item>
-           <widget class="QLabel" name="token_balance_label">
-            <property name="styleSheet">
-             <string notr="true">color: #ddd; font-weight: bold; font-size: 14px; border: none;</string>
-            </property>
-            <property name="text">
-             <string notr="true">-</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLabel" name="token_name_label">
-            <property name="styleSheet">
-             <string notr="true">color: #ddd; font-size: 12px; border: none;</string>
-            </property>
-            <property name="text">
-             <string>Token balance</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignCenter</set>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <spacer name="horizontalSpacer_68">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>10</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <widget class="QToolButton" name="settings_button">
-         <property name="minimumSize">
-          <size>
-           <width>22</width>
-           <height>22</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>22</width>
-           <height>22</height>
-          </size>
-         </property>
-         <property name="cursor">
-          <cursorShape>PointingHandCursor</cursorShape>
-         </property>
-         <property name="toolTip">
-          <string>Settings</string>
-         </property>
-         <property name="styleSheet">
-          <string notr="true">border: none;
-background: none;</string>
-         </property>
-         <property name="text">
-          <string notr="true"/>
-         </property>
-         <property name="icon">
-          <iconset>
-           <normaloff>../images/gear.png</normaloff>../images/gear.png</iconset>
-         </property>
-         <property name="iconSize">
-          <size>
-           <width>20</width>
-           <height>20</height>
-          </size>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="horizontalSpacer_67">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>10</width>
-           <height>10</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </widget>
-    </item>
     <item row="1" column="0">
      <widget class="QWidget" name="tribler_status_bar" native="true">
       <property name="styleSheet">
@@ -622,7 +288,13 @@ color: white;
 QPushButton::checked {
 border-left: 4px solid #e67300;
 color: white;
-}</string>
+}
+
+QLabel{
+padding-left:20px;
+color: #B5B5B5;
+}
+</string>
         </property>
         <property name="locale">
          <locale language="Dutch" country="Netherlands"/>
@@ -646,12 +318,6 @@ color: white;
             <size>
              <width>0</width>
              <height>38</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>10000</width>
-             <height>32</height>
             </size>
            </property>
            <property name="cursor">
@@ -689,7 +355,46 @@ QPushButton::menu-indicator{width:0px;}</string>
           </widget>
          </item>
          <item>
-          <spacer name="verticalSpacer_3">
+          <widget class="QPushButton" name="left_menu_button_downloads">
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>26</height>
+            </size>
+           </property>
+           <property name="cursor">
+            <cursorShape>PointingHandCursor</cursorShape>
+           </property>
+           <property name="focusPolicy">
+            <enum>Qt::NoFocus</enum>
+           </property>
+           <property name="styleSheet">
+            <string notr="true"/>
+           </property>
+           <property name="text">
+            <string> Downloads</string>
+           </property>
+           <property name="icon">
+            <iconset>
+             <normaloff>../images/downloads.png</normaloff>
+             <disabledon>../images/downloads.png</disabledon>../images/downloads.png</iconset>
+           </property>
+           <property name="iconSize">
+            <size>
+             <width>16</width>
+             <height>16</height>
+            </size>
+           </property>
+           <property name="checkable">
+            <bool>true</bool>
+           </property>
+           <property name="flat">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="verticalSpacer">
            <property name="orientation">
             <enum>Qt::Vertical</enum>
            </property>
@@ -705,6 +410,13 @@ QPushButton::menu-indicator{width:0px;}</string>
           </spacer>
          </item>
          <item>
+          <widget class="QLabel" name="channels_menu_label">
+           <property name="text">
+            <string>CHANNELS</string>
+           </property>
+          </widget>
+         </item>
+         <item>
           <widget class="QPushButton" name="left_menu_button_discovered">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -716,12 +428,6 @@ QPushButton::menu-indicator{width:0px;}</string>
             <size>
              <width>0</width>
              <height>26</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>16777215</width>
-             <height>30</height>
             </size>
            </property>
            <property name="cursor">
@@ -770,20 +476,11 @@ QPushButton::menu-indicator{width:0px;}</string>
              <height>26</height>
             </size>
            </property>
-           <property name="maximumSize">
-            <size>
-             <width>16777215</width>
-             <height>30</height>
-            </size>
-           </property>
            <property name="cursor">
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="focusPolicy">
             <enum>Qt::NoFocus</enum>
-           </property>
-           <property name="styleSheet">
-            <string notr="true"/>
            </property>
            <property name="text">
             <string> Popular</string>
@@ -809,17 +506,11 @@ QPushButton::menu-indicator{width:0px;}</string>
           </widget>
          </item>
          <item>
-          <widget class="QPushButton" name="left_menu_button_downloads">
+          <widget class="QPushButton" name="left_menu_button_new_channel">
            <property name="minimumSize">
             <size>
              <width>0</width>
              <height>26</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>16777215</width>
-             <height>30</height>
             </size>
            </property>
            <property name="cursor">
@@ -828,149 +519,17 @@ QPushButton::menu-indicator{width:0px;}</string>
            <property name="focusPolicy">
             <enum>Qt::NoFocus</enum>
            </property>
-           <property name="styleSheet">
-            <string notr="true"/>
-           </property>
            <property name="text">
-            <string> Downloads</string>
+            <string>Create channel</string>
            </property>
            <property name="icon">
             <iconset>
-             <normaloff>../images/downloads.png</normaloff>
-             <disabledon>../images/downloads.png</disabledon>../images/downloads.png</iconset>
-           </property>
-           <property name="iconSize">
-            <size>
-             <width>16</width>
-             <height>16</height>
-            </size>
-           </property>
-           <property name="checkable">
-            <bool>true</bool>
+             <normaloff>../images/plus.svg</normaloff>../images/plus.svg</iconset>
            </property>
            <property name="flat">
             <bool>true</bool>
            </property>
           </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="left_menu_button_trust_graph">
-           <property name="minimumSize">
-            <size>
-             <width>0</width>
-             <height>26</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>16777215</width>
-             <height>30</height>
-            </size>
-           </property>
-           <property name="cursor">
-            <cursorShape>PointingHandCursor</cursorShape>
-           </property>
-           <property name="focusPolicy">
-            <enum>Qt::NoFocus</enum>
-           </property>
-           <property name="styleSheet">
-            <string notr="true"/>
-           </property>
-           <property name="text">
-            <string> Trust Graph </string>
-           </property>
-           <property name="icon">
-            <iconset>
-             <normaloff>../images/network.png</normaloff>
-             <disabledon>../images/network.png</disabledon>../images/network.png</iconset>
-           </property>
-           <property name="iconSize">
-            <size>
-             <width>16</width>
-             <height>16</height>
-            </size>
-           </property>
-           <property name="checkable">
-            <bool>true</bool>
-           </property>
-           <property name="flat">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="left_menu_button_debug">
-           <property name="minimumSize">
-            <size>
-             <width>0</width>
-             <height>26</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>16777215</width>
-             <height>30</height>
-            </size>
-           </property>
-           <property name="cursor">
-            <cursorShape>PointingHandCursor</cursorShape>
-           </property>
-           <property name="focusPolicy">
-            <enum>Qt::NoFocus</enum>
-           </property>
-           <property name="styleSheet">
-            <string notr="true"/>
-           </property>
-           <property name="text">
-            <string> Debug</string>
-           </property>
-           <property name="icon">
-            <iconset>
-             <normaloff>../images/debug.png</normaloff>
-             <disabledon>../images/debug.png</disabledon>../images/debug.png</iconset>
-           </property>
-           <property name="iconSize">
-            <size>
-             <width>16</width>
-             <height>16</height>
-            </size>
-           </property>
-           <property name="checkable">
-            <bool>false</bool>
-           </property>
-           <property name="flat">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <spacer name="verticalSpacer_2">
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
-           </property>
-           <property name="sizeType">
-            <enum>QSizePolicy::Fixed</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>5</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
-          <spacer name="horizontalSpacer">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
          </item>
          <item>
           <layout class="QVBoxLayout" name="verticalLayout_5">
@@ -1020,49 +579,13 @@ QListWidget::item:disabled
            </item>
           </layout>
          </item>
-         <item>
-          <spacer name="verticalSpacer">
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
-           </property>
-           <property name="sizeType">
-            <enum>QSizePolicy::Minimum</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>10</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
-          <widget class="QPushButton" name="left_menu_button_new_channel">
-           <property name="focusPolicy">
-            <enum>Qt::NoFocus</enum>
-           </property>
-           <property name="text">
-            <string>New channel</string>
-           </property>
-           <property name="icon">
-            <iconset>
-             <normaloff>../images/plus.svg</normaloff>../images/plus.svg</iconset>
-           </property>
-           <property name="checkable">
-            <bool>false</bool>
-           </property>
-           <property name="flat">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
         </layout>
        </widget>
       </item>
       <item>
        <widget class="QStackedWidget" name="stackedWidget">
         <property name="currentIndex">
-         <number>1</number>
+         <number>6</number>
         </property>
         <widget class="SearchResultsWidget" name="search_results_page"/>
         <widget class="SettingsPage" name="settings_page">
@@ -1494,8 +1017,8 @@ border-top: 1px solid #555;
               <rect>
                <x>0</x>
                <y>0</y>
-               <width>854</width>
-               <height>697</height>
+               <width>300</width>
+               <height>506</height>
               </rect>
              </property>
              <layout class="QVBoxLayout" name="verticalLayout_22">
@@ -3919,7 +3442,7 @@ QTabBar::tab:selected {
 }</string>
                 </property>
                 <property name="currentIndex">
-                 <number>0</number>
+                 <number>3</number>
                 </property>
                 <property name="movable">
                  <bool>false</bool>
@@ -4888,6 +4411,53 @@ border-radius: 10px;
               </widget>
              </item>
              <item>
+              <spacer name="horizontalSpacer_6">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeType">
+                <enum>QSizePolicy::Fixed</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>5</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+             <item>
+              <widget class="QToolButton" name="trust_graph_button">
+               <property name="minimumSize">
+                <size>
+                 <width>20</width>
+                 <height>20</height>
+                </size>
+               </property>
+               <property name="cursor">
+                <cursorShape>PointingHandCursor</cursorShape>
+               </property>
+               <property name="toolTip">
+                <string>Show trust graph</string>
+               </property>
+               <property name="styleSheet">
+                <string notr="true">QToolButton{
+border: 1px solid white;
+color: white;
+border-radius: 10px;
+}
+</string>
+               </property>
+               <property name="text">
+                <string notr="true"/>
+               </property>
+               <property name="icon">
+                <iconset>
+                 <normaloff>../images/network.png</normaloff>../images/network.png</iconset>
+               </property>
+              </widget>
+             </item>
+             <item>
               <spacer name="horizontalSpacer_69">
                <property name="orientation">
                 <enum>Qt::Horizontal</enum>
@@ -5666,6 +5236,385 @@ margin: 10px 4px 2px 10px;</string>
       </item>
      </layout>
     </item>
+    <item row="0" column="0">
+     <widget class="QWidget" name="top_bar" native="true">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>0</width>
+        <height>50</height>
+       </size>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>16777215</width>
+        <height>50</height>
+       </size>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">QWidget {
+background-color: #282828;
+border-bottom: 1px solid #242424;
+}
+
+CircleButton {
+border: 2px solid white;
+}</string>
+      </property>
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <property name="spacing">
+        <number>0</number>
+       </property>
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <spacer name="horizontalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Fixed</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>10</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QToolButton" name="top_menu_button">
+         <property name="minimumSize">
+          <size>
+           <width>16</width>
+           <height>18</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>16</width>
+           <height>18</height>
+          </size>
+         </property>
+         <property name="cursor">
+          <cursorShape>PointingHandCursor</cursorShape>
+         </property>
+         <property name="styleSheet">
+          <string notr="true">border: none; 
+</string>
+         </property>
+         <property name="text">
+          <string notr="true"/>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer_7">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Fixed</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>10</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QLabel" name="tribler_name">
+         <property name="styleSheet">
+          <string notr="true">color: #e67300;
+font-size: 28px;
+font-weight: bold;
+font-family: &quot;Arial&quot;;</string>
+         </property>
+         <property name="text">
+          <string notr="true">Tribler</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer_4">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Fixed</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>12</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="ClickableLineEdit" name="top_search_bar">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>350</width>
+           <height>28</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>350</width>
+           <height>28</height>
+          </size>
+         </property>
+         <property name="styleSheet">
+          <string notr="true">QLineEdit {
+background-color: #eee;
+border: none;
+padding-left: 5px;
+border-radius: 14px;
+color: black;
+}</string>
+         </property>
+         <property name="placeholderText">
+          <string>Search for your favorite content</string>
+         </property>
+         <property name="clearButtonEnabled">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Expanding</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QPushButton" name="debug_panel_button">
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>26</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>16777215</width>
+           <height>30</height>
+          </size>
+         </property>
+         <property name="cursor">
+          <cursorShape>PointingHandCursor</cursorShape>
+         </property>
+         <property name="focusPolicy">
+          <enum>Qt::NoFocus</enum>
+         </property>
+         <property name="styleSheet">
+          <string notr="true"/>
+         </property>
+         <property name="text">
+          <string> Debug</string>
+         </property>
+         <property name="icon">
+          <iconset>
+           <normaloff>../images/debug.png</normaloff>
+           <disabledon>../images/debug.png</disabledon>../images/debug.png</iconset>
+         </property>
+         <property name="iconSize">
+          <size>
+           <width>16</width>
+           <height>16</height>
+          </size>
+         </property>
+         <property name="checkable">
+          <bool>false</bool>
+         </property>
+         <property name="flat">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QWidget" name="token_balance_widget" native="true">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>92</width>
+           <height>34</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>92</width>
+           <height>34</height>
+          </size>
+         </property>
+         <property name="cursor">
+          <cursorShape>PointingHandCursor</cursorShape>
+         </property>
+         <property name="styleSheet">
+          <string notr="true">QWidget { background-color: #4c4c4c; border-radius: 4px; }</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_6">
+          <property name="spacing">
+           <number>0</number>
+          </property>
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>2</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>2</number>
+          </property>
+          <item>
+           <widget class="QLabel" name="token_balance_label">
+            <property name="styleSheet">
+             <string notr="true">color: #ddd; font-weight: bold; font-size: 14px; border: none;</string>
+            </property>
+            <property name="text">
+             <string notr="true">-</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="token_name_label">
+            <property name="styleSheet">
+             <string notr="true">color: #ddd; font-size: 12px; border: none;</string>
+            </property>
+            <property name="text">
+             <string>Token balance</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignCenter</set>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer_68">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Fixed</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>10</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QToolButton" name="settings_button">
+         <property name="minimumSize">
+          <size>
+           <width>22</width>
+           <height>22</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>22</width>
+           <height>22</height>
+          </size>
+         </property>
+         <property name="cursor">
+          <cursorShape>PointingHandCursor</cursorShape>
+         </property>
+         <property name="toolTip">
+          <string>Settings</string>
+         </property>
+         <property name="styleSheet">
+          <string notr="true">border: none;
+background: none;</string>
+         </property>
+         <property name="text">
+          <string notr="true"/>
+         </property>
+         <property name="icon">
+          <iconset>
+           <normaloff>../images/gear.png</normaloff>../images/gear.png</iconset>
+         </property>
+         <property name="iconSize">
+          <size>
+           <width>20</width>
+           <height>20</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer_67">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Fixed</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>10</width>
+           <height>10</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+    </item>
    </layout>
   </widget>
  </widget>
@@ -5860,38 +5809,6 @@ margin: 10px 4px 2px 10px;</string>
    </hints>
   </connection>
   <connection>
-   <sender>left_menu_button_trust_graph</sender>
-   <signal>clicked()</signal>
-   <receiver>MainWindow</receiver>
-   <slot>clicked_menu_button_trust_graph()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>101</x>
-     <y>367</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>427</x>
-     <y>317</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>left_menu_button_debug</sender>
-   <signal>clicked()</signal>
-   <receiver>MainWindow</receiver>
-   <slot>clicked_menu_button_debug()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>95</x>
-     <y>403</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>427</x>
-     <y>327</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
    <sender>left_menu_button_discovered</sender>
    <signal>clicked()</signal>
    <receiver>MainWindow</receiver>
@@ -5936,7 +5853,6 @@ margin: 10px 4px 2px 10px;</string>
   <slot>on_search_text_change()</slot>
   <slot>on_edit_channel_clicked()</slot>
   <slot>clicked_menu_button_discovered()</slot>
-  <slot>clicked_menu_button_debug()</slot>
   <slot>clicked_menu_button_trust()</slot>
   <slot>on_settings_button_click()</slot>
   <slot>on_trust_button_click()</slot>

--- a/src/tribler-gui/tribler_gui/qt_resources/mainwindow.ui
+++ b/src/tribler-gui/tribler_gui/qt_resources/mainwindow.ui
@@ -107,8 +107,7 @@ QCheckBox::indicator:unchecked {border: 1px solid #555;}</string>
   <widget class="QWidget" name="central_widget">
    <property name="styleSheet">
     <string notr="true">QWidget {
-background-color: #202020;
-}
+background-color: #282828;}
 
 TabButtonPanel UnderlineTabButton{
 color: #B5B5B5;
@@ -268,7 +267,7 @@ color: #eee;</string>
         </property>
         <property name="styleSheet">
          <string notr="true">QWidget {
-background-color: #282828;
+background-color: #202020;
 }
 
 QPushButton {
@@ -585,7 +584,7 @@ QListWidget::item:disabled
       <item>
        <widget class="QStackedWidget" name="stackedWidget">
         <property name="currentIndex">
-         <number>6</number>
+         <number>4</number>
         </property>
         <widget class="SearchResultsWidget" name="search_results_page"/>
         <widget class="SettingsPage" name="settings_page">
@@ -1017,8 +1016,8 @@ border-top: 1px solid #555;
               <rect>
                <x>0</x>
                <y>0</y>
-               <width>300</width>
-               <height>506</height>
+               <width>854</width>
+               <height>697</height>
               </rect>
              </property>
              <layout class="QVBoxLayout" name="verticalLayout_22">
@@ -1068,9 +1067,6 @@ color: white;
 }
 QComboBox::drop-down {
 border: 0px;
-}
-QStackedWidget {
-background-color: #202020;
 }
 
 QCheckBox{margin-left: 10px;}
@@ -2672,11 +2668,6 @@ color: white;</string>
          </layout>
         </widget>
         <widget class="DownloadsPage" name="downloads_page">
-         <property name="styleSheet">
-          <string notr="true">QTreeWidget {
-background-color: #202020;
-}</string>
-         </property>
          <layout class="QVBoxLayout" name="verticalLayout">
           <property name="spacing">
            <number>0</number>
@@ -3442,7 +3433,7 @@ QTabBar::tab:selected {
 }</string>
                 </property>
                 <property name="currentIndex">
-                 <number>3</number>
+                 <number>0</number>
                 </property>
                 <property name="movable">
                  <bool>false</bool>
@@ -3470,9 +3461,7 @@ QTabBar::tab:selected {
                   <item>
                    <widget class="QScrollArea" name="scrollArea_2">
                     <property name="styleSheet">
-                     <string notr="true">border: none;
-background-color: #202020;
-color: white</string>
+                     <string notr="true"/>
                     </property>
                     <property name="widgetResizable">
                      <bool>true</bool>
@@ -3482,8 +3471,8 @@ color: white</string>
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>321</width>
-                       <height>259</height>
+                       <width>854</width>
+                       <height>377</height>
                       </rect>
                      </property>
                      <layout class="QFormLayout" name="formLayout_4">
@@ -5258,7 +5247,7 @@ margin: 10px 4px 2px 10px;</string>
       </property>
       <property name="styleSheet">
        <string notr="true">QWidget {
-background-color: #282828;
+background-color: #202020;
 border-bottom: 1px solid #242424;
 }
 

--- a/src/tribler-gui/tribler_gui/tests/test_gui.py
+++ b/src/tribler-gui/tribler_gui/tests/test_gui.py
@@ -430,7 +430,7 @@ def test_debug_pane(tribler_api, window):
     if not window.developer_mode_enabled_checkbox.isChecked():
         QTest.mouseClick(window.developer_mode_enabled_checkbox, Qt.LeftButton)
 
-    QTest.mouseClick(window.left_menu_button_debug, Qt.LeftButton)
+    QTest.mouseClick(window.debug_panel_button, Qt.LeftButton)
     screenshot(window.debug_window, name="debug_panel_just_opened")
     wait_for_list_populated(window.debug_window.general_tree_widget)
     screenshot(window.debug_window, name="debug_panel_general_tab")

--- a/src/tribler-gui/tribler_gui/tribler_window.py
+++ b/src/tribler-gui/tribler_gui/tribler_window.py
@@ -75,7 +75,8 @@ from tribler_gui.utilities import (
     get_gui_setting,
     get_image_path,
     get_ui_file_path,
-    is_dir_writable, tr,
+    is_dir_writable,
+    tr,
 )
 from tribler_gui.widgets.channelsmenulistwidget import ChannelsMenuListWidget
 from tribler_gui.widgets.tablecontentmodel import DiscoveredChannelsModel, PopularTorrentsModel
@@ -159,7 +160,7 @@ class TriblerWindow(QMainWindow):
         QDesktopServices.setUrlHandler("magnet", self.magnet_handler, "on_open_magnet_link")
 
         self.debug_pane_shortcut = QShortcut(QKeySequence("Ctrl+d"), self)
-        connect(self.debug_pane_shortcut.activated, self.clicked_menu_button_debug)
+        connect(self.debug_pane_shortcut.activated, self.clicked_debug_panel_button)
         self.import_torrent_shortcut = QShortcut(QKeySequence("Ctrl+o"), self)
         connect(self.import_torrent_shortcut.activated, self.on_add_torrent_browse_file)
         self.add_torrent_url_shortcut = QShortcut(QKeySequence("Ctrl+i"), self)
@@ -175,7 +176,6 @@ class TriblerWindow(QMainWindow):
         self.menu_buttons = [
             self.left_menu_button_downloads,
             self.left_menu_button_discovered,
-            self.left_menu_button_trust_graph,
             self.left_menu_button_popular,
         ]
 
@@ -221,7 +221,7 @@ class TriblerWindow(QMainWindow):
             menu.addAction(tr('Quit Tribler'), self.close_tribler)
             self.tray_icon.setContextMenu(menu)
 
-        self.left_menu_button_debug.setHidden(True)
+        self.debug_panel_button.setHidden(True)
         self.top_menu_button.setHidden(True)
         self.left_menu.setHidden(True)
         self.token_balance_widget.setHidden(True)
@@ -256,11 +256,6 @@ class TriblerWindow(QMainWindow):
         """
         )
         self.top_search_bar.setCompleter(completer)
-
-        # Toggle debug if developer mode is enabled
-        self.window().left_menu_button_debug.setHidden(
-            not get_gui_setting(self.gui_settings, "debug", False, is_bool=True)
-        )
 
         # Start Tribler
         self.core_manager.start(core_args=core_args, core_env=core_env)
@@ -304,6 +299,8 @@ class TriblerWindow(QMainWindow):
             lambda data: self.channels_menu_list.reload_if_necessary([data]),
         )
         connect(self.left_menu_button_new_channel.clicked, self.create_new_channel)
+        connect(self.debug_panel_button.clicked, self.clicked_debug_panel_button)
+        connect(self.trust_graph_button.clicked, self.clicked_trust_graph_page_button)
 
     def create_new_channel(self, checked):
         # TODO: DRY this with tablecontentmodel, possibly using QActions
@@ -382,6 +379,7 @@ class TriblerWindow(QMainWindow):
         self.top_menu_button.setHidden(True)
         self.left_menu.setHidden(True)
         self.token_balance_widget.setHidden(True)
+        self.debug_panel_button.setHidden(True)
         self.settings_button.setHidden(True)
         self.add_torrent_button.setHidden(True)
         self.top_search_bar.setHidden(True)
@@ -466,6 +464,9 @@ class TriblerWindow(QMainWindow):
             self.left_menu_button_discovered.setChecked(True)
 
         self.channels_menu_list.load_channels()
+
+        # Toggle debug if developer mode is enabled
+        self.window().debug_panel_button.setHidden(not get_gui_setting(self.gui_settings, "debug", False, is_bool=True))
 
     @property
     def hide_xxx(self):
@@ -979,8 +980,8 @@ class TriblerWindow(QMainWindow):
         self.stackedWidget.setCurrentIndex(PAGE_POPULAR)
         self.popular_page.content_table.setFocus()
 
-    def clicked_menu_button_trust_graph(self):
-        self.deselect_all_menu_buttons(self.left_menu_button_trust_graph)
+    def clicked_trust_graph_page_button(self, _):
+        self.deselect_all_menu_buttons()
         self.stackedWidget.setCurrentIndex(PAGE_TRUST_GRAPH_PAGE)
 
     def clicked_menu_button_downloads(self):
@@ -989,7 +990,7 @@ class TriblerWindow(QMainWindow):
         self.left_menu_button_downloads.setChecked(True)
         self.stackedWidget.setCurrentIndex(PAGE_DOWNLOADS)
 
-    def clicked_menu_button_debug(self, index=False):
+    def clicked_debug_panel_button(self, _):
         if not self.debug_window:
             self.debug_window = DebugWindow(self.tribler_settings, self.gui_settings, self.tribler_version)
         self.debug_window.show()

--- a/src/tribler-gui/tribler_gui/widgets/settingspage.py
+++ b/src/tribler-gui/tribler_gui/widgets/settingspage.py
@@ -82,7 +82,7 @@ class SettingsPage(AddBreadcrumbOnShowMixin, QWidget):
 
     def on_developer_mode_checkbox_changed(self, _):
         self.window().gui_settings.setValue("debug", self.window().developer_mode_enabled_checkbox.isChecked())
-        self.window().left_menu_button_debug.setHidden(not self.window().developer_mode_enabled_checkbox.isChecked())
+        self.window().debug_panel_button.setHidden(not self.window().developer_mode_enabled_checkbox.isChecked())
 
     def on_use_monochrome_icon_checkbox_changed(self, _):
         use_monochrome_icon = self.window().use_monochrome_icon_checkbox.isChecked()


### PR DESCRIPTION
This PR changes some aspects of the GUI: 
* the Trust Graph button is moved from the left menu to Trust Page to avoid confusing new users
* the Debug button is moved to the top right corner of the app to maintain the menu uniformity
* Channels-related items are now grouped under a separate label
* the color for the left and top panel is swapped with the main panel color. This brings the GUI more in line with modern standards, accentuating the content instead of the controls.

Overall, this PR takes our GUI even closer to standards, even more "total ripoff"-style :wink: 

![изображение](https://user-images.githubusercontent.com/2509103/117728627-f7557000-b1e9-11eb-8350-24a8f00433b5.png)

![изображение](https://user-images.githubusercontent.com/2509103/117728711-118f4e00-b1ea-11eb-9b41-cd11ccc32bde.png)

