### PR TITLE
Fixes #6076: Object BandwidthTransaction was deleted outside of current transaction

### DIFF
--- a/src/tribler-core/tribler_core/modules/bandwidth_accounting/community.py
+++ b/src/tribler-core/tribler_core/modules/bandwidth_accounting/community.py
@@ -11,8 +11,6 @@ from ipv8.peer import Peer
 from ipv8.requestcache import RequestCache
 from ipv8.types import Address
 
-from pony.orm import db_session
-
 from tribler_core.modules.bandwidth_accounting import EMPTY_SIGNATURE
 from tribler_core.modules.bandwidth_accounting.cache import BandwidthTransactionSignCache
 from tribler_core.modules.bandwidth_accounting.database import BandwidthDatabase
@@ -80,8 +78,7 @@ class BandwidthAccountingCommunity(Community):
         :return A Future that fires when the counterparty has acknowledged the payout.
         """
         tx = self.construct_signed_transaction(peer, amount)
-        with db_session:
-            self.database.BandwidthTransaction.insert(tx)
+        self.database.BandwidthTransaction.insert(tx)
         cache = self.request_cache.add(BandwidthTransactionSignCache(self, tx))
         self.send_transaction(tx, peer.address, cache.number)
 

--- a/src/tribler-core/tribler_core/modules/bandwidth_accounting/database.py
+++ b/src/tribler-core/tribler_core/modules/bandwidth_accounting/database.py
@@ -50,7 +50,6 @@ class BandwidthDatabase:
             with db_session:
                 self.MiscData(name="db_version", value=str(self.CURRENT_DB_VERSION))
 
-    @db_session
     def has_transaction(self, transaction: BandwidthTransactionData) -> bool:
         """
         Return whether a transaction is persisted to the database.

--- a/src/tribler-core/tribler_core/modules/bandwidth_accounting/transaction.py
+++ b/src/tribler-core/tribler_core/modules/bandwidth_accounting/transaction.py
@@ -141,7 +141,7 @@ def define_binding(bandwidth_database):
         PrimaryKey(sequence_number, public_key_a, public_key_b)
 
         @classmethod
-        @db_session
+        @db_session(optimistic=False)
         def insert(cls, transaction: BandwidthTransaction) -> None:
             """
             Insert a BandwidthTransaction object in the database.


### PR DESCRIPTION
Basically, OptimisticCheckError was raised incorrectly by PonyORM: the current transaction tries to delete a BandwidthTransaction instance, but it was somehow already deleted outside of the current db_session. Pony thinks this is suspicious and raises the error.

I don't quite understand at this moment when the BandwidthTransaction instance was actually deleted (and why it happened outside of the current transaction), but the exception looks like an overreaction from PonyORM: if we want for an object to be deleted after the end of the transaction, and it was already deleted, then the final result will be what we expect to have.

In the next release of PonyORM, I plan to remove this optimistic check, and currently, I just turned off all optimistic checks for db_session in `BandwidthTransaction.insert` . They are not useful here anyway.

Also, I removed some unnecessary db_sessions (PonyORM ignores nested db_sessions).