### PR TITLE
Significantly reduced the number of redraws in GUI tables

### DIFF
--- a/src/tribler-gui/tribler_gui/widgets/lazytableview.py
+++ b/src/tribler-gui/tribler_gui/widgets/lazytableview.py
@@ -102,8 +102,9 @@ class TriblerContentTableView(QTableView):
         """
         Deselect all rows in the table view.
         """
+        old_selected = self.delegate.hover_index
         self.delegate.hover_index = self.delegate.no_index
-        self.redraw()
+        self.redraw(old_selected)
 
     def leaveEvent(self, event):
         """
@@ -117,8 +118,8 @@ class TriblerContentTableView(QTableView):
         index = QModelIndex(self.indexAt(event.pos()))
         self.mouse_moved.emit(event.pos(), index)
 
-    def redraw(self):
-        self.viewport().update()
+    def redraw(self, index):
+        self.model().dataChanged.emit(index, index, [])
         # This is required to drop the sensitivity zones of the controls,
         # so there are no invisible controls left over from a previous state of the view
         for control in self.delegate.controls:

--- a/src/tribler-gui/tribler_gui/widgets/tablecontentdelegate.py
+++ b/src/tribler-gui/tribler_gui/widgets/tablecontentdelegate.py
@@ -117,7 +117,7 @@ class CheckClickedMixin:
 
 
 class TriblerButtonsDelegate(QStyledItemDelegate):
-    redraw_required = pyqtSignal()
+    redraw_required = pyqtSignal(QModelIndex)
 
     def __init__(self, parent=None):
         QStyledItemDelegate.__init__(self, parent)
@@ -155,8 +155,7 @@ class TriblerButtonsDelegate(QStyledItemDelegate):
             redraw = controls.on_mouse_moved(pos, index) or redraw
 
         if redraw:
-            # TODO: optimize me to only redraw the rows that actually changed!
-            self.redraw_required.emit()
+            self.redraw_required.emit(index)
 
     @staticmethod
     def split_rect_into_squares(r, buttons):


### PR DESCRIPTION
We used to repaint all (visible) rows when moving the mouse through the table with content. This PR significantly reduces the number of repaints by only repainting the index that has been changed in the table. In GUI test mode, scrolling through the table of content feels much smoother now.

Fixes #6377