### PR TITLE
Removed channels from metadata endpoint docstring

### DIFF
--- a/src/tribler-core/tribler_core/components/metadata_store/restapi/metadata_endpoint.py
+++ b/src/tribler-core/tribler_core/components/metadata_store/restapi/metadata_endpoint.py
@@ -48,7 +48,6 @@ class MetadataEndpoint(MetadataEndpointBase, UpdateEntryMixin):
     This is the top-level endpoint class that serves other endpoints.
 
     # /metadata
-    #          /channels
     #          /torrents
     #          /<public_key>
     """


### PR DESCRIPTION
/channels seems to be a root endpoint and is not part of /metadata anymore.