### PR TITLE
Uncover the real exception from CoreConnectTimeoutError's event

### DIFF
--- a/src/tribler-common/tribler_common/sentry_reporter/sentry_scrubber.py
+++ b/src/tribler-common/tribler_common/sentry_reporter/sentry_scrubber.py
@@ -2,14 +2,7 @@ import re
 
 from tribler_common.sentry_reporter.sentry_reporter import (
     BREADCRUMBS,
-    CONTEXTS,
-    EXTRA,
-    LOGENTRY,
-    OS_ENVIRON,
     RELEASE,
-    REPORTER,
-    STACKTRACE,
-    SYSINFO,
     VALUES,
 )
 from tribler_common.sentry_reporter.sentry_tools import delete_item, distinct_by, format_version, modify_value

--- a/src/tribler-gui/tribler_gui/dialogs/feedbackdialog.py
+++ b/src/tribler-gui/tribler_gui/dialogs/feedbackdialog.py
@@ -30,6 +30,7 @@ class FeedbackDialog(AddBreadcrumbOnShowMixin, QDialog):
         error_reporting_requires_user_consent=True,
         stop_application_on_close=True,
         additional_tags=None,
+        retrieve_error_message_from_stacktrace=False
     ):
         QDialog.__init__(self, parent)
 
@@ -42,6 +43,7 @@ class FeedbackDialog(AddBreadcrumbOnShowMixin, QDialog):
         self.scrubber = SentryScrubber()
         self.stop_application_on_close = stop_application_on_close
         self.additional_tags = additional_tags
+        self.retrieve_error_message_from_stacktrace = retrieve_error_message_from_stacktrace
 
         # Qt 5.2 does not have the setPlaceholderText property
         if hasattr(self.comments_text_edit, "setPlaceholderText"):
@@ -162,7 +164,8 @@ class FeedbackDialog(AddBreadcrumbOnShowMixin, QDialog):
             "stack": stack,
         }
 
-        SentryReporter.send_event(self.sentry_event, post_data, sys_info_dict, self.additional_tags)
+        SentryReporter.send_event(self.sentry_event, post_data, sys_info_dict, self.additional_tags,
+                                  self.retrieve_error_message_from_stacktrace)
         self.on_report_sent()
 
     def on_report_sent(self):

--- a/src/tribler-gui/tribler_gui/error_handler.py
+++ b/src/tribler-gui/tribler_gui/error_handler.py
@@ -3,7 +3,6 @@ import os
 import traceback
 
 from tribler_common.sentry_reporter.sentry_reporter import SentryReporter
-
 from tribler_gui.dialogs.feedbackdialog import FeedbackDialog
 from tribler_gui.event_request_manager import CoreConnectTimeoutError
 
@@ -30,7 +29,8 @@ class ErrorHandler:
 
         text = "".join(traceback.format_exception(info_type, info_error, tb))
 
-        if info_type is CoreConnectTimeoutError:
+        is_core_timeout_exception = info_type is CoreConnectTimeoutError
+        if is_core_timeout_exception:
             text = text + self.tribler_window.core_manager.core_traceback
             self._stop_tribler(text)
 
@@ -44,7 +44,8 @@ class ErrorHandler:
             sentry_event=SentryReporter.event_from_exception(info_error),
             error_reporting_requires_user_consent=True,
             stop_application_on_close=self._tribler_stopped,
-            additional_tags={'source': 'gui'}
+            additional_tags={'source': 'gui'},
+            retrieve_error_message_from_stacktrace=is_core_timeout_exception
         ).show()
 
     def core_error(self, text, core_event):


### PR DESCRIPTION
This PR uncover the real exception from `CoreConnectTimeoutError`'s event.

Now the `CoreConnectTimeoutError` shows the biggest count of issues in `7.9.0` release:
![image](https://user-images.githubusercontent.com/13798583/120203688-48281980-c228-11eb-8364-5e9fb7256a20.png)

The problem for us as developers is that `CoreConnectTimeoutError` just covers a real exception. 
This PR uncover the real exception by retrieving it from a stacktrace. 

An issue before the PR: https://sentry.tribler.org/organizations/tribler/issues/270
An issue after the PR: https://sentry.tribler.org/organizations/tribler/issues/739 