### PR TITLE
Refactoring of test_get_first_free_port

### DIFF
--- a/src/tribler-gui/tribler_gui/tribler_window.py
+++ b/src/tribler-gui/tribler_gui/tribler_window.py
@@ -36,7 +36,7 @@ from PyQt5.QtWidgets import (
     QTreeWidget,
 )
 
-from tribler_common.network_utils import get_first_free_port
+from tribler_common.network_utils import NetworkUtils
 
 from tribler_core.modules.process_checker import ProcessChecker
 from tribler_core.utilities.unicode import hexlify
@@ -116,7 +116,7 @@ class TriblerWindow(QMainWindow):
         api_key = api_key or get_gui_setting(self.gui_settings, "api_key", hexlify(os.urandom(16)).encode('utf-8'))
         self.gui_settings.setValue("api_key", api_key)
 
-        api_port = get_first_free_port(start=api_port, limit=100)
+        api_port = NetworkUtils().get_first_free_port(start=api_port, limit=100)
         request_manager.port, request_manager.key = api_port, api_key
 
         self.tribler_started = False


### PR DESCRIPTION
This PR contains refactoring of `test_get_first_free_port`. Fixes #6042

Suggestions have been implemented:
* Split test into `get_first_free_port` and `get_first_free_port_none_available`
* Move the tests into the right folder.
* Refactor the function in `network_utils.py` into a `NetworkUtils`-type class

Credits to @qstokkink 