### PR TITLE
Fixes #6265: start Tribler with ipv8 disabled

### DIFF
--- a/src/tribler-core/tribler_core/components/interfaces/gigachannel.py
+++ b/src/tribler-core/tribler_core/components/interfaces/gigachannel.py
@@ -12,7 +12,7 @@ class GigaChannelComponent(Component):
 
     @classmethod
     def should_be_enabled(cls, config: TriblerConfig):
-        return config.chant.enabled
+        return config.ipv8.enabled and config.chant.enabled
 
     @classmethod
     def make_implementation(cls, config: TriblerConfig, enable: bool):


### PR DESCRIPTION
This PR fixes #6265 issue. When IPv8 component is disabled, the gigachannel channels component should be disabled as well