### PR TITLE
Extract loaders from ipv8_module_catalog.py

### DIFF
--- a/src/run_tribler.py
+++ b/src/run_tribler.py
@@ -91,11 +91,8 @@ def start_tribler_core(base_path, api_port, api_key, root_state_dir, core_test_m
         log_dir = config.general.get_path_as_absolute('log_dir', config.state_dir)
         trace_logger = check_and_enable_code_tracing('core', log_dir)
 
-        community_loader = create_default_loader(config, chant_testnet=is_chant_testnet(config),
-                                                 tunnel_testnet=is_tunnel_testnet(config),
-                                                 bandwidth_testnet=is_bandwidth_testnet(config))
-        session = Session(config, core_test_mode=core_test_mode, community_loader=community_loader,
-                          chant_testnet=is_chant_testnet(config), trustchain_testnet=is_trustchain_testnet(config))
+        community_loader = create_default_loader(config)
+        session = Session(config, core_test_mode=core_test_mode, community_loader=community_loader)
 
         signal.signal(signal.SIGTERM, lambda signum, stack: shutdown(session, signum, stack))
         await session.start()
@@ -126,30 +123,6 @@ def init_sentry_reporter():
                             scrubber=None,
                             strategy=SentryStrategy.SEND_ALLOWED)
         logger.info('Sentry has been initialised in debug mode')
-
-
-def is_chant_testnet(config):
-    return ('TESTNET' in os.environ or
-            'CHANT_TESTNET' in os.environ or
-            config.chant.testnet)
-
-
-def is_bandwidth_testnet(config):
-    return ('TESTNET' in os.environ or
-            'BANDWIDTH_TESTNET' in os.environ or
-            config.bandwidth_accounting.testnet)
-
-
-def is_tunnel_testnet(config):
-    return ('TESTNET' in os.environ or
-            'TUNNEL_TESTNET' in os.environ or
-            config.tunnel_community.testnet)
-
-
-def is_trustchain_testnet(config):
-    return ('TESTNET' in os.environ or
-            'TRUSTCHAIN_TESTNET' in os.environ or
-            config.trustchain.testnet)
 
 
 def init_boot_logger():

--- a/src/tribler-core/run_bandwidth_crawler.py
+++ b/src/tribler-core/run_bandwidth_crawler.py
@@ -10,8 +10,8 @@ from ipv8.loader import IPv8CommunityLoader
 
 from tribler_core.config.tribler_config import TriblerConfig
 from tribler_core.modules.bandwidth_accounting.database import BandwidthDatabase
+from tribler_core.modules.bandwidth_accounting.launcher import BandwidthCommunityLauncher
 from tribler_core.modules.bandwidth_accounting.settings import BandwidthAccountingSettings
-from tribler_core.modules.ipv8_module_catalog import BandwidthCommunityLauncher
 from tribler_core.session import Session
 
 
@@ -38,12 +38,11 @@ class BandwidthCommunityCrawlerLauncher(BandwidthCommunityLauncher):
 
 
 async def start_crawler(tribler_config):
-    session = Session(tribler_config)
 
     # We use our own community loader
     loader = IPv8CommunityLoader()
-    session.ipv8_community_loader = loader
     loader.set_launcher(BandwidthCommunityCrawlerLauncher())
+    session = Session(tribler_config, community_loader=loader)
 
     await session.start()
 

--- a/src/tribler-core/tribler_core/modules/bandwidth_accounting/launcher.py
+++ b/src/tribler-core/tribler_core/modules/bandwidth_accounting/launcher.py
@@ -9,7 +9,6 @@ from tribler_core.modules.ipv8_module_catalog import IPv8CommunityLauncher, Test
 
 
 @overlay(BandwidthAccountingCommunity)
-@precondition('not session.bandwidth_testnet()')
 @walk_strategy(RandomWalk)
 @set_in_session('bandwidth_community')
 class BandwidthCommunityLauncher(IPv8CommunityLauncher):
@@ -21,6 +20,5 @@ class BandwidthCommunityLauncher(IPv8CommunityLauncher):
 
 
 @overlay(BandwidthAccountingTestnetCommunity)
-@precondition('session.bandwidth_testnet()')
 class BandwidthTestnetCommunityLauncher(TestnetMixIn, BandwidthCommunityLauncher):
     pass

--- a/src/tribler-core/tribler_core/modules/bandwidth_accounting/launcher.py
+++ b/src/tribler-core/tribler_core/modules/bandwidth_accounting/launcher.py
@@ -1,0 +1,26 @@
+from ipv8.loader import overlay, precondition, set_in_session, walk_strategy
+from ipv8.peerdiscovery.discovery import RandomWalk
+
+from tribler_core.modules.bandwidth_accounting.community import (
+    BandwidthAccountingCommunity,
+    BandwidthAccountingTestnetCommunity,
+)
+from tribler_core.modules.ipv8_module_catalog import IPv8CommunityLauncher, TestnetMixIn
+
+
+@overlay(BandwidthAccountingCommunity)
+@precondition('not session.bandwidth_testnet()')
+@walk_strategy(RandomWalk)
+@set_in_session('bandwidth_community')
+class BandwidthCommunityLauncher(IPv8CommunityLauncher):
+    def get_kwargs(self, session):
+        return {
+            'settings': session.config.bandwidth_accounting,
+            'database_path': session.config.state_dir / "sqlite" / "bandwidth.db",
+        }
+
+
+@overlay(BandwidthAccountingTestnetCommunity)
+@precondition('session.bandwidth_testnet()')
+class BandwidthTestnetCommunityLauncher(TestnetMixIn, BandwidthCommunityLauncher):
+    pass

--- a/src/tribler-core/tribler_core/modules/bandwidth_accounting/launcher.py
+++ b/src/tribler-core/tribler_core/modules/bandwidth_accounting/launcher.py
@@ -1,17 +1,17 @@
-from ipv8.loader import overlay, precondition, set_in_session, walk_strategy
+from ipv8.loader import overlay, set_in_session, walk_strategy
 from ipv8.peerdiscovery.discovery import RandomWalk
 
 from tribler_core.modules.bandwidth_accounting.community import (
     BandwidthAccountingCommunity,
     BandwidthAccountingTestnetCommunity,
 )
-from tribler_core.modules.ipv8_module_catalog import IPv8CommunityLauncher, TestnetMixIn
+from tribler_core.modules.community_loader import TestnetMixIn, TriblerCommunityLauncher
 
 
 @overlay(BandwidthAccountingCommunity)
 @walk_strategy(RandomWalk)
 @set_in_session('bandwidth_community')
-class BandwidthCommunityLauncher(IPv8CommunityLauncher):
+class BandwidthCommunityLauncher(TriblerCommunityLauncher):
     def get_kwargs(self, session):
         return {
             'settings': session.config.bandwidth_accounting,

--- a/src/tribler-core/tribler_core/modules/bandwidth_accounting/settings.py
+++ b/src/tribler-core/tribler_core/modules/bandwidth_accounting/settings.py
@@ -1,7 +1,9 @@
+from pydantic import Field
+
 from tribler_core.config.tribler_config_section import TriblerConfigSection
 
 
 class BandwidthAccountingSettings(TriblerConfigSection):
-    testnet: bool = False
+    testnet: bool = Field(default=False, env='BANDWIDTH_TESTNET')
     outgoing_query_interval: int = 30  # The interval at which we send out queries to other peers, in seconds.
     max_tx_returned_in_query: int = 10  # The maximum number of bandwidth transactions to return in response to a query.

--- a/src/tribler-core/tribler_core/modules/community_loader.py
+++ b/src/tribler-core/tribler_core/modules/community_loader.py
@@ -1,7 +1,4 @@
 # pylint: disable=import-outside-toplevel
-import inspect
-import sys
-
 from ipv8.loader import (
     CommunityLauncher,
     IPv8CommunityLoader,
@@ -23,7 +20,8 @@ The amount of target_peers for a walk_strategy definition to never stop.
 
 class TriblerCommunityLauncher(CommunityLauncher):
     def get_my_peer(self, ipv8, session):
-        return (Peer(session.trustchain_testnet_keypair) if session.trustchain_testnet
+        trustchain_testnet = session.config.general.testnet or session.config.trustchain.testnet
+        return (Peer(session.trustchain_testnet_keypair) if trustchain_testnet
                 else Peer(session.trustchain_keypair))
 
     def get_bootstrappers(self, session):
@@ -92,20 +90,21 @@ class DHTCommunityLauncher(TriblerCommunityLauncher):
     pass
 
 
-def create_default_loader(config: TriblerConfig, tunnel_testnet: bool = False,
-                          bandwidth_testnet: bool = False, chant_testnet: bool = False):
+def create_default_loader(config: TriblerConfig):
     loader = IPv8CommunityLoader()
 
     loader.set_launcher(IPv8DiscoveryCommunityLauncher())
     loader.set_launcher(DHTCommunityLauncher())
 
-    if bandwidth_testnet:
+    bandwidth_accounting_testnet = config.general.testnet or config.bandwidth_accounting.testnet
+    if bandwidth_accounting_testnet:
         from tribler_core.modules.bandwidth_accounting.launcher import BandwidthTestnetCommunityLauncher
         loader.set_launcher(BandwidthTestnetCommunityLauncher())
     else:
         from tribler_core.modules.bandwidth_accounting.launcher import BandwidthCommunityLauncher
         loader.set_launcher(BandwidthCommunityLauncher())
 
+    tunnel_testnet = config.general.testnet or config.tunnel_community.testnet
     if config.tunnel_community.enabled and not tunnel_testnet:
         from tribler_core.modules.tunnel.community.launcher import TriblerTunnelCommunityLauncher
         loader.set_launcher(TriblerTunnelCommunityLauncher())
@@ -118,6 +117,7 @@ def create_default_loader(config: TriblerConfig, tunnel_testnet: bool = False,
         from tribler_core.modules.popularity.launcher import PopularityCommunityLauncher
         loader.set_launcher(PopularityCommunityLauncher())
 
+    chant_testnet = config.general.testnet or config.chant.testnet
     if config.chant.enabled and not chant_testnet:
         from tribler_core.modules.metadata_store.community.launcher import GigaChannelCommunityLauncher
         loader.set_launcher(GigaChannelCommunityLauncher())

--- a/src/tribler-core/tribler_core/modules/community_loader.py
+++ b/src/tribler-core/tribler_core/modules/community_loader.py
@@ -12,6 +12,7 @@ from ipv8.loader import (
     walk_strategy,
 )
 from ipv8.peer import Peer
+
 from tribler_core.config.tribler_config import TriblerConfig
 
 INFINITE = -1
@@ -37,7 +38,7 @@ class TriblerCommunityLauncher(CommunityLauncher):
 
 
 class TestnetMixIn:
-    def should_launch(self, session):
+    def should_launch(self, _):
         return True
 
 
@@ -126,15 +127,3 @@ def create_default_loader(config: TriblerConfig, tunnel_testnet: bool = False,
         loader.set_launcher(GigaChannelTestnetCommunityLauncher())
 
     return loader
-
-
-def get_hiddenimports():
-    """
-    Return the set of all hidden imports defined by all CommunityLaunchers in this file.
-    """
-    hiddenimports = set()
-
-    for _, obj in inspect.getmembers(sys.modules[__name__]):
-        hiddenimports.update(getattr(obj, "hiddenimports", set()))
-
-    return hiddenimports

--- a/src/tribler-core/tribler_core/modules/ipv8_module_catalog.py
+++ b/src/tribler-core/tribler_core/modules/ipv8_module_catalog.py
@@ -2,7 +2,15 @@
 import inspect
 import sys
 
-from ipv8.loader import CommunityLauncher, kwargs, overlay, precondition, set_in_session, walk_strategy
+from ipv8.loader import (
+    CommunityLauncher,
+    IPv8CommunityLoader,
+    kwargs,
+    overlay,
+    precondition,
+    set_in_session,
+    walk_strategy,
+)
 from ipv8.peer import Peer
 
 INFINITE = -1
@@ -32,7 +40,6 @@ class TestnetMixIn:
         return True
 
 
-# communities
 def discovery_community():
     from ipv8.peerdiscovery.community import DiscoveryCommunity
     return DiscoveryCommunity
@@ -96,7 +103,7 @@ def get_hiddenimports():
     return hiddenimports
 
 
-def register_default_launchers(loader):
+def register_launchers(session, loader):
     """
     Register the default CommunityLaunchers into the given CommunityLoader.
     If you define a new default CommunityLauncher, add it here.
@@ -108,23 +115,29 @@ def register_default_launchers(loader):
     loader.set_launcher(IPv8DiscoveryCommunityLauncher())
     loader.set_launcher(DHTCommunityLauncher())
 
-    from tribler_core.modules.bandwidth_accounting.launcher import BandwidthCommunityLauncher
-    loader.set_launcher(BandwidthCommunityLauncher())
+    if session.bandwidth_testnet():
+        from tribler_core.modules.bandwidth_accounting.launcher import BandwidthTestnetCommunityLauncher
+        loader.set_launcher(BandwidthTestnetCommunityLauncher())
+    else:
+        from tribler_core.modules.bandwidth_accounting.launcher import BandwidthCommunityLauncher
+        loader.set_launcher(BandwidthCommunityLauncher())
 
-    from tribler_core.modules.bandwidth_accounting.launcher import BandwidthTestnetCommunityLauncher
-    loader.set_launcher(BandwidthTestnetCommunityLauncher())
+    if session.config.tunnel_community.enabled and not session.tunnel_testnet():
+        from tribler_core.modules.tunnel.community.launcher import TriblerTunnelCommunityLauncher
+        loader.set_launcher(TriblerTunnelCommunityLauncher())
 
-    from tribler_core.modules.tunnel.community.launcher import TriblerTunnelCommunityLauncher
-    loader.set_launcher(TriblerTunnelCommunityLauncher())
+    if session.config.tunnel_community.enabled and session.tunnel_testnet():
+        from tribler_core.modules.tunnel.community.launcher import TriblerTunnelTestnetCommunityLauncher
+        loader.set_launcher(TriblerTunnelTestnetCommunityLauncher())
 
-    from tribler_core.modules.tunnel.community.launcher import TriblerTunnelTestnetCommunityLauncher
-    loader.set_launcher(TriblerTunnelTestnetCommunityLauncher())
+    if session.config.popularity_community.enabled:
+        from tribler_core.modules.popularity.launcher import PopularityCommunityLauncher
+        loader.set_launcher(PopularityCommunityLauncher())
 
-    from tribler_core.modules.popularity.launcher import PopularityCommunityLauncher
-    loader.set_launcher(PopularityCommunityLauncher())
+    if session.config.chant.enabled and not session.chant_testnet():
+        from tribler_core.modules.metadata_store.community.launcher import GigaChannelCommunityLauncher
+        loader.set_launcher(GigaChannelCommunityLauncher())
 
-    from tribler_core.modules.metadata_store.community.launcher import GigaChannelCommunityLauncher
-    loader.set_launcher(GigaChannelCommunityLauncher())
-
-    from tribler_core.modules.metadata_store.community.launcher import GigaChannelTestnetCommunityLauncher
-    loader.set_launcher(GigaChannelTestnetCommunityLauncher())
+    if session.config.chant.enabled and session.chant_testnet():
+        from tribler_core.modules.metadata_store.community.launcher import GigaChannelTestnetCommunityLauncher
+        loader.set_launcher(GigaChannelTestnetCommunityLauncher())

--- a/src/tribler-core/tribler_core/modules/ipv8_module_catalog.py
+++ b/src/tribler-core/tribler_core/modules/ipv8_module_catalog.py
@@ -2,7 +2,7 @@
 import inspect
 import sys
 
-from ipv8.loader import CommunityLauncher, after, kwargs, overlay, precondition, set_in_session, walk_strategy
+from ipv8.loader import CommunityLauncher, kwargs, overlay, precondition, set_in_session, walk_strategy
 from ipv8.peer import Peer
 
 INFINITE = -1
@@ -43,41 +43,6 @@ def dht_discovery_community():
     return DHTDiscoveryCommunity
 
 
-def tribler_tunnel_community():
-    from tribler_core.modules.tunnel.community.community import TriblerTunnelCommunity
-    return TriblerTunnelCommunity
-
-
-def bandwidth_accounting_community():
-    from tribler_core.modules.bandwidth_accounting.community import BandwidthAccountingCommunity
-    return BandwidthAccountingCommunity
-
-
-def bandwidth_accounting_testnet_community():
-    from tribler_core.modules.bandwidth_accounting.community import BandwidthAccountingTestnetCommunity
-    return BandwidthAccountingTestnetCommunity
-
-
-def popularity_community():
-    from tribler_core.modules.popularity.community import PopularityCommunity
-    return PopularityCommunity
-
-
-def giga_channel_community():
-    from tribler_core.modules.metadata_store.community.gigachannel_community import GigaChannelCommunity
-    return GigaChannelCommunity
-
-
-def giga_channel_testnet_community():
-    from tribler_core.modules.metadata_store.community.gigachannel_community import GigaChannelTestnetCommunity
-    return GigaChannelTestnetCommunity
-
-
-def tribler_tunnel_testnet_community():
-    from tribler_core.modules.tunnel.community.community import TriblerTunnelTestnetCommunity
-    return TriblerTunnelTestnetCommunity
-
-
 # strategies
 def random_churn():
     from ipv8.peerdiscovery.churn import RandomChurn
@@ -99,16 +64,6 @@ def periodic_similarity():
     return PeriodicSimilarity
 
 
-def golden_ratio_strategy():
-    from tribler_core.modules.tunnel.community.discovery import GoldenRatioStrategy
-    return GoldenRatioStrategy
-
-
-def remove_peers():
-    from tribler_core.modules.metadata_store.community.sync_strategy import RemovePeers
-    return RemovePeers
-
-
 @precondition('session.config.discovery_community.enabled')
 @overlay(discovery_community)
 @kwargs(max_peers='100')
@@ -119,24 +74,6 @@ class IPv8DiscoveryCommunityLauncher(IPv8CommunityLauncher):
     pass
 
 
-@overlay(bandwidth_accounting_community)
-@precondition('not session.bandwidth_testnet()')
-@walk_strategy(random_walk)
-@set_in_session('bandwidth_community')
-class BandwidthCommunityLauncher(IPv8CommunityLauncher):
-    def get_kwargs(self, session):
-        return {
-            'settings': session.config.bandwidth_accounting,
-            'database_path': session.config.state_dir / "sqlite" / "bandwidth.db",
-        }
-
-
-@overlay(bandwidth_accounting_testnet_community)
-@precondition('session.bandwidth_testnet()')
-class BandwidthTestnetCommunityLauncher(TestnetMixIn, BandwidthCommunityLauncher):
-    pass
-
-
 @precondition('session.config.dht.enabled')
 @set_in_session('dht_community')
 @overlay(dht_discovery_community)
@@ -144,83 +81,6 @@ class BandwidthTestnetCommunityLauncher(TestnetMixIn, BandwidthCommunityLauncher
 @walk_strategy(ping_churn, target_peers=INFINITE)
 @walk_strategy(random_walk)
 class DHTCommunityLauncher(IPv8CommunityLauncher):
-    pass
-
-
-@after('DHTCommunityLauncher', 'BandwidthCommunityLauncher', 'BandwidthTestnetCommunityLauncher')
-@precondition('session.config.tunnel_community.enabled')
-@precondition('not session.tunnel_testnet()')
-@set_in_session('tunnel_community')
-@overlay(tribler_tunnel_community)
-@walk_strategy(random_walk)
-@walk_strategy(golden_ratio_strategy, target_peers=INFINITE)
-class TriblerTunnelCommunityLauncher(IPv8CommunityLauncher):
-    def get_kwargs(self, session):
-        from ipv8.dht.provider import DHTCommunityProvider
-        from ipv8.messaging.anonymization.community import TunnelSettings
-
-        settings = TunnelSettings()
-        settings.min_circuits = session.config.tunnel_community.min_circuits
-        settings.max_circuits = session.config.tunnel_community.max_circuits
-
-        return {
-            'bandwidth_community': session.bandwidth_community,
-            'competing_slots': session.config.tunnel_community.competing_slots,
-            'ipv8': session.ipv8,
-            'random_slots': session.config.tunnel_community.random_slots,
-            'tribler_session': session,
-            'dht_provider': DHTCommunityProvider(session.dht_community, session.config.ipv8.port),
-            'settings': settings
-        }
-
-
-@precondition('session.config.tunnel_community.enabled')
-@precondition('session.tunnel_testnet()')
-@overlay(tribler_tunnel_testnet_community)
-class TriblerTunnelTestnetCommunityLauncher(TestnetMixIn, TriblerTunnelCommunityLauncher):
-    pass
-
-
-@precondition('session.config.popularity_community.enabled')
-@set_in_session('popularity_community')
-@overlay(popularity_community)
-@walk_strategy(random_walk, target_peers=30)
-@walk_strategy(remove_peers, target_peers=INFINITE)
-class PopularityCommunityLauncher(IPv8CommunityLauncher):
-    def get_kwargs(self, session):
-        return {
-            'settings': session.config.popularity_community,
-            'rqc_settings': session.config.remote_query_community,
-
-            'metadata_store': session.mds,
-            'torrent_checker': session.torrent_checker,
-        }
-
-
-@overlay(giga_channel_community)
-@precondition('session.config.chant.enabled')
-@precondition('not session.chant_testnet()')
-@set_in_session('gigachannel_community')
-@overlay(giga_channel_community)
-# GigaChannelCommunity remote search feature works better with higher amount of connected peers
-@walk_strategy(random_walk, target_peers=30)
-@walk_strategy(remove_peers, target_peers=INFINITE)
-class GigaChannelCommunityLauncher(IPv8CommunityLauncher):
-    def get_kwargs(self, session):
-        return {
-            'settings': session.config.chant,
-            'rqc_settings': session.config.remote_query_community,
-
-            'metadata_store': session.mds,
-            'notifier': session.notifier,
-            'max_peers': 50,
-        }
-
-
-@precondition('session.config.chant.enabled')
-@precondition('session.chant_testnet()')
-@overlay(giga_channel_testnet_community)
-class GigaChannelTestnetCommunityLauncher(TestnetMixIn, GigaChannelCommunityLauncher):
     pass
 
 
@@ -246,11 +106,25 @@ def register_default_launchers(loader):
      the CommunityLaunchers themselves to be properly scoped and lazy-loaded.
     """
     loader.set_launcher(IPv8DiscoveryCommunityLauncher())
-    loader.set_launcher(BandwidthCommunityLauncher())
-    loader.set_launcher(BandwidthTestnetCommunityLauncher())
     loader.set_launcher(DHTCommunityLauncher())
+
+    from tribler_core.modules.bandwidth_accounting.launcher import BandwidthCommunityLauncher
+    loader.set_launcher(BandwidthCommunityLauncher())
+
+    from tribler_core.modules.bandwidth_accounting.launcher import BandwidthTestnetCommunityLauncher
+    loader.set_launcher(BandwidthTestnetCommunityLauncher())
+
+    from tribler_core.modules.tunnel.community.launcher import TriblerTunnelCommunityLauncher
     loader.set_launcher(TriblerTunnelCommunityLauncher())
+
+    from tribler_core.modules.tunnel.community.launcher import TriblerTunnelTestnetCommunityLauncher
     loader.set_launcher(TriblerTunnelTestnetCommunityLauncher())
+
+    from tribler_core.modules.popularity.launcher import PopularityCommunityLauncher
     loader.set_launcher(PopularityCommunityLauncher())
+
+    from tribler_core.modules.metadata_store.community.launcher import GigaChannelCommunityLauncher
     loader.set_launcher(GigaChannelCommunityLauncher())
+
+    from tribler_core.modules.metadata_store.community.launcher import GigaChannelTestnetCommunityLauncher
     loader.set_launcher(GigaChannelTestnetCommunityLauncher())

--- a/src/tribler-core/tribler_core/modules/metadata_store/community/launcher.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/community/launcher.py
@@ -10,8 +10,6 @@ from tribler_core.modules.metadata_store.community.sync_strategy import RemovePe
 
 
 @overlay(GigaChannelCommunity)
-@precondition('session.config.chant.enabled')
-@precondition('not session.chant_testnet()')
 @set_in_session('gigachannel_community')
 # GigaChannelCommunity remote search feature works better with higher amount of connected peers
 @walk_strategy(RandomWalk, target_peers=30)
@@ -27,8 +25,7 @@ class GigaChannelCommunityLauncher(IPv8CommunityLauncher):
         }
 
 
-@precondition('session.config.chant.enabled')
-@precondition('session.chant_testnet()')
+
 @overlay(GigaChannelTestnetCommunity)
 class GigaChannelTestnetCommunityLauncher(TestnetMixIn, GigaChannelCommunityLauncher):
     pass

--- a/src/tribler-core/tribler_core/modules/metadata_store/community/launcher.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/community/launcher.py
@@ -1,0 +1,34 @@
+from ipv8.loader import overlay, precondition, set_in_session, walk_strategy
+from ipv8.peerdiscovery.discovery import RandomWalk
+
+from tribler_core.modules.ipv8_module_catalog import INFINITE, IPv8CommunityLauncher, TestnetMixIn
+from tribler_core.modules.metadata_store.community.gigachannel_community import (
+    GigaChannelCommunity,
+    GigaChannelTestnetCommunity,
+)
+from tribler_core.modules.metadata_store.community.sync_strategy import RemovePeers
+
+
+@overlay(GigaChannelCommunity)
+@precondition('session.config.chant.enabled')
+@precondition('not session.chant_testnet()')
+@set_in_session('gigachannel_community')
+# GigaChannelCommunity remote search feature works better with higher amount of connected peers
+@walk_strategy(RandomWalk, target_peers=30)
+@walk_strategy(RemovePeers, target_peers=INFINITE)
+class GigaChannelCommunityLauncher(IPv8CommunityLauncher):
+    def get_kwargs(self, session):
+        return {
+            'settings': session.config.chant,
+            'rqc_settings': session.config.remote_query_community,
+            'metadata_store': session.mds,
+            'notifier': session.notifier,
+            'max_peers': 50,
+        }
+
+
+@precondition('session.config.chant.enabled')
+@precondition('session.chant_testnet()')
+@overlay(GigaChannelTestnetCommunity)
+class GigaChannelTestnetCommunityLauncher(TestnetMixIn, GigaChannelCommunityLauncher):
+    pass

--- a/src/tribler-core/tribler_core/modules/metadata_store/community/launcher.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/community/launcher.py
@@ -1,7 +1,7 @@
-from ipv8.loader import overlay, precondition, set_in_session, walk_strategy
+from ipv8.loader import overlay, set_in_session, walk_strategy
 from ipv8.peerdiscovery.discovery import RandomWalk
+from tribler_core.modules.community_loader import INFINITE, TestnetMixIn, TriblerCommunityLauncher
 
-from tribler_core.modules.ipv8_module_catalog import INFINITE, IPv8CommunityLauncher, TestnetMixIn
 from tribler_core.modules.metadata_store.community.gigachannel_community import (
     GigaChannelCommunity,
     GigaChannelTestnetCommunity,
@@ -14,7 +14,7 @@ from tribler_core.modules.metadata_store.community.sync_strategy import RemovePe
 # GigaChannelCommunity remote search feature works better with higher amount of connected peers
 @walk_strategy(RandomWalk, target_peers=30)
 @walk_strategy(RemovePeers, target_peers=INFINITE)
-class GigaChannelCommunityLauncher(IPv8CommunityLauncher):
+class GigaChannelCommunityLauncher(TriblerCommunityLauncher):
     def get_kwargs(self, session):
         return {
             'settings': session.config.chant,
@@ -23,7 +23,6 @@ class GigaChannelCommunityLauncher(IPv8CommunityLauncher):
             'notifier': session.notifier,
             'max_peers': 50,
         }
-
 
 
 @overlay(GigaChannelTestnetCommunity)

--- a/src/tribler-core/tribler_core/modules/metadata_store/settings.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/settings.py
@@ -1,3 +1,5 @@
+from pydantic import Field
+
 from tribler_core.config.tribler_config_section import TriblerConfigSection
 
 
@@ -6,7 +8,7 @@ class ChantSettings(TriblerConfigSection):
     manager_enabled: bool = True
     channel_edit: bool = False
     channels_dir: str = 'channels'
-    testnet: bool = False
+    testnet: bool = Field(default=False, env='CHANT_TESTNET')
 
     queried_peers_limit: int = 1000
     # The maximum number of peers that we got from channels to peers mapping,

--- a/src/tribler-core/tribler_core/modules/popularity/launcher.py
+++ b/src/tribler-core/tribler_core/modules/popularity/launcher.py
@@ -1,0 +1,22 @@
+from ipv8.loader import overlay, precondition, set_in_session, walk_strategy
+from ipv8.peerdiscovery.discovery import RandomWalk
+
+from tribler_core.modules.ipv8_module_catalog import INFINITE, IPv8CommunityLauncher
+from tribler_core.modules.metadata_store.community.sync_strategy import RemovePeers
+from tribler_core.modules.popularity.community import PopularityCommunity
+
+
+@precondition('session.config.popularity_community.enabled')
+@set_in_session('popularity_community')
+@overlay(PopularityCommunity)
+@walk_strategy(RandomWalk, target_peers=30)
+@walk_strategy(RemovePeers, target_peers=INFINITE)
+class PopularityCommunityLauncher(IPv8CommunityLauncher):
+    def get_kwargs(self, session):
+        return {
+            'settings': session.config.popularity_community,
+            'rqc_settings': session.config.remote_query_community,
+
+            'metadata_store': session.mds,
+            'torrent_checker': session.torrent_checker,
+        }

--- a/src/tribler-core/tribler_core/modules/popularity/launcher.py
+++ b/src/tribler-core/tribler_core/modules/popularity/launcher.py
@@ -1,7 +1,7 @@
-from ipv8.loader import overlay, precondition, set_in_session, walk_strategy
+from ipv8.loader import overlay, set_in_session, walk_strategy
 from ipv8.peerdiscovery.discovery import RandomWalk
+from tribler_core.modules.community_loader import INFINITE, TriblerCommunityLauncher
 
-from tribler_core.modules.ipv8_module_catalog import INFINITE, IPv8CommunityLauncher
 from tribler_core.modules.metadata_store.community.sync_strategy import RemovePeers
 from tribler_core.modules.popularity.community import PopularityCommunity
 
@@ -10,7 +10,7 @@ from tribler_core.modules.popularity.community import PopularityCommunity
 @overlay(PopularityCommunity)
 @walk_strategy(RandomWalk, target_peers=30)
 @walk_strategy(RemovePeers, target_peers=INFINITE)
-class PopularityCommunityLauncher(IPv8CommunityLauncher):
+class PopularityCommunityLauncher(TriblerCommunityLauncher):
     def get_kwargs(self, session):
         return {
             'settings': session.config.popularity_community,

--- a/src/tribler-core/tribler_core/modules/popularity/launcher.py
+++ b/src/tribler-core/tribler_core/modules/popularity/launcher.py
@@ -6,7 +6,6 @@ from tribler_core.modules.metadata_store.community.sync_strategy import RemovePe
 from tribler_core.modules.popularity.community import PopularityCommunity
 
 
-@precondition('session.config.popularity_community.enabled')
 @set_in_session('popularity_community')
 @overlay(PopularityCommunity)
 @walk_strategy(RandomWalk, target_peers=30)

--- a/src/tribler-core/tribler_core/modules/settings.py
+++ b/src/tribler-core/tribler_core/modules/settings.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from pydantic import validator
+from pydantic import Field, validator
 
 from tribler_common.network_utils import NetworkUtils
 
@@ -41,7 +41,7 @@ class DHTSettings(TriblerConfigSection):
 class TrustchainSettings(TriblerConfigSection):
     ec_keypair_filename: str = 'ec_multichain.pem'
     testnet_keypair_filename: str = 'ec_trustchain_testnet.pem'
-    testnet: bool = False
+    testnet: bool = Field(default=False, env='TRUSTCHAIN_TESTNET')
 
 
 class WatchFolderSettings(TriblerConfigSection):

--- a/src/tribler-core/tribler_core/modules/tests/test_community_loader.py
+++ b/src/tribler-core/tribler_core/modules/tests/test_community_loader.py
@@ -1,14 +1,7 @@
 from unittest.mock import Mock
 
 from tribler_core.config.tribler_config import TriblerConfig
-from tribler_core.modules.community_loader import IPv8DiscoveryCommunityLauncher, get_hiddenimports
-
-
-def test_hiddenimports():
-    """
-    Check if all hidden imports are detected
-    """
-    assert not get_hiddenimports()
+from tribler_core.modules.community_loader import IPv8DiscoveryCommunityLauncher
 
 
 def test_bootstrap_override():

--- a/src/tribler-core/tribler_core/modules/tests/test_community_loader.py
+++ b/src/tribler-core/tribler_core/modules/tests/test_community_loader.py
@@ -1,7 +1,7 @@
 from unittest.mock import Mock
 
 from tribler_core.config.tribler_config import TriblerConfig
-from tribler_core.modules.ipv8_module_catalog import IPv8DiscoveryCommunityLauncher, get_hiddenimports
+from tribler_core.modules.community_loader import IPv8DiscoveryCommunityLauncher, get_hiddenimports
 
 
 def test_hiddenimports():

--- a/src/tribler-core/tribler_core/modules/tunnel/community/launcher.py
+++ b/src/tribler-core/tribler_core/modules/tunnel/community/launcher.py
@@ -7,8 +7,6 @@ from tribler_core.modules.tunnel.community.discovery import GoldenRatioStrategy
 
 
 @after('DHTCommunityLauncher', 'BandwidthCommunityLauncher', 'BandwidthTestnetCommunityLauncher')
-@precondition('session.config.tunnel_community.enabled')
-@precondition('not session.tunnel_testnet()')
 @set_in_session('tunnel_community')
 @overlay(TriblerTunnelCommunity)
 @walk_strategy(RandomWalk)
@@ -33,8 +31,6 @@ class TriblerTunnelCommunityLauncher(IPv8CommunityLauncher):
         }
 
 
-@precondition('session.config.tunnel_community.enabled')
-@precondition('session.tunnel_testnet()')
 @overlay(TriblerTunnelTestnetCommunity)
 class TriblerTunnelTestnetCommunityLauncher(TestnetMixIn, TriblerTunnelCommunityLauncher):
     pass

--- a/src/tribler-core/tribler_core/modules/tunnel/community/launcher.py
+++ b/src/tribler-core/tribler_core/modules/tunnel/community/launcher.py
@@ -1,7 +1,7 @@
-from ipv8.loader import after, overlay, precondition, set_in_session, walk_strategy
+from ipv8.loader import after, overlay, set_in_session, walk_strategy
 from ipv8.peerdiscovery.discovery import RandomWalk
 
-from tribler_core.modules.ipv8_module_catalog import INFINITE, IPv8CommunityLauncher, TestnetMixIn
+from tribler_core.modules.community_loader import INFINITE, TestnetMixIn, TriblerCommunityLauncher
 from tribler_core.modules.tunnel.community.community import TriblerTunnelCommunity, TriblerTunnelTestnetCommunity
 from tribler_core.modules.tunnel.community.discovery import GoldenRatioStrategy
 
@@ -11,7 +11,7 @@ from tribler_core.modules.tunnel.community.discovery import GoldenRatioStrategy
 @overlay(TriblerTunnelCommunity)
 @walk_strategy(RandomWalk)
 @walk_strategy(GoldenRatioStrategy, target_peers=INFINITE)
-class TriblerTunnelCommunityLauncher(IPv8CommunityLauncher):
+class TriblerTunnelCommunityLauncher(TriblerCommunityLauncher):
     def get_kwargs(self, session):
         from ipv8.dht.provider import DHTCommunityProvider
         from ipv8.messaging.anonymization.community import TunnelSettings

--- a/src/tribler-core/tribler_core/modules/tunnel/community/launcher.py
+++ b/src/tribler-core/tribler_core/modules/tunnel/community/launcher.py
@@ -1,0 +1,40 @@
+from ipv8.loader import after, overlay, precondition, set_in_session, walk_strategy
+from ipv8.peerdiscovery.discovery import RandomWalk
+
+from tribler_core.modules.ipv8_module_catalog import INFINITE, IPv8CommunityLauncher, TestnetMixIn
+from tribler_core.modules.tunnel.community.community import TriblerTunnelCommunity, TriblerTunnelTestnetCommunity
+from tribler_core.modules.tunnel.community.discovery import GoldenRatioStrategy
+
+
+@after('DHTCommunityLauncher', 'BandwidthCommunityLauncher', 'BandwidthTestnetCommunityLauncher')
+@precondition('session.config.tunnel_community.enabled')
+@precondition('not session.tunnel_testnet()')
+@set_in_session('tunnel_community')
+@overlay(TriblerTunnelCommunity)
+@walk_strategy(RandomWalk)
+@walk_strategy(GoldenRatioStrategy, target_peers=INFINITE)
+class TriblerTunnelCommunityLauncher(IPv8CommunityLauncher):
+    def get_kwargs(self, session):
+        from ipv8.dht.provider import DHTCommunityProvider
+        from ipv8.messaging.anonymization.community import TunnelSettings
+
+        settings = TunnelSettings()
+        settings.min_circuits = session.config.tunnel_community.min_circuits
+        settings.max_circuits = session.config.tunnel_community.max_circuits
+
+        return {
+            'bandwidth_community': session.bandwidth_community,
+            'competing_slots': session.config.tunnel_community.competing_slots,
+            'ipv8': session.ipv8,
+            'random_slots': session.config.tunnel_community.random_slots,
+            'tribler_session': session,
+            'dht_provider': DHTCommunityProvider(session.dht_community, session.config.ipv8.port),
+            'settings': settings
+        }
+
+
+@precondition('session.config.tunnel_community.enabled')
+@precondition('session.tunnel_testnet()')
+@overlay(TriblerTunnelTestnetCommunity)
+class TriblerTunnelTestnetCommunityLauncher(TestnetMixIn, TriblerTunnelCommunityLauncher):
+    pass

--- a/src/tribler-core/tribler_core/modules/tunnel/community/launcher.py
+++ b/src/tribler-core/tribler_core/modules/tunnel/community/launcher.py
@@ -6,6 +6,7 @@ from tribler_core.modules.tunnel.community.community import TriblerTunnelCommuni
 from tribler_core.modules.tunnel.community.discovery import GoldenRatioStrategy
 
 
+# pylint: disable=import-outside-toplevel
 @after('DHTCommunityLauncher', 'BandwidthCommunityLauncher', 'BandwidthTestnetCommunityLauncher')
 @set_in_session('tunnel_community')
 @overlay(TriblerTunnelCommunity)

--- a/src/tribler-core/tribler_core/modules/tunnel/community/settings.py
+++ b/src/tribler-core/tribler_core/modules/tunnel/community/settings.py
@@ -1,5 +1,7 @@
 from typing import List, Optional
 
+from pydantic import Field
+
 from tribler_core.config.tribler_config_section import TriblerConfigSection
 
 
@@ -9,6 +11,6 @@ class TunnelCommunitySettings(TriblerConfigSection):
     exitnode_enabled: bool = False
     random_slots: int = 5
     competing_slots: int = 15
-    testnet: bool = False
+    testnet: bool = Field(default=False, env='TUNNEL_TESTNET')
     min_circuits: int = 3
     max_circuits: int = 10

--- a/src/tribler-core/tribler_core/session.py
+++ b/src/tribler-core/tribler_core/session.py
@@ -36,7 +36,8 @@ from tribler_common.simpledefs import (
 )
 
 import tribler_core.utilities.permid as permid_module
-from tribler_core.modules.ipv8_module_catalog import register_default_launchers
+from tribler_core.config.tribler_config import TriblerConfig
+from tribler_core.modules.ipv8_module_catalog import register_launchers
 from tribler_core.modules.metadata_store.utils import generate_test_channels
 from tribler_core.modules.tracker_manager import TrackerManager
 from tribler_core.notifier import Notifier
@@ -73,7 +74,7 @@ class Session(TaskManager):
     """
     __single = None
 
-    def __init__(self, config, core_test_mode=False):
+    def __init__(self, config: TriblerConfig, core_test_mode: bool = False):
         """
         A Session object is created
         Only a single session instance can exist at a time in a process.
@@ -106,7 +107,7 @@ class Session(TaskManager):
 
         # modules
         self.ipv8_community_loader = IPv8CommunityLoader()
-        register_default_launchers(self.ipv8_community_loader)
+        register_launchers(self, self.ipv8_community_loader)
 
         self.api_manager = None
         self.watch_folder = None

--- a/src/tribler-core/tribler_core/session.py
+++ b/src/tribler-core/tribler_core/session.py
@@ -71,8 +71,7 @@ class Session(TaskManager):
     __single = None
 
     def __init__(self, config: TriblerConfig, core_test_mode: bool = False,
-                 community_loader: IPv8CommunityLoader = None, chant_testnet: bool = False,
-                 trustchain_testnet: bool = False):
+                 community_loader: IPv8CommunityLoader = None):
         """
         A Session object is created
         Only a single session instance can exist at a time in a process.
@@ -105,15 +104,12 @@ class Session(TaskManager):
 
         # modules
         if not community_loader:
-            community_loader = create_default_loader(config, chant_testnet=chant_testnet)
+            community_loader = create_default_loader(config)
         self.community_loader = community_loader
         self.api_manager = None
         self.watch_folder = None
         self.version_check_manager = None
         self.resource_monitor = None
-
-        self.chant_testnet = chant_testnet
-        self.trustchain_testnet = trustchain_testnet
 
         self.gigachannel_manager = None
 
@@ -306,7 +302,8 @@ class Session(TaskManager):
         if chant_enabled:
             from tribler_core.modules.metadata_store.store import MetadataStore
             channels_dir = self.config.chant.get_path_as_absolute('channels_dir', self.config.state_dir)
-            metadata_db_name = 'metadata.db' if not self.chant_testnet else 'metadata_testnet.db'
+            chant_testnet = self.config.general.testnet or self.config.chant.testnet
+            metadata_db_name = 'metadata.db' if not chant_testnet else 'metadata_testnet.db'
             database_path = state_dir / 'sqlite' / metadata_db_name
             self.mds = MetadataStore(database_path, channels_dir, self.trustchain_keypair,
                                      notifier=self.notifier,

--- a/src/tribler-core/tribler_core/settings.py
+++ b/src/tribler-core/tribler_core/settings.py
@@ -1,3 +1,5 @@
+from pydantic import Field
+
 from tribler_core.config.tribler_config_section import TriblerConfigSection
 
 
@@ -5,6 +7,7 @@ class GeneralSettings(TriblerConfigSection):
     version: str = ""
     log_dir: str = "log"
     version_checker_enabled: bool = True
+    testnet: bool = Field(default=False, env='TESTNET')
 
 
 class ErrorHandlingSettings(TriblerConfigSection):

--- a/src/tribler-core/tribler_core/tests/test_session.py
+++ b/src/tribler-core/tribler_core/tests/test_session.py
@@ -148,7 +148,7 @@ async def test_load_ipv8_overlays_testnet(mocked_endpoints, enable_ipv8, session
     session.trustchain_testnet = True
     session.chant_testnet = True
 
-    session.community_loader = create_default_loader(session.config, True, True, True)
+    session.community_loader = create_default_loader(session.config)
 
     await session.start()
 

--- a/src/tribler-core/tribler_core/tests/test_session.py
+++ b/src/tribler-core/tribler_core/tests/test_session.py
@@ -1,20 +1,19 @@
 import asyncio
 import shutil
+from _socket import getaddrinfo
 from asyncio import get_event_loop, sleep
 from unittest.mock import Mock
 
-from _socket import getaddrinfo
-
-from ipv8.util import succeed
-
 import pytest
 
+from ipv8.util import succeed
 from tribler_common.simpledefs import NTFY
-
 from tribler_core.config.tests.test_tribler_config import CONFIG_PATH
 from tribler_core.config.tribler_config import TriblerConfig
+from tribler_core.modules.community_loader import create_default_loader
 from tribler_core.session import IGNORED_ERRORS, Session
 from tribler_core.tests.tools.base_test import MockObject
+
 
 # Pylint does not agree with the way pytest handles fixtures.
 # pylint: disable=W0613,W0621
@@ -119,6 +118,8 @@ async def test_load_ipv8_overlays(mocked_endpoints, enable_ipv8, session):
     session.config.popularity_community.enabled = True
     session.config.chant.enabled = True
 
+    session.community_loader = create_default_loader(session.config)
+
     await session.start()
 
     loaded_launchers = [overlay.__class__.__name__ for overlay in session.ipv8.overlays]
@@ -143,6 +144,11 @@ async def test_load_ipv8_overlays_testnet(mocked_endpoints, enable_ipv8, session
     session.config.tunnel_community.enabled = True
     session.config.popularity_community.enabled = True
     session.config.chant.enabled = True
+
+    session.trustchain_testnet = True
+    session.chant_testnet = True
+
+    session.community_loader = create_default_loader(session.config, True, True, True)
 
     await session.start()
 

--- a/src/tribler-core/tribler_core/utilities/tiny_tribler_service.py
+++ b/src/tribler-core/tribler_core/utilities/tiny_tribler_service.py
@@ -4,6 +4,7 @@ import signal
 from pathlib import Path
 
 from tribler_core.config.tribler_config import TriblerConfig
+from tribler_core.modules.ipv8_module_catalog import create_default_loader
 from tribler_core.modules.process_checker import ProcessChecker
 from tribler_core.session import Session
 
@@ -61,7 +62,7 @@ class TinyTriblerService:
     async def _start_session(self):
         self.logger.info(f"Starting Tribler session with config: {self.config}")
 
-        self.session = Session(self.config)
+        self.session = Session(self.config, community_loader=create_default_loader(self.config))
         await self.session.start()
 
         self.logger.info("Tribler session started")

--- a/src/tribler-core/tribler_core/utilities/tiny_tribler_service.py
+++ b/src/tribler-core/tribler_core/utilities/tiny_tribler_service.py
@@ -3,8 +3,9 @@ import logging
 import signal
 from pathlib import Path
 
+from ipv8.loader import IPv8CommunityLoader
+
 from tribler_core.config.tribler_config import TriblerConfig
-from tribler_core.modules.ipv8_module_catalog import create_default_loader
 from tribler_core.modules.process_checker import ProcessChecker
 from tribler_core.session import Session
 
@@ -16,7 +17,7 @@ class TinyTriblerService:
     """
 
     def __init__(self, config, timeout_in_sec=None, working_dir=Path('/tmp/tribler'),
-                 config_path=Path('tribler.conf')):
+                 config_path=Path('tribler.conf'), loader: IPv8CommunityLoader = None):
         self.logger = logging.getLogger(self.__class__.__name__)
 
         self.session = None
@@ -25,6 +26,7 @@ class TinyTriblerService:
         self.config_path = config_path
         self.config = config
         self.timeout_in_sec = timeout_in_sec
+        self.loader = loader
 
     async def on_tribler_started(self):
         """Function will calls after the Tribler session is started
@@ -62,7 +64,7 @@ class TinyTriblerService:
     async def _start_session(self):
         self.logger.info(f"Starting Tribler session with config: {self.config}")
 
-        self.session = Session(self.config, community_loader=create_default_loader(self.config))
+        self.session = Session(self.config, community_loader=self.loader)
         await self.session.start()
 
         self.logger.info("Tribler session started")


### PR DESCRIPTION
One step closer to the atomic community: introduction of `launcher.py`

I've extracted `IPv8CommunityLauncher` for each Tribler's community from `ipv8_module_catalog.py` and put them into `launcher.py` next to corresponding communities. 

![image](https://user-images.githubusercontent.com/13798583/123447948-b28b6a00-d5da-11eb-9074-b8f548fc9250.png)


### Preconditions

`Preconditions` have been separated from `Launcher` definition to `Loader` implementation:

`community_loader.py`
```python
def create_default_loader(config: TriblerConfig, tunnel_testnet: bool = False,
                          bandwidth_testnet: bool = False, chant_testnet: bool = False):
    loader = IPv8CommunityLoader()

    loader.set_launcher(IPv8DiscoveryCommunityLauncher())
    loader.set_launcher(DHTCommunityLauncher())

    if bandwidth_testnet:
        from tribler_core.modules.bandwidth_accounting.launcher import BandwidthTestnetCommunityLauncher
        loader.set_launcher(BandwidthTestnetCommunityLauncher())
    else:
        from tribler_core.modules.bandwidth_accounting.launcher import BandwidthCommunityLauncher
        loader.set_launcher(BandwidthCommunityLauncher())
   ...
```

This allowed the use of top imports inside each loader (which should lead to easier navigation and more convenient work inside IDE). 

`launcher.py`
```python
from ipv8.loader import overlay, set_in_session, walk_strategy
from ipv8.peerdiscovery.discovery import RandomWalk
from tribler_core.modules.community_loader import INFINITE, TriblerCommunityLauncher

from tribler_core.modules.metadata_store.community.sync_strategy import RemovePeers
from tribler_core.modules.popularity.community import PopularityCommunity


@set_in_session('popularity_community')
@overlay(PopularityCommunity)
@walk_strategy(RandomWalk, target_peers=30)
@walk_strategy(RemovePeers, target_peers=INFINITE)
class PopularityCommunityLauncher(TriblerCommunityLauncher):
    def get_kwargs(self, session):
        return {
            'settings': session.config.popularity_community,
            'rqc_settings': session.config.remote_query_community,

            'metadata_store': session.mds,
            'torrent_checker': session.torrent_checker,
        }
```

### Community loader

Community loader can be passed to `Session` constructor now:

`session.py`
```python
    def __init__(self, config: TriblerConfig, core_test_mode: bool = False,
                 community_loader: IPv8CommunityLoader = None):
        if not community_loader:
            community_loader = create_default_loader(config)
```

Therefore you don't need to cheat session to specify your own set of community launchers:

`run_bandwith_crawler.py`
```python
async def start_crawler(tribler_config):
    # We use our own community loader
    loader = IPv8CommunityLoader()
    loader.set_launcher(BandwidthCommunityCrawlerLauncher())
    session = Session(tribler_config, community_loader=loader)
```
