### PR TITLE
Fixes #6250, fixes #6251: each community should use a separate bootstrapper

### DIFF
--- a/src/tribler-core/tribler_core/components/implementation/bandwidth_accounting.py
+++ b/src/tribler-core/tribler_core/components/implementation/bandwidth_accounting.py
@@ -39,8 +39,7 @@ class BandwidthAccountingComponentImp(BandwidthAccountingComponent):
                                   database=database)
         ipv8.strategies.append((RandomWalk(community), 20))
 
-        if ipv8_component.bootstrapper:
-            community.bootstrappers.append(ipv8_component.bootstrapper)
+        community.bootstrappers.append(ipv8_component.make_bootstrapper())
 
         ipv8.overlays.append(community)
         self.community = community

--- a/src/tribler-core/tribler_core/components/implementation/gigachannel.py
+++ b/src/tribler-core/tribler_core/components/implementation/gigachannel.py
@@ -46,8 +46,7 @@ class GigaChannelComponentImp(GigaChannelComponent):
         ipv8.strategies.append((RandomWalk(community), 30))
         ipv8.strategies.append((RemovePeers(community), INFINITE))
 
-        if ipv8_component.bootstrapper:
-            community.bootstrappers.append(ipv8_component.bootstrapper)
+        community.bootstrappers.append(ipv8_component.make_bootstrapper())
 
         ipv8.overlays.append(community)
 

--- a/src/tribler-core/tribler_core/components/implementation/popularity.py
+++ b/src/tribler-core/tribler_core/components/implementation/popularity.py
@@ -32,8 +32,7 @@ class PopularityComponentImp(PopularityComponent):
         ipv8.strategies.append((RandomWalk(community), 30))
         ipv8.strategies.append((RemovePeers(community), INFINITE))
 
-        if ipv8_component.bootstrapper:
-            community.bootstrappers.append(ipv8_component.bootstrapper)
+        community.bootstrappers.append(ipv8_component.make_bootstrapper())
 
         ipv8.overlays.append(community)
 

--- a/src/tribler-core/tribler_core/components/implementation/tunnels.py
+++ b/src/tribler-core/tribler_core/components/implementation/tunnels.py
@@ -52,8 +52,7 @@ class TunnelsComponentImp(TunnelsComponent):
         ipv8.strategies.append((RemovePeers(community), INFINITE))
         ipv8.overlays.append(community)
 
-        if ipv8_component.bootstrapper:
-            community.bootstrappers.append(ipv8_component.bootstrapper)
+        community.bootstrappers.append(ipv8_component.make_bootstrapper())
 
         self.community = community
 

--- a/src/tribler-core/tribler_core/components/interfaces/ipv8.py
+++ b/src/tribler-core/tribler_core/components/interfaces/ipv8.py
@@ -1,3 +1,4 @@
+from abc import abstractmethod
 from typing import Optional
 from unittest.mock import Mock
 
@@ -17,7 +18,6 @@ class Ipv8Component(Component):
 
     ipv8: IPv8
     peer: Peer
-    bootstrapper: Optional[DispersyBootstrapper]
     peer_discovery_community: Optional[DiscoveryCommunity]
     dht_discovery_community: Optional[DHTDiscoveryCommunity]
 
@@ -32,11 +32,17 @@ class Ipv8Component(Component):
             return Ipv8ComponentImp(cls)
         return Ipv8ComponentMock(cls)
 
+    @abstractmethod
+    def make_bootstrapper(self) -> DispersyBootstrapper:
+        pass
+
 
 @testcomponent
 class Ipv8ComponentMock(Ipv8Component):
     ipv8 = Mock()
     peer = Mock()
-    bootstrapper = Mock()
     peer_discovery_community = Mock()
     dht_discovery_community = Mock()
+
+    def make_bootstrapper(self):
+        return Mock()


### PR DESCRIPTION
Fixes #6250 and #6251.
Adds `Ipv8Component.make_bootstrapper()` factory and uses it for each community