### PR TITLE
Component fixes

### DIFF
--- a/src/tribler-core/tribler_core/components/bandwidth_accounting/tests/test_bandwidth_accounting_component.py
+++ b/src/tribler-core/tribler_core/components/bandwidth_accounting/tests/test_bandwidth_accounting_component.py
@@ -21,7 +21,7 @@ async def test_bandwidth_accounting_component(tribler_config):
         await session.start()
 
         comp = BandwidthAccountingComponent.instance()
-        assert comp.started.is_set() and not comp.failed
+        assert comp.started_event.is_set() and not comp.failed
         assert comp.community
         assert comp._ipv8
 

--- a/src/tribler-core/tribler_core/components/base.py
+++ b/src/tribler-core/tribler_core/components/base.py
@@ -189,7 +189,7 @@ class Component:
 
         if dep not in self.dependencies:
             self.dependencies.add(dep)
-            dep._use_by(self)
+            dep._use_by(self)  # pylint: disable=protected-access
 
         return dep
 
@@ -201,7 +201,7 @@ class Component:
     def _release_instance(self, dep: Component):
         if dep in self.dependencies:
             self.dependencies.discard(dep)
-            dep._unuse_by(self)
+            dep._unuse_by(self)  # pylint: disable=protected-access
 
     def _use_by(self, component: Component):
         assert component not in self.reverse_dependencies

--- a/src/tribler-core/tribler_core/components/base.py
+++ b/src/tribler-core/tribler_core/components/base.py
@@ -141,11 +141,16 @@ class Component:
         self.logger.info("Waiting for other components to release me")
         await self.unused.wait()
         self.logger.info("Component free, shutting down")
-        await self.shutdown()
-        self.stopped = True
-        for dep in list(self.dependencies):
-            self._release_instance(dep)
-        self.logger.info("Component free, shutting down")
+        try:
+            await self.shutdown()
+        except Exception as e:
+            self.logger.exception(f"Exception in {self.__class__.__name__}.shutdown(): {type(e).__name__}:{e}")
+            raise
+        finally:
+            self.stopped = True
+            for dep in list(self.dependencies):
+                self._release_instance(dep)
+            self.logger.info("Component free, shutting down")
 
     async def run(self):
         pass

--- a/src/tribler-core/tribler_core/components/base.py
+++ b/src/tribler-core/tribler_core/components/base.py
@@ -109,7 +109,7 @@ class Component:
         self.logger.info('__init__')
         self.session: Optional[Session] = None
         self.dependencies: Set[Component] = set()
-        self.in_use_by: Set[Component] = set()
+        self.reverse_dependencies: Set[Component] = set()
         self.started = Event()
         self.failed = False
         self.unused = Event()
@@ -183,7 +183,7 @@ class Component:
             return None
 
         self.dependencies.add(dep)
-        dep.in_use_by.add(self)
+        dep.reverse_dependencies.add(self)
         return dep
 
     def release_component(self, dependency: Type[T]):
@@ -194,6 +194,6 @@ class Component:
     def _release_instance(self, dep: Component):
         assert dep in self.dependencies
         self.dependencies.discard(dep)
-        dep.in_use_by.discard(self)
-        if not dep.in_use_by:
+        dep.reverse_dependencies.discard(self)
+        if not dep.reverse_dependencies:
             dep.unused.set()

--- a/src/tribler-core/tribler_core/components/gigachannel/tests/test_gigachannel_component.py
+++ b/src/tribler-core/tribler_core/components/gigachannel/tests/test_gigachannel_component.py
@@ -25,7 +25,7 @@ async def test_giga_channel_component(tribler_config):
         await session.start()
 
         comp = GigaChannelComponent.instance()
-        assert comp.started.is_set() and not comp.failed
+        assert comp.started_event.is_set() and not comp.failed
         assert comp.community
         assert comp._ipv8
 

--- a/src/tribler-core/tribler_core/components/gigachannel_manager/tests/test_gigachannel_manager_component.py
+++ b/src/tribler-core/tribler_core/components/gigachannel_manager/tests/test_gigachannel_manager_component.py
@@ -26,7 +26,7 @@ async def test_gigachannel_manager_component(tribler_config):
         comp = GigachannelManagerComponent.instance()
         await session.start()
 
-        assert comp.started.is_set() and not comp.failed
+        assert comp.started_event.is_set() and not comp.failed
         assert comp.gigachannel_manager
 
         await session.shutdown()

--- a/src/tribler-core/tribler_core/components/metadata_store/tests/test_metadata_store_component.py
+++ b/src/tribler-core/tribler_core/components/metadata_store/tests/test_metadata_store_component.py
@@ -21,7 +21,7 @@ async def test_metadata_store_component(tribler_config):
         comp = MetadataStoreComponent.instance()
         await session.start()
 
-        assert comp.started.is_set() and not comp.failed
+        assert comp.started_event.is_set() and not comp.failed
         assert comp.mds
 
         await session.shutdown()

--- a/src/tribler-core/tribler_core/components/tests/test_base_component.py
+++ b/src/tribler-core/tribler_core/components/tests/test_base_component.py
@@ -34,7 +34,7 @@ async def test_session_start_shutdown(tribler_config):
 
         for component in a, b:
             assert not component.run_was_executed
-            assert not component.started.is_set()
+            assert not component.started_event.is_set()
             assert not component.shutdown_was_executed
             assert not component.stopped
 
@@ -43,7 +43,7 @@ async def test_session_start_shutdown(tribler_config):
         assert ComponentA.instance() is a and ComponentB.instance() is b
         for component in a, b:
             assert component.run_was_executed
-            assert component.started.is_set()
+            assert component.started_event.is_set()
             assert not component.shutdown_was_executed
             assert not component.stopped
 
@@ -53,7 +53,7 @@ async def test_session_start_shutdown(tribler_config):
         assert ComponentA.instance() is a and ComponentB.instance() is b
         for component in a, b:
             assert component.run_was_executed
-            assert component.started.is_set()
+            assert component.started_event.is_set()
             assert component.shutdown_was_executed
             assert component.stopped
 
@@ -73,20 +73,20 @@ async def test_required_dependency(tribler_config):
 
         for component in a, b:
             assert not component.dependencies and not component.reverse_dependencies
-            assert component.unused.is_set()
+            assert component.unused_event.is_set()
 
         await session.start()
 
         assert a in b.dependencies and not b.reverse_dependencies
         assert not a.dependencies and b in a.reverse_dependencies
-        assert b.unused.is_set() and not a.unused.is_set()
+        assert b.unused_event.is_set() and not a.unused_event.is_set()
 
         session.shutdown_event.set()
         await session.shutdown()
 
         for component in a, b:
             assert not component.dependencies and not component.reverse_dependencies
-            assert component.unused.is_set()
+            assert component.unused_event.is_set()
 
 
 async def test_required_dependency_missed(tribler_config):
@@ -112,7 +112,7 @@ async def test_required_dependency_missed(tribler_config):
         await session.start(failfast=False)
 
         assert ComponentB.instance() is b
-        assert b.started.is_set()
+        assert b.started_event.is_set()
         assert b.failed
 
 
@@ -134,7 +134,7 @@ async def test_component_shutdown_failure(tribler_config):
 
         await session.start()
 
-        assert not a.unused.is_set()
+        assert not a.unused_event.is_set()
 
         with pytest.raises(TestException):
             await session.shutdown()
@@ -142,5 +142,5 @@ async def test_component_shutdown_failure(tribler_config):
         for component in a, b:
             assert not component.dependencies
             assert not component.reverse_dependencies
-            assert component.unused.is_set()
+            assert component.unused_event.is_set()
             assert component.stopped

--- a/src/tribler-core/tribler_core/components/tests/test_base_component.py
+++ b/src/tribler-core/tribler_core/components/tests/test_base_component.py
@@ -74,20 +74,20 @@ async def test_required_dependency_enabled(tribler_config):
         b = ComponentB.instance()
 
         assert not a.started.is_set() and not b.started.is_set()
-        assert not b.dependencies and not a.in_use_by
+        assert not b.dependencies and not a.reverse_dependencies
 
         await session.start()
 
         assert a.started.is_set() and b.started.is_set()
         assert a in b.dependencies
-        assert b in a.in_use_by
+        assert b in a.reverse_dependencies
 
         session.shutdown_event.set()
         await session.shutdown()
 
         assert a.started.is_set() and b.started.is_set()
         assert a.stopped and b.stopped
-        assert not b.dependencies and not a.in_use_by
+        assert not b.dependencies and not a.reverse_dependencies
 
 
 async def test_required_dependency_disabled(tribler_config):
@@ -100,20 +100,20 @@ async def test_required_dependency_disabled(tribler_config):
         b = ComponentB.instance()
 
         assert not a.started.is_set() and not b.started.is_set()
-        assert not b.dependencies and not a.in_use_by
+        assert not b.dependencies and not a.reverse_dependencies
 
         await session.start()
 
         assert a.started.is_set() and b.started.is_set()
         assert a in b.dependencies
-        assert b in a.in_use_by
+        assert b in a.reverse_dependencies
 
         session.shutdown_event.set()
         await session.shutdown()
 
         assert a.started.is_set() and b.started.is_set()
         assert a.stopped and b.stopped
-        assert not b.dependencies and not a.in_use_by
+        assert not b.dependencies and not a.reverse_dependencies
 
 
 async def test_dependency_missed(tribler_config):

--- a/src/tribler-core/tribler_core/components/tests/test_base_component.py
+++ b/src/tribler-core/tribler_core/components/tests/test_base_component.py
@@ -73,17 +73,20 @@ async def test_required_dependency(tribler_config):
 
         for component in a, b:
             assert not component.dependencies and not component.reverse_dependencies
+            assert component.unused.is_set()
 
         await session.start()
 
         assert a in b.dependencies and not b.reverse_dependencies
         assert not a.dependencies and b in a.reverse_dependencies
+        assert b.unused.is_set() and not a.unused.is_set()
 
         session.shutdown_event.set()
         await session.shutdown()
 
         for component in a, b:
             assert not component.dependencies and not component.reverse_dependencies
+            assert component.unused.is_set()
 
 
 async def test_required_dependency_missed(tribler_config):
@@ -130,6 +133,8 @@ async def test_component_shutdown_failure(tribler_config):
         b = ComponentB.instance()
 
         await session.start()
+
+        assert not a.unused.is_set()
 
         with pytest.raises(TestException):
             await session.shutdown()

--- a/src/tribler-core/tribler_core/components/tests/test_base_component.py
+++ b/src/tribler-core/tribler_core/components/tests/test_base_component.py
@@ -74,12 +74,12 @@ async def test_required_dependency_enabled(tribler_config):
         b = ComponentB.instance()
 
         assert not a.started.is_set() and not b.started.is_set()
-        assert not b.components_used_by_me and not a.in_use_by
+        assert not b.dependencies and not a.in_use_by
 
         await session.start()
 
         assert a.started.is_set() and b.started.is_set()
-        assert a in b.components_used_by_me
+        assert a in b.dependencies
         assert b in a.in_use_by
 
         session.shutdown_event.set()
@@ -87,7 +87,7 @@ async def test_required_dependency_enabled(tribler_config):
 
         assert a.started.is_set() and b.started.is_set()
         assert a.stopped and b.stopped
-        assert not b.components_used_by_me and not a.in_use_by
+        assert not b.dependencies and not a.in_use_by
 
 
 async def test_required_dependency_disabled(tribler_config):
@@ -100,12 +100,12 @@ async def test_required_dependency_disabled(tribler_config):
         b = ComponentB.instance()
 
         assert not a.started.is_set() and not b.started.is_set()
-        assert not b.components_used_by_me and not a.in_use_by
+        assert not b.dependencies and not a.in_use_by
 
         await session.start()
 
         assert a.started.is_set() and b.started.is_set()
-        assert a in b.components_used_by_me
+        assert a in b.dependencies
         assert b in a.in_use_by
 
         session.shutdown_event.set()
@@ -113,7 +113,7 @@ async def test_required_dependency_disabled(tribler_config):
 
         assert a.started.is_set() and b.started.is_set()
         assert a.stopped and b.stopped
-        assert not b.components_used_by_me and not a.in_use_by
+        assert not b.dependencies and not a.in_use_by
 
 
 async def test_dependency_missed(tribler_config):
@@ -129,6 +129,6 @@ async def test_dependency_missed(tribler_config):
         assert not ComponentA.instance()
 
         b = ComponentB.instance()
-        assert not b.components_used_by_me
+        assert not b.dependencies
         with pytest.raises(ComponentError):
             await session.start()

--- a/src/tribler-core/tribler_core/components/tests/test_tribler_components.py
+++ b/src/tribler-core/tribler_core/components/tests/test_tribler_components.py
@@ -55,7 +55,7 @@ async def test_ipv8_component(tribler_config):
         await session.start()
 
         comp = Ipv8Component.instance()
-        assert comp.started.is_set() and not comp.failed
+        assert comp.started_event.is_set() and not comp.failed
         assert comp.ipv8
         assert comp.peer
         assert not comp.dht_discovery_community
@@ -74,7 +74,7 @@ async def test_libtorrent_component(tribler_config):
         await session.start()
 
         comp = LibtorrentComponent.instance()
-        assert comp.started.is_set() and not comp.failed
+        assert comp.started_event.is_set() and not comp.failed
         assert comp.download_manager
 
         await session.shutdown()
@@ -89,7 +89,7 @@ async def test_payout_component(tribler_config):
         await session.start()
 
         comp = PayoutComponent.instance()
-        assert comp.started.is_set() and not comp.failed
+        assert comp.started_event.is_set() and not comp.failed
         assert comp.payout_manager
 
         await session.shutdown()
@@ -119,7 +119,7 @@ async def test_reporter_component(tribler_config):
         await session.start()
 
         comp = ReporterComponent.instance()
-        assert comp.started.is_set() and not comp.failed
+        assert comp.started_event.is_set() and not comp.failed
 
         await session.shutdown()
 
@@ -134,7 +134,7 @@ async def test_resource_monitor_component(tribler_config):
         await session.start()
 
         comp = ResourceMonitorComponent.instance()
-        assert comp.started.is_set() and not comp.failed
+        assert comp.started_event.is_set() and not comp.failed
         assert comp.resource_monitor
 
         await session.shutdown()
@@ -147,7 +147,7 @@ async def test_REST_component(tribler_config):
         await session.start()
 
         comp = RESTComponent.instance()
-        assert comp.started.is_set() and not comp.failed
+        assert comp.started_event.is_set() and not comp.failed
         assert comp.rest_manager
 
         await session.shutdown()
@@ -160,7 +160,7 @@ async def test_socks_servers_component(tribler_config):
         await session.start()
 
         comp = SocksServersComponent.instance()
-        assert comp.started.is_set() and not comp.failed
+        assert comp.started_event.is_set() and not comp.failed
         assert comp.socks_ports
         assert comp.socks_servers
 
@@ -177,7 +177,7 @@ async def test_torrent_checker_component(tribler_config):
         await session.start()
 
         comp = TorrentCheckerComponent.instance()
-        assert comp.started.is_set() and not comp.failed
+        assert comp.started_event.is_set() and not comp.failed
         assert comp.torrent_checker
 
         await session.shutdown()
@@ -193,7 +193,7 @@ async def test_tunnels_component(tribler_config):
         await session.start()
 
         comp = TunnelsComponent.instance()
-        assert comp.started.is_set() and not comp.failed
+        assert comp.started_event.is_set() and not comp.failed
         assert comp.community
         assert comp._ipv8
 
@@ -207,7 +207,7 @@ async def test_upgrade_component(tribler_config):
         await session.start()
 
         comp = UpgradeComponent.instance()
-        assert comp.started.is_set() and not comp.failed
+        assert comp.started_event.is_set() and not comp.failed
         assert comp.upgrader
 
         await session.shutdown()
@@ -220,7 +220,7 @@ async def test_version_check_component(tribler_config):
         await session.start()
 
         comp = VersionCheckComponent.instance()
-        assert comp.started.is_set() and not comp.failed
+        assert comp.started_event.is_set() and not comp.failed
         assert comp.version_check_manager
 
         await session.shutdown()
@@ -236,7 +236,7 @@ async def test_watch_folder_component(tribler_config):
         await session.start()
 
         comp = WatchFolderComponent.instance()
-        assert comp.started.is_set() and not comp.failed
+        assert comp.started_event.is_set() and not comp.failed
         assert comp.watch_folder
 
         await session.shutdown()


### PR DESCRIPTION
This PR:
* Fixes issue #6359: an exception in component's `shutdown()` method can prevent correct shutdown of other components.
* Fixes incorrect component tests
* Fixes a bug when component's `unused` event was always set, and component `shutdown()` method could start before all reverse dependencies were released
* Also it renames some component's attributes to make it more readable (`components_used_by_me` -> `dependencies`) and to avoid possible confusion of events with bool flags