### PR TITLE
Fixed width and vertical text alignment in table headers

### DIFF
--- a/src/tribler-gui/tribler_gui/widgets/tablecontentmodel.py
+++ b/src/tribler-gui/tribler_gui/widgets/tablecontentmodel.py
@@ -365,11 +365,11 @@ class ChannelContentModel(RemoteTableModel):
         if role == Qt.InitialSortOrderRole and num != self.column_position.get('name'):
             return Qt.DescendingOrder
         if role == Qt.TextAlignmentRole:
-            return (
-                Qt.AlignHCenter
-                if num in [self.column_position.get('subscribed'), self.column_position.get('torrents')]
+            alignment = Qt.AlignHCenter \
+                if num in [self.column_position.get('subscribed'), self.column_position.get('torrents')] \
                 else Qt.AlignLeft
-            )
+            return alignment | Qt.AlignVCenter
+
         return super().headerData(num, orientation, role)
 
     def rowCount(self, *_, **__):

--- a/src/tribler-gui/tribler_gui/widgets/tablecontentmodel.py
+++ b/src/tribler-gui/tribler_gui/widgets/tablecontentmodel.py
@@ -58,7 +58,7 @@ def define_columns():
         Column.STATUS:     d('status',     "",               sortable=False),
         Column.STATE:      d('state',      "",               width=80, tooltip_filter=lambda data: data, sortable=False),
         Column.TORRENTS:   d('torrents',   tr("Torrents"),   width=90),
-        Column.SUBSCRIBED: d('subscribed', tr("Subscribed"), width=90),
+        Column.SUBSCRIBED: d('subscribed', tr("Subscribed"), width=95),
     }
     # pylint: enable=line-too-long
     # fmt:on


### PR DESCRIPTION
Very minor issue, but this has been bothering me for some time. The text is now always vertically aligned in the center of the available space. Also, I slightly increased the size of the 'subscribed' column.

Before:

![Schermafbeelding 2021-09-26 om 15 13 42](https://user-images.githubusercontent.com/1707075/134809704-0172b163-5d37-426d-8943-ec1138bb83a9.png)

After:

![Schermafbeelding 2021-09-26 om 15 25 06](https://user-images.githubusercontent.com/1707075/134810014-0ee814b0-ed02-42f2-9dbc-d12808a80d12.png)
