### PR TITLE
Refactoring/session logic outside of session

### DIFF
--- a/src/tribler-core/tribler_core/components/base.py
+++ b/src/tribler-core/tribler_core/components/base.py
@@ -1,17 +1,16 @@
 from __future__ import annotations
 
-from abc import abstractmethod
-from asyncio import Event, create_task, gather, get_event_loop
-from contextlib import contextmanager
-from itertools import count
 import logging
 import os
 import sys
-from typing import Dict, Iterable, List, Optional, Set, Type, TypeVar
-
+from abc import abstractmethod
+from asyncio import Event, create_task, gather
+from itertools import count
 from pathlib import Path
+from typing import Dict, List, Optional, Set, Type, TypeVar
 
 from tribler_common.simpledefs import STATEDIR_CHANNELS_DIR, STATEDIR_DB_DIR
+
 from tribler_core.config.tribler_config import TriblerConfig
 from tribler_core.notifier import Notifier
 from tribler_core.utilities.crypto_patcher import patch_crypto_be_discovery

--- a/src/tribler-core/tribler_core/components/base.py
+++ b/src/tribler-core/tribler_core/components/base.py
@@ -60,6 +60,13 @@ class Session:
             raise SessionError("Default session was not set")
         return Session._default
 
+    def set_as_default(self):
+        Session._default = self
+
+    @staticmethod
+    def unset_default_session():
+        Session._default = None
+
     def register(self, comp_cls: Type[Component], comp: Component):
         if comp.session is not None:
             raise ComponentError(f'Component {comp.__class__.__name__} is already registered in session {comp.session}')
@@ -95,10 +102,6 @@ class Session:
     def __exit__(self, exc_type, exc_val, exc_tb):
         assert Session._stack and Session._stack[-1] is self
         Session._stack.pop()
-
-
-def set_default_session(session: Session):
-    Session._default = session
 
 
 def get_session() -> Session:

--- a/src/tribler-core/tribler_core/components/base.py
+++ b/src/tribler-core/tribler_core/components/base.py
@@ -54,6 +54,12 @@ class Session:
     def __repr__(self):
         return f'<{self.__class__.__name__}:{self.id}>'
 
+    @staticmethod
+    def _get_default_session() -> Session:
+        if Session._default is None:
+            raise SessionError("Default session was not set")
+        return Session._default
+
     def register(self, comp_cls: Type[Component], comp: Component):
         if comp.session is not None:
             raise ComponentError(f'Component {comp.__class__.__name__} is already registered in session {comp.session}')
@@ -91,12 +97,6 @@ class Session:
         Session._stack.pop()
 
 
-def _get_default_session() -> Session:
-    if Session._default is None:
-        raise SessionError("Default session was not set")
-    return Session._default
-
-
 def set_default_session(session: Session):
     Session._default = session
 
@@ -104,7 +104,7 @@ def set_default_session(session: Session):
 def get_session() -> Session:
     if Session._stack:
         return Session._stack[-1]
-    return _get_default_session()
+    return Session._get_default_session()
 
 
 T = TypeVar('T', bound='Component')

--- a/src/tribler-core/tribler_core/components/base.py
+++ b/src/tribler-core/tribler_core/components/base.py
@@ -35,6 +35,7 @@ def create_state_directory_structure(state_dir: Path):
 
 class Session:
     _next_session_id = count(1)
+    _default: Optional[Session] = None
 
     def __init__(self, config: TriblerConfig = None, components: List[Component] = (),
                  shutdown_event: Event = None, notifier: Notifier = None):
@@ -89,18 +90,14 @@ class Session:
         _session_stack.pop()
 
 
-_default_session: Optional[Session] = None
-
-
 def _get_default_session() -> Session:
-    if _default_session is None:
+    if Session._default is None:
         raise SessionError("Default session was not set")
-    return _default_session
+    return Session._default
 
 
 def set_default_session(session: Session):
-    global _default_session
-    _default_session = session
+    Session._default = session
 
 
 _session_stack = []

--- a/src/tribler-core/tribler_core/components/base.py
+++ b/src/tribler-core/tribler_core/components/base.py
@@ -67,6 +67,12 @@ class Session:
     def unset_default_session():
         Session._default = None
 
+    @staticmethod
+    def current() -> Session:
+        if Session._stack:
+            return Session._stack[-1]
+        return Session._get_default_session()
+
     def register(self, comp_cls: Type[Component], comp: Component):
         if comp.session is not None:
             raise ComponentError(f'Component {comp.__class__.__name__} is already registered in session {comp.session}')
@@ -104,12 +110,6 @@ class Session:
         Session._stack.pop()
 
 
-def get_session() -> Session:
-    if Session._stack:
-        return Session._stack[-1]
-    return Session._get_default_session()
-
-
 T = TypeVar('T', bound='Component')
 
 
@@ -143,7 +143,7 @@ class Component:
 
     @classmethod
     def _find_implementation(cls: Type[T]) -> T:
-        session = get_session()
+        session = Session.current()
         return session.get(cls)
 
     @classmethod

--- a/src/tribler-core/tribler_core/components/base.py
+++ b/src/tribler-core/tribler_core/components/base.py
@@ -33,14 +33,13 @@ def create_state_directory_structure(state_dir: Path):
     (state_dir / STATEDIR_CHANNELS_DIR).mkdir(exist_ok=True)
 
 
-session_counter = count(1)
-
-
 class Session:
+    _next_session_id = count(1)
+
     def __init__(self, config: TriblerConfig = None, components: List[Component] = (),
                  shutdown_event: Event = None, notifier: Notifier = None):
-        #  deepcode ignore unguarded~next~call: not necessary to catch StopIteration on infinite iterator
-        self.id = next(session_counter)
+        # deepcode ignore unguarded~next~call: not necessary to catch StopIteration on infinite iterator
+        self.id = next(Session._next_session_id)
         self.logger = logging.getLogger(self.__class__.__name__)
         self.config: TriblerConfig = config or TriblerConfig()
         self.shutdown_event: Event = shutdown_event or Event()

--- a/src/tribler-core/tribler_core/components/base.py
+++ b/src/tribler-core/tribler_core/components/base.py
@@ -36,6 +36,7 @@ def create_state_directory_structure(state_dir: Path):
 class Session:
     _next_session_id = count(1)
     _default: Optional[Session] = None
+    _stack: List[Session] = []
 
     def __init__(self, config: TriblerConfig = None, components: List[Component] = (),
                  shutdown_event: Event = None, notifier: Notifier = None):
@@ -83,11 +84,11 @@ class Session:
         return imp
 
     def __enter__(self):
-        _session_stack.append(self)
+        Session._stack.append(self)
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        assert _session_stack and _session_stack[-1] is self
-        _session_stack.pop()
+        assert Session._stack and Session._stack[-1] is self
+        Session._stack.pop()
 
 
 def _get_default_session() -> Session:
@@ -100,12 +101,9 @@ def set_default_session(session: Session):
     Session._default = session
 
 
-_session_stack = []
-
-
 def get_session() -> Session:
-    if _session_stack:
-        return _session_stack[-1]
+    if Session._stack:
+        return Session._stack[-1]
     return _get_default_session()
 
 

--- a/src/tribler-core/tribler_core/components/tests/test_components.py
+++ b/src/tribler-core/tribler_core/components/tests/test_components.py
@@ -7,15 +7,15 @@ from tribler_core.components.interfaces.gigachannel import GigaChannelComponent
 from tribler_core.components.interfaces.gigachannel_manager import GigachannelManagerComponent
 from tribler_core.components.interfaces.ipv8 import Ipv8Component
 from tribler_core.components.interfaces.libtorrent import LibtorrentComponent
+from tribler_core.components.interfaces.masterkey import MasterKeyComponent
 from tribler_core.components.interfaces.metadata_store import MetadataStoreComponent
 from tribler_core.components.interfaces.payout import PayoutComponent
 from tribler_core.components.interfaces.popularity import PopularityComponent
-from tribler_core.components.interfaces.resource_monitor import ResourceMonitorComponent
 from tribler_core.components.interfaces.reporter import ReporterComponent
+from tribler_core.components.interfaces.resource_monitor import ResourceMonitorComponent
 from tribler_core.components.interfaces.restapi import RESTComponent
 from tribler_core.components.interfaces.socks_configurator import SocksServersComponent
 from tribler_core.components.interfaces.torrent_checker import TorrentCheckerComponent
-from tribler_core.components.interfaces.masterkey import MasterKeyComponent
 from tribler_core.components.interfaces.tunnels import TunnelsComponent
 from tribler_core.components.interfaces.upgrade import UpgradeComponent
 from tribler_core.components.interfaces.version_check import VersionCheckComponent

--- a/src/tribler-core/tribler_core/components/tests/test_components.py
+++ b/src/tribler-core/tribler_core/components/tests/test_components.py
@@ -1,6 +1,5 @@
 import pytest
 
-from tribler_core.components import base
 from tribler_core.components.base import Session, SessionError, get_session
 from tribler_core.components.components_catalog import components_gen
 from tribler_core.components.interfaces.bandwidth_accounting import BandwidthAccountingComponent
@@ -61,7 +60,7 @@ def test_session_context_manager(loop, tribler_config):
     with pytest.raises(SessionError, match="Default session was not set"):
         get_session()
 
-    base.set_default_session(session1)
+    session1.set_as_default()
     assert get_session() is session1
 
     with session2:
@@ -71,7 +70,8 @@ def test_session_context_manager(loop, tribler_config):
         assert get_session() is session2
     assert get_session() is session1
 
-    base.set_default_session(None)
+    Session.unset_default_session()
+
     with pytest.raises(SessionError, match="Default session was not set"):
         get_session()
 

--- a/src/tribler-core/tribler_core/components/tests/test_components.py
+++ b/src/tribler-core/tribler_core/components/tests/test_components.py
@@ -1,6 +1,6 @@
 import pytest
 
-from tribler_core.components.base import Session, SessionError, get_session
+from tribler_core.components.base import Session, SessionError
 from tribler_core.components.components_catalog import components_gen
 from tribler_core.components.interfaces.bandwidth_accounting import BandwidthAccountingComponent
 from tribler_core.components.interfaces.gigachannel import GigaChannelComponent
@@ -58,22 +58,22 @@ def test_session_context_manager(loop, tribler_config):
     session3 = Session(tribler_config, [])
 
     with pytest.raises(SessionError, match="Default session was not set"):
-        get_session()
+        Session.current()
 
     session1.set_as_default()
-    assert get_session() is session1
+    assert Session.current() is session1
 
     with session2:
-        assert get_session() is session2
+        assert Session.current() is session2
         with session3:
-            assert get_session() is session3
-        assert get_session() is session2
-    assert get_session() is session1
+            assert Session.current() is session3
+        assert Session.current() is session2
+    assert Session.current() is session1
 
     Session.unset_default_session()
 
     with pytest.raises(SessionError, match="Default session was not set"):
-        get_session()
+        Session.current()
 
 
 def test_components_creation(loop, tribler_config):

--- a/src/tribler-core/tribler_core/start_core.py
+++ b/src/tribler-core/tribler_core/start_core.py
@@ -14,7 +14,7 @@ from tribler_common.version_manager import VersionHistory
 from tribler_common.simpledefs import NTFY
 import tribler_core
 from tribler_core.check_os import check_and_enable_code_tracing, set_process_priority
-from tribler_core.components.base import Component, Session, set_default_session
+from tribler_core.components.base import Component, Session
 from tribler_core.components.components_catalog import components_gen
 from tribler_core.components.interfaces.masterkey import MasterKeyComponent
 from tribler_core.config.tribler_config import TriblerConfig
@@ -33,7 +33,7 @@ CONFIG_FILE_NAME = 'triblerd.conf'
 async def core_session(config: TriblerConfig, components: List[Component]):
     session = Session(config, components)
     signal.signal(signal.SIGTERM, lambda signum, stack: session.shutdown_event.set)
-    set_default_session(session)
+    session.set_as_default()
 
     await session.start()
 

--- a/src/tribler-core/tribler_core/start_core.py
+++ b/src/tribler-core/tribler_core/start_core.py
@@ -6,12 +6,10 @@ import signal
 import sys
 from typing import List
 
-from pathlib import Path
-
 from tribler_common.sentry_reporter.sentry_reporter import SentryReporter, SentryStrategy
+from tribler_common.simpledefs import NTFY
 from tribler_common.version_manager import VersionHistory
 
-from tribler_common.simpledefs import NTFY
 import tribler_core
 from tribler_core.check_os import check_and_enable_code_tracing, set_process_priority
 from tribler_core.components.base import Component, Session
@@ -21,7 +19,6 @@ from tribler_core.config.tribler_config import TriblerConfig
 from tribler_core.dependencies import check_for_missing_dependencies
 from tribler_core.exception_handler import CoreExceptionHandler
 from tribler_core.modules.process_checker import ProcessChecker
-
 
 logger = logging.getLogger(__name__)
 CONFIG_FILE_NAME = 'triblerd.conf'


### PR DESCRIPTION
Fixes #6254

In this pull request, I refactor session-based logic into class methods/attributes of Session.
It makes the code a bit cleaner.

- `get_session()` becomes `Session.current()`
- `set_default_session(session)` becomes `session.set_as_default()`