### PR TITLE
Set exit node cache path on Tunnel community

### DIFF
--- a/src/tribler-core/tribler_core/components/implementation/tunnels.py
+++ b/src/tribler-core/tribler_core/components/implementation/tunnels.py
@@ -47,6 +47,7 @@ class TunnelsComponentImp(TunnelsComponent):
             tunnel_cls = TriblerTunnelCommunity
 
         provider = DHTCommunityProvider(dht_discovery_community, config.ipv8.port) if dht_discovery_community else None
+        exitnode_cache = config.state_dir / "exitnode_cache.dat"
 
         # TODO: decouple bandwidth community and dlmgr to initiate later
         community = tunnel_cls(peer, ipv8.endpoint, ipv8.network,
@@ -56,6 +57,7 @@ class TunnelsComponentImp(TunnelsComponent):
                                dlmgr=download_manager,
                                bandwidth_community=bandwidth_community,
                                dht_provider=provider,
+                               exitnode_cache=exitnode_cache,
                                settings=settings)
 
         # Value of `target_peers` must not be equal to the value of `max_peers` for this community.


### PR DESCRIPTION
Exit node cache path is not currently set on initialization of the Tunnel Community because of which the cache is not saved during shutdown