### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# About CODEOWNERS: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+# Code owners are automatically requested for review when someone opens a pull request that modifies code that they own
+
+
+# These owners will be the default owners for everything in the repo.
+*       @Tribler/dev
+
+# Order is important; the last matching pattern takes the most precedence.


### PR DESCRIPTION
This PR adds the CODEOWNERS file (see [About Code Owners](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) for more information) for Tribler with one rule:

```python
# These owners will be the default owners for everything in the repo.
*      @Tribler/dev 
```

That means that all PR will be assigned (by default) to @Tribler/dev. 

Then @Tribler/dev will be automatically changed to one of {@drew2a, @xoriole, @ichorid, @kozlovsky} by [Round robin routing algorithm](https://docs.github.com/en/organizations/organizing-members-into-teams/managing-code-review-assignment-for-your-team#routing-algorithms)

