### PR TITLE
Disable EVA timeout in test_dynamically_changed_window_size

### DIFF
--- a/src/tribler-core/tribler_core/modules/metadata_store/community/tests/test_eva_protocol.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/community/tests/test_eva_protocol.py
@@ -375,6 +375,8 @@ class TestEVA(TestBase):
 
         self.overlay(0).eva_protocol.block_size = block_size
         self.overlay(1).eva_protocol.window_size = window_size
+        self.overlay(0).eva_protocol.terminate_by_timeout_enabled = False
+        self.overlay(1).eva_protocol.terminate_by_timeout_enabled = False
 
         data = os.urandom(1), os.urandom(block_size * 1024), 42
 


### PR DESCRIPTION
This PR fixes #6166 by disabling EVA timeout in the test.

As we see in full logs (thanks @qstokkink), the core issue of the test's failure is:

```python
DEBUG    EVA:eva_protocol.py:437 Acknowledgement (450). Window size: 43. Peer hash: 233461499389175895
INFO     EVA:eva_protocol.py:494 Finish. Peer hash: 1909838577825146852. Transfer: Type: TransferType.OUTGOING. Info: b'?'. Block: 409(1024). Window size: 41. Updated: 1624017632.813049
WARNING  EVA:eva_protocol.py:507 Exception.Peer hash 1909838577825146852: "Terminated by timeout. Timeout is: 1 sec"
```

So it would be enough to just disable this timeout in this particular test.

