### PR TITLE
Fixes #6262, fixes #6268: correct delayed initialization of endpoints

### DIFF
--- a/src/tribler-core/tribler_core/components/implementation/libtorrent.py
+++ b/src/tribler-core/tribler_core/components/implementation/libtorrent.py
@@ -44,8 +44,7 @@ class LibtorrentComponentImp(LibtorrentComponent):
 
         self.download_manager = download_manager
 
-        for endpoint in self.endpoints:
-            rest_manager.get_endpoint(endpoint).download_manager = download_manager
+        rest_manager.set_attr_for_endpoints(self.endpoints, 'download_manager', download_manager, skip_missing=True)
 
         if config.gui_test_mode:
             uri = "magnet:?xt=urn:btih:0000000000000000000000000000000000000000"
@@ -53,8 +52,8 @@ class LibtorrentComponentImp(LibtorrentComponent):
 
     async def shutdown(self):
         # Release endpoints
-        for endpoint in self.endpoints:
-            self.rest_manager.get_endpoint(endpoint).download_manager = None
+        self.rest_manager.set_attr_for_endpoints(self.endpoints, 'download_manager', None, skip_missing=True)
+
         await self.release(RESTComponent)
 
         self.download_manager.stop_download_states_callback()

--- a/src/tribler-core/tribler_core/components/implementation/metadata_store.py
+++ b/src/tribler-core/tribler_core/components/implementation/metadata_store.py
@@ -38,17 +38,14 @@ class MetadataStoreComponentImp(MetadataStoreComponent):
             disable_sync=config.gui_test_mode,
         )
         self.mds = metadata_store
-
-        for endpoint in self.endpoints:
-            rest_manager.get_endpoint(endpoint).mds = metadata_store
+        rest_manager.set_attr_for_endpoints(self.endpoints, 'mds', metadata_store, skip_missing=True)
 
         if config.gui_test_mode:
             generate_test_channels(metadata_store)
 
     async def shutdown(self):
         # Release endpoints
-        for endpoint in self.endpoints:
-            self.rest_manager.get_endpoint(endpoint).mds = None
+        self.rest_manager.set_attr_for_endpoints(self.endpoints, 'mds', None, skip_missing=True)
         await self.release(RESTComponent)
 
         await self.unused.wait()

--- a/src/tribler-core/tribler_core/components/implementation/torrent_checker.py
+++ b/src/tribler-core/tribler_core/components/implementation/torrent_checker.py
@@ -36,11 +36,12 @@ class TorrentCheckerComponentImp(TorrentCheckerComponent):
         rest_manager.get_endpoint('state').readable_status = STATE_START_TORRENT_CHECKER
 
         await torrent_checker.initialize()
-        rest_manager.get_endpoint('metadata').torrent_checker = torrent_checker
+        rest_manager.set_attr_for_endpoints(['metadata'], 'torrent_checker', torrent_checker, skip_missing=True)
 
     async def shutdown(self):
         self.session.notifier.notify_shutdown_state("Shutting down Torrent Checker...")
-        self.rest_manager.get_endpoint('metadata').torrent_checker = None
+        self.rest_manager.set_attr_for_endpoints(['metadata'], 'torrent_checker', None, skip_missing=True)
+
         await self.release(RESTComponent)
 
         await self.torrent_checker.shutdown()

--- a/src/tribler-core/tribler_core/components/interfaces/metadata_store.py
+++ b/src/tribler-core/tribler_core/components/interfaces/metadata_store.py
@@ -12,7 +12,7 @@ class MetadataStoreComponent(Component):
 
     @classmethod
     def should_be_enabled(cls, config: TriblerConfig):
-        return config.chant.enabled
+        return config.chant.enabled or config.torrent_checking.enabled
 
     @classmethod
     def make_implementation(cls, config: TriblerConfig, enable: bool):

--- a/src/tribler-core/tribler_core/restapi/rest_manager.py
+++ b/src/tribler-core/tribler_core/restapi/rest_manager.py
@@ -2,6 +2,7 @@ import logging
 import os
 import ssl
 import traceback
+from typing import List
 
 from aiohttp import web
 from aiohttp.web_exceptions import HTTPNotFound
@@ -96,6 +97,17 @@ class RESTManager:
 
     def get_endpoint(self, name):
         return self.root_endpoint.endpoints['/' + name]
+
+    def set_attr_for_endpoints(self, endpoints: List[str], attr_name: str, attr_value, skip_missing=False):
+        """
+        Set attribute value for each endpoint in the list. Can be used for delayed initialization of endpoints.
+        """
+        for endpoint_name in endpoints:
+            endpoint = self.root_endpoint.endpoints.get('/' + endpoint_name)
+            if endpoint is not None:
+                setattr(endpoint, attr_name, attr_value)
+            elif not skip_missing:
+                raise KeyError(f'Endpoint not found: /{endpoint_name}')
 
     async def start(self):
         """


### PR DESCRIPTION
This PR fixes incorrect initialization of REST endpoints, which causes issues #6262 and #6268.

Currently, a REST endpoint needs to be created before the corresponding component, so the component needs to inject the necessary data to the endpoint later. The mapping between some components and REST endpoints is "many-to-many". If some component was disabled in the config, the corresponding REST endpoint is not created, so other components should not inject their data into the missing endpoint.

This is achieved by using a new helper method of the REST manager, which skips assigning attributes to the missing endpoints.