### PR TITLE
Fixes #6267: crash when clicking in channel with torrent_checking disabled

### DIFF
--- a/src/tribler-core/tribler_core/components/implementation/popularity.py
+++ b/src/tribler-core/tribler_core/components/implementation/popularity.py
@@ -20,7 +20,9 @@ class PopularityComponentImp(PopularityComponent):
         ipv8 = ipv8_component.ipv8
         peer = ipv8_component.peer
         metadata_store = (await self.use(MetadataStoreComponent)).mds
-        torrent_checker = (await self.use(TorrentCheckerComponent)).torrent_checker
+
+        torrent_checker_component = await self.use(TorrentCheckerComponent)
+        torrent_checker = torrent_checker_component.torrent_checker if torrent_checker_component.enabled else None
 
         community = PopularityCommunity(peer, ipv8.endpoint, ipv8.network,
                                         settings=config.popularity_community,


### PR DESCRIPTION
This PR fixes #6267: Popularity community should work even if the torrent checker is disabled