### PR TITLE
Fixes #6245: Wrong target peers for DiscoveryCommunity

### DIFF
--- a/src/tribler-core/tribler_core/components/implementation/ipv8.py
+++ b/src/tribler-core/tribler_core/components/implementation/ipv8.py
@@ -105,7 +105,7 @@ class Ipv8ComponentImp(Ipv8Component):
         community = DiscoveryCommunity(self.peer, ipv8.endpoint, ipv8.network, max_peers=100)
         ipv8.strategies.append((RandomChurn(community), INFINITE))
         ipv8.strategies.append((PeriodicSimilarity(community), INFINITE))
-        ipv8.strategies.append((RandomWalk(community), INFINITE))
+        ipv8.strategies.append((RandomWalk(community), 20))
         ipv8.overlays.append(community)
         community.bootstrappers.append(self.bootstrapper)
         self.peer_discovery_community = community


### PR DESCRIPTION
Fixes #6245. This PR fixes a regression appeared after the incorrect refactoring when splitting Tribler code into components.