### PR TITLE
Fixed test_popular_page

### DIFF
--- a/src/tribler-core/tribler_core/components/metadata_store/utils.py
+++ b/src/tribler-core/tribler_core/components/metadata_store/utils.py
@@ -1,3 +1,6 @@
+import random
+import time
+
 from ipv8.keyvault.crypto import default_eccrypto
 
 from pony.orm import db_session
@@ -16,7 +19,14 @@ class NoChannelSourcesException(Exception):
 
 @db_session
 def generate_torrent(metadata_store, parent):
-    metadata_store.TorrentMetadata(title=random_utf8_string(50), infohash=random_infohash(), origin_id=parent.id_)
+    infohash = random_infohash()
+
+    # Give each torrent some health information. For now, we assume all torrents are healthy.
+    now = int(time.time())
+    last_check = now - random.randint(3600, 24 * 3600)
+    torrent_state = metadata_store.TorrentState(infohash=infohash, seeders=10, last_check=last_check)
+    metadata_store.TorrentMetadata(title=random_utf8_string(50), infohash=infohash, origin_id=parent.id_,
+                                   health=torrent_state)
 
 
 @db_session

--- a/src/tribler-gui/tribler_gui/tests/test_gui.py
+++ b/src/tribler-gui/tribler_gui/tests/test_gui.py
@@ -254,11 +254,9 @@ def test_discovered_page(tribler_api, window):
 @pytest.mark.guitest
 def test_popular_page(tribler_api, window):
     QTest.mouseClick(window.left_menu_button_popular, Qt.LeftButton)
-    # tst_channels_widget(window, window.discovered_page, "discovered_page", sort_column=2)
-    widget = window.discovered_page
-    widget_name = "popular_page"
+    widget = window.popular_page
     wait_for_list_populated(widget.content_table)
-    screenshot(window, name=f"{widget_name}-page")
+    screenshot(window, name="popular_page")
 
 
 def wait_for_thumbnail(chan_widget):


### PR DESCRIPTION
Specifically, added some content to the 'popular torrents' page by adding health information to generated torrents when in GUI test mode.

![screenshot_popular_page](https://user-images.githubusercontent.com/1707075/135237553-8e7acd81-a269-42c8-ab3e-a1a0fd307d00.jpg)

Fixes #6386