### PR TITLE
Fixes #6266: uncaught error when starting with tunnel_community disabled

### DIFF
--- a/src/tribler-core/tribler_core/components/interfaces/socks_configurator.py
+++ b/src/tribler-core/tribler_core/components/interfaces/socks_configurator.py
@@ -11,7 +11,7 @@ class SocksServersComponent(Component):
 
     @classmethod
     def should_be_enabled(cls, config: TriblerConfig):
-        return config.tunnel_community.enabled and config.libtorrent.enabled
+        return config.libtorrent.enabled
 
     @classmethod
     def make_implementation(cls, config: TriblerConfig, enable: bool):


### PR DESCRIPTION
This PR fixes #6266: the download manager uses socks server even if tunnels are disabled