### PR TITLE
Don’t create a Tribler subfolder in the Start

### DIFF
--- a/build/win/resources/tribler.nsi
+++ b/build/win/resources/tribler.nsi
@@ -170,9 +170,7 @@ SectionEnd
 
 
 Section "Startmenu Icons" SecStart
-    CreateDirectory "$SMPROGRAMS\${PRODUCT}"
-    CreateShortCut "$SMPROGRAMS\${PRODUCT}\Uninstall ${PRODUCT}.lnk" "$INSTDIR\Uninstall.exe"
-    CreateShortCut "$SMPROGRAMS\${PRODUCT}\${PRODUCT}.lnk" "$INSTDIR\${PRODUCT}.exe"
+    CreateShortCut "$SMPROGRAMS\${PRODUCT}.lnk" "$INSTDIR\${PRODUCT}.exe"
 SectionEnd
 
 
@@ -222,8 +220,7 @@ Section "Uninstall"
     Delete "$DESKTOP\${PRODUCT}.lnk"
 
     SetShellVarContext all
-    RMDir "$SMPROGRAMS\${PRODUCT}"
-    RMDir /r "$SMPROGRAMS\${PRODUCT}"
+    Delete "$SMPROGRAMS\${PRODUCT}.lnk"
 
     DeleteRegKey HKEY_LOCAL_MACHINE "SOFTWARE\${PRODUCT}"
     DeleteRegKey HKEY_LOCAL_MACHINE "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT}"


### PR DESCRIPTION
Install the Tribler shortcut directly into the root of the Start Menu. A subfolder adds an unnecessary extra click to open Tribler. This has been the [best practice](https://www.ctrl.blog/entry/windows-start-menu-folders.html) since Windows 8 when Windows stopped listing folders above icons in the Start Menu. This also gives Tribler a better appearance and brand recognition in the start menu as the listing will feature Tribler’s icon instead of a generic folder icon.

Don’t create a shortcut to uninstall Tribler in the Start Menu. The entry shows up when searching for Tribler in the Start Menu, and it’s easy to missclick on it from Search (as results rearrange as they pop in) and in the Start Menu. Rely on the regular uninstallation flow instead. (Right-clicking on the icon the Start Menu and choosing Uninstall, or going to the Windows Settings app: Apps: Remove apps.)