### PR TITLE
Implement row deselection on mouse leave

### DIFF
--- a/src/tribler-gui/tribler_gui/widgets/channelcontentswidget.py
+++ b/src/tribler-gui/tribler_gui/widgets/channelcontentswidget.py
@@ -347,6 +347,7 @@ class ChannelContentsWidget(AddBreadcrumbOnShowMixin, widget_form, widget_class)
             self.push_channels_stack(self.default_channel_model(channel_info=channel_info))
         self.controller.set_model(self.model)
         self.update_navigation_breadcrumbs()
+        self.controller.table_view.deselect_all_rows()
         self.controller.table_view.resizeEvent(None)
 
         self.content_table.setFocus()

--- a/src/tribler-gui/tribler_gui/widgets/tablecontentdelegate.py
+++ b/src/tribler-gui/tribler_gui/widgets/tablecontentdelegate.py
@@ -150,10 +150,6 @@ class TriblerButtonsDelegate(QStyledItemDelegate):
                 redraw = True
                 # Hide the tooltip when cell hover changes
                 QToolTip.hideText()
-        # Redraw when the mouse leaves the table
-        if index.row() == -1 and self.hoverrow != -1:
-            self.hoverrow = -1
-            redraw = True
 
         for controls in self.controls:
             redraw = controls.on_mouse_moved(pos, index) or redraw

--- a/src/tribler-gui/tribler_gui/widgets/tablecontentdelegate.py
+++ b/src/tribler-gui/tribler_gui/widgets/tablecontentdelegate.py
@@ -122,8 +122,7 @@ class TriblerButtonsDelegate(QStyledItemDelegate):
     def __init__(self, parent=None):
         QStyledItemDelegate.__init__(self, parent)
         self.no_index = QModelIndex()
-        self.hoverrow = None
-        self.hover_index = None
+        self.hover_index = self.no_index
         self.controls = []
         self.column_drawing_actions = []
 
@@ -147,7 +146,6 @@ class TriblerButtonsDelegate(QStyledItemDelegate):
         redraw = False
         if self.hover_index != index:
             self.hover_index = index
-            self.hoverrow = index.row()
             if not self.button_box.contains(pos):
                 redraw = True
                 # Hide the tooltip when cell hover changes
@@ -179,7 +177,7 @@ class TriblerButtonsDelegate(QStyledItemDelegate):
 
     def paint(self, painter, option, index):
         # Draw 'hover' state highlight for every cell of a row
-        if index.row() == self.hoverrow:
+        if index.row() == self.hover_index.row():
             option.state |= QStyle.State_MouseOver
         if not self.paint_exact(painter, option, index):
             # Draw the rest of the columns
@@ -327,7 +325,7 @@ class DownloadControlsMixin:
             option.rect.height() - 2 * border_thickness,
         )
         # When cursor leaves the table, we must "forget" about the button_box
-        if self.hoverrow == -1:
+        if self.hover_index.row() == -1:
             self.button_box = QRect()
 
         progress = data_item.get('progress')
@@ -338,7 +336,7 @@ class DownloadControlsMixin:
                 draw_progress_bar(painter, bordered_rect, progress=progress)
             return True
 
-        if index.row() == self.hoverrow:
+        if index.row() == self.hover_index.row():
             extended_border_height = int(option.rect.height() * self.button_box_extended_border_ratio)
             button_box_extended_rect = option.rect.adjusted(0, -extended_border_height, 0, extended_border_height)
             self.button_box = button_box_extended_rect


### PR DESCRIPTION
When the mouse leaves the table, it should deselect the currently selected row. This PR implements this behaviour. It also captures the event when moving the mouse through the (top) header of the table, which required the implementation of an event filter. Note that sometimes rows remain selected when moving the mouse quickly out of the viewport, but I believe this is acceptable for now.

I also removed the redundant `hoverrow` variable in the table delegate.