### PR TITLE
Increase maximum request size for AIOHTTP to 2MB

### DIFF
--- a/src/tribler-core/tribler_core/restapi/rest_endpoint.py
+++ b/src/tribler-core/tribler_core/restapi/rest_endpoint.py
@@ -14,7 +14,7 @@ class RESTEndpoint:
 
     def __init__(self, middlewares=()):
         self._logger = logging.getLogger(self.__class__.__name__)
-        self.app = web.Application(middlewares=middlewares)
+        self.app = web.Application(middlewares=middlewares, client_max_size=2*1024**2)
         self.endpoints = {}
         self.setup_routes()
 


### PR DESCRIPTION
fixes #6301 by increasing the maximum request size to 2MB. It should be enough to open even the biggest torrents out there, such as [the GeoCities archive](https://academictorrents.com/details/2dc18f47afee0307e138dab3015ee7e5154766f6)