### PR TITLE
Fixes #6257: restore lint checks for tests

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -11,8 +11,6 @@ init-hook='import sys; import os; sys.path.append(os.path.join("src", "pyipv8"))
 # paths.
 ignore=.git,libnacl,data,.pylint.rc,pyproject.toml
 
-ignore-patterns=test_.*?py
-
 # Pickle collected data for later comparisons.
 persistent=yes
 


### PR DESCRIPTION
This PR restores lint checks for tests that were turned off during the refactoring of Tribler core in #6206