### PR TITLE
Don’t filter any groups of people out of existence

### DIFF
--- a/src/tribler-core/tribler_core/modules/category_filter/filter_terms.filter
+++ b/src/tribler-core/tribler_core/modules/category_filter/filter_terms.filter
@@ -1,7 +1,5 @@
 *adult
 *fuck
-*gay
-*lesbian
 *porn
 *sex
 *shemale
@@ -52,7 +50,6 @@ agustina
 akiba
 asa akira
 alba
-albanian
 alektra
 alektra blue
 alex divine
@@ -126,7 +123,6 @@ amber rayne
 amor
 amore
 ampland
-amputee
 anaal
 anaallikken
 anaalneuken
@@ -167,7 +163,6 @@ animalporno
 animalsex
 animalsexcom
 animalsexverhalen
-anime
 anita crystal
 anja
 anjali
@@ -185,8 +180,6 @@ anyone but my husband (1975).avi
 anywebcam
 aoki
 apodacab
-arab
-arabian
 archieven
 archiv
 ariana
@@ -203,16 +196,13 @@ arse
 ashley
 ashley blue
 ashley long
-asia
 asia carrera
 asiagirl
-asian
 asianbabecams
 asianbabes
 asianlolita
 asianporn
 asianporno
-asians
 asiansex
 asiansexyshemales
 asianteen
@@ -279,6 +269,7 @@ banned
 barbara summer
 barbie
 bare
+bareback
 barebacking
 barefoot
 barely
@@ -315,7 +306,6 @@ bejaardensex
 bekendbloot
 bekijksex
 bekommt
-belgian
 belgischeporno
 bella starr
 belladonna
@@ -359,8 +349,6 @@ birape
 bisex
 bisexcam
 bisexfilms
-bisexual
-bisexueel
 bisexverhalen
 bitch
 bitches
@@ -381,8 +369,6 @@ blasluder
 blass
 blasschlampe
 blindfolded
-blond
-blonde
 blonde1
 blonde2
 blonde3
@@ -474,15 +460,11 @@ breezersletjes
 briana banks
 brigitte
 brinquedinho
-britney spears
 brittany andrews
 brittney skye
 brooke
 brooke alexander
 brooke haven
-brunete
-brunette
-brunettes
 brutal
 brutaldildos
 brutalviolence
@@ -569,9 +551,6 @@ cathy barry
 catsuit
 caught
 cearense
-celeb
-celebrities
-celebrity
 celebs
 celeste star
 celia
@@ -656,7 +635,6 @@ cogiendo
 cojida
 cojiendo
 coke
-colombia
 colombiana
 comicsex
 coming
@@ -769,7 +747,6 @@ dafreexxxmovies
 daisy rock
 dames
 danielle louise kelson
-danish
 daphne rosen
 daria glower
 darla crane
@@ -907,8 +884,6 @@ dutchliteroticacom
 dutchpussy
 dutchroxy
 dutchstuds
-dwerg
-dwergen
 dwergenseks
 dyanna lauren
 eating
@@ -1011,7 +986,6 @@ facialized
 facials
 facialsusana
 facialthreesome
-familie
 familiesex
 famouspornstars
 fanny
@@ -1210,7 +1184,6 @@ gayboys
 gayfilms
 gayfotos
 gayporn
-gays
 gayscat
 gayseks
 gaysex
@@ -1471,7 +1444,6 @@ hoertje
 hoertjes
 hoes
 hogtied
-hollandse
 hollandsesex
 homefuck
 homefucking
@@ -1563,7 +1535,6 @@ inari vachs
 incest
 incestporno
 incestsex
-inclusive
 incubus
 industrion
 ingetrokken
@@ -1577,7 +1548,6 @@ interraciaal
 interracial
 intiem
 invalide
-iranerin
 isabel ice
 isabelle
 ishotmyself
@@ -1788,7 +1758,6 @@ lacie
 lacie heart
 lactacting
 lactating
-ladies
 ladung
 ladyboy
 laetitia
@@ -1811,7 +1780,6 @@ lasses
 latex
 latexsex
 latincouple
-latino
 laura
 laura giotto
 laura hermenson
@@ -1820,7 +1788,6 @@ lauren
 lauren phoenix
 layla jade
 lea walker
-leabian
 leah
 leah caprice
 leather
@@ -1842,16 +1809,9 @@ lekkerneuken
 lekkershowen
 lemayzing
 lerares
-lesbe
-lesben
 lesbenspiele
-lesbian
-lesbianas
 lesbianpink
-lesbians
 lesbianswebcam
-lesbisch
-lesbische
 lesbischsexstart
 lesbisex
 lesbo
@@ -2109,7 +2069,6 @@ moglie
 mohootje
 mokkels
 molige
-moms
 mondneuken
 moni
 monica sweetheart
@@ -2125,7 +2084,6 @@ monstertits
 mooiebillen
 mooievrouwen
 moran
-moremoms
 morgane
 morrigan hel
 motel
@@ -2189,7 +2147,6 @@ natuursteen
 naughty
 naughtyteens
 naugthy
-nederlandse
 nedersex
 neger
 negerinen
@@ -2331,7 +2288,6 @@ orgasmus
 orgie
 orgies
 orgy
-oriental
 oudegokkasten
 ouderensex
 ouderesex
@@ -2485,7 +2441,6 @@ poepseks
 poepsex
 poes
 poesjes
-poland
 polandbathroom
 polderrape
 pompino
@@ -2510,6 +2465,7 @@ pornfilms
 porngirl
 porngirls
 pornhot
+pornhub
 pornication
 pornmovie
 pornmovies
@@ -2557,9 +2513,6 @@ pornstarbook
 pornstargals
 pornstars
 porntube
-portugal
-portuguesa
-portuguese
 posiert
 position
 positionblonde
@@ -2764,7 +2717,6 @@ sborra
 sborrata
 scandal
 scandals
-scandinavian
 scarlet haze
 scat
 scatsex
@@ -3301,9 +3253,6 @@ swallow
 swallowing
 swallows
 swapping
-swede
-swedish
-sweedish
 sweedish3
 sweet
 sweetbabes
@@ -3360,8 +3309,6 @@ teasing
 techniek
 teef
 teefjes
-teen
-teenagers
 teenagesex
 teenagesexvideo
 teenass
@@ -3381,7 +3328,6 @@ teenporn
 teenporno
 teenport
 teenrape
-teens
 teensex
 teensluts
 teeny
@@ -3402,7 +3348,6 @@ terri summers
 tess
 tetas
 texas presley
-thai
 thaigirl
 thailand
 thaisau
@@ -3543,10 +3488,7 @@ troia
 tsibouki
 tugjob
 tugjobs
-turk
-turkey
 turkhisblowjob
-turksh
 twat
 twentegirl
 twopetra

--- a/src/tribler-core/tribler_core/modules/category_filter/filter_terms.filter
+++ b/src/tribler-core/tribler_core/modules/category_filter/filter_terms.filter
@@ -3309,6 +3309,8 @@ teasing
 techniek
 teef
 teefjes
+teen
+teenagers
 teenagesex
 teenagesexvideo
 teenass
@@ -3328,6 +3330,7 @@ teenporn
 teenporno
 teenport
 teenrape
+teens
 teensex
 teensluts
 teeny


### PR DESCRIPTION
The keyword filter list is discriminating.

Some searches that aren’t allowed with the current filter:

* belgian waffles
* asian tv, asian cousine, asuan culture
* scandianvian nature, scandinavian architecture
* gay interest (a common label for media with LGBTQ characters)
* turkish movies
* danish children tv (watch [John Dillermand](https://www.youtube.com/watch?v=A51mJjFyG_w))

I’ve removed the groups of people (but left in slurs) I could identify from the list. I was surprised that there were so many given names are on the list. I understand these may be adult performers, but blocking every artist or creator named Alexis, Charlie, or one of the hundred other names on the list is crazy. These should be removed as well, but let’s address those in a separate pr.