### PR TITLE
[macOS] Fix display name capitalization

### DIFF
--- a/tribler.spec
+++ b/tribler.spec
@@ -141,10 +141,10 @@ coll = COLLECT(exe,
                name='tribler')
 
 app = BUNDLE(coll,
-             name='tribler.app',
+             name='Tribler.app',
              icon='build/mac/resources/tribler.icns',
              bundle_identifier='nl.tudelft.tribler',
-             info_plist={'NSHighResolutionCapable': 'True', 'CFBundleInfoDictionaryVersion': 1.0, 'CFBundleVersion': version_str, 'CFBundleShortVersionString': version_str},
+             info_plist={'CFBundleName': 'Tribler', 'CFBundleDisplayName': 'Tribler', 'NSHighResolutionCapable': 'True', 'CFBundleInfoDictionaryVersion': 1.0, 'CFBundleVersion': version_str, 'CFBundleShortVersionString': version_str},
              console=show_console)
 
 # Replace the Info.plist file on MacOS


### PR DESCRIPTION
* Change app bundle name to “Tribler.app”.
* Set CFBundleName and CFBundleDisplayName to “Tribler”.

The changes ensures the app is displayed as “Tribler” rather than “tribler” throughout macOS.