### PR TITLE
Remove obsolete database_blob type

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,4 @@
 [flake8]
-jobs = auto 
 max-line-length = 120
 select=E901,E999,F821,F822,F823,I100,I101,I201,I202,T001,T002,T003,T004
 ignore=E203,W503,C0330

--- a/src/tribler-core/tribler_core/conftest.py
+++ b/src/tribler-core/tribler_core/conftest.py
@@ -2,15 +2,18 @@ import os
 from pathlib import Path
 from unittest.mock import Mock
 
-import pytest
 from aiohttp import web
-from pony.orm import db_session
 
-from ipv8.database import database_blob
 from ipv8.keyvault.private.libnaclkey import LibNaCLSK
 from ipv8.util import succeed
+
+from pony.orm import db_session
+
+import pytest
+
 from tribler_common.network_utils import NetworkUtils
 from tribler_common.simpledefs import DLSTATUS_SEEDING
+
 from tribler_core.config.tribler_config import TriblerConfig
 from tribler_core.modules.libtorrent.download import Download
 from tribler_core.modules.libtorrent.download_config import DownloadConfig
@@ -313,6 +316,6 @@ def needle_in_haystack(enable_chant, enable_api, session):  # pylint: disable=un
         _ = session.mds.ChannelMetadata(title='test', tags='test', subscribed=True, infohash=random_infohash())
         for x in range(0, num_hay):
             session.mds.TorrentMetadata(title='hay ' + str(x), infohash=random_infohash())
-        session.mds.TorrentMetadata(title='needle', infohash=database_blob(bytearray(random_infohash())))
-        session.mds.TorrentMetadata(title='needle2', infohash=database_blob(bytearray(random_infohash())))
+        session.mds.TorrentMetadata(title='needle', infohash=random_infohash())
+        session.mds.TorrentMetadata(title='needle2', infohash=random_infohash())
     return session

--- a/src/tribler-core/tribler_core/modules/bandwidth_accounting/transaction.py
+++ b/src/tribler-core/tribler_core/modules/bandwidth_accounting/transaction.py
@@ -39,7 +39,7 @@ class BandwidthTransactionData:
         Encode this block for transport.
         :param signature_a: False to pack EMPTY_SIG in the location of signature A, true to pack the signature A field.
         :param signature_b: False to pack EMPTY_SIG in the location of signature B, true to pack the signature B field.
-        :return: the database_blob the data was packed into.
+        :return: bytes object the data was packed into.
         """
         args = [self.sequence_number, self.public_key_a, self.public_key_b,
                 self.signature_a if signature_a else EMPTY_SIGNATURE,

--- a/src/tribler-core/tribler_core/modules/metadata_store/community/tests/test_gigachannel_community.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/community/tests/test_gigachannel_community.py
@@ -3,7 +3,6 @@ from datetime import datetime
 from unittest import mock
 from unittest.mock import Mock, PropertyMock, patch
 
-from ipv8.database import database_blob
 from ipv8.keyvault.crypto import default_eccrypto
 from ipv8.peer import Peer
 from ipv8.test.base import TestBase
@@ -25,7 +24,7 @@ from tribler_core.notifier import Notifier
 from tribler_core.utilities.path_util import Path
 from tribler_core.utilities.random_utils import random_infohash
 
-EMPTY_BLOB = database_blob(b"")
+EMPTY_BLOB = b""
 
 # pylint:disable=protected-access
 

--- a/src/tribler-core/tribler_core/modules/metadata_store/gigachannel_manager.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/gigachannel_manager.py
@@ -1,7 +1,6 @@
 import asyncio
 from asyncio import CancelledError, wait_for
 
-from ipv8.database import database_blob
 from ipv8.taskmanager import TaskManager, task
 
 from pony.orm import db_session
@@ -310,7 +309,7 @@ class GigaChannelManager(TaskManager):
         Notify the core that we updated our channel.
         """
         with db_session:
-            my_channel = self.session.mds.ChannelMetadata.get(infohash=database_blob(tdef.get_infohash()))
+            my_channel = self.session.mds.ChannelMetadata.get(infohash=tdef.get_infohash())
         if (
             my_channel
             and my_channel.status == COMMITTED

--- a/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/channel_metadata.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/channel_metadata.py
@@ -2,8 +2,6 @@ import os
 from binascii import unhexlify
 from datetime import datetime
 
-from ipv8.database import database_blob
-
 from lz4.frame import LZ4FrameCompressor
 
 from pony import orm
@@ -246,7 +244,7 @@ def define_binding(db):  # pylint: disable=R0915
         @db_session
         def get_my_channels(cls):
             return ChannelMetadata.select(
-                lambda g: g.origin_id == 0 and g.public_key == database_blob(cls._my_key.pub().key_to_bin()[10:])
+                lambda g: g.origin_id == 0 and g.public_key == cls._my_key.pub().key_to_bin()[10:]
             )
 
         @classmethod
@@ -261,7 +259,7 @@ def define_binding(db):  # pylint: disable=R0915
             """
             my_channel = cls(
                 origin_id=origin_id,
-                public_key=database_blob(cls._my_key.pub().key_to_bin()[10:]),
+                public_key=cls._my_key.pub().key_to_bin()[10:],
                 title=title,
                 tags=description,
                 subscribed=True,
@@ -447,15 +445,12 @@ def define_binding(db):  # pylint: disable=R0915
         @classmethod
         @db_session
         def get_channel_with_infohash(cls, infohash):
-            return cls.get(infohash=database_blob(infohash))
+            return cls.get(infohash=infohash)
 
         @classmethod
         @db_session
         def get_recent_channel_with_public_key(cls, public_key):
-            return (
-                cls.select(lambda g: g.public_key == database_blob(public_key)).sort_by(lambda g: desc(g.id_)).first()
-                or None
-            )
+            return cls.select(lambda g: g.public_key == public_key).sort_by(lambda g: desc(g.id_)).first() or None
 
         @classmethod
         @db_session
@@ -487,7 +482,7 @@ def define_binding(db):  # pylint: disable=R0915
                 if g.subscribed == 1
                 and g.status != LEGACY_ENTRY
                 and (g.local_version < g.timestamp)
-                and g.public_key != database_blob(cls._my_key.pub().key_to_bin()[10:])
+                and g.public_key != cls._my_key.pub().key_to_bin()[10:]
             )  # don't simplify `g.subscribed == 1` to bool form, it is used by partial index!
 
         @property
@@ -553,7 +548,7 @@ def define_binding(db):  # pylint: disable=R0915
 
             if not channel:
                 return dl_name
-            if channel.infohash == database_blob(infohash):
+            if channel.infohash == infohash:
                 return channel.title
             return 'OLD:' + channel.title
 

--- a/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/channel_peer.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/channel_peer.py
@@ -1,7 +1,5 @@
 from datetime import datetime
 
-from ipv8.database import database_blob
-
 from pony import orm
 
 
@@ -13,7 +11,7 @@ def define_binding(db):
         """
 
         rowid = orm.PrimaryKey(int, size=64, auto=True)
-        public_key = orm.Required(database_blob, unique=True)
+        public_key = orm.Required(bytes, unique=True)
         individual_votes = orm.Set("ChannelVote", reverse='voter')
         added_on = orm.Optional(datetime, default=datetime.utcnow)
 

--- a/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/collection_node.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/collection_node.py
@@ -1,8 +1,6 @@
 import os
 from pathlib import Path
 
-from ipv8.database import database_blob
-
 from pony import orm
 from pony.orm import db_session, select
 
@@ -22,7 +20,7 @@ from tribler_core.modules.metadata_store.orm_bindings.channel_node import (
     UPDATED,
 )
 from tribler_core.modules.metadata_store.orm_bindings.torrent_metadata import tdef_to_metadata_dict
-from tribler_core.modules.metadata_store.serialization import COLLECTION_NODE, CollectionNodePayload, CHANNEL_TORRENT
+from tribler_core.modules.metadata_store.serialization import CHANNEL_TORRENT, COLLECTION_NODE, CollectionNodePayload
 from tribler_core.utilities.random_utils import random_infohash
 
 # pylint: disable=too-many-statements
@@ -57,8 +55,10 @@ def define_binding(db):
                 return CHANNEL_STATE.PERSONAL.value
 
             toplevel_parent = self.get_parent_nodes()[0]
-            if (toplevel_parent.metadata_type == CHANNEL_TORRENT and
-                toplevel_parent.local_version == toplevel_parent.timestamp):
+            if (
+                toplevel_parent.metadata_type == CHANNEL_TORRENT
+                and toplevel_parent.local_version == toplevel_parent.timestamp
+            ):
                 return CHANNEL_STATE.COMPLETE.value
 
             return CHANNEL_STATE.PREVIEW.value
@@ -94,7 +94,7 @@ def define_binding(db):
             :return: New TorrentMetadata signed with your key.
             """
 
-            existing = db.TorrentMetadata.select(lambda g: g.infohash == database_blob(infohash)).first()
+            existing = db.TorrentMetadata.select(lambda g: g.infohash == infohash).first()
 
             if not existing:
                 return None
@@ -298,8 +298,7 @@ def define_binding(db):
                 dead_parents.remove(0)
             # Delete orphans
             db.ChannelNode.select(
-                lambda g: database_blob(db.ChannelNode._my_key.pub().key_to_bin()[10:])  # pylint: disable=W0212
-                == g.public_key
+                lambda g: db.ChannelNode._my_key.pub().key_to_bin()[10:] == g.public_key  # pylint: disable=W0212
                 and g.origin_id in dead_parents
             ).delete()
             orm.flush()  # Just in case...

--- a/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/torrent_metadata.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/torrent_metadata.py
@@ -1,8 +1,6 @@
 from datetime import datetime
 from struct import unpack
 
-from ipv8.database import database_blob
-
 from pony import orm
 from pony.orm import db_session
 
@@ -55,7 +53,7 @@ def define_binding(db):
         _discriminator_ = REGULAR_TORRENT
 
         # Serializable
-        infohash = orm.Required(database_blob, index=True)
+        infohash = orm.Required(bytes, index=True)
         size = orm.Optional(int, size=64, default=0)
         torrent_date = orm.Optional(datetime, default=datetime.utcnow, index=True)
         tracker_info = orm.Optional(str, default='')
@@ -112,8 +110,8 @@ def define_binding(db):
             # Check that this torrent is yet unknown to GigaChannel, and if there is no duplicate FFA entry.
             # Test for a duplicate id_+public_key is necessary to account for a (highly improbable) situation when
             # two entries have different infohashes but the same id_. We do not want people to exploit this.
-            ih_blob = database_blob(ffa_dict["infohash"])
-            pk_blob = database_blob(b"")
+            ih_blob = ffa_dict["infohash"]
+            pk_blob = b""
             if cls.exists(lambda g: (g.infohash == ih_blob) or (g.id_ == id_ and g.public_key == pk_blob)):
                 return None
             # Add the torrent as a free-for-all entry if it is unknown to GigaChannel
@@ -152,7 +150,7 @@ def define_binding(db):
         @classmethod
         @db_session
         def get_with_infohash(cls, infohash):
-            return cls.select(lambda g: g.infohash == database_blob(infohash)).first()
+            return cls.select(lambda g: g.infohash == infohash).first()
 
         @classmethod
         @db_session

--- a/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/torrent_state.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/torrent_state.py
@@ -1,5 +1,3 @@
-from ipv8.database import database_blob
-
 from pony import orm
 
 
@@ -10,7 +8,7 @@ def define_binding(db):
         """
 
         rowid = orm.PrimaryKey(int, auto=True)
-        infohash = orm.Required(database_blob, unique=True)
+        infohash = orm.Required(bytes, unique=True)
         seeders = orm.Optional(int, default=0)
         leechers = orm.Optional(int, default=0)
         last_check = orm.Optional(int, size=64, default=0)

--- a/src/tribler-core/tribler_core/modules/metadata_store/payload_checker.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/payload_checker.py
@@ -1,8 +1,6 @@
 import enum
 from dataclasses import dataclass, field
 
-from ipv8.database import database_blob
-
 from pony.orm import db_session
 
 from tribler_core.modules.category_filter.l2_filter import is_forbidden
@@ -187,9 +185,7 @@ class PayloadChecker:
         If we don't have some version of the node locally, CONTINUE control to further checks.
         """
         # Check for the older version of the added node
-        node = self.mds.ChannelNode.get_for_update(
-            public_key=database_blob(self.payload.public_key), id_=self.payload.id_
-        )
+        node = self.mds.ChannelNode.get_for_update(public_key=self.payload.public_key, id_=self.payload.id_)
         if not node:
             return CONTINUE
 

--- a/src/tribler-core/tribler_core/modules/metadata_store/restapi/metadata_endpoint.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/restapi/metadata_endpoint.py
@@ -5,7 +5,6 @@ from aiohttp import ContentTypeError, web
 from aiohttp_apispec import docs
 
 from ipv8.REST.schema import schema
-from ipv8.database import database_blob
 
 from marshmallow.fields import Integer, String
 
@@ -88,7 +87,7 @@ class MetadataEndpoint(MetadataEndpointBase, UpdateEntryMixin):
             return RESTResponse({"error": "Bad JSON"}, status=HTTP_BAD_REQUEST)
         results_list = []
         for entry in request_parsed:
-            public_key = database_blob(unhexlify(entry.pop("public_key")))
+            public_key = unhexlify(entry.pop("public_key"))
             id_ = entry.pop("id")
             error, result = self.update_entry(public_key, id_, entry)
             # TODO: handle the results for a list that contains some errors in a smarter way
@@ -119,7 +118,7 @@ class MetadataEndpoint(MetadataEndpointBase, UpdateEntryMixin):
             request_parsed = await request.json()
             results_list = []
             for entry in request_parsed:
-                public_key = database_blob(unhexlify(entry.pop("public_key")))
+                public_key = unhexlify(entry.pop("public_key"))
                 id_ = entry.pop("id")
                 entry = self.session.mds.ChannelNode.get(public_key=public_key, id_=id_)
                 if not entry:
@@ -159,7 +158,7 @@ class MetadataEndpoint(MetadataEndpointBase, UpdateEntryMixin):
         public_key = unhexlify(request.match_info['public_key'])
         id_ = request.match_info['id']
         with db_session:
-            entry = self.session.mds.ChannelNode.get(public_key=database_blob(public_key), id_=id_)
+            entry = self.session.mds.ChannelNode.get(public_key=public_key, id_=id_)
 
             if entry:
                 # TODO: handle costly attributes in a more graceful and generic way for all types of metadata

--- a/src/tribler-core/tribler_core/modules/metadata_store/serialization.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/serialization.py
@@ -4,7 +4,6 @@ import struct
 from datetime import datetime, timedelta
 from typing import List, Tuple
 
-from ipv8.database import database_blob
 from ipv8.keyvault.crypto import default_eccrypto
 from ipv8.messaging.lazy_payload import VariablePayload, vp_compile
 from ipv8.messaging.payload import Payload
@@ -66,7 +65,7 @@ class UnknownBlobTypeException(Exception):
 
 def read_payload_with_offset(data, offset=0):
     # First we have to determine the actual payload type
-    metadata_type = struct.unpack_from('>H', database_blob(data), offset=offset)[0]
+    metadata_type = struct.unpack_from('>H', data, offset=offset)[0]
     payload_class = DISCRIMINATOR_TO_PAYLOAD_CLASS.get(metadata_type)
     if payload_class is not None:
         return payload_class.from_signed_blob_with_offset(data, offset=offset)

--- a/src/tribler-core/tribler_core/modules/metadata_store/store.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/store.py
@@ -4,8 +4,6 @@ from asyncio import get_event_loop
 from datetime import datetime, timedelta
 from time import sleep, time
 
-from ipv8.database import database_blob
-
 from lz4.frame import LZ4FrameDecompressor
 
 from pony import orm
@@ -148,7 +146,7 @@ class MetadataStore:
         self.db_filename = db_filename
         self.channels_dir = channels_dir
         self.my_key = my_key
-        self.my_public_key_bin = bytes(database_blob(self.my_key.pub().key_to_bin()[10:]))
+        self.my_public_key_bin = self.my_key.pub().key_to_bin()[10:]
         self._logger = logging.getLogger(self.__class__.__name__)
 
         self._shutting_down = False
@@ -565,9 +563,7 @@ class MetadataStore:
         :return: True if torrent exists else False
         """
         return self.TorrentMetadata.exists(
-            lambda g: g.public_key == self.my_public_key_bin
-            and g.infohash == database_blob(infohash)
-            and g.status != LEGACY_ENTRY
+            lambda g: g.public_key == self.my_public_key_bin and g.infohash == infohash and g.status != LEGACY_ENTRY
         )
 
     # pylint: disable=unused-argument

--- a/src/tribler-core/tribler_core/modules/metadata_store/tests/test_channel_download.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/tests/test_channel_download.py
@@ -1,4 +1,3 @@
-from ipv8.database import database_blob
 from ipv8.util import succeed
 
 from pony.orm import db_session
@@ -56,7 +55,7 @@ async def test_channel_update_and_download(
 
     with db_session:
         # There should be 8 torrents + 1 channel torrent
-        channel2 = session.mds.ChannelMetadata.get(public_key=database_blob(payload.public_key))
+        channel2 = session.mds.ChannelMetadata.get(public_key=payload.public_key)
         assert channel2.timestamp == channel2.local_version
         assert channel2.timestamp == 1565621688018
         assert session.mds.ChannelNode.select().count() == 8

--- a/src/tribler-core/tribler_core/modules/metadata_store/tests/test_channel_metadata.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/tests/test_channel_metadata.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from time import sleep
 from unittest.mock import Mock, patch
 
-from ipv8.database import database_blob
 from ipv8.keyvault.crypto import default_eccrypto
 
 from lz4.frame import LZ4FrameDecompressor
@@ -28,11 +27,10 @@ from tribler_core.modules.metadata_store.orm_bindings.channel_node import COMMIT
 from tribler_core.modules.metadata_store.serialization import CHANNEL_TORRENT, COLLECTION_NODE, REGULAR_TORRENT
 from tribler_core.modules.metadata_store.store import HealthItemsPayload
 from tribler_core.tests.tools.common import TESTS_DATA_DIR, TORRENT_UBUNTU_FILE
-from tribler_core.utilities import path_util
 from tribler_core.utilities.random_utils import random_infohash
 
-
 # pylint: disable=protected-access
+
 
 @pytest.fixture
 def my_key():
@@ -47,12 +45,12 @@ def torrent_template():
 @pytest.fixture
 def sample_torrent_dict(my_key):
     return {
-        "infohash": database_blob(b"1" * 20),
+        "infohash": b"1" * 20,
         "size": 123,
         "torrent_date": datetime.utcnow(),
         "tags": "bla",
         "id_": 123,
-        "public_key": database_blob(my_key.pub().key_to_bin()[10:]),
+        "public_key": my_key.pub().key_to_bin()[10:],
         "title": "lalala",
     }
 
@@ -171,7 +169,7 @@ def test_get_channel_with_dirname(sample_channel_dict, metadata_store):
     assert channel_metadata == channel_result
 
     # Test for corner-case of channel PK starting with zeroes
-    channel_metadata.public_key = database_blob(unhexlify('0' * 128))
+    channel_metadata.public_key = unhexlify('0' * 128)
     channel_result = metadata_store.ChannelMetadata.get_channel_with_dirname(channel_metadata.dirname)
     assert channel_metadata == channel_result
 
@@ -831,7 +829,7 @@ def test_get_channel_name(metadata_store):
     """
     infohash = b"\x00" * 20
     title = "testchan"
-    chan = metadata_store.ChannelMetadata(title=title, infohash=database_blob(infohash))
+    chan = metadata_store.ChannelMetadata(title=title, infohash=infohash)
     dirname = chan.dirname
 
     assert title == metadata_store.ChannelMetadata.get_channel_name(dirname, infohash)

--- a/src/tribler-core/tribler_core/modules/metadata_store/tests/test_metadata.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/tests/test_metadata.py
@@ -1,4 +1,3 @@
-from ipv8.database import database_blob
 from ipv8.keyvault.crypto import default_eccrypto
 
 from pony import orm
@@ -122,7 +121,7 @@ def test_has_valid_signature(metadata_store):
 
     # Create metadata with wrong key
     metadata.delete()
-    md_dict.update(public_key=database_blob(b"aaa"))
+    md_dict.update(public_key=b"aaa")
     md_dict.pop("rowid")
 
     metadata = metadata_store.ChannelNode(skip_key_check=True, **md_dict)
@@ -130,7 +129,7 @@ def test_has_valid_signature(metadata_store):
 
     key = default_eccrypto.generate_key("curve25519")
     metadata2 = metadata_store.ChannelNode(sign_with=key, **md_dict)
-    assert database_blob(key.pub().key_to_bin()[10:]), metadata2.public_key
+    assert key.pub().key_to_bin()[10:], metadata2.public_key
     md_dict2 = metadata2.to_dict()
     md_dict2["signature"] = md_dict["signature"]
     with pytest.raises(InvalidSignatureException):

--- a/src/tribler-core/tribler_core/modules/metadata_store/tests/test_torrent_metadata.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/tests/test_torrent_metadata.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 from time import time
 
-from ipv8.database import database_blob
 from ipv8.keyvault.crypto import default_eccrypto
 
 from pony import orm
@@ -17,7 +16,7 @@ from tribler_core.modules.metadata_store.serialization import CHANNEL_TORRENT, R
 from tribler_core.tests.tools.common import TORRENT_UBUNTU_FILE
 from tribler_core.utilities.random_utils import random_infohash
 
-EMPTY_BLOB = database_blob(b"")
+EMPTY_BLOB = b""
 
 
 def rnd_torrent():

--- a/src/tribler-core/tribler_core/modules/torrent_checker/torrent_checker.py
+++ b/src/tribler-core/tribler_core/modules/torrent_checker/torrent_checker.py
@@ -4,7 +4,6 @@ import random
 import time
 from asyncio import CancelledError, gather
 
-from ipv8.database import database_blob
 from ipv8.taskmanager import TaskManager, task
 
 from pony.orm import db_session, desc, select
@@ -232,7 +231,7 @@ class TorrentChecker(TaskManager):
     @db_session
     def get_valid_trackers_of_torrent(self, torrent_id):
         """ Get a set of valid trackers for torrent. Also remove any invalid torrent."""
-        db_tracker_list = self.tribler_session.mds.TorrentState.get(infohash=database_blob(torrent_id)).trackers
+        db_tracker_list = self.tribler_session.mds.TorrentState.get(infohash=torrent_id).trackers
         return {tracker.url for tracker in db_tracker_list
                     if is_valid_url(tracker.url) and not self.is_blacklisted_tracker(tracker.url)}
 
@@ -303,7 +302,7 @@ class TorrentChecker(TaskManager):
 
         # We first check whether the torrent is already in the database and checked before
         with db_session:
-            result = self.tribler_session.mds.TorrentState.get(infohash=database_blob(infohash))
+            result = self.tribler_session.mds.TorrentState.get(infohash=infohash)
             if result:
                 torrent_id = result.infohash
                 last_check = result.last_check
@@ -382,7 +381,7 @@ class TorrentChecker(TaskManager):
 
         with db_session:
             # Update torrent state
-            torrent = self.tribler_session.mds.TorrentState.get(infohash=database_blob(infohash))
+            torrent = self.tribler_session.mds.TorrentState.get(infohash=infohash)
             if not torrent:
                 self._logger.warning(
                     "Tried to update torrent health data in DB for an unknown torrent: %s", hexlify(infohash))


### PR DESCRIPTION
fixes #6097  with some `bowler` magic:

<details>

```python

import mmap
import re
from lib2to3.pgen2.parse import ParseError
from pathlib import Path

from bowler.query import Query

fun_name = "database_blob"

dbblob = re.compile(fun_name.encode())


def modify_file(filename):
    (
        Query(filename).
            select_function(fun_name).
            is_call().
            modify(remove_call).execute(interactive=False, write=True)
    )


def remove_call(ast_node, capture, _):
    args = capture.get('function_arguments')

    parent = ast_node.parent
    children_list = parent.children
    for ind, leaf in enumerate(children_list):
        if leaf is ast_node:
            children_list[ind] = args[0].clone()


if __name__ == "__main__":
    for file in Path("src/tribler-core").rglob("*.py"):
        try:
            with open(file, "r+") as f:
                data = mmap.mmap(f.fileno(), 0)
                if not re.search(dbblob, data):
                    continue
        except:
            continue
        try:
            modify_file(file)
        except ParseError:
            print("Can't handle file ", file)


```

</details>