### PR TITLE
Fixes #6407: `RESTManager.get_endpoint(endpoint_name)` should return …

### DIFF
--- a/src/tribler-core/tribler_core/restapi/rest_manager.py
+++ b/src/tribler-core/tribler_core/restapi/rest_manager.py
@@ -96,7 +96,7 @@ class RESTManager:
         self.state_dir = state_dir
 
     def get_endpoint(self, name):
-        return self.root_endpoint.endpoints['/' + name]
+        return self.root_endpoint.endpoints.get('/' + name)
 
     async def start(self):
         """


### PR DESCRIPTION
This PR fixes #6407. Now `RESTManager.get_endpoint(endpoint_name)` returns None if endpoint with this name does not exist.

Also, some types were added to previously untyped variables.