### PR TITLE
Move Network overwrite from community to component

### DIFF
--- a/src/tribler-core/tribler_core/components/gigachannel/community/gigachannel_community.py
+++ b/src/tribler-core/tribler_core/components/gigachannel/community/gigachannel_community.py
@@ -90,11 +90,11 @@ class GigaChannelCommunity(RemoteQueryCommunity):
         )
 
     def __init__(
-        self, my_peer, endpoint, network, max_peers=None, notifier=None, **kwargs
+        self, *args, notifier=None, **kwargs
     ):  # pylint: disable=unused-argument
         # ACHTUNG! We create a separate instance of Network for this community because it
         # walks aggressively and wants lots of peers, which can interfere with other communities
-        super().__init__(my_peer, endpoint, Network(), max_peers=50, **kwargs)
+        super().__init__(*args, **kwargs)
 
         self.notifier = notifier
 

--- a/src/tribler-core/tribler_core/components/gigachannel/gigachannel_component.py
+++ b/src/tribler-core/tribler_core/components/gigachannel/gigachannel_component.py
@@ -1,4 +1,5 @@
 from ipv8.peerdiscovery.discovery import RandomWalk
+from ipv8.peerdiscovery.network import Network
 
 from tribler_core.components.gigachannel.community.gigachannel_community import (
     GigaChannelCommunity,
@@ -30,7 +31,7 @@ class GigaChannelComponent(RestfulComponent):
         community = giga_channel_cls(
             self._ipv8_component.peer,
             self._ipv8_component.ipv8.endpoint,
-            self._ipv8_component.ipv8.network,
+            Network(),
             notifier=notifier,
             settings=config.chant,
             rqc_settings=config.remote_query_community,

--- a/src/tribler-core/tribler_core/components/popularity.py
+++ b/src/tribler-core/tribler_core/components/popularity.py
@@ -1,3 +1,4 @@
+from ipv8.peerdiscovery.network import Network
 from tribler_core.components.base import Component
 from tribler_core.components.gigachannel.community.sync_strategy import RemovePeers
 from tribler_core.components.ipv8 import INFINITE, Ipv8Component
@@ -24,7 +25,7 @@ class PopularityComponent(Component):
         config = self.session.config
         community = PopularityCommunity(self._ipv8_component.peer,
                                         self._ipv8_component.ipv8.endpoint,
-                                        self._ipv8_component.ipv8.network,
+                                        Network(),
                                         settings=config.popularity_community,
                                         rqc_settings=config.remote_query_community,
                                         metadata_store=metadata_store_component.mds,

--- a/src/tribler-core/tribler_core/modules/popularity/community.py
+++ b/src/tribler-core/tribler_core/modules/popularity/community.py
@@ -30,9 +30,9 @@ class PopularityCommunity(RemoteQueryCommunity, VersionCommunityMixin):
 
     community_id = unhexlify('9aca62f878969c437da9844cba29a134917e1648')
 
-    def __init__(self, my_peer, endpoint, network, torrent_checker=None, **kwargs):
+    def __init__(self, *args, torrent_checker=None, **kwargs):
         # Creating a separate instance of Network for this community to find more peers
-        super().__init__(my_peer, endpoint, Network(), **kwargs)
+        super().__init__(*args, **kwargs)
         self.torrent_checker = torrent_checker
 
         self.add_message_handler(TorrentsHealthPayload, self.on_torrents_health)


### PR DESCRIPTION
@qstokkink 
> We're injecting self._ipv8_component.ipv8.network as a dependency and then the component itself is overwriting its input with a Network() of its own creation. We should, at some point (probably not this PR) move the Network() overwrite to this file (same for PopularityCommunity).

The `Network() overwrite` has been moved for:
* `PopularityCommunity`
* `GigachannelCommunity`

For `BandwidthAccountingCommunity` I didn't find any place with `Network()` overwriting.