### PR TITLE
Fix removing all peers for channel instead of the failing one

### DIFF
--- a/src/tribler-core/tribler_core/modules/metadata_store/community/gigachannel_community.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/community/gigachannel_community.py
@@ -58,7 +58,9 @@ class ChannelsPeersMapping:
 
     def remove_peer(self, peer):
         for id_tuple in self._peers_channels[peer]:
-            self._channels_dict.pop(id_tuple, None)
+            self._channels_dict[id_tuple].discard(peer)
+            if not self._channels_dict[id_tuple]:
+                self._channels_dict.pop(id_tuple)
         self._peers_channels.pop(peer)
 
     def get_last_seen_peers_for_channel(self, channel_pk: bytes, channel_id: int, limit=None):


### PR DESCRIPTION
This PR fixes the bug that results in removing _all_ the peers serving a channel from channels<->peers mapping in GigaChannel Community. The result was lower quality online browsing of channels.