### PR TITLE
Silently pass when user tries to add duplicate torrents to channel

### DIFF
--- a/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/collection_node.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/orm_bindings/collection_node.py
@@ -159,6 +159,7 @@ def define_binding(db):
 
             # See if the torrent is already in the channel
             old_torrent = db.TorrentMetadata.get(public_key=self.public_key, infohash=tdef.get_infohash())
+            torrent_metadata = old_torrent
             if old_torrent:
                 # If it is there, check if we were going to delete it
                 if old_torrent.status == TODELETE:
@@ -168,9 +169,6 @@ def define_binding(db):
                     # As we really don't know what status this torrent had _before_ it got its TODELETE status,
                     # we _must_ set its status to UPDATED, for safety
                     old_torrent.status = UPDATED
-                    torrent_metadata = old_torrent
-                else:
-                    raise DuplicateTorrentFileError()
             else:
                 torrent_metadata = db.TorrentMetadata.from_dict(dict(origin_id=self.id_, **new_entry_dict))
             return torrent_metadata

--- a/src/tribler-core/tribler_core/modules/metadata_store/restapi/tests/test_channels_endpoint.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/restapi/tests/test_channels_endpoint.py
@@ -515,7 +515,7 @@ async def test_add_invalid_torrent(enable_chant, enable_api, my_channel, session
 @pytest.mark.asyncio
 async def test_add_torrent_duplicate(enable_chant, enable_api, my_channel, session):
     """
-    Test whether adding a duplicate torrent to you channel results in an error
+    Test that adding a duplicate torrent to you channel does not result in an error
     """
     with db_session:
         tdef = TorrentDef.load(TORRENT_UBUNTU_FILE)
@@ -530,7 +530,7 @@ async def test_add_torrent_duplicate(enable_chant, enable_api, my_channel, sessi
                 f'channels/{hexlify(my_channel.public_key)}/{my_channel.id_}/torrents',
                 request_type='PUT',
                 post_data=post_params,
-                expected_code=500,
+                expected_code=200,
             )
 
 

--- a/src/tribler-core/tribler_core/modules/metadata_store/tests/test_channel_metadata.py
+++ b/src/tribler-core/tribler_core/modules/metadata_store/tests/test_channel_metadata.py
@@ -197,8 +197,9 @@ def test_add_torrent_to_channel(metadata_store):
     tdef = TorrentDef.load(TORRENT_UBUNTU_FILE)
     channel_metadata.add_torrent_to_channel(tdef, {'description': 'blabla'})
     assert channel_metadata.contents_list
-    with pytest.raises(DuplicateTorrentFileError):
-        channel_metadata.add_torrent_to_channel(tdef, None)
+
+    # Make sure trying to add a duplicate torrent does not result in an error
+    channel_metadata.add_torrent_to_channel(tdef, None)
 
 
 @db_session


### PR DESCRIPTION
Stops bugging the user with endless "Duplicate torrent" popups when trying to repeatedly add multiple torrents to a personal channel by using "Add torrent" action.
[Reported by forum user.](https://forum.tribler.org/t/metainfo-timeout-after-adding-torrents-to-my-channel/6790/2)