### PR TITLE
Fixes #6360: Optional dependency on REST manager in components

### DIFF
--- a/src/tribler-core/tribler_core/components/bandwidth_accounting/bandwidth_accounting_component.py
+++ b/src/tribler-core/tribler_core/components/bandwidth_accounting/bandwidth_accounting_component.py
@@ -47,8 +47,8 @@ class BandwidthAccountingComponent(RestfulComponent):
         community.bootstrappers.append(ipv8_component.make_bootstrapper())
 
         self.community = community
-        await self.init_endpoints(['trustview', 'bandwidth'],
-                                  [('bandwidth_db', community.database), ('bandwidth_community', community)])
+        await self.init_endpoints(endpoints=['trustview', 'bandwidth'],
+                                  values={'bandwidth_db': community.database, 'bandwidth_community': community})
 
     async def shutdown(self):
         await super().shutdown()

--- a/src/tribler-core/tribler_core/components/bandwidth_accounting/bandwidth_accounting_component.py
+++ b/src/tribler-core/tribler_core/components/bandwidth_accounting/bandwidth_accounting_component.py
@@ -51,5 +51,5 @@ class BandwidthAccountingComponent(RestfulComponent):
                                   [('bandwidth_db', community.database), ('bandwidth_community', community)])
 
     async def shutdown(self):
-        self.release_endpoints()
+        await super().shutdown()
         await self._ipv8.unload_overlay(self.community)

--- a/src/tribler-core/tribler_core/components/bandwidth_accounting/bandwidth_accounting_component.py
+++ b/src/tribler-core/tribler_core/components/bandwidth_accounting/bandwidth_accounting_component.py
@@ -23,7 +23,7 @@ class BandwidthAccountingComponent(RestfulComponent):
     _ipv8: IPv8
 
     async def run(self):
-        await self.get_component(ReporterComponent)
+        await super().run()
         await self.get_component(UpgradeComponent)
         config = self.session.config
 

--- a/src/tribler-core/tribler_core/components/bandwidth_accounting/bandwidth_accounting_component.py
+++ b/src/tribler-core/tribler_core/components/bandwidth_accounting/bandwidth_accounting_component.py
@@ -1,10 +1,13 @@
 from ipv8.peerdiscovery.discovery import RandomWalk
+
 from ipv8_service import IPv8
+
 from tribler_common.simpledefs import STATEDIR_DB_DIR
+
 from tribler_core.components.base import Component
 from tribler_core.components.ipv8 import Ipv8Component
 from tribler_core.components.reporter import ReporterComponent
-from tribler_core.components.restapi import RESTComponent
+from tribler_core.components.restapi import RestfulComponent
 from tribler_core.components.upgrade import UpgradeComponent
 from tribler_core.components.bandwidth_accounting.community.community import (
     BandwidthAccountingCommunity,
@@ -14,10 +17,9 @@ from tribler_core.components.bandwidth_accounting.db.database import BandwidthDa
 from tribler_core.restapi.rest_manager import RESTManager
 
 
-class BandwidthAccountingComponent(Component):
+class BandwidthAccountingComponent(RestfulComponent):
     community: BandwidthAccountingCommunity
 
-    _rest_manager: RESTManager
     _ipv8: IPv8
 
     async def run(self):
@@ -28,9 +30,6 @@ class BandwidthAccountingComponent(Component):
         ipv8_component = await self.require_component(Ipv8Component)
         self._ipv8 = ipv8_component.ipv8
         peer = ipv8_component.peer
-
-        rest_component = await self.require_component(RESTComponent)
-        self._rest_manager = rest_component.rest_manager
 
         if config.general.testnet or config.bandwidth_accounting.testnet:
             bandwidth_cls = BandwidthAccountingTestnetCommunity
@@ -48,10 +47,9 @@ class BandwidthAccountingComponent(Component):
         community.bootstrappers.append(ipv8_component.make_bootstrapper())
 
         self.community = community
-        self._rest_manager.get_endpoint('trustview').bandwidth_db = community.database
-        self._rest_manager.get_endpoint('bandwidth').bandwidth_community = community
+        await self.init_endpoints(['trustview', 'bandwidth'],
+                                  [('bandwidth_db', community.database), ('bandwidth_community', community)])
 
     async def shutdown(self):
-        self._rest_manager.get_endpoint('trustview').bandwidth_db = None
-        self._rest_manager.get_endpoint('bandwidth').bandwidth_community = None
+        self.release_endpoints()
         await self._ipv8.unload_overlay(self.community)

--- a/src/tribler-core/tribler_core/components/bandwidth_accounting/restapi/bandwidth_endpoint.py
+++ b/src/tribler-core/tribler_core/components/bandwidth_accounting/restapi/bandwidth_endpoint.py
@@ -18,6 +18,7 @@ class BandwidthEndpoint(RESTEndpoint):
 
     def __init__(self):
         super().__init__()
+        self.bandwidth_db = None  # added to simlify the initialization code of BandwidthAccountingComponent
         self.bandwidth_community = None
 
     def setup_routes(self) -> None:

--- a/src/tribler-core/tribler_core/components/bandwidth_accounting/tests/test_bandwidth_accounting_component.py
+++ b/src/tribler-core/tribler_core/components/bandwidth_accounting/tests/test_bandwidth_accounting_component.py
@@ -21,7 +21,6 @@ async def test_bandwidth_accounting_component(tribler_config):
         comp = BandwidthAccountingComponent.instance()
         assert comp.started.is_set() and not comp.failed
         assert comp.community
-        assert comp._rest_manager
         assert comp._ipv8
 
         await session.shutdown()

--- a/src/tribler-core/tribler_core/components/bandwidth_accounting/tests/test_bandwidth_accounting_component.py
+++ b/src/tribler-core/tribler_core/components/bandwidth_accounting/tests/test_bandwidth_accounting_component.py
@@ -12,15 +12,16 @@ from tribler_core.restapi.rest_manager import RESTManager
 
 
 async def test_bandwidth_accounting_component(tribler_config):
+    tribler_config.ipv8.enabled = True
     components = [RESTComponent(), MasterKeyComponent(), Ipv8Component(), BandwidthAccountingComponent()]
     session = Session(tribler_config, components)
     with session:
+        await session.start()
+
         comp = BandwidthAccountingComponent.instance()
-        with patch.object(RESTManager, 'get_endpoint'):
-            await session.start()
+        assert comp.started.is_set() and not comp.failed
+        assert comp.community
+        assert comp._rest_manager
+        assert comp._ipv8
 
-            assert comp.community
-            assert comp._rest_manager
-            assert comp._ipv8
-
-            await session.shutdown()
+        await session.shutdown()

--- a/src/tribler-core/tribler_core/components/base.py
+++ b/src/tribler-core/tribler_core/components/base.py
@@ -186,7 +186,7 @@ class Component:
         dep.in_use_by.add(self)
         return dep
 
-    async def release_component(self, dependency: Type[T]):
+    def release_component(self, dependency: Type[T]):
         dep = dependency.instance()
         if dep:
             self._release_instance(dep)

--- a/src/tribler-core/tribler_core/components/gigachannel/gigachannel_component.py
+++ b/src/tribler-core/tribler_core/components/gigachannel/gigachannel_component.py
@@ -21,6 +21,7 @@ class GigaChannelComponent(RestfulComponent):
     _ipv8: IPv8
 
     async def run(self):
+        await super().run()
         await self.get_component(ReporterComponent)
 
         config = self.session.config
@@ -51,7 +52,6 @@ class GigaChannelComponent(RestfulComponent):
         community.bootstrappers.append(ipv8_component.make_bootstrapper())
 
         await self.init_endpoints(['remote_query', 'channels', 'collections'], [('gigachannel_community', community)])
-
 
     async def shutdown(self):
         await super().shutdown()

--- a/src/tribler-core/tribler_core/components/gigachannel/gigachannel_component.py
+++ b/src/tribler-core/tribler_core/components/gigachannel/gigachannel_component.py
@@ -51,7 +51,8 @@ class GigaChannelComponent(RestfulComponent):
 
         community.bootstrappers.append(ipv8_component.make_bootstrapper())
 
-        await self.init_endpoints(['remote_query', 'channels', 'collections'], [('gigachannel_community', community)])
+        await self.init_endpoints(endpoints=['remote_query', 'channels', 'collections'],
+                                  values={'gigachannel_community': community})
 
     async def shutdown(self):
         await super().shutdown()

--- a/src/tribler-core/tribler_core/components/gigachannel/gigachannel_component.py
+++ b/src/tribler-core/tribler_core/components/gigachannel/gigachannel_component.py
@@ -54,7 +54,6 @@ class GigaChannelComponent(RestfulComponent):
 
 
     async def shutdown(self):
-        self.release_endpoints()
-
+        await super().shutdown()
         if self._ipv8:
             await self._ipv8.unload_overlay(self.community)

--- a/src/tribler-core/tribler_core/components/gigachannel/tests/test_gigachannel_component.py
+++ b/src/tribler-core/tribler_core/components/gigachannel/tests/test_gigachannel_component.py
@@ -13,16 +13,19 @@ from tribler_core.restapi.rest_manager import RESTManager
 
 
 async def test_giga_channel_component(tribler_config):
+    tribler_config.ipv8.enabled = True
+    tribler_config.libtorrent.enabled = True
+    tribler_config.chant.enabled = True
     components = [MetadataStoreComponent(), RESTComponent(), MasterKeyComponent(), Ipv8Component(),
                   GigaChannelComponent()]
     session = Session(tribler_config, components)
     with session:
+        await session.start()
+
         comp = GigaChannelComponent.instance()
-        with patch.object(RESTManager, 'get_endpoint'):
-            await session.start()
+        assert comp.started.is_set() and not comp.failed
+        assert comp.community
+        assert comp._rest_manager
+        assert comp._ipv8
 
-            assert comp.community
-            assert comp._rest_manager
-            assert comp._ipv8
-
-            await session.shutdown()
+        await session.shutdown()

--- a/src/tribler-core/tribler_core/components/gigachannel/tests/test_gigachannel_component.py
+++ b/src/tribler-core/tribler_core/components/gigachannel/tests/test_gigachannel_component.py
@@ -25,7 +25,6 @@ async def test_giga_channel_component(tribler_config):
         comp = GigaChannelComponent.instance()
         assert comp.started.is_set() and not comp.failed
         assert comp.community
-        assert comp._rest_manager
         assert comp._ipv8
 
         await session.shutdown()

--- a/src/tribler-core/tribler_core/components/gigachannel_manager/gigachannel_manager_component.py
+++ b/src/tribler-core/tribler_core/components/gigachannel_manager/gigachannel_manager_component.py
@@ -2,15 +2,13 @@ from tribler_core.components.base import Component
 from tribler_core.components.libtorrent import LibtorrentComponent
 from tribler_core.components.metadata_store.metadata_store_component import MetadataStoreComponent
 from tribler_core.components.reporter import ReporterComponent
-from tribler_core.components.restapi import RESTComponent
+from tribler_core.components.restapi import RestfulComponent
 from tribler_core.components.gigachannel_manager.gigachannel_manager import GigaChannelManager
 from tribler_core.restapi.rest_manager import RESTManager
 
 
-class GigachannelManagerComponent(Component):
+class GigachannelManagerComponent(RestfulComponent):
     gigachannel_manager: GigaChannelManager
-
-    _rest_manager: RESTManager
 
     async def run(self):
         await self.get_component(ReporterComponent)
@@ -22,9 +20,6 @@ class GigachannelManagerComponent(Component):
         download_manager = libtorrent_component.download_manager if libtorrent_component else None
 
         metadata_store_component = await self.require_component(MetadataStoreComponent)
-        rest_component = await self.require_component(RESTComponent)
-
-        self._rest_manager = rest_component.rest_manager
 
         self.gigachannel_manager = GigaChannelManager(
             notifier=notifier, metadata_store=metadata_store_component.mds, download_manager=download_manager
@@ -32,14 +27,9 @@ class GigachannelManagerComponent(Component):
         if not config.gui_test_mode:
             self.gigachannel_manager.start()
 
-        self._rest_manager.get_endpoint('channels').gigachannel_manager = self.gigachannel_manager
-        self._rest_manager.get_endpoint('collections').gigachannel_manager = self.gigachannel_manager
+        await self.init_endpoints(['channels', 'collections'], [('gigachannel_manager', self.gigachannel_manager)])
 
     async def shutdown(self):
         self.session.notifier.notify_shutdown_state("Shutting down Gigachannel Manager...")
-        self._rest_manager.get_endpoint('channels').gigachannel_manager = None
-        self._rest_manager.get_endpoint('collections').gigachannel_manager = None
-
-        await self.release_component(RESTComponent)
-
+        self.release_endpoints()
         await self.gigachannel_manager.shutdown()

--- a/src/tribler-core/tribler_core/components/gigachannel_manager/gigachannel_manager_component.py
+++ b/src/tribler-core/tribler_core/components/gigachannel_manager/gigachannel_manager_component.py
@@ -27,7 +27,8 @@ class GigachannelManagerComponent(RestfulComponent):
         if not config.gui_test_mode:
             self.gigachannel_manager.start()
 
-        await self.init_endpoints(['channels', 'collections'], [('gigachannel_manager', self.gigachannel_manager)])
+        await self.init_endpoints(endpoints=['channels', 'collections'],
+                                  values={'gigachannel_manager': self.gigachannel_manager})
 
     async def shutdown(self):
         self.session.notifier.notify_shutdown_state("Shutting down Gigachannel Manager...")

--- a/src/tribler-core/tribler_core/components/gigachannel_manager/gigachannel_manager_component.py
+++ b/src/tribler-core/tribler_core/components/gigachannel_manager/gigachannel_manager_component.py
@@ -11,7 +11,7 @@ class GigachannelManagerComponent(RestfulComponent):
     gigachannel_manager: GigaChannelManager
 
     async def run(self):
-        await self.get_component(ReporterComponent)
+        await super().run()
 
         config = self.session.config
         notifier = self.session.notifier

--- a/src/tribler-core/tribler_core/components/gigachannel_manager/gigachannel_manager_component.py
+++ b/src/tribler-core/tribler_core/components/gigachannel_manager/gigachannel_manager_component.py
@@ -31,5 +31,5 @@ class GigachannelManagerComponent(RestfulComponent):
 
     async def shutdown(self):
         self.session.notifier.notify_shutdown_state("Shutting down Gigachannel Manager...")
-        self.release_endpoints()
+        await super().shutdown()
         await self.gigachannel_manager.shutdown()

--- a/src/tribler-core/tribler_core/components/gigachannel_manager/tests/test_gigachannel_manager_component.py
+++ b/src/tribler-core/tribler_core/components/gigachannel_manager/tests/test_gigachannel_manager_component.py
@@ -13,15 +13,18 @@ from tribler_core.restapi.rest_manager import RESTManager
 # pylint: disable=protected-access
 
 async def test_gigachannel_manager_component(tribler_config):
+    tribler_config.ipv8.enabled = True
+    tribler_config.libtorrent.enabled = True
+    tribler_config.chant.enabled = True
     components = [SocksServersComponent(), MasterKeyComponent(), RESTComponent(), MetadataStoreComponent(),
                   LibtorrentComponent(), GigachannelManagerComponent()]
     session = Session(tribler_config, components)
     with session:
         comp = GigachannelManagerComponent.instance()
-        with patch.object(RESTManager, 'get_endpoint'):
-            await session.start()
+        await session.start()
 
-            assert comp.gigachannel_manager
-            assert comp._rest_manager
+        assert comp.started.is_set() and not comp.failed
+        assert comp.gigachannel_manager
+        assert comp._rest_manager
 
-            await session.shutdown()
+        await session.shutdown()

--- a/src/tribler-core/tribler_core/components/gigachannel_manager/tests/test_gigachannel_manager_component.py
+++ b/src/tribler-core/tribler_core/components/gigachannel_manager/tests/test_gigachannel_manager_component.py
@@ -25,6 +25,5 @@ async def test_gigachannel_manager_component(tribler_config):
 
         assert comp.started.is_set() and not comp.failed
         assert comp.gigachannel_manager
-        assert comp._rest_manager
 
         await session.shutdown()

--- a/src/tribler-core/tribler_core/components/ipv8.py
+++ b/src/tribler-core/tribler_core/components/ipv8.py
@@ -89,7 +89,7 @@ class Ipv8Component(RestfulComponent):
 
         await self.init_endpoints(['statistics'], [('ipv8', ipv8)])
         await self.init_ipv8_endpoints(ipv8, [
-            '/asyncio', '/attestation', '/dht', '/identity', '/isolation', '/network', '/noblockdht', '/overlays'
+            'asyncio', 'attestation', 'dht', 'identity', 'isolation', 'network', 'noblockdht', 'overlays'
         ])
 
     def make_bootstrapper(self) -> DispersyBootstrapper:

--- a/src/tribler-core/tribler_core/components/ipv8.py
+++ b/src/tribler-core/tribler_core/components/ipv8.py
@@ -31,7 +31,7 @@ class Ipv8Component(RestfulComponent):
     _peer_discovery_community: Optional[DiscoveryCommunity] = None
 
     async def run(self):
-        await self.get_component(ReporterComponent)
+        await super().run()
 
         config = self.session.config
 

--- a/src/tribler-core/tribler_core/components/ipv8.py
+++ b/src/tribler-core/tribler_core/components/ipv8.py
@@ -87,7 +87,8 @@ class Ipv8Component(RestfulComponent):
             if config.dht.enabled:
                 self.dht_discovery_community.routing_tables[UDPv4Address] = RoutingTable('\x00' * 20)
 
-        await self.init_endpoints(['statistics'], [('ipv8', ipv8)], ipv8=ipv8, ipv8_endpoints=[
+        await self.init_endpoints(['statistics'], [('ipv8', ipv8)])
+        await self.init_ipv8_endpoints(ipv8, [
             '/asyncio', '/attestation', '/dht', '/identity', '/isolation', '/network', '/noblockdht', '/overlays'
         ])
 

--- a/src/tribler-core/tribler_core/components/ipv8.py
+++ b/src/tribler-core/tribler_core/components/ipv8.py
@@ -116,13 +116,12 @@ class Ipv8Component(RestfulComponent):
         self.dht_discovery_community = community
 
     async def shutdown(self):
-        self.release_endpoints()
+        await super().shutdown()
 
         for overlay in (self.dht_discovery_community, self._peer_discovery_community):
             if overlay:
                 await self.ipv8.unload_overlay(overlay)
 
-        await self.unused.wait()
         self.session.notifier.notify_shutdown_state("Shutting down IPv8...")
         await self._task_manager.shutdown_task_manager()
         await self.ipv8.stop(stop_loop=False)

--- a/src/tribler-core/tribler_core/components/ipv8.py
+++ b/src/tribler-core/tribler_core/components/ipv8.py
@@ -87,8 +87,8 @@ class Ipv8Component(RestfulComponent):
             if config.dht.enabled:
                 self.dht_discovery_community.routing_tables[UDPv4Address] = RoutingTable('\x00' * 20)
 
-        await self.init_endpoints(['statistics'], [('ipv8', ipv8)])
-        await self.init_ipv8_endpoints(ipv8, [
+        await self.init_endpoints(endpoints=['statistics'], values={'ipv8': ipv8})
+        await self.init_ipv8_endpoints(ipv8, endpoints=[
             'asyncio', 'attestation', 'dht', 'identity', 'isolation', 'network', 'noblockdht', 'overlays'
         ])
 

--- a/src/tribler-core/tribler_core/components/libtorrent.py
+++ b/src/tribler-core/tribler_core/components/libtorrent.py
@@ -37,10 +37,8 @@ class LibtorrentComponent(RestfulComponent):
         await self.download_manager.load_checkpoints()
         await self.set_readable_status(STATE_CHECKPOINTS_LOADED)
 
-        await self.init_endpoints(
-            ['createtorrent', 'libtorrent', 'torrentinfo', 'downloads', 'channels', 'collections', 'settings'],
-            [('download_manager', self.download_manager)]
-        )
+        endpoints = ['createtorrent', 'libtorrent', 'torrentinfo', 'downloads', 'channels', 'collections', 'settings']
+        await self.init_endpoints(endpoints=endpoints, values={'download_manager': self.download_manager})
 
         if config.gui_test_mode:
             uri = "magnet:?xt=urn:btih:0000000000000000000000000000000000000000"

--- a/src/tribler-core/tribler_core/components/libtorrent.py
+++ b/src/tribler-core/tribler_core/components/libtorrent.py
@@ -47,6 +47,6 @@ class LibtorrentComponent(RestfulComponent):
             await self.download_manager.start_download_from_uri(uri)
 
     async def shutdown(self):
-        self.release_endpoints()
+        await super().shutdown()
         self.download_manager.stop_download_states_callback()
         await self.download_manager.shutdown()

--- a/src/tribler-core/tribler_core/components/libtorrent.py
+++ b/src/tribler-core/tribler_core/components/libtorrent.py
@@ -14,7 +14,7 @@ class LibtorrentComponent(RestfulComponent):
     download_manager: DownloadManager
 
     async def run(self):
-        await self.get_component(ReporterComponent)
+        await super().run()
         await self.get_component(UpgradeComponent)
         socks_servers_component = await self.require_component(SocksServersComponent)
         master_key_component = await self.require_component(MasterKeyComponent)

--- a/src/tribler-core/tribler_core/components/metadata_store/metadata_store_component.py
+++ b/src/tribler-core/tribler_core/components/metadata_store/metadata_store_component.py
@@ -50,8 +50,8 @@ class MetadataStoreComponent(RestfulComponent):
         self.mds = metadata_store
 
         await self.init_endpoints(
-            ['search', 'metadata', 'remote_query', 'downloads', 'channels', 'collections', 'statistics'],
-            [('mds', metadata_store)]
+            endpoints=['search', 'metadata', 'remote_query', 'downloads', 'channels', 'collections', 'statistics'],
+            values={'mds': metadata_store}
         )
 
         self.session.notifier.add_observer(NTFY.TORRENT_METADATA_ADDED,

--- a/src/tribler-core/tribler_core/components/metadata_store/metadata_store_component.py
+++ b/src/tribler-core/tribler_core/components/metadata_store/metadata_store_component.py
@@ -14,7 +14,7 @@ class MetadataStoreComponent(RestfulComponent):
     mds: MetadataStore
 
     async def run(self):
-        await self.get_component(ReporterComponent)
+        await super().run()
         await self.get_component(UpgradeComponent)
 
         config = self.session.config

--- a/src/tribler-core/tribler_core/components/metadata_store/metadata_store_component.py
+++ b/src/tribler-core/tribler_core/components/metadata_store/metadata_store_component.py
@@ -61,7 +61,6 @@ class MetadataStoreComponent(RestfulComponent):
             generate_test_channels(metadata_store)
 
     async def shutdown(self):
-        self.release_endpoints()
-        await self.unused.wait()
+        await super().shutdown()
         self.session.notifier.notify_shutdown_state("Shutting down Metadata Store...")
         self.mds.shutdown()

--- a/src/tribler-core/tribler_core/components/metadata_store/tests/test_metadata_store_component.py
+++ b/src/tribler-core/tribler_core/components/metadata_store/tests/test_metadata_store_component.py
@@ -10,14 +10,16 @@ from tribler_core.restapi.rest_manager import RESTManager
 # pylint: disable=protected-access
 
 async def test_metadata_store_component(tribler_config):
+    tribler_config.libtorrent.enabled = True
+    tribler_config.chant.enabled = True
     components = [MasterKeyComponent(), RESTComponent(), MetadataStoreComponent()]
     session = Session(tribler_config, components)
     with session:
         comp = MetadataStoreComponent.instance()
-        with patch.object(RESTManager, 'get_endpoint'):
-            await session.start()
+        await session.start()
 
-            assert comp.mds
-            assert comp._rest_manager
+        assert comp.started.is_set() and not comp.failed
+        assert comp.mds
+        assert comp._rest_manager
 
-            await session.shutdown()
+        await session.shutdown()

--- a/src/tribler-core/tribler_core/components/metadata_store/tests/test_metadata_store_component.py
+++ b/src/tribler-core/tribler_core/components/metadata_store/tests/test_metadata_store_component.py
@@ -20,6 +20,5 @@ async def test_metadata_store_component(tribler_config):
 
         assert comp.started.is_set() and not comp.failed
         assert comp.mds
-        assert comp._rest_manager
 
         await session.shutdown()

--- a/src/tribler-core/tribler_core/components/resource_monitor.py
+++ b/src/tribler-core/tribler_core/components/resource_monitor.py
@@ -1,11 +1,11 @@
 from tribler_core.components.base import Component
 from tribler_core.components.reporter import ReporterComponent
-from tribler_core.components.restapi import RESTComponent
+from tribler_core.components.restapi import RestfulComponent
 from tribler_core.components.upgrade import UpgradeComponent
 from tribler_core.modules.resource_monitor.core import CoreResourceMonitor
 
 
-class ResourceMonitorComponent(Component):
+class ResourceMonitorComponent(RestfulComponent):
     resource_monitor: CoreResourceMonitor
 
     async def run(self):
@@ -23,9 +23,11 @@ class ResourceMonitorComponent(Component):
         resource_monitor.start()
         self.resource_monitor = resource_monitor
 
-        rest_component = await self.require_component(RESTComponent)
-        rest_component.rest_manager.get_endpoint('debug').resource_monitor = resource_monitor
+        await self.init_endpoints(['debug'], [('resource_monitor', resource_monitor)])
 
     async def shutdown(self):
+        if self._rest_manager:
+            self._rest_manager.get_endpoint('debug').resource_monitor = None
+
         self.session.notifier.notify_shutdown_state("Shutting down Resource Monitor...")
         await self.resource_monitor.stop()

--- a/src/tribler-core/tribler_core/components/resource_monitor.py
+++ b/src/tribler-core/tribler_core/components/resource_monitor.py
@@ -23,7 +23,7 @@ class ResourceMonitorComponent(RestfulComponent):
         resource_monitor.start()
         self.resource_monitor = resource_monitor
 
-        await self.init_endpoints(['debug'], [('resource_monitor', resource_monitor)])
+        await self.init_endpoints(endpoints=['debug'], values={'resource_monitor': resource_monitor})
 
     async def shutdown(self):
         self.session.notifier.notify_shutdown_state("Shutting down Resource Monitor...")

--- a/src/tribler-core/tribler_core/components/resource_monitor.py
+++ b/src/tribler-core/tribler_core/components/resource_monitor.py
@@ -9,7 +9,7 @@ class ResourceMonitorComponent(RestfulComponent):
     resource_monitor: CoreResourceMonitor
 
     async def run(self):
-        await self.get_component(ReporterComponent)
+        await super().run()
         await self.get_component(UpgradeComponent)
 
         config = self.session.config

--- a/src/tribler-core/tribler_core/components/resource_monitor.py
+++ b/src/tribler-core/tribler_core/components/resource_monitor.py
@@ -26,8 +26,6 @@ class ResourceMonitorComponent(RestfulComponent):
         await self.init_endpoints(['debug'], [('resource_monitor', resource_monitor)])
 
     async def shutdown(self):
-        if self._rest_manager:
-            self._rest_manager.get_endpoint('debug').resource_monitor = None
-
         self.session.notifier.notify_shutdown_state("Shutting down Resource Monitor...")
+        await super().shutdown()
         await self.resource_monitor.stop()

--- a/src/tribler-core/tribler_core/components/restapi.py
+++ b/src/tribler-core/tribler_core/components/restapi.py
@@ -45,7 +45,7 @@ class RestfulComponent(Component, ABC):
                     setattr(endpoint, attr_name, attr_value)
                     self.endpoint_attrs.add((endpoint_name, attr_name))
 
-    def release_endpoints(self):
+    async def shutdown(self):
         if not self._rest_manager:
             return
 

--- a/src/tribler-core/tribler_core/components/restapi.py
+++ b/src/tribler-core/tribler_core/components/restapi.py
@@ -47,6 +47,9 @@ class RestfulComponent(Component, ABC):
                 if path in path_set:
                     endpoint.initialize(ipv8)
 
+    async def run(self):
+        await self.get_component(ReporterComponent)
+
     async def shutdown(self):
         rest_component = await self.get_component(RESTComponent)
         if not rest_component:

--- a/src/tribler-core/tribler_core/components/restapi.py
+++ b/src/tribler-core/tribler_core/components/restapi.py
@@ -1,5 +1,5 @@
 from abc import ABC
-from typing import Optional, Set, Tuple
+from typing import Set, Tuple
 
 from tribler_common.simpledefs import STATE_START_API
 from tribler_core.components.base import Component
@@ -11,7 +11,6 @@ from tribler_core.restapi.state_endpoint import StateEndpoint
 
 
 class RestfulComponent(Component, ABC):
-    _rest_manager: Optional[RESTManager] = None
     endpoint_attrs: Set[Tuple[str, str]]
 
     def __init__(self):
@@ -24,36 +23,37 @@ class RestfulComponent(Component, ABC):
             state_endpoint: StateEndpoint = rest_component.rest_manager.get_endpoint('state')
             state_endpoint.readable_status = readable_status
 
-    async def init_endpoints(self, endpoints, values, ipv8=None, ipv8_endpoints=()):
+    async def init_endpoints(self, endpoints, values):
         rest_component = await self.get_component(RESTComponent)
         if not rest_component:
             return
 
-        self._rest_manager = rest_component.rest_manager
-
-        if ipv8 and ipv8_endpoints:
-            ipv8_root_endpoint = self._rest_manager.get_endpoint('ipv8')
-            if ipv8_root_endpoint:
-                for path, endpoint in ipv8_root_endpoint.endpoints.items():
-                    if path in ipv8_endpoints:
-                        endpoint.initialize(ipv8)
-
         for endpoint_name in endpoints:
-            endpoint = self._rest_manager.get_endpoint(endpoint_name)
+            endpoint = rest_component.rest_manager.get_endpoint(endpoint_name)
             if endpoint:
                 for attr_name, attr_value in values:
                     setattr(endpoint, attr_name, attr_value)
                     self.endpoint_attrs.add((endpoint_name, attr_name))
 
+    async def init_ipv8_endpoints(self, ipv8, endpoints):
+        rest_component = await self.get_component(RESTComponent)
+        if not rest_component:
+            return
+
+        ipv8_root_endpoint = rest_component.rest_manager.get_endpoint('ipv8')
+        if ipv8_root_endpoint:
+            for path, endpoint in ipv8_root_endpoint.endpoints.items():
+                if path in endpoints:
+                    endpoint.initialize(ipv8)
+
     async def shutdown(self):
-        if not self._rest_manager:
+        rest_component = await self.get_component(RESTComponent)
+        if not rest_component:
             return
 
         for endpoint_name, attr_name in self.endpoint_attrs:
-            endpoint = self._rest_manager.get_endpoint(endpoint_name)
+            endpoint = rest_component.rest_manager.get_endpoint(endpoint_name)
             setattr(endpoint, attr_name, None)
-
-        self.release_component(RESTComponent)
 
 
 class RESTComponent(Component):

--- a/src/tribler-core/tribler_core/components/restapi.py
+++ b/src/tribler-core/tribler_core/components/restapi.py
@@ -42,8 +42,9 @@ class RestfulComponent(Component, ABC):
 
         ipv8_root_endpoint = rest_component.rest_manager.get_endpoint('ipv8')
         if ipv8_root_endpoint:
+            path_set = {'/' + name for name in endpoints}
             for path, endpoint in ipv8_root_endpoint.endpoints.items():
-                if path in endpoints:
+                if path in path_set:
                     endpoint.initialize(ipv8)
 
     async def shutdown(self):

--- a/src/tribler-core/tribler_core/components/restapi.py
+++ b/src/tribler-core/tribler_core/components/restapi.py
@@ -1,5 +1,7 @@
 from abc import ABC
-from typing import Set, Tuple
+from typing import Any, Dict, List, Set, Tuple
+
+from ipv8_service import IPv8
 
 from tribler_common.simpledefs import STATE_START_API
 from tribler_core.components.base import Component
@@ -23,7 +25,7 @@ class RestfulComponent(Component, ABC):
             state_endpoint: StateEndpoint = rest_component.rest_manager.get_endpoint('state')
             state_endpoint.readable_status = readable_status
 
-    async def init_endpoints(self, endpoints, values):
+    async def init_endpoints(self, endpoints: List[str], values: Dict[str, Any]):
         rest_component = await self.get_component(RESTComponent)
         if not rest_component:
             return
@@ -31,11 +33,11 @@ class RestfulComponent(Component, ABC):
         for endpoint_name in endpoints:
             endpoint = rest_component.rest_manager.get_endpoint(endpoint_name)
             if endpoint:
-                for attr_name, attr_value in values:
+                for attr_name, attr_value in values.items():
                     setattr(endpoint, attr_name, attr_value)
                     self.endpoint_attrs.add((endpoint_name, attr_name))
 
-    async def init_ipv8_endpoints(self, ipv8, endpoints):
+    async def init_ipv8_endpoints(self, ipv8: IPv8, endpoints: List[str]):
         rest_component = await self.get_component(RESTComponent)
         if not rest_component:
             return

--- a/src/tribler-core/tribler_core/components/tests/test_tribler_components.py
+++ b/src/tribler-core/tribler_core/components/tests/test_tribler_components.py
@@ -75,7 +75,6 @@ async def test_ipv8_component(tribler_config):
         assert comp.peer
         assert not comp.dht_discovery_community
         assert comp._task_manager
-        assert comp._rest_manager
         assert not comp._peer_discovery_community
 
         await session.shutdown()
@@ -92,7 +91,6 @@ async def test_libtorrent_component(tribler_config):
         comp = LibtorrentComponent.instance()
         assert comp.started.is_set() and not comp.failed
         assert comp.download_manager
-        assert comp._rest_manager
 
         await session.shutdown()
 
@@ -196,7 +194,6 @@ async def test_torrent_checker_component(tribler_config):
         comp = TorrentCheckerComponent.instance()
         assert comp.started.is_set() and not comp.failed
         assert comp.torrent_checker
-        assert comp._rest_manager
 
         await session.shutdown()
 

--- a/src/tribler-core/tribler_core/components/tests/test_tribler_components.py
+++ b/src/tribler-core/tribler_core/components/tests/test_tribler_components.py
@@ -53,73 +53,80 @@ def test_session_context_manager(loop, tribler_config):
 async def test_masterkey_component(tribler_config):
     session = Session(tribler_config, [MasterKeyComponent()])
     with session:
-        comp = MasterKeyComponent.instance()
         await session.start()
 
+        comp = MasterKeyComponent.instance()
+        assert comp.started.is_set() and not comp.failed
         assert comp.keypair
 
         await session.shutdown()
 
 
 async def test_ipv8_component(tribler_config):
+    tribler_config.ipv8.enabled = True
     components = [MasterKeyComponent(), RESTComponent(), Ipv8Component()]
     session = Session(tribler_config, components)
     with session:
+        await session.start()
+
         comp = Ipv8Component.instance()
-        with patch.object(RESTManager, 'get_endpoint'):
-            await session.start()
+        assert comp.started.is_set() and not comp.failed
+        assert comp.ipv8
+        assert comp.peer
+        assert not comp.dht_discovery_community
+        assert comp._task_manager
+        assert comp._rest_manager
+        assert not comp._peer_discovery_community
 
-            assert comp.ipv8
-            assert comp.peer
-            assert not comp.dht_discovery_community
-            assert comp._task_manager
-            assert comp._rest_manager
-            assert not comp._peer_discovery_community
-
-            await session.shutdown()
+        await session.shutdown()
 
 
 async def test_libtorrent_component(tribler_config):
+    tribler_config.libtorrent.enabled = True
+    tribler_config.chant.enabled = True
     components = [RESTComponent(), MasterKeyComponent(), SocksServersComponent(), LibtorrentComponent()]
     session = Session(tribler_config, components)
     with session:
+        await session.start()
+
         comp = LibtorrentComponent.instance()
-        with patch.object(RESTManager, 'get_endpoint'):
-            await session.start()
+        assert comp.started.is_set() and not comp.failed
+        assert comp.download_manager
+        assert comp._rest_manager
 
-            assert comp.download_manager
-            assert comp._rest_manager
-
-            await session.shutdown()
+        await session.shutdown()
 
 
 async def test_payout_component(tribler_config):
+    tribler_config.ipv8.enabled = True
     components = [BandwidthAccountingComponent(), MasterKeyComponent(), RESTComponent(), Ipv8Component(),
                   PayoutComponent()]
     session = Session(tribler_config, components)
     with session:
+        await session.start()
+
         comp = PayoutComponent.instance()
-        with patch.object(RESTManager, 'get_endpoint'):
-            await session.start()
+        assert comp.started.is_set() and not comp.failed
+        assert comp.payout_manager
 
-            assert comp.payout_manager
-
-            await session.shutdown()
+        await session.shutdown()
 
 
 async def test_popularity_component(tribler_config):
+    tribler_config.ipv8.enabled = True
+    tribler_config.libtorrent.enabled = True
+    tribler_config.chant.enabled = True
     components = [SocksServersComponent(), LibtorrentComponent(), TorrentCheckerComponent(), MetadataStoreComponent(),
                   MasterKeyComponent(), RESTComponent(), Ipv8Component(), PopularityComponent()]
     session = Session(tribler_config, components)
     with session:
+        await session.start()
+
         comp = PopularityComponent.instance()
-        with patch.object(RESTManager, 'get_endpoint'):
-            await session.start()
+        assert comp.community
+        assert comp._ipv8
 
-            assert comp.community
-            assert comp._ipv8
-
-            await session.shutdown()
+        await session.shutdown()
 
 
 async def test_reporter_component(tribler_config):
@@ -127,113 +134,127 @@ async def test_reporter_component(tribler_config):
     session = Session(tribler_config, components)
     with session:
         await session.start()
+
+        comp = ReporterComponent.instance()
+        assert comp.started.is_set() and not comp.failed
+
         await session.shutdown()
 
 
 async def test_resource_monitor_component(tribler_config):
+    tribler_config.ipv8.enabled = True
+    tribler_config.libtorrent.enabled = True
+    tribler_config.chant.enabled = True
     components = [MasterKeyComponent(), RESTComponent(), ResourceMonitorComponent()]
     session = Session(tribler_config, components)
     with session:
+        await session.start()
+
         comp = ResourceMonitorComponent.instance()
-        with patch.object(RESTManager, 'get_endpoint'):
-            await session.start()
+        assert comp.started.is_set() and not comp.failed
+        assert comp.resource_monitor
 
-            assert comp.resource_monitor
-
-            await session.shutdown()
+        await session.shutdown()
 
 
 async def test_REST_component(tribler_config):
     components = [MasterKeyComponent(), RESTComponent()]
     session = Session(tribler_config, components)
     with session:
+        await session.start()
+
         comp = RESTComponent.instance()
-        with patch.object(RESTManager, 'get_endpoint'):
-            await session.start()
+        assert comp.started.is_set() and not comp.failed
+        assert comp.rest_manager
 
-            assert comp.rest_manager
-
-            await session.shutdown()
+        await session.shutdown()
 
 
 async def test_socks_servers_component(tribler_config):
     components = [SocksServersComponent()]
     session = Session(tribler_config, components)
     with session:
+        await session.start()
+
         comp = SocksServersComponent.instance()
-        with patch.object(RESTManager, 'get_endpoint'):
-            await session.start()
+        assert comp.started.is_set() and not comp.failed
+        assert comp.socks_ports
+        assert comp.socks_servers
 
-            assert comp.socks_ports
-            assert comp.socks_servers
-
-            await session.shutdown()
+        await session.shutdown()
 
 
 async def test_torrent_checker_component(tribler_config):
+    tribler_config.libtorrent.enabled = True
+    tribler_config.chant.enabled = True
     components = [SocksServersComponent(), LibtorrentComponent(), MasterKeyComponent(), RESTComponent(),
                   MetadataStoreComponent(), TorrentCheckerComponent()]
     session = Session(tribler_config, components)
     with session:
+        await session.start()
+
         comp = TorrentCheckerComponent.instance()
-        with patch.object(RESTManager, 'get_endpoint'):
-            await session.start()
+        assert comp.started.is_set() and not comp.failed
+        assert comp.torrent_checker
+        assert comp._rest_manager
 
-            assert comp.torrent_checker
-            assert comp._rest_manager
-
-            await session.shutdown()
+        await session.shutdown()
 
 
 async def test_tunnels_component(tribler_config):
+    tribler_config.ipv8.enabled = True
+    tribler_config.libtorrent.enabled = True
+    tribler_config.chant.enabled = True
     components = [Ipv8Component(), MasterKeyComponent(), RESTComponent(), TunnelsComponent()]
     session = Session(tribler_config, components)
     with session:
+        await session.start()
+
         comp = TunnelsComponent.instance()
-        with patch.object(RESTManager, 'get_endpoint'):
-            await session.start()
+        assert comp.started.is_set() and not comp.failed
+        assert comp.community
+        assert comp._ipv8
 
-            assert comp.community
-            assert comp._ipv8
-
-            await session.shutdown()
+        await session.shutdown()
 
 
 async def test_upgrade_component(tribler_config):
     components = [MasterKeyComponent(), RESTComponent(), UpgradeComponent()]
     session = Session(tribler_config, components)
     with session:
+        await session.start()
+
         comp = UpgradeComponent.instance()
-        with patch.object(RESTManager, 'get_endpoint'):
-            await session.start()
+        assert comp.started.is_set() and not comp.failed
+        assert comp.upgrader
 
-            assert comp.upgrader
-
-            await session.shutdown()
+        await session.shutdown()
 
 
 async def test_version_check_component(tribler_config):
     components = [VersionCheckComponent()]
     session = Session(tribler_config, components)
     with session:
+        await session.start()
+
         comp = VersionCheckComponent.instance()
-        with patch.object(RESTManager, 'get_endpoint'):
-            await session.start()
+        assert comp.started.is_set() and not comp.failed
+        assert comp.version_check_manager
 
-            assert comp.version_check_manager
-
-            await session.shutdown()
+        await session.shutdown()
 
 
 async def test_watch_folder_component(tribler_config):
+    tribler_config.libtorrent.enabled = True
+    tribler_config.chant.enabled = True
     components = [MasterKeyComponent(), RESTComponent(), SocksServersComponent(), LibtorrentComponent(),
                   WatchFolderComponent()]
     session = Session(tribler_config, components)
     with session:
+        await session.start()
+
         comp = WatchFolderComponent.instance()
-        with patch.object(RESTManager, 'get_endpoint'):
-            await session.start()
+        assert comp.started.is_set() and not comp.failed
+        assert comp.watch_folder
 
-            assert comp.watch_folder
-
-            await session.shutdown()
+        await session.shutdown()

--- a/src/tribler-core/tribler_core/components/torrent_checker.py
+++ b/src/tribler-core/tribler_core/components/torrent_checker.py
@@ -1,19 +1,18 @@
 from tribler_common.simpledefs import STATE_START_TORRENT_CHECKER
+
 from tribler_core.components.base import Component
 from tribler_core.components.libtorrent import LibtorrentComponent
 from tribler_core.components.metadata_store.metadata_store_component import MetadataStoreComponent
 from tribler_core.components.reporter import ReporterComponent
-from tribler_core.components.restapi import RESTComponent
+from tribler_core.components.restapi import RestfulComponent
 from tribler_core.components.socks_configurator import SocksServersComponent
 from tribler_core.modules.torrent_checker.torrent_checker import TorrentChecker
 from tribler_core.modules.torrent_checker.tracker_manager import TrackerManager
 from tribler_core.restapi.rest_manager import RESTManager
 
 
-class TorrentCheckerComponent(Component):
+class TorrentCheckerComponent(RestfulComponent):
     torrent_checker: TorrentChecker
-
-    _rest_manager: RESTManager
 
     async def run(self):
         await self.get_component(ReporterComponent)
@@ -22,9 +21,6 @@ class TorrentCheckerComponent(Component):
 
         metadata_store_component = await self.require_component(MetadataStoreComponent)
         libtorrent_component = await self.require_component(LibtorrentComponent)
-        rest_component = await self.require_component(RESTComponent)
-        self._rest_manager = rest_component.rest_manager
-
         socks_servers_component = await self.require_component(SocksServersComponent)
 
         tracker_manager = TrackerManager(state_dir=config.state_dir, metadata_store=metadata_store_component.mds)
@@ -35,16 +31,10 @@ class TorrentCheckerComponent(Component):
                                          socks_listen_ports=socks_servers_component.socks_ports,
                                          metadata_store=metadata_store_component.mds)
         self.torrent_checker = torrent_checker
-        self._rest_manager.get_endpoint('state').readable_status = STATE_START_TORRENT_CHECKER
-
         await torrent_checker.initialize()
-        self._rest_manager.set_attr_for_endpoints(['metadata'], 'torrent_checker', torrent_checker,
-                                                  skip_missing=True)
+        await self.init_endpoints(['metadata'], [('torrent_checker', torrent_checker)])
 
     async def shutdown(self):
         self.session.notifier.notify_shutdown_state("Shutting down Torrent Checker...")
-        self._rest_manager.set_attr_for_endpoints(['metadata'], 'torrent_checker', None, skip_missing=True)
-
-        await self.release_component(RESTComponent)
-
+        self.release_endpoints()
         await self.torrent_checker.shutdown()

--- a/src/tribler-core/tribler_core/components/torrent_checker.py
+++ b/src/tribler-core/tribler_core/components/torrent_checker.py
@@ -32,7 +32,7 @@ class TorrentCheckerComponent(RestfulComponent):
                                          metadata_store=metadata_store_component.mds)
         self.torrent_checker = torrent_checker
         await torrent_checker.initialize()
-        await self.init_endpoints(['metadata'], [('torrent_checker', torrent_checker)])
+        await self.init_endpoints(endpoints=['metadata'], values={'torrent_checker': torrent_checker})
 
     async def shutdown(self):
         self.session.notifier.notify_shutdown_state("Shutting down Torrent Checker...")

--- a/src/tribler-core/tribler_core/components/torrent_checker.py
+++ b/src/tribler-core/tribler_core/components/torrent_checker.py
@@ -36,5 +36,5 @@ class TorrentCheckerComponent(RestfulComponent):
 
     async def shutdown(self):
         self.session.notifier.notify_shutdown_state("Shutting down Torrent Checker...")
-        self.release_endpoints()
+        await super().shutdown()
         await self.torrent_checker.shutdown()

--- a/src/tribler-core/tribler_core/components/torrent_checker.py
+++ b/src/tribler-core/tribler_core/components/torrent_checker.py
@@ -15,7 +15,7 @@ class TorrentCheckerComponent(RestfulComponent):
     torrent_checker: TorrentChecker
 
     async def run(self):
-        await self.get_component(ReporterComponent)
+        await super().run()
 
         config = self.session.config
 

--- a/src/tribler-core/tribler_core/components/tunnels.py
+++ b/src/tribler-core/tribler_core/components/tunnels.py
@@ -71,7 +71,7 @@ class TunnelsComponent(RestfulComponent):
         self.community = community
 
         await self.init_endpoints(['downloads', 'debug'], [('tunnel_community', community)])
-        await self.init_ipv8_endpoints(self._ipv8, ['/tunnel'])
+        await self.init_ipv8_endpoints(self._ipv8, ['tunnel'])
 
     async def shutdown(self):
         await super().shutdown()

--- a/src/tribler-core/tribler_core/components/tunnels.py
+++ b/src/tribler-core/tribler_core/components/tunnels.py
@@ -70,8 +70,8 @@ class TunnelsComponent(RestfulComponent):
 
         self.community = community
 
-        await self.init_endpoints(['downloads', 'debug'], [('tunnel_community', community)])
-        await self.init_ipv8_endpoints(self._ipv8, ['tunnel'])
+        await self.init_endpoints(endpoints=['downloads', 'debug'], values={'tunnel_community': community})
+        await self.init_ipv8_endpoints(self._ipv8, endpoints=['tunnel'])
 
     async def shutdown(self):
         await super().shutdown()

--- a/src/tribler-core/tribler_core/components/tunnels.py
+++ b/src/tribler-core/tribler_core/components/tunnels.py
@@ -70,8 +70,8 @@ class TunnelsComponent(RestfulComponent):
 
         self.community = community
 
-        await self.init_endpoints(['downloads', 'debug'], [('tunnel_community', community)],
-                                  ipv8=self._ipv8, ipv8_endpoints=['/tunnel'])
+        await self.init_endpoints(['downloads', 'debug'], [('tunnel_community', community)])
+        await self.init_ipv8_endpoints(self._ipv8, ['/tunnel'])
 
     async def shutdown(self):
         await super().shutdown()

--- a/src/tribler-core/tribler_core/components/tunnels.py
+++ b/src/tribler-core/tribler_core/components/tunnels.py
@@ -20,7 +20,7 @@ class TunnelsComponent(RestfulComponent):
     _ipv8: IPv8
 
     async def run(self):
-        await self.get_component(ReporterComponent)
+        await super().run()
 
         config = self.session.config
         ipv8_component = await self.require_component(Ipv8Component)

--- a/src/tribler-core/tribler_core/components/tunnels.py
+++ b/src/tribler-core/tribler_core/components/tunnels.py
@@ -74,5 +74,5 @@ class TunnelsComponent(RestfulComponent):
                                   ipv8=self._ipv8, ipv8_endpoints=['/tunnel'])
 
     async def shutdown(self):
-        self.release_endpoints()
+        await super().shutdown()
         await self._ipv8.unload_overlay(self.community)

--- a/src/tribler-core/tribler_core/components/upgrade.py
+++ b/src/tribler-core/tribler_core/components/upgrade.py
@@ -23,6 +23,6 @@ class UpgradeComponent(RestfulComponent):
             trustchain_keypair=master_key_component.keypair,
             notifier=notifier)
 
-        await self.init_endpoints(['upgrader'], [('upgrader', self.upgrader)])
+        await self.init_endpoints(endpoints=['upgrader'], values={'upgrader': self.upgrader})
         await self.set_readable_status(STATE_UPGRADING_READABLE)
         await self.upgrader.run()

--- a/src/tribler-core/tribler_core/components/upgrade.py
+++ b/src/tribler-core/tribler_core/components/upgrade.py
@@ -26,6 +26,3 @@ class UpgradeComponent(RestfulComponent):
         await self.init_endpoints(['upgrader'], [('upgrader', self.upgrader)])
         await self.set_readable_status(STATE_UPGRADING_READABLE)
         await self.upgrader.run()
-
-    async def shutdown(self):
-        self.release_endpoints()

--- a/src/tribler-core/tribler_core/components/upgrade.py
+++ b/src/tribler-core/tribler_core/components/upgrade.py
@@ -11,7 +11,7 @@ class UpgradeComponent(RestfulComponent):
     upgrader: TriblerUpgrader
 
     async def run(self):
-        await self.get_component(ReporterComponent)
+        await super().run()
         config = self.session.config
         notifier = self.session.notifier
         master_key_component = await self.require_component(MasterKeyComponent)

--- a/src/tribler-core/tribler_core/components/watch_folder.py
+++ b/src/tribler-core/tribler_core/components/watch_folder.py
@@ -26,4 +26,5 @@ class WatchFolderComponent(RestfulComponent):
 
     async def shutdown(self):
         self.session.notifier.notify_shutdown_state("Shutting down Watch Folder...")
+        await super().shutdown()
         await self.watch_folder.stop()

--- a/src/tribler-core/tribler_core/components/watch_folder.py
+++ b/src/tribler-core/tribler_core/components/watch_folder.py
@@ -11,7 +11,7 @@ class WatchFolderComponent(RestfulComponent):
     watch_folder: WatchFolder
 
     async def run(self):
-        await self.get_component(ReporterComponent)
+        await super().run()
         config = self.session.config
         notifier = self.session.notifier
         libtorrent_component = await self.require_component(LibtorrentComponent)

--- a/src/tribler-core/tribler_core/components/watch_folder.py
+++ b/src/tribler-core/tribler_core/components/watch_folder.py
@@ -1,12 +1,13 @@
 from tribler_common.simpledefs import STATE_START_WATCH_FOLDER
+
 from tribler_core.components.base import Component
 from tribler_core.components.libtorrent import LibtorrentComponent
 from tribler_core.components.reporter import ReporterComponent
-from tribler_core.components.restapi import RESTComponent
+from tribler_core.components.restapi import RestfulComponent
 from tribler_core.modules.watch_folder.watch_folder import WatchFolder
 
 
-class WatchFolderComponent(Component):
+class WatchFolderComponent(RestfulComponent):
     watch_folder: WatchFolder
 
     async def run(self):
@@ -19,10 +20,7 @@ class WatchFolderComponent(Component):
         watch_folder = WatchFolder(watch_folder_path=watch_folder_path,
                                    download_manager=libtorrent_component.download_manager,
                                    notifier=notifier)
-
-        rest_component = await self.require_component(RESTComponent)
-        rest_component.rest_manager.get_endpoint('state').readable_status = STATE_START_WATCH_FOLDER
-
+        await self.set_readable_status(STATE_START_WATCH_FOLDER)
         watch_folder.start()
         self.watch_folder = watch_folder
 

--- a/src/tribler-core/tribler_core/restapi/rest_manager.py
+++ b/src/tribler-core/tribler_core/restapi/rest_manager.py
@@ -98,17 +98,6 @@ class RESTManager:
     def get_endpoint(self, name):
         return self.root_endpoint.endpoints['/' + name]
 
-    def set_attr_for_endpoints(self, endpoints: List[str], attr_name: str, attr_value, skip_missing=False):
-        """
-        Set attribute value for each endpoint in the list. Can be used for delayed initialization of endpoints.
-        """
-        for endpoint_name in endpoints:
-            endpoint = self.root_endpoint.endpoints.get('/' + endpoint_name)
-            if endpoint is not None:
-                setattr(endpoint, attr_name, attr_value)
-            elif not skip_missing:
-                raise KeyError(f'Endpoint not found: /{endpoint_name}')
-
     async def start(self):
         """
         Starts the HTTP API with the listen port as specified in the session configuration.

--- a/src/tribler-core/tribler_core/restapi/trustview_endpoint.py
+++ b/src/tribler-core/tribler_core/restapi/trustview_endpoint.py
@@ -18,8 +18,8 @@ from tribler_core.utilities.utilities import froze_it
 class TrustViewEndpoint(RESTEndpoint):
     def __init__(self):
         super().__init__()
-
         self.bandwidth_db = None
+        self.bandwidth_community = None  # added to simlify the initialization code of BandwidthAccountingComponent
 
     def setup_routes(self):
         self.app.add_routes([web.get('', self.get_view)])


### PR DESCRIPTION
This PR makes the dependency of components on REST manager optional. It adds a base class `RestfulComponent`, which provides three methods:

The `init_endpoints` method simplifies endpoint initialization and can be used inside a component's `run` method to inject values to REST endpoints:

```python
async def run(self):
    ...
    await self.init_endpoints(
        ["endpoint_name1", "endpoint_name2"]
        [(attr_name1, value1), (attr_name2, value2)]
    )
```
The method sets specified attributes to all enlisted endpoints. If RESTComponent or some specific endpoint is not available, it just skipped silently.

It also is possible to initialize `ipv8` endpoints as well by specifying the `ipv8` instance.

```python
        await self.init_ipv8_endpoints(self._ipv8, ['tunnel'])
```
This way it becomes not necessary to explicitly access RESTComponent and REST endpoints in a component's code.

The `shutdown` method of RestfulComponent will release endpoints by replacing previously set values to `None`:

The `set_readable_status` abstracts out the setting Tribler user-readable status to a specific value.
```python
async def run(self):
    ...
    await self.set_readable_status(STATE_START_WATCH_FOLDER)
```