### PR TITLE
Added search box focus, increased width of 'health' column in GUI

### DIFF
--- a/src/tribler-gui/tribler_gui/qt_resources/mainwindow.ui
+++ b/src/tribler-gui/tribler_gui/qt_resources/mainwindow.ui
@@ -3503,8 +3503,8 @@ QTabBar::tab:selected {
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>321</width>
-                       <height>259</height>
+                       <width>308</width>
+                       <height>276</height>
                       </rect>
                      </property>
                      <layout class="QFormLayout" name="formLayout_4">
@@ -5420,6 +5420,10 @@ border: none;
 padding-left: 5px;
 border-radius: 14px;
 color: black;
+}
+
+QLineEdit:focus {
+border: 1px solid #FF924F;
 }</string>
          </property>
          <property name="placeholderText">

--- a/src/tribler-gui/tribler_gui/widgets/tablecontentmodel.py
+++ b/src/tribler-gui/tribler_gui/widgets/tablecontentmodel.py
@@ -60,7 +60,7 @@ def define_columns():
         Column.CATEGORY:   d('category',   "",               width=30, tooltip_filter=lambda data: data),
         Column.NAME:       d('name',       tr("Name"),       width=EXPANDING),
         Column.SIZE:       d('size',       tr("Size"),       width=90, display_filter=lambda data: (format_size(float(data)) if data != "" else "")),
-        Column.HEALTH:     d('health',     tr("Health"),     width=100, tooltip_filter=lambda data: f"{data}" + ('' if data == HEALTH_CHECKING else '\n(Click to recheck)'),),
+        Column.HEALTH:     d('health',     tr("Health"),     width=120, tooltip_filter=lambda data: f"{data}" + ('' if data == HEALTH_CHECKING else '\n(Click to recheck)'),),
         Column.UPDATED:    d('updated',    tr("Updated"),    width=120, display_filter=lambda timestamp: pretty_date(timestamp) if timestamp and timestamp > BITTORRENT_BIRTHDAY else 'N/A',),
         Column.VOTES:      d('votes',      tr("Popularity"), width=120, display_filter=format_votes, tooltip_filter=lambda data: get_votes_rating_description(data) if data is not None else None,),
         Column.STATUS:     d('status',     "",               sortable=False),


### PR DESCRIPTION
- Added focus on the search box focus. Fixes #6260.

<img width="556" alt="Schermafbeelding 2021-10-05 om 12 07 26" src="https://user-images.githubusercontent.com/1707075/136031324-3e2ff8cc-d362-4fa3-9182-778a61497a4c.png">

- Slightly increased the width of the 'health' column in the GUI. Fixes #6409.

<img width="471" alt="Schermafbeelding 2021-10-05 om 15 22 53" src="https://user-images.githubusercontent.com/1707075/136031432-eac15d0e-0606-4eba-b8f6-b10afb611db3.png">


