### PR TITLE
Add @pytest.mark.asyncio to test functions

### DIFF
--- a/src/tribler-core/tribler_core/components/bandwidth_accounting/tests/test_bandwidth_accounting_component.py
+++ b/src/tribler-core/tribler_core/components/bandwidth_accounting/tests/test_bandwidth_accounting_component.py
@@ -1,5 +1,7 @@
 from unittest.mock import patch
 
+import pytest
+
 from tribler_core.components.bandwidth_accounting.bandwidth_accounting_component import BandwidthAccountingComponent
 from tribler_core.components.base import Session
 from tribler_core.components.ipv8 import Ipv8Component
@@ -10,7 +12,7 @@ from tribler_core.restapi.rest_manager import RESTManager
 
 # pylint: disable=protected-access
 
-
+@pytest.mark.asyncio
 async def test_bandwidth_accounting_component(tribler_config):
     tribler_config.ipv8.enabled = True
     components = [RESTComponent(), MasterKeyComponent(), Ipv8Component(), BandwidthAccountingComponent()]

--- a/src/tribler-core/tribler_core/components/gigachannel/tests/test_gigachannel_component.py
+++ b/src/tribler-core/tribler_core/components/gigachannel/tests/test_gigachannel_component.py
@@ -1,5 +1,7 @@
 from unittest.mock import patch
 
+import pytest
+
 from tribler_core.components.base import Session
 from tribler_core.components.gigachannel.gigachannel_component import GigaChannelComponent
 from tribler_core.components.ipv8 import Ipv8Component
@@ -11,7 +13,7 @@ from tribler_core.restapi.rest_manager import RESTManager
 
 # pylint: disable=protected-access
 
-
+@pytest.mark.asyncio
 async def test_giga_channel_component(tribler_config):
     tribler_config.ipv8.enabled = True
     tribler_config.libtorrent.enabled = True

--- a/src/tribler-core/tribler_core/components/gigachannel_manager/tests/test_gigachannel_manager_component.py
+++ b/src/tribler-core/tribler_core/components/gigachannel_manager/tests/test_gigachannel_manager_component.py
@@ -1,5 +1,7 @@
 from unittest.mock import patch
 
+import pytest
+
 from tribler_core.components.base import Session
 from tribler_core.components.gigachannel_manager.gigachannel_manager_component import GigachannelManagerComponent
 from tribler_core.components.libtorrent import LibtorrentComponent
@@ -12,6 +14,7 @@ from tribler_core.restapi.rest_manager import RESTManager
 
 # pylint: disable=protected-access
 
+@pytest.mark.asyncio
 async def test_gigachannel_manager_component(tribler_config):
     tribler_config.ipv8.enabled = True
     tribler_config.libtorrent.enabled = True

--- a/src/tribler-core/tribler_core/components/metadata_store/tests/test_metadata_store_component.py
+++ b/src/tribler-core/tribler_core/components/metadata_store/tests/test_metadata_store_component.py
@@ -1,5 +1,7 @@
 from unittest.mock import patch
 
+import pytest
+
 from tribler_core.components.base import Session
 from tribler_core.components.masterkey import MasterKeyComponent
 from tribler_core.components.metadata_store.metadata_store_component import MetadataStoreComponent
@@ -9,6 +11,7 @@ from tribler_core.restapi.rest_manager import RESTManager
 
 # pylint: disable=protected-access
 
+@pytest.mark.asyncio
 async def test_metadata_store_component(tribler_config):
     tribler_config.libtorrent.enabled = True
     tribler_config.chant.enabled = True

--- a/src/tribler-core/tribler_core/components/tests/test_base_component.py
+++ b/src/tribler-core/tribler_core/components/tests/test_base_component.py
@@ -4,6 +4,7 @@ from tribler_core.components.base import Component, ComponentError, Session, T
 
 pytestmark = pytest.mark.asyncio
 
+
 # pylint: disable=protected-access
 
 


### PR DESCRIPTION
This PR fixes #6382 by adding `@pytest.mark.asyncio` to all components-related test functions.