### PR TITLE
Fix collection always in preview state

### DIFF
--- a/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/collection_node.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/collection_node.py
@@ -6,6 +6,8 @@ from ipv8.database import database_blob
 from pony import orm
 from pony.orm import db_session, select
 
+from tribler_common.simpledefs import CHANNEL_STATE
+
 from tribler_core.exceptions import DuplicateTorrentFileError
 from tribler_core.modules.libtorrent.torrentdef import TorrentDef
 from tribler_core.modules.metadata_store.discrete_clock import clock
@@ -20,7 +22,7 @@ from tribler_core.modules.metadata_store.orm_bindings.channel_node import (
     UPDATED,
 )
 from tribler_core.modules.metadata_store.orm_bindings.torrent_metadata import tdef_to_metadata_dict
-from tribler_core.modules.metadata_store.serialization import COLLECTION_NODE, CollectionNodePayload
+from tribler_core.modules.metadata_store.serialization import COLLECTION_NODE, CollectionNodePayload, CHANNEL_TORRENT
 from tribler_core.utilities.random_utils import random_infohash
 
 # pylint: disable=too-many-statements
@@ -52,8 +54,14 @@ def define_binding(db):
         @db_session
         def state(self):
             if self.is_personal:
-                return "Personal"
-            return "Preview"
+                return CHANNEL_STATE.PERSONAL.value
+
+            toplevel_parent = self.get_parent_nodes()[0]
+            if (toplevel_parent.metadata_type == CHANNEL_TORRENT and
+                toplevel_parent.local_version == toplevel_parent.timestamp):
+                return CHANNEL_STATE.COMPLETE.value
+
+            return CHANNEL_STATE.PREVIEW.value
 
         def to_simple_dict(self):
             result = super().to_simple_dict()

--- a/src/tribler-gui/tribler_gui/widgets/channelcontentswidget.py
+++ b/src/tribler-gui/tribler_gui/widgets/channelcontentswidget.py
@@ -1,4 +1,3 @@
-import uuid
 from base64 import b64encode
 
 from PyQt5 import uic
@@ -220,9 +219,6 @@ class ChannelContentsWidget(AddBreadcrumbOnShowMixin, widget_form, widget_class)
         self.channels_stack.append(model)
         connect(self.model.info_changed, self.on_model_info_changed)
 
-        connect(
-            self.window().core_manager.events_manager.received_remote_query_results, self.model.on_new_entry_received
-        )
         connect(self.window().core_manager.events_manager.node_info_updated, self.model.update_node_info)
 
         with self.freeze_controls():
@@ -280,9 +276,6 @@ class ChannelContentsWidget(AddBreadcrumbOnShowMixin, widget_form, widget_class)
 
     def disconnect_current_model(self):
         disconnect(self.window().core_manager.events_manager.node_info_updated, self.model.update_node_info)
-        disconnect(
-            self.window().core_manager.events_manager.received_remote_query_results, self.model.on_new_entry_received
-        )
         self.controller.unset_model()  # Disconnect the selectionChanged signal
 
     def go_back(self, checked=False):  # pylint: disable=W0613
@@ -327,32 +320,6 @@ class ChannelContentsWidget(AddBreadcrumbOnShowMixin, widget_form, widget_class)
 
     def on_channel_clicked(self, channel_dict):
         self.initialize_with_channel(channel_dict)
-
-    def preview_clicked(self, checked=False):  # pylint: disable=W0613
-        params = dict()
-
-        if "public_key" in self.model.channel_info:
-            # This is a channel contents query, limit the search by channel_pk and origin_id
-            params.update(
-                {'channel_pk': self.model.channel_info["public_key"], 'origin_id': self.model.channel_info["id"]}
-            )
-        if self.model.text_filter:
-            params.update({'txt_filter': self.model.text_filter})
-        if self.model.hide_xxx is not None:
-            params.update({'hide_xxx': self.model.hide_xxx})
-        if self.model.sort_by is not None:
-            params.update({'sort_by': self.model.sort_by})
-        if self.model.sort_desc is not None:
-            params.update({'sort_desc': self.model.sort_desc})
-        if self.model.category_filter is not None:
-            params.update({'category_filter': self.model.category_filter})
-
-        def add_request_uuid(response):
-            request_uuid = response["request_uuid"]
-            if self.model:
-                self.model.remote_queries.add(uuid.UUID(request_uuid))
-
-        TriblerNetworkRequest('remote_query', add_request_uuid, method="PUT", url_params=params)
 
     def create_new_channel(self, checked):  # pylint: disable=W0613
         NewChannelDialog(self, self.model.create_new_channel)

--- a/src/tribler-gui/tribler_gui/widgets/tablecontentmodel.py
+++ b/src/tribler-gui/tribler_gui/widgets/tablecontentmodel.py
@@ -292,7 +292,6 @@ class RemoteTableModel(QAbstractTableModel):
         update_labels = len(self.data_items) == 0
 
         if not remote or (uuid.UUID(response.get('uuid')) in self.remote_queries):
-
             prev_total = self.channel_info.get("total")
             if not remote:
                 if "total" in response:
@@ -590,6 +589,9 @@ class PersonalChannelsModel(ChannelContentModel):
         # This is a hack to put the newly created object at the top of the table
         kwargs["on_top"] = 1
         self.on_query_results(response, **kwargs)
+        if not response or self.qt_object_destroyed:
+            return False
+        self.info_changed.emit(response['results'])
 
     @property
     def edit_enabled(self):


### PR DESCRIPTION
This makes folders(collections) inherit status from parent channels. Otherwise, multi-level channels always open sub-collections in preview mode.

Also, remove some obsolete preview-related code.
Also, fix the bug with reverting to the root of the channels view.