### PR TITLE
Fixed scrolling in GUI tables

### DIFF
--- a/src/tribler-gui/tribler_gui/widgets/lazytableview.py
+++ b/src/tribler-gui/tribler_gui/widgets/lazytableview.py
@@ -98,6 +98,13 @@ class TriblerContentTableView(QTableView):
             self.deselect_all_rows()
         return False
 
+    def wheelEvent(self, event):
+        super().wheelEvent(event)
+
+        # We trigger a mouse movement event to make sure that the whole row remains selected when scrolling.
+        index = QModelIndex(self.indexAt(event.pos()))
+        self.mouse_moved.emit(event.pos(), index)
+
     def deselect_all_rows(self):
         """
         Deselect all rows in the table view.

--- a/src/tribler-gui/tribler_gui/widgets/lazytableview.py
+++ b/src/tribler-gui/tribler_gui/widgets/lazytableview.py
@@ -104,7 +104,7 @@ class TriblerContentTableView(QTableView):
         """
         old_selected = self.delegate.hover_index
         self.delegate.hover_index = self.delegate.no_index
-        self.redraw(old_selected)
+        self.redraw(old_selected, True)
 
     def leaveEvent(self, event):
         """
@@ -118,8 +118,17 @@ class TriblerContentTableView(QTableView):
         index = QModelIndex(self.indexAt(event.pos()))
         self.mouse_moved.emit(event.pos(), index)
 
-    def redraw(self, index):
-        self.model().dataChanged.emit(index, index, [])
+    def redraw(self, index, redraw_whole_row):
+        """
+        Redraw the cell at a particular index.
+        """
+        if redraw_whole_row:
+            for col_ind in range(self.model().columnCount()):
+                index = self.model().index(index.row(), col_ind)
+                self.model().dataChanged.emit(index, index, [])
+        else:
+            self.model().dataChanged.emit(index, index, [])
+
         # This is required to drop the sensitivity zones of the controls,
         # so there are no invisible controls left over from a previous state of the view
         for control in self.delegate.controls:

--- a/src/tribler-gui/tribler_gui/widgets/tablecontentdelegate.py
+++ b/src/tribler-gui/tribler_gui/widgets/tablecontentdelegate.py
@@ -117,7 +117,7 @@ class CheckClickedMixin:
 
 
 class TriblerButtonsDelegate(QStyledItemDelegate):
-    redraw_required = pyqtSignal(QModelIndex)
+    redraw_required = pyqtSignal(QModelIndex, bool)
 
     def __init__(self, parent=None):
         QStyledItemDelegate.__init__(self, parent)
@@ -144,7 +144,9 @@ class TriblerButtonsDelegate(QStyledItemDelegate):
     def on_mouse_moved(self, pos, index):
         # This method controls for which rows the buttons/box should be drawn
         redraw = False
+        old_hover_index = None
         if self.hover_index != index:
+            old_hover_index = self.hover_index
             self.hover_index = index
             if not self.button_box.contains(pos):
                 redraw = True
@@ -155,7 +157,9 @@ class TriblerButtonsDelegate(QStyledItemDelegate):
             redraw = controls.on_mouse_moved(pos, index) or redraw
 
         if redraw:
-            self.redraw_required.emit(index)
+            self.redraw_required.emit(index, False)
+            if old_hover_index:
+                self.redraw_required.emit(old_hover_index, True)
 
     @staticmethod
     def split_rect_into_squares(r, buttons):


### PR DESCRIPTION
This PR fixes two issues:
- When scrolling through the GUI tables, the old row would sometimes not be deselected. I fixed this by repainting the old hovered row entirely.
- When scrolling through the GUI tables without moving the mouse, the new row selection would be incomplete (e.g., only a particular cell would be highlighted). I addressed this by emitting a mouse move event when scrolling.