### PR TITLE
Disable EVA terminate by timeout in test_multiply_duplex

### DIFF
--- a/src/tribler-core/tribler_core/modules/metadata_store/community/tests/test_eva_protocol.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/community/tests/test_eva_protocol.py
@@ -275,6 +275,10 @@ class TestEVA(TestBase):
     async def test_multiply_duplex(self):
         data_set_count = 10
 
+        self.overlay(0).eva_protocol.terminate_by_timeout_enabled = False
+        self.overlay(1).eva_protocol.terminate_by_timeout_enabled = False
+        self.overlay(2).eva_protocol.terminate_by_timeout_enabled = False
+
         self.overlay(0).eva_protocol.block_size = 10
         self.overlay(1).eva_protocol.block_size = 10
         self.overlay(2).eva_protocol.block_size = 10


### PR DESCRIPTION
This PR fixes #6167 by disabling terminating EVA session by timeout in `test_multiply_duplex`