### PR TITLE
EXAMPLE: Use DependencyInjector for modules

### DIFF
--- a/src/tribler-core/tribler_core/modules/metadata_store/container.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/container.py
@@ -5,8 +5,8 @@ from tribler_core.modules.metadata_store.store import MetadataStore
 
 class MetadataStoreContainer(containers.DeclarativeContainer):
     config = providers.Configuration()
-    trustchain_keypair = providers.Singleton()
-    notifier = providers.Singleton()
+    trustchain_keypair = providers.Object()
+    notifier = providers.Object()
 
     metadata_store = providers.Singleton(
         MetadataStore,

--- a/src/tribler-core/tribler_core/modules/metadata_store/container.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/container.py
@@ -1,0 +1,18 @@
+from dependency_injector import containers, providers
+
+from tribler_core.modules.metadata_store.store import MetadataStore
+
+
+class MetadataStoreContainer(containers.DeclarativeContainer):
+    config = providers.Configuration()
+    trustchain_keypair = providers.Singleton()
+    notifier = providers.Singleton()
+
+    metadata_store = providers.Singleton(
+        MetadataStore,
+        db_filename=config.db_filename,
+        channels_dir=config.channels_dir,
+        my_key=trustchain_keypair,
+        notifier=notifier,
+        disable_sync=config.core_test_mode,
+    )

--- a/src/tribler-core/tribler_core/modules/metadata_store/settings.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/settings.py
@@ -7,6 +7,7 @@ class ChantSettings(TriblerConfigSection):
     channel_edit: bool = False
     channels_dir: str = 'channels'
     testnet: bool = False
+    db_filename: str = None
 
     queried_peers_limit: int = 1000
     # The maximum number of peers that we got from channels to peers mapping,

--- a/src/tribler-core/tribler_core/session.py
+++ b/src/tribler-core/tribler_core/session.py
@@ -301,7 +301,8 @@ class Session(TaskManager):
             self.config.chant.channels_dir = self.config.chant.get_path_as_absolute('channels_dir',
                                                                                        self.config.state_dir)
             mds_container.config.from_pydantic(self.config.chant)
-            mds_container.wire(modules=[sys.modules[__name__]])
+            from tribler_core.modules.metadata_store.restapi import channels_endpoint
+            mds_container.wire(modules=[sys.modules[__name__], channels_endpoint])
             self._start_metadata_store()
             assert (self.mds.my_key is self.trustchain_keypair)
 

--- a/src/tribler-core/tribler_core/trustchain_keypair/container.py
+++ b/src/tribler-core/tribler_core/trustchain_keypair/container.py
@@ -1,0 +1,12 @@
+from dependency_injector import containers, providers
+
+from tribler_core.trustchain_keypair.keypair_utils import load_keypair
+
+
+class KeypairUtilsContainer(containers.DeclarativeContainer):
+    keypair_filename = providers.Object()
+    trustchain_pubfilename = providers.Object()
+    trustchain_keypair = providers.Singleton(load_keypair,
+                                             keypair_filename=keypair_filename,
+                                             trustchain_pubfilename=trustchain_pubfilename)
+

--- a/src/tribler-core/tribler_core/trustchain_keypair/keypair_utils.py
+++ b/src/tribler-core/tribler_core/trustchain_keypair/keypair_utils.py
@@ -1,0 +1,14 @@
+import tribler_core.utilities.permid as permid_module
+
+def load_keypair(keypair_filename, trustchain_pubfilename):
+
+    if keypair_filename.exists():
+        trustchain_keypair = permid_module.read_keypair_trustchain(keypair_filename)
+    else:
+        trustchain_keypair = permid_module.generate_keypair_trustchain()
+
+        # Save keypair
+        permid_module.save_keypair_trustchain(trustchain_keypair, keypair_filename)
+        permid_module.save_pub_key_trustchain(trustchain_keypair, trustchain_pubfilename)
+
+    return trustchain_keypair


### PR DESCRIPTION
This PR shows how we can gradually start using the [DependencyInjector framework](https://github.com/ets-labs/python-dependency-injector). The example is a bit silly, because it puts MetadataStore and Trustchain keypair into two separate containers.
Note the usage of the `Singleton` provider.

While working on this example, I realised two things:
 * we probably don't really *need* DepencyInjector _at the Session level_, because Tribler consists of a bunch of singletons, and DI framework's most powerful feature is injecting the dependencies into factories (which we don't use). Nonetheless, the framework can be of great use _inside_ some communities, where we have to e.g. instance Tunnels, Caches, etc. Also, the future Channels design can put it to great use by instancing Communities per each Channel.
 * **we don' really need the Session god-object**. It will take only a limited amount of effort to stop passing the `Session` object around, thus ceasing the backreference antipattern. In turn that will allow us to start our components asynchronously, making each one into an independent `Task`.