### PR TITLE
Introduce "default init" and "unload" methods for Ipv8Component

### DIFF
--- a/src/tribler-core/tribler_core/components/bandwidth_accounting/tests/test_bandwidth_accounting_component.py
+++ b/src/tribler-core/tribler_core/components/bandwidth_accounting/tests/test_bandwidth_accounting_component.py
@@ -7,7 +7,6 @@ from tribler_core.components.base import Session
 from tribler_core.components.ipv8 import Ipv8Component
 from tribler_core.components.masterkey.masterkey_component import MasterKeyComponent
 from tribler_core.components.restapi import RESTComponent
-from tribler_core.restapi.rest_manager import RESTManager
 
 
 # pylint: disable=protected-access
@@ -23,6 +22,6 @@ async def test_bandwidth_accounting_component(tribler_config):
         comp = BandwidthAccountingComponent.instance()
         assert comp.started_event.is_set() and not comp.failed
         assert comp.community
-        assert comp._ipv8
+        assert comp._ipv8_component
 
         await session.shutdown()

--- a/src/tribler-core/tribler_core/components/gigachannel/gigachannel_component.py
+++ b/src/tribler-core/tribler_core/components/gigachannel/gigachannel_component.py
@@ -1,24 +1,20 @@
 from ipv8.peerdiscovery.discovery import RandomWalk
 
-from ipv8_service import IPv8
-
 from tribler_core.components.gigachannel.community.gigachannel_community import (
     GigaChannelCommunity,
     GigaChannelTestnetCommunity,
 )
 from tribler_core.components.gigachannel.community.sync_strategy import RemovePeers
-from tribler_core.components.ipv8 import Ipv8Component
+from tribler_core.components.ipv8 import INFINITE, Ipv8Component
 from tribler_core.components.metadata_store.metadata_store_component import MetadataStoreComponent
 from tribler_core.components.reporter import ReporterComponent
 from tribler_core.components.restapi import RestfulComponent
-
-INFINITE = -1
 
 
 class GigaChannelComponent(RestfulComponent):
     community: GigaChannelCommunity
 
-    _ipv8: IPv8
+    _ipv8_component: Ipv8Component
 
     async def run(self):
         await super().run()
@@ -27,17 +23,14 @@ class GigaChannelComponent(RestfulComponent):
         config = self.session.config
         notifier = self.session.notifier
 
-        ipv8_component = await self.require_component(Ipv8Component)
-        self._ipv8 = ipv8_component.ipv8
-        peer = ipv8_component.peer
-
+        self._ipv8_component = await self.require_component(Ipv8Component)
         metadata_store_component = await self.require_component(MetadataStoreComponent)
 
         giga_channel_cls = GigaChannelTestnetCommunity if config.general.testnet else GigaChannelCommunity
         community = giga_channel_cls(
-            peer,
-            self._ipv8.endpoint,
-            self._ipv8.network,
+            self._ipv8_component.peer,
+            self._ipv8_component.ipv8.endpoint,
+            self._ipv8_component.ipv8.network,
             notifier=notifier,
             settings=config.chant,
             rqc_settings=config.remote_query_community,
@@ -46,15 +39,14 @@ class GigaChannelComponent(RestfulComponent):
         )
         self.community = community
 
-        self._ipv8.add_strategy(community, RandomWalk(community), 30)
-        self._ipv8.add_strategy(community, RemovePeers(community), INFINITE)
+        self._ipv8_component.ipv8.add_strategy(community, RandomWalk(community), 30)
+        self._ipv8_component.ipv8.add_strategy(community, RemovePeers(community), INFINITE)
 
-        community.bootstrappers.append(ipv8_component.make_bootstrapper())
+        community.bootstrappers.append(self._ipv8_component.make_bootstrapper())
 
         await self.init_endpoints(endpoints=['remote_query', 'channels', 'collections'],
                                   values={'gigachannel_community': community})
 
     async def shutdown(self):
         await super().shutdown()
-        if self._ipv8:
-            await self._ipv8.unload_overlay(self.community)
+        await self._ipv8_component.unload_community(self.community)

--- a/src/tribler-core/tribler_core/components/gigachannel/gigachannel_component.py
+++ b/src/tribler-core/tribler_core/components/gigachannel/gigachannel_component.py
@@ -38,12 +38,8 @@ class GigaChannelComponent(RestfulComponent):
             max_peers=50,
         )
         self.community = community
-
-        self._ipv8_component.ipv8.add_strategy(community, RandomWalk(community), 30)
+        self._ipv8_component.initialise_community_by_default(community, default_random_walk_max_peers=30)
         self._ipv8_component.ipv8.add_strategy(community, RemovePeers(community), INFINITE)
-
-        community.bootstrappers.append(self._ipv8_component.make_bootstrapper())
-
         await self.init_endpoints(endpoints=['remote_query', 'channels', 'collections'],
                                   values={'gigachannel_community': community})
 

--- a/src/tribler-core/tribler_core/components/gigachannel/tests/test_gigachannel_component.py
+++ b/src/tribler-core/tribler_core/components/gigachannel/tests/test_gigachannel_component.py
@@ -27,6 +27,6 @@ async def test_giga_channel_component(tribler_config):
         comp = GigaChannelComponent.instance()
         assert comp.started_event.is_set() and not comp.failed
         assert comp.community
-        assert comp._ipv8
+        assert comp._ipv8_component
 
         await session.shutdown()

--- a/src/tribler-core/tribler_core/components/popularity.py
+++ b/src/tribler-core/tribler_core/components/popularity.py
@@ -31,7 +31,7 @@ class PopularityComponent(Component):
                                         torrent_checker=torrent_checker_component.torrent_checker)
         self.community = community
 
-        self._ipv8_component.initialise_community_by_default(community)
+        self._ipv8_component.initialise_community_by_default(community, default_random_walk_max_peers=30)
         self._ipv8_component.ipv8.add_strategy(community, RemovePeers(community), INFINITE)
 
     async def shutdown(self):

--- a/src/tribler-core/tribler_core/components/popularity.py
+++ b/src/tribler-core/tribler_core/components/popularity.py
@@ -1,41 +1,39 @@
-from ipv8.peerdiscovery.discovery import RandomWalk
-from ipv8_service import IPv8
 from tribler_core.components.base import Component
-from tribler_core.components.ipv8 import Ipv8Component
+from tribler_core.components.gigachannel.community.sync_strategy import RemovePeers
+from tribler_core.components.ipv8 import INFINITE, Ipv8Component
 from tribler_core.components.metadata_store.metadata_store_component import MetadataStoreComponent
 from tribler_core.components.reporter import ReporterComponent
 from tribler_core.components.torrent_checker import TorrentCheckerComponent
-from tribler_core.components.gigachannel.community.sync_strategy import RemovePeers
 from tribler_core.modules.popularity.community import PopularityCommunity
 
-INFINITE = -1
 
 
 class PopularityComponent(Component):
     community: PopularityCommunity
-    _ipv8: IPv8
+
+    _ipv8_component: Ipv8Component
 
     async def run(self):
+        await super().run()
         await self.get_component(ReporterComponent)
 
-        config = self.session.config
-        ipv8_component = await self.require_component(Ipv8Component)
-        self._ipv8 = ipv8_component.ipv8
-        peer = ipv8_component.peer
+        self._ipv8_component = await self.require_component(Ipv8Component)
         metadata_store_component = await self.require_component(MetadataStoreComponent)
         torrent_checker_component = await self.require_component(TorrentCheckerComponent)
 
-        community = PopularityCommunity(peer, self._ipv8.endpoint, self._ipv8.network,
+        config = self.session.config
+        community = PopularityCommunity(self._ipv8_component.peer,
+                                        self._ipv8_component.ipv8.endpoint,
+                                        self._ipv8_component.ipv8.network,
                                         settings=config.popularity_community,
                                         rqc_settings=config.remote_query_community,
                                         metadata_store=metadata_store_component.mds,
                                         torrent_checker=torrent_checker_component.torrent_checker)
         self.community = community
 
-        self._ipv8.add_strategy(community, RandomWalk(community), 30)
-        self._ipv8.add_strategy(community, RemovePeers(community), INFINITE)
-
-        community.bootstrappers.append(ipv8_component.make_bootstrapper())
+        self._ipv8_component.initialise_community_by_default(community)
+        self._ipv8_component.ipv8.add_strategy(community, RemovePeers(community), INFINITE)
 
     async def shutdown(self):
-        await self._ipv8.unload_overlay(self.community)
+        await super().shutdown()
+        await self._ipv8_component.unload_community(self.community)

--- a/src/tribler-core/tribler_core/components/tests/test_tribler_components.py
+++ b/src/tribler-core/tribler_core/components/tests/test_tribler_components.py
@@ -63,7 +63,9 @@ async def test_ipv8_component(tribler_config):
 
         await session.shutdown()
 
-    # test dht disabled
+
+async def test_ipv8_component_dht_disabled(tribler_config):
+    tribler_config.ipv8.enabled = True
     tribler_config.dht.enabled = True
     session = Session(tribler_config, [MasterKeyComponent(), RESTComponent(), Ipv8Component()])
     with session:
@@ -72,7 +74,9 @@ async def test_ipv8_component(tribler_config):
         comp = Ipv8Component.instance()
         assert comp.dht_discovery_community
 
-    # test discovery_community enabled
+
+async def test_ipv8_component_discovery_community_enabled(tribler_config):
+    tribler_config.ipv8.enabled = True
     tribler_config.gui_test_mode = False
     tribler_config.discovery_community.enabled = True
     session = Session(tribler_config, [MasterKeyComponent(), RESTComponent(), Ipv8Component()])

--- a/src/tribler-core/tribler_core/components/tunnels.py
+++ b/src/tribler-core/tribler_core/components/tunnels.py
@@ -1,32 +1,25 @@
 from ipv8.dht.provider import DHTCommunityProvider
 from ipv8.messaging.anonymization.community import TunnelSettings
-from ipv8.peerdiscovery.discovery import RandomWalk
-
-from ipv8_service import IPv8
 
 from tribler_core.components.bandwidth_accounting.bandwidth_accounting_component import BandwidthAccountingComponent
-from tribler_core.components.ipv8 import Ipv8Component
+from tribler_core.components.ipv8 import INFINITE, Ipv8Component
 from tribler_core.components.libtorrent import LibtorrentComponent
 from tribler_core.components.restapi import RestfulComponent
 from tribler_core.components.socks_configurator import SocksServersComponent
 from tribler_core.modules.tunnel.community.community import TriblerTunnelCommunity, TriblerTunnelTestnetCommunity
 from tribler_core.modules.tunnel.community.discovery import GoldenRatioStrategy
 
-INFINITE = -1
-
 
 class TunnelsComponent(RestfulComponent):
     community: TriblerTunnelCommunity
-    _ipv8: IPv8
+
+    _ipv8_component: Ipv8Component
 
     async def run(self):
         await super().run()
 
-        config = self.session.config
-        ipv8_component = await self.require_component(Ipv8Component)
-        self._ipv8 = ipv8_component.ipv8
-        peer = ipv8_component.peer
-        dht_discovery_community = ipv8_component.dht_discovery_community
+        self._ipv8_component = await self.require_component(Ipv8Component)
+        dht_discovery_community = self._ipv8_component.dht_discovery_community
 
         bandwidth_component = await self.get_component(BandwidthAccountingComponent)
         bandwidth_community = bandwidth_component.community if bandwidth_component else None
@@ -38,6 +31,7 @@ class TunnelsComponent(RestfulComponent):
         socks_servers = socks_servers_component.socks_servers if socks_servers_component else None
 
         settings = TunnelSettings()
+        config = self.session.config
         settings.min_circuits = config.tunnel_community.min_circuits
         settings.max_circuits = config.tunnel_community.max_circuits
 
@@ -50,29 +44,24 @@ class TunnelsComponent(RestfulComponent):
         exitnode_cache = config.state_dir / "exitnode_cache.dat"
 
         # TODO: decouple bandwidth community and dlmgr to initiate later
-        community = tunnel_cls(peer, self._ipv8.endpoint, self._ipv8.network,
-                               socks_servers=socks_servers,
-                               config=config.tunnel_community,
-                               notifier=self.session.notifier,
-                               dlmgr=download_manager,
-                               bandwidth_community=bandwidth_community,
-                               dht_provider=provider,
-                               exitnode_cache=exitnode_cache,
-                               settings=settings)
+        self.community = tunnel_cls(self._ipv8_component.peer,
+                                    self._ipv8_component.ipv8.endpoint,
+                                    self._ipv8_component.ipv8.network,
+                                    socks_servers=socks_servers,
+                                    config=config.tunnel_community,
+                                    notifier=self.session.notifier,
+                                    dlmgr=download_manager,
+                                    bandwidth_community=bandwidth_community,
+                                    dht_provider=provider,
+                                    exitnode_cache=exitnode_cache,
+                                    settings=settings)
 
-        # Value of `target_peers` must not be equal to the value of `max_peers` for this community.
-        # This causes a deformed network topology and makes it harder for peers to connect to others.
-        # More information: https://github.com/Tribler/py-ipv8/issues/979#issuecomment-896643760
-        self._ipv8.add_strategy(community, RandomWalk(community), 20)
-        self._ipv8.add_strategy(community, GoldenRatioStrategy(community), INFINITE)
+        self._ipv8_component.initialise_community_by_default(self.community)
+        self._ipv8_component.ipv8.add_strategy(self.community, GoldenRatioStrategy(self.community), INFINITE)
 
-        community.bootstrappers.append(ipv8_component.make_bootstrapper())
-
-        self.community = community
-
-        await self.init_endpoints(endpoints=['downloads', 'debug'], values={'tunnel_community': community})
-        await self.init_ipv8_endpoints(self._ipv8, endpoints=['tunnel'])
+        await self.init_endpoints(endpoints=['downloads', 'debug'], values={'tunnel_community': self.community})
+        await self.init_ipv8_endpoints(self._ipv8_component.ipv8, endpoints=['tunnel'])
 
     async def shutdown(self):
         await super().shutdown()
-        await self._ipv8.unload_overlay(self.community)
+        await self._ipv8_component.unload_community(self.community)


### PR DESCRIPTION
Based on https://github.com/Tribler/tribler/pull/6396

```python

class Ipv8Component(RestfulComponent):
    ipv8: IPv8

    def initialise_community_by_default(self, community):
        community.bootstrappers.append(self.make_bootstrapper())

        # Value of `target_peers` must not be equal to the value of `max_peers` for this community.
        # This causes a deformed network topology and makes it harder for peers to connect to others.
        # More information: https://github.com/Tribler/py-ipv8/issues/979#issuecomment-896643760
        random_walk_max_peers = max(10, community.max_peers - 10)
        self.ipv8.add_strategy(community, RandomWalk(community), random_walk_max_peers)

    async def unload_community(self, community):
        await self.ipv8.unload_overlay(community)
```