### PR TITLE
Fix #6271

### DIFF
--- a/src/tribler-core/tribler_core/components/implementation/resource_monitor.py
+++ b/src/tribler-core/tribler_core/components/implementation/resource_monitor.py
@@ -1,7 +1,6 @@
+from tribler_core.components.interfaces.reporter import ReporterComponent
 from tribler_core.components.interfaces.resource_monitor import ResourceMonitorComponent
 from tribler_core.components.interfaces.restapi import RESTComponent
-from tribler_core.components.interfaces.reporter import ReporterComponent
-from tribler_core.components.interfaces.tunnels import TunnelsComponent
 from tribler_core.components.interfaces.upgrade import UpgradeComponent
 from tribler_core.modules.resource_monitor.core import CoreResourceMonitor
 
@@ -10,7 +9,6 @@ class ResourceMonitorComponentImp(ResourceMonitorComponent):
     async def run(self):
         await self.use(ReporterComponent, required=False)
         await self.use(UpgradeComponent, required=False)
-        tunnel_community = (await self.use(TunnelsComponent)).community
 
         config = self.session.config
         notifier = self.session.notifier
@@ -24,13 +22,7 @@ class ResourceMonitorComponentImp(ResourceMonitorComponent):
         self.resource_monitor = resource_monitor
 
         rest_manager = (await self.use(RESTComponent)).rest_manager
-
-        # TODO: Split debug endpoint initialization
-        debug_endpoint = rest_manager.get_endpoint('debug')
-        debug_endpoint.resource_monitor = resource_monitor
-        debug_endpoint.tunnel_community = tunnel_community
-        debug_endpoint.log_dir = log_dir
-        debug_endpoint.state_dir = config.state_dir
+        rest_manager.get_endpoint('debug').resource_monitor = resource_monitor
 
     async def shutdown(self):
         self.session.notifier.notify_shutdown_state("Shutting down Resource Monitor...")

--- a/src/tribler-core/tribler_core/components/implementation/restapi.py
+++ b/src/tribler-core/tribler_core/components/implementation/restapi.py
@@ -1,8 +1,8 @@
 from tribler_common.simpledefs import STATE_START_API
 
+from tribler_core.components.interfaces.reporter import ReporterComponent
 from tribler_core.components.interfaces.restapi import RESTComponent
 from tribler_core.exception_handler import CoreExceptionHandler
-from tribler_core.components.interfaces.reporter import ReporterComponent
 from tribler_core.restapi.rest_manager import ApiKeyMiddleware, RESTManager, error_middleware
 from tribler_core.restapi.root_endpoint import RootEndpoint
 
@@ -33,6 +33,11 @@ class RESTComponentImp(RESTComponent):
 
         events_endpoint = rest_manager.get_endpoint('events')
         events_endpoint.connect_notifier(notifier)
+
+        debug_endpoint = rest_manager.get_endpoint('debug')
+        log_dir = config.general.get_path_as_absolute('log_dir', config.state_dir)
+        debug_endpoint.log_dir = log_dir
+        debug_endpoint.state_dir = config.state_dir
 
         def report_callback(text_long, sentry_event):
             events_endpoint.on_tribler_exception(text_long, sentry_event,

--- a/src/tribler-core/tribler_core/components/implementation/tunnels.py
+++ b/src/tribler-core/tribler_core/components/implementation/tunnels.py
@@ -74,5 +74,8 @@ class TunnelsComponentImp(TunnelsComponent):
             if download_component.enabled:
                 rest_manager.get_endpoint('downloads').tunnel_community = community
 
+            debug_endpoint = rest_manager.get_endpoint('debug')
+            debug_endpoint.tunnel_community = community
+
     async def shutdown(self):
         await self.community.unload()

--- a/src/tribler-core/tribler_core/restapi/debug_endpoint.py
+++ b/src/tribler-core/tribler_core/restapi/debug_endpoint.py
@@ -323,6 +323,8 @@ class DebugEndpoint(RESTEndpoint):
         }
     )
     async def get_profiler_state(self, _):
+        if self.resource_monitor is None:
+            return RESTResponse(status=404)
         state = "STARTED" if self.resource_monitor.profiler.is_running() else "STOPPED"
         return RESTResponse({"state": state})
 

--- a/src/tribler-gui/tribler_gui/debug_window.py
+++ b/src/tribler-gui/tribler_gui/debug_window.py
@@ -299,22 +299,21 @@ class DebugWindow(QMainWindow):
         # Heading: GUI Settings
         self.create_and_add_widget_item("GUI Settings:", "", self.window().general_tree_widget)
         # Location of the settings file
-        self.create_and_add_widget_item(
-            "Qt file", self.gui_settings.fileName(), self.window().general_tree_widget
-        )
+        self.create_and_add_widget_item("Qt file", self.gui_settings.fileName(), self.window().general_tree_widget)
 
-        selected_settings = {"api_key": lambda val: val.decode('utf-8'),
-                             "api_port": lambda val: val,
-                             "pos": lambda val: f"(x : {val.x()} px,  y : {val.y()} px)",
-                             "size": lambda val: f"(width : {val.width()} px,  height : {val.height()} px)",
-                             "ask_download_settings": lambda val: val,
-                             "autocommit_enabled": lambda val: val,
-                             "debug": lambda val: val,
-                             "family_filter": lambda val: val,
-                             "first_discover": lambda val: val,
-                             "use_monochrome_icon": lambda val: val,
-                             "recent_download_locations": lambda val: [unhexlify(url).decode('utf-8')
-                                                                       for url in val.split(",")]}
+        selected_settings = {
+            "api_key": lambda val: val.decode('utf-8'),
+            "api_port": lambda val: val,
+            "pos": lambda val: f"(x : {val.x()} px,  y : {val.y()} px)",
+            "size": lambda val: f"(width : {val.width()} px,  height : {val.height()} px)",
+            "ask_download_settings": lambda val: val,
+            "autocommit_enabled": lambda val: val,
+            "debug": lambda val: val,
+            "family_filter": lambda val: val,
+            "first_discover": lambda val: val,
+            "use_monochrome_icon": lambda val: val,
+            "recent_download_locations": lambda val: [unhexlify(url).decode('utf-8') for url in val.split(",")],
+        }
 
         # List only selected gui settings
         for key in self.gui_settings.allKeys():
@@ -788,8 +787,8 @@ class DebugWindow(QMainWindow):
     def on_profiler_info(self, data):
         if not data:
             return
-        self.profiler_enabled = data["state"] == "STARTED"
         self.window().toggle_profiler_button.setEnabled(True)
+        self.profiler_enabled = data["state"] == "STARTED"
         self.window().toggle_profiler_button.setText(f"{'Stop' if self.profiler_enabled else 'Start'} profiler")
 
     def on_toggle_profiler_button_clicked(self, checked=False):


### PR DESCRIPTION
Fixes #6271 by splitting Debug endpoint initialization and disabling Profiler button in Debug window when Profiler is disabled in the Core