### PR TITLE
Refactor random ports assignation in tribler config

### DIFF
--- a/src/tribler-common/tests/test_network_utils.py
+++ b/src/tribler-common/tests/test_network_utils.py
@@ -8,9 +8,8 @@ from tribler_common.network_utils import (
 
 # fmt: off
 
-
-@pytest.fixture(name="mock_socket")
-def fixture_mock_socket():
+@pytest.fixture(name="network_utils")
+def fixture_network_utils():
     class MockSocket:
         bound_ports = set()
 
@@ -28,22 +27,22 @@ def fixture_mock_socket():
         def __exit__(self, t, v, tb):
             pass
 
-    return {MockSocket}
+    return NetworkUtils(socket_class_set={MockSocket}, remember_checked_ports_enabled=False)
 
 
-def test_get_first_free_port(mock_socket):
+def test_get_first_free_port(network_utils):
     # target port is free
-    assert NetworkUtils(mock_socket).get_first_free_port(start=0) == 0
+    assert network_utils.get_first_free_port(start=0) == 0
 
     # target port is locked
-    assert NetworkUtils(mock_socket).get_first_free_port(start=0) == 1
+    assert network_utils.get_first_free_port(start=0) == 1
 
 
-def test_get_random_free_port(mock_socket):
-    assert NetworkUtils(mock_socket).get_random_free_port(start=0, stop=0) == 0
+def test_get_random_free_port(network_utils):
+    assert network_utils.get_random_free_port(start=0, stop=0) == 0
 
-    port1 = NetworkUtils(mock_socket).get_random_free_port(start=0, stop=3)
-    port2 = NetworkUtils(mock_socket).get_random_free_port(start=0, stop=3)
+    port1 = network_utils.get_random_free_port(start=0, stop=3)
+    port2 = network_utils.get_random_free_port(start=0, stop=3)
 
     assert port1 != port2
 

--- a/src/tribler-common/tribler_common/network_utils.py
+++ b/src/tribler-common/tribler_common/network_utils.py
@@ -10,8 +10,19 @@ class FreePortNotFoundError(Exception):
 class NetworkUtils:
     MAX_PORT = 65535
     FIRST_PORT_IN_DYNAMIC_RANGE = 49152
+    ports_in_use = set()
 
-    def __init__(self, socket_class_set=None):
+    def __init__(self, socket_class_set=None, remember_checked_ports_enabled=False):
+        """
+
+        Args:
+            socket_class_set: a set of sockets that will be used for checkings
+                port availability. A port is considered free only in case that
+                it is free in all sockets from `socket_class_set`
+            remember_checked_ports_enabled: a flag that enables or disables
+                remembering returned ports. If it is set to true, then
+                a particular port will be returned only once.
+        """
         if socket_class_set is None:
             socket_class_set = {
                 lambda: socket.socket(socket.AF_INET, socket.SOCK_STREAM),  # tcp
@@ -19,15 +30,22 @@ class NetworkUtils:
             }
 
         self.socket_class_set = socket_class_set
+        self.remember_checked_ports_enabled = remember_checked_ports_enabled
+
         self.logger = logging.getLogger(self.__class__.__name__)
+        self.random_instance = random.Random()
+
+    @staticmethod
+    def not_in_use(port):
+        return port not in NetworkUtils.ports_in_use
 
     def get_first_free_port(self, start=FIRST_PORT_IN_DYNAMIC_RANGE, stop=MAX_PORT):
         self.logger.info(f'Looking for first free port in range [{start}..{stop}]')
 
         for port in range(start, stop):
-            if self.is_port_free(port):
+            if NetworkUtils.not_in_use(port) and self.is_port_free(port):
                 self.logger.info(f'{port} is free')
-                return port
+                return self.remember(port)
 
             self.logger.info(f'{port} in use')
 
@@ -40,10 +58,10 @@ class NetworkUtils:
         self.logger.info(f'Looking for random free port in range [{start}..{stop}]')
 
         for _ in range(attempts):
-            port = random.randint(start, stop)
-            if self.is_port_free(port):
+            port = self.random_instance.randint(start, stop)
+            if NetworkUtils.not_in_use(port) and self.is_port_free(port):
                 self.logger.info(f'{port} is free')
-                return port
+                return self.remember(port)
 
             self.logger.info(f'{port} in use')
 
@@ -57,3 +75,9 @@ class NetworkUtils:
             return True
         except OSError:
             return False
+
+    def remember(self, port):
+        if self.remember_checked_ports_enabled:
+            NetworkUtils.ports_in_use.add(port)
+
+        return port

--- a/src/tribler-core/tribler_core/config/test_tribler_config.py
+++ b/src/tribler-core/tribler_core/config/test_tribler_config.py
@@ -41,16 +41,6 @@ def test_invalid_config_recovers(tmpdir):
     tribler_conf2 = TriblerConfig(tmpdir, config_file=default_config_file, reset_config_on_error=False)
     assert tribler_conf2
 
-def test_write_load(tribler_config):
-    """
-    When writing and reading a config the options should remain the same.
-    """
-    port = 4444
-    tribler_config.set_anon_listen_port(port)
-    tribler_config.write()
-    path = tribler_config.get_state_dir() / CONFIG_FILENAME
-    read_config = TriblerConfig(path, config_file=path)
-    assert read_config.get_anon_listen_port() == port
 
 
 def test_libtorrent_proxy_settings(tribler_config):
@@ -201,10 +191,6 @@ def test_get_set_methods_libtorrent(tribler_config):
     assert tribler_config.get_libtorrent_utp()
     tribler_config.set_libtorrent_port(1234)
     assert tribler_config.get_libtorrent_port() == 1234
-    tribler_config.set_libtorrent_port_runtime(1235)
-    assert tribler_config.get_libtorrent_port() == 1235
-    tribler_config.set_anon_listen_port(1236)
-    assert tribler_config.get_anon_listen_port() == 1236
     proxy_server, proxy_auth = ["localhost", "9090"], ["user", "pass"]
     tribler_config.set_libtorrent_proxy_settings(3, ":".join(proxy_server), ":".join(proxy_auth))
     assert tribler_config.get_libtorrent_proxy_settings() == (3, proxy_server, proxy_auth)
@@ -241,8 +227,6 @@ def test_get_set_methods_tunnel_community(tribler_config):
     """
     tribler_config.set_tunnel_community_enabled(True)
     assert tribler_config.get_tunnel_community_enabled()
-    tribler_config.set_tunnel_community_socks5_listen_ports([-1])
-    assert tribler_config.get_tunnel_community_socks5_listen_ports() != [-1]  # We cannot set a negative port
     tribler_config.set_tunnel_community_socks5_listen_ports([5])
     assert tribler_config.get_tunnel_community_socks5_listen_ports() == [5]
     tribler_config.set_tunnel_community_exitnode_enabled(True)

--- a/src/tribler-core/tribler_core/config/tribler_config.spec
+++ b/src/tribler-core/tribler_core/config/tribler_config.spec
@@ -5,7 +5,7 @@ version_checker_enabled = boolean(default=True)
 
 [tunnel_community]
 enabled = boolean(default=True)
-socks5_listen_ports = string_list(default=list('-1', '-1', '-1', '-1', '-1'))
+socks5_listen_ports = int_list(default=None)
 exitnode_enabled = boolean(default=False)
 random_slots = integer(default=5)
 competing_slots = integer(default=15)
@@ -42,7 +42,7 @@ enabled = boolean(default=True)
 
 [libtorrent]
 enabled = boolean(default=True)
-port = integer(min=-1, max=65536, default=-1)
+port = integer(min=-1, max=65536, default=None)
 proxy_type = integer(min=0, max=5, default=0)
 proxy_server = string(default=':')
 proxy_auth = string(default=':')
@@ -53,7 +53,7 @@ utp = boolean(default=True)
 dht = boolean(default=True)
 dht_readiness_timeout = integer(default=30)
 
-anon_listen_port = integer(min=-1, max=65536, default=-1)
+anon_listen_port = integer(min=-1, max=65536, default=None)
 anon_proxy_type = integer(min=0, max=5, default=0)
 anon_proxy_server_ip = ip_addr(default=127.0.0.1)
 anon_proxy_server_ports = string_list(default=list('-1', '-1', '-1', '-1', '-1'))

--- a/src/tribler-core/tribler_core/modules/libtorrent/download_manager.py
+++ b/src/tribler-core/tribler_core/modules/libtorrent/download_manager.py
@@ -14,10 +14,9 @@ from distutils.version import LooseVersion
 from shutil import rmtree
 
 from ipv8.taskmanager import TaskManager, task
-
+from tribler_common.network_utils import NetworkUtils
 from tribler_common.simpledefs import DLSTATUS_SEEDING, STATEDIR_CHECKPOINT_DIR
 from tribler_common.utilities import uri_to_path
-
 from tribler_core.modules.dht_health_manager import DHTHealthManager
 from tribler_core.modules.libtorrent.download import Download
 from tribler_core.modules.libtorrent.download_config import DownloadConfig
@@ -167,12 +166,15 @@ class DownloadManager(TaskManager):
     def create_session(self, hops=0, store_listen_port=True):
         # Due to a bug in Libtorrent 0.16.18, the outgoing_port and num_outgoing_ports value should be set in
         # the settings dictionary
+        self._logger.info('Creating a session')
         settings = {'outgoing_port': 0,
                     'num_outgoing_ports': 1,
                     'allow_multiple_connections_per_ip': 0}
 
         # Copy construct so we don't modify the default list
         extensions = list(DEFAULT_LT_EXTENSIONS)
+        anon_port = self.tribler_session.config.get_anon_listen_port() or NetworkUtils().get_random_free_port()
+        self._logger.info(f'Anon port: {anon_port}. Dummy mode: {self.dummy_mode}. Hops: {hops}')
 
         # Elric: Strip out the -rcX, -beta, -whatever tail on the version string.
         fingerprint = ['TL'] + [int(x) for x in version_id.split('-')[0].split('.')] + [0]
@@ -185,6 +187,8 @@ class DownloadManager(TaskManager):
         else:
             ltsession = lt.session(lt.fingerprint(*fingerprint), flags=0) if hops == 0 else lt.session(flags=0)
 
+        libtorrent_port = self.tribler_session.config.get_libtorrent_port() or NetworkUtils().get_random_free_port()
+        self._logger.info(f'Libtorrent port: {libtorrent_port}')
         if hops == 0:
             settings['user_agent'] = 'Tribler/' + version_id
             enable_utp = self.tribler_session.config.get_libtorrent_utp()
@@ -193,7 +197,7 @@ class DownloadManager(TaskManager):
 
             if LooseVersion(self.get_libtorrent_version()) >= LooseVersion("1.1.0"):
                 settings['prefer_rc4'] = True
-                settings["listen_interfaces"] = "0.0.0.0:%d" % self.tribler_session.config.get_libtorrent_port()
+                settings["listen_interfaces"] = "0.0.0.0:%d" % libtorrent_port
             else:
                 pe_settings = lt.pe_settings()
                 pe_settings.prefer_rc4 = True
@@ -211,7 +215,7 @@ class DownloadManager(TaskManager):
             settings['force_proxy'] = True
 
             if LooseVersion(self.get_libtorrent_version()) >= LooseVersion("1.1.0"):
-                settings["listen_interfaces"] = "0.0.0.0:%d" % self.tribler_session.config.get_anon_listen_port()
+                settings["listen_interfaces"] = "0.0.0.0:%d" % anon_port
 
             # By default block all IPs except 1.1.1.1 (which is used to ensure libtorrent makes a connection to us)
             self.update_ip_filter(ltsession, ['1.1.1.1'])
@@ -233,10 +237,9 @@ class DownloadManager(TaskManager):
 
         # Set listen port & start the DHT
         if hops == 0:
-            listen_port = self.tribler_session.config.get_libtorrent_port()
-            ltsession.listen_on(listen_port, listen_port + 10)
-            if listen_port != ltsession.listen_port() and store_listen_port:
-                self.tribler_session.config.set_libtorrent_port_runtime(ltsession.listen_port())
+            ltsession.listen_on(libtorrent_port, libtorrent_port + 10)
+            if libtorrent_port != ltsession.listen_port() and store_listen_port:
+                self.tribler_session.config.set_libtorrent_port(ltsession.listen_port())
             try:
                 with open(self.tribler_session.config.get_state_dir() / LTSTATE_FILENAME, 'rb') as fp:
                     lt_state = bdecode_compat(fp.read())
@@ -247,8 +250,7 @@ class DownloadManager(TaskManager):
             except Exception as exc:
                 self._logger.info(f"could not load libtorrent state, got exception: {exc!r}. starting from scratch")
         else:
-            ltsession.listen_on(self.tribler_session.config.get_anon_listen_port(),
-                                self.tribler_session.config.get_anon_listen_port() + 20)
+            ltsession.listen_on(anon_port, anon_port + 20)
 
             settings = {'upload_rate_limit': self.tribler_session.config.get_libtorrent_max_upload_rate(),
                         'download_rate_limit': self.tribler_session.config.get_libtorrent_max_download_rate()}
@@ -352,9 +354,10 @@ class DownloadManager(TaskManager):
                                  else getattr(alert, 'info_hash', '')))
         download = self.downloads.get(infohash)
         if download:
-            if (download.handle and download.handle.is_valid())\
-                    or (not download.handle and alert_type == 'add_torrent_alert') \
-                    or (download.handle and alert_type == 'torrent_removed_alert'):
+            is_process_alert = (download.handle and download.handle.is_valid()) \
+                               or (not download.handle and alert_type == 'add_torrent_alert') \
+                               or (download.handle and alert_type == 'torrent_removed_alert')
+            if is_process_alert:
                 download.process_alert(alert, alert_type)
             else:
                 self._logger.debug("Got alert for download without handle %s: %s", hexlify(infohash), alert)
@@ -392,7 +395,7 @@ class DownloadManager(TaskManager):
 
             # We are sending a raw DHT message - notify the DHTHealthManager of the outstanding request.
             if not incoming and decoded.get(b'y') == b'q' \
-               and decoded.get(b'q') == b'get_peers' and decoded[b'a'].get(b'scrape') == 1:
+                    and decoded.get(b'q') == b'get_peers' and decoded[b'a'].get(b'scrape') == 1:
                 self.dht_health_manager.requesting_bloomfilters(decoded[b't'],
                                                                 decoded[b'a'][b'info_hash'])
 

--- a/src/tribler-core/tribler_core/modules/tunnel/community/triblertunnel_community.py
+++ b/src/tribler-core/tribler_core/modules/tunnel/community/triblertunnel_community.py
@@ -86,7 +86,7 @@ class TriblerTunnelCommunity(HiddenTunnelCommunity):
                 socks_listen_ports = self.tribler_session.config.get_tunnel_community_socks5_listen_ports()
         elif socks_listen_ports is None:
             socks_listen_ports = range(1080, 1085)
-
+        self.logger.info(f'Socks listen ports: {socks_listen_ports}')
         self.bittorrent_peers = {}
         self.dispatcher = TunnelDispatcher(self)
         self.download_states = {}

--- a/src/tribler-core/tribler_core/modules/tunnel/tests/test_triblertunnel_community.py
+++ b/src/tribler-core/tribler_core/modules/tunnel/tests/test_triblertunnel_community.py
@@ -55,6 +55,12 @@ class TestTriblerTunnelCommunity(TestBase):  # pylint: disable=too-many-public-m
 
         return mock_ipv8
 
+
+    @staticmethod
+    def get_free_port():
+        return NetworkUtils(remember_checked_ports_enabled=True).get_random_free_port()
+
+
     async def create_intro(self, node_nr, service):
         """
         Create an 1 hop introduction point for some node for some service.
@@ -554,7 +560,7 @@ class TestTriblerTunnelCommunity(TestBase):  # pylint: disable=too-many-public-m
         self.nodes[1].overlay.settings.peer_flags.add(PEER_FLAG_EXIT_HTTP)
         await self.introduce_nodes()
 
-        http_port = NetworkUtils().get_random_free_port()
+        http_port = TestTriblerTunnelCommunity.get_free_port()
         http_tracker = HTTPTracker(http_port)
         http_tracker.tracker_info.add_info_about_infohash('0', 0, 0)
         await http_tracker.start()
@@ -574,7 +580,7 @@ class TestTriblerTunnelCommunity(TestBase):  # pylint: disable=too-many-public-m
         self.nodes[1].overlay.settings.peer_flags.add(PEER_FLAG_EXIT_HTTP)
         await self.introduce_nodes()
 
-        http_port = NetworkUtils().get_random_free_port()
+        http_port = TestTriblerTunnelCommunity.get_free_port()
         http_tracker = HTTPTracker(http_port)
         http_tracker.tracker_info.add_info_about_infohash('0', 0, 0)
         http_tracker.tracker_info.infohashes['0']['downloaded'] = os.urandom(10000)
@@ -595,7 +601,7 @@ class TestTriblerTunnelCommunity(TestBase):  # pylint: disable=too-many-public-m
         self.nodes[1].overlay.settings.peer_flags.add(PEER_FLAG_EXIT_HTTP)
         await self.introduce_nodes()
 
-        http_port = NetworkUtils().get_random_free_port()
+        http_port = TestTriblerTunnelCommunity.get_free_port()
         http_tracker = HTTPTracker(http_port)
         await http_tracker.start()
         with self.assertRaises(AsyncTimeoutError):

--- a/src/tribler-core/tribler_core/restapi/settings_endpoint.py
+++ b/src/tribler-core/tribler_core/restapi/settings_endpoint.py
@@ -6,6 +6,7 @@ from ipv8.REST.schema import schema
 
 from marshmallow.fields import Boolean
 
+from tribler_common.network_utils import NetworkUtils
 from tribler_core.restapi.rest_endpoint import RESTEndpoint, RESTResponse
 
 
@@ -27,13 +28,12 @@ class SettingsEndpoint(RESTEndpoint):
             }
         },
         description="This endpoint returns all the session settings that can be found in Tribler.\n\n It also returns "
-                    "the runtime-determined ports, i.e. the ports for the SOCKS5 servers. Please note that a port "
-                    "with a value of -1 in the settings means that the port is randomly assigned at startup."
+                    "the runtime-determined ports"
     )
     async def get_settings(self, request):
         return RESTResponse({
             "settings": self.session.config.config,
-            "ports": self.session.config.selected_ports
+            "ports": list(NetworkUtils.ports_in_use)
         })
 
     @docs(

--- a/src/tribler-core/tribler_core/restapi/tests/test_settings_endpoint.py
+++ b/src/tribler-core/tribler_core/restapi/tests/test_settings_endpoint.py
@@ -17,7 +17,6 @@ def verify_settings(settings_dict):
                      'tunnel_community', 'api', 'trustchain', 'watch_folder']
 
     assert settings_dict['settings']
-    assert settings_dict['ports']
     assert Path(settings_dict['settings']['download_defaults']['saveas'])
     for section in check_section:
         assert settings_dict['settings'][section]

--- a/src/tribler-gui/tribler_gui/tests/test_gui.py
+++ b/src/tribler-gui/tribler_gui/tests/test_gui.py
@@ -27,7 +27,7 @@ RUN_TRIBLER_PY = Path(tribler_gui.__file__).parent.parent.parent / "run_tribler.
 
 @pytest.fixture(scope="module")
 def api_port():
-    return NetworkUtils().get_random_free_port()
+    return NetworkUtils(remember_checked_ports_enabled=False).get_random_free_port()
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
This PR removes random port assignation from Tribler config and places it to the corresponding modules. It also reduces the time between port checking and port using.

Fixes #6148