### PR TITLE
Disable EVA timeout in test_duplex

### DIFF
--- a/src/tribler-core/tribler_core/modules/remote_query_community/tests/test_eva_protocol.py
+++ b/src/tribler-core/tribler_core/modules/remote_query_community/tests/test_eva_protocol.py
@@ -236,6 +236,9 @@ class TestEVA(TestBase):
         count = 100
         block_size = 10
 
+        self.overlay(0).eva_protocol.terminate_by_timeout_enabled = False
+        self.overlay(1).eva_protocol.terminate_by_timeout_enabled = False
+
         self.overlay(0).eva_protocol.block_size = block_size
         self.overlay(1).eva_protocol.block_size = block_size
 


### PR DESCRIPTION
This PR fixes #6195 by disabling timeout in `test_duplex` test function.