### PR TITLE
Add shutdown call to each mds instance created inside RQC tests

### DIFF
--- a/src/tribler-core/tribler_core/modules/metadata_store/community/tests/test_gigachannel_community.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/community/tests/test_gigachannel_community.py
@@ -36,8 +36,14 @@ class TestGigaChannelUnits(TestBase):
     def setUp(self):
         super().setUp()
         self.count = 0
+        self.metadata_store_set = set()
         self.initialize(GigaChannelCommunity, 3)
         self.torrent_template = {"title": "", "infohash": b"", "torrent_date": datetime(1970, 1, 1), "tags": "video"}
+
+    async def tearDown(self):
+        for metadata_store in self.metadata_store_set:
+            metadata_store.shutdown()
+        await super().tearDown()
 
     def create_node(self, *args, **kwargs):
         metadata_store = MetadataStore(
@@ -46,6 +52,7 @@ class TestGigaChannelUnits(TestBase):
             default_eccrypto.generate_key("curve25519"),
             disable_sync=True,
         )
+        self.metadata_store_set.add(metadata_store)
         kwargs['metadata_store'] = metadata_store
         kwargs['settings'] = ChantSettings()
         kwargs['rqc_settings'] = RemoteQueryCommunitySettings()

--- a/src/tribler-core/tribler_core/modules/popularity/tests/test_popularity_community.py
+++ b/src/tribler-core/tribler_core/modules/popularity/tests/test_popularity_community.py
@@ -25,15 +25,23 @@ class TestPopularityCommunity(TestBase):
     def setUp(self):
         super().setUp()
         self.count = 0
+        self.metadata_store_set = set()
         self.initialize(PopularityCommunity, self.NUM_NODES)
 
+    async def tearDown(self):
+        for metadata_store in self.metadata_store_set:
+            metadata_store.shutdown()
+        await super().tearDown()
+
     def create_node(self, *args, **kwargs):
-        mds = MetadataStore(Path(self.temporary_directory()) / ("%d.db" % self.count),
+        mds = MetadataStore(Path(self.temporary_directory()) / f"{self.count}",
                             Path(self.temporary_directory()),
                             default_eccrypto.generate_key("curve25519"))
-
+        self.metadata_store_set.add(mds)
         torrent_checker = MockObject()
         torrent_checker.torrents_checked = set()
+
+        self.count += 1
 
         return MockIPv8("curve25519", PopularityCommunity, metadata_store=mds,
                         torrent_checker=torrent_checker)

--- a/src/tribler-core/tribler_core/modules/remote_query_community/tests/test_remote_query_community.py
+++ b/src/tribler-core/tribler_core/modules/remote_query_community/tests/test_remote_query_community.py
@@ -58,8 +58,14 @@ class TestRemoteQueryCommunity(TestBase):
         random.seed(456)
         super().setUp()
         self.count = 0
+        self.metadata_store_set = set()
         self.initialize(BasicRemoteQueryCommunity, 2)
         self.torrent_template = {"title": "", "infohash": b"", "torrent_date": datetime(1970, 1, 1), "tags": "video"}
+
+    async def tearDown(self):
+        for metadata_store in self.metadata_store_set:
+            metadata_store.shutdown()
+        await super().tearDown()
 
     def create_node(self, *args, **kwargs):
         metadata_store = MetadataStore(
@@ -68,6 +74,7 @@ class TestRemoteQueryCommunity(TestBase):
             default_eccrypto.generate_key("curve25519"),
             disable_sync=True,
         )
+        self.metadata_store_set.add(metadata_store)
         kwargs['metadata_store'] = metadata_store
         kwargs['rqc_settings'] = RemoteQueryCommunitySettings()
         node = super().create_node(*args, **kwargs)
@@ -133,7 +140,6 @@ class TestRemoteQueryCommunity(TestBase):
         """
         Test querying back preview contents for previously unknown channels.
         """
-
         num_channels = 5
         max_received_torrents_per_channel_query_back = 4
 


### PR DESCRIPTION
This PR fixes #6158 by adding shutdown call to each `mds` instance created.

```python
async def tearDown(self):
    self.mds.shutdown()
    await super().tearDown()
```

For the history, if you want to use tmpdir from pytest, you could use this trick:

```python
class MyTest(TestBase):
    @pytest.fixture(autouse=True)
    def init_tmpdir(self, tmpdir):
        self.tmpdir = tmpdir
``` 