### PR TITLE
Removed popular torrents explanation box

### DIFF
--- a/src/tribler-gui/tribler_gui/qt_resources/mainwindow.ui
+++ b/src/tribler-gui/tribler_gui/qt_resources/mainwindow.ui
@@ -102,7 +102,11 @@ color:#B5B5B5;
 }
 
 QCheckBox { color:#B5B5B5; }
-QCheckBox::indicator:unchecked {border: 1px solid #555;}</string>
+QCheckBox::indicator:unchecked {border: 1px solid #555;}
+
+QToolButton QToolTip {
+padding: 4px;
+}</string>
   </property>
   <widget class="QWidget" name="central_widget">
    <property name="styleSheet">
@@ -613,7 +617,7 @@ QListWidget::item:disabled
       <item>
        <widget class="QStackedWidget" name="stackedWidget">
         <property name="currentIndex">
-         <number>1</number>
+         <number>6</number>
         </property>
         <widget class="SearchResultsWidget" name="search_results_page"/>
         <widget class="SettingsPage" name="settings_page">

--- a/src/tribler-gui/tribler_gui/qt_resources/torrents_list.ui
+++ b/src/tribler-gui/tribler_gui/qt_resources/torrents_list.ui
@@ -247,6 +247,39 @@ color: #B5B5B5;</string>
        </widget>
       </item>
       <item>
+       <widget class="InstantTooltipButton" name="explanation_tooltip_button">
+        <property name="minimumSize">
+         <size>
+          <width>20</width>
+          <height>20</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>20</width>
+          <height>20</height>
+         </size>
+        </property>
+        <property name="font">
+         <font>
+          <pointsize>14</pointsize>
+         </font>
+        </property>
+        <property name="toolTip">
+         <string>This page show the list of popular torrents collected by Tribler during the last 24 hours.</string>
+        </property>
+        <property name="styleSheet">
+         <string notr="true">border: 1px solid white;
+color: white;
+border-radius: 10px;
+</string>
+        </property>
+        <property name="text">
+         <string>i</string>
+        </property>
+       </widget>
+      </item>
+      <item>
        <spacer name="horizontalSpacer_16">
         <property name="orientation">
          <enum>Qt::Horizontal</enum>
@@ -488,28 +521,6 @@ QToolButton{border:none;margin-left:16px;}</string>
           </spacer>
          </item>
         </layout>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QWidget" name="explanation_container" native="true">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout2324">
-      <item>
-       <widget class="QLabel" name="explanation_text">
-        <property name="styleSheet">
-         <string notr="true">color: #eee; font-size: 15px; font-style: italic;</string>
-        </property>
-        <property name="text">
-         <string notr="true">explanation text for channel</string>
-        </property>
        </widget>
       </item>
      </layout>
@@ -855,6 +866,11 @@ QTableView::item::hover {
    <class>ChannelDescriptionWidget</class>
    <extends>QWidget</extends>
    <header>tribler_gui.widgets.channeldescriptionwidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>InstantTooltipButton</class>
+   <extends>QToolButton</extends>
+   <header>tribler_gui.widgets.instanttooltipbutton.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/src/tribler-gui/tribler_gui/tribler_window.py
+++ b/src/tribler-gui/tribler_gui/tribler_window.py
@@ -81,6 +81,7 @@ from tribler_gui.utilities import (
     tr,
 )
 from tribler_gui.widgets.channelsmenulistwidget import ChannelsMenuListWidget
+from tribler_gui.widgets.instanttooltipstyle import InstantTooltipStyle
 from tribler_gui.widgets.tablecontentmodel import DiscoveredChannelsModel, PopularTorrentsModel
 from tribler_gui.widgets.triblertablecontrollers import PopularContentTableViewController
 
@@ -446,10 +447,7 @@ class TriblerWindow(QMainWindow):
         self.popular_page.initialize_root_model(
             PopularTorrentsModel(channel_info={"name": tr("Popular torrents")}, hide_xxx=self.hide_xxx)
         )
-        self.popular_page.explanation_text.setText(
-            tr("This page show the list of popular torrents collected by Tribler during the last 24 hours.")
-        )
-        self.popular_page.explanation_container.setHidden(False)
+        self.popular_page.explanation_tooltip_button.setHidden(False)
 
         self.add_to_channel_dialog.load_channel(0)
 
@@ -466,6 +464,8 @@ class TriblerWindow(QMainWindow):
 
         # Toggle debug if developer mode is enabled
         self.window().debug_panel_button.setHidden(not get_gui_setting(self.gui_settings, "debug", False, is_bool=True))
+
+        QApplication.setStyle(InstantTooltipStyle(QApplication.style()))
 
     @property
     def hide_xxx(self):

--- a/src/tribler-gui/tribler_gui/widgets/channelcontentswidget.py
+++ b/src/tribler-gui/tribler_gui/widgets/channelcontentswidget.py
@@ -86,10 +86,9 @@ class ChannelContentsWidget(AddBreadcrumbOnShowMixin, widget_form, widget_class)
                     obj.blockSignals(False)
 
         self.freeze_controls = freeze_controls_class
-        self.setStyleSheet("QToolTip { color: #222222; background-color: #eeeeee; border: 0px; }")
         self.channel_description_container.setHidden(True)
 
-        self.explanation_container.setHidden(True)
+        self.explanation_tooltip_button.setHidden(True)
 
     def hide_all_labels(self):
         self.edit_channel_contents_top_bar.setHidden(True)

--- a/src/tribler-gui/tribler_gui/widgets/instanttooltipbutton.py
+++ b/src/tribler-gui/tribler_gui/widgets/instanttooltipbutton.py
@@ -1,0 +1,10 @@
+from PyQt5.QtWidgets import QToolButton
+
+
+class InstantTooltipButton(QToolButton):
+    """
+    This class represents a button that immediately shows a tooltip when being hovered over.
+    Unfortunately, there are some issues in PyQt that makes it challenging to customize the background.
+    For example, the background is not correctly clipped, also see https://stackoverflow.com/questions/39120586.
+    Also, it seems that we are unable to modify the border-radius on tooltips without using a custom mask.
+    """

--- a/src/tribler-gui/tribler_gui/widgets/instanttooltipstyle.py
+++ b/src/tribler-gui/tribler_gui/widgets/instanttooltipstyle.py
@@ -1,0 +1,15 @@
+from PyQt5.QtWidgets import QProxyStyle, QStyle
+
+from tribler_gui.widgets.instanttooltipbutton import InstantTooltipButton
+
+
+class InstantTooltipStyle(QProxyStyle):
+    """
+    Proxy style to make sure that there is a zero tooltip delay for particular widgets.
+    Specifically used to implement InstantTooltipButton.
+    """
+
+    def styleHint(self, hint, option=None, widget=None, returnData=None):
+        if isinstance(widget, InstantTooltipButton) and hint == QStyle.SH_ToolTip_WakeUpDelay:
+            return 0
+        return QProxyStyle.styleHint(self, hint, option, widget, returnData)


### PR DESCRIPTION
This was harder than I thought. There were two complications when implementing this. First, I was unable to place the explanation box directly to the right of the text (as I did on the trust page). This is because the title widget is used for the channel navigation breadcrumb and modifying the width constraints breaks the breadcrumb computations. So I decided to put the widget to the right of the page.

Second, it seems that there is a bug that prevents customization of the QToolTip using CSS. The proper way to address this issue is by providing a custom mask but that's more complicated for now. The tooltip is not clipped correctly and there are some ugly borders visible. Fortunately, they blend with the background so they are hard to spot.

I believe the end result is acceptable and preferred over the old approach, but let me know if not (note that I cannot change the border radius/color due to the bug).

![Schermafbeelding 2021-10-08 om 14 08 14](https://user-images.githubusercontent.com/1707075/136555516-42a92795-ee15-4eb9-beb6-4c115ea78b72.png)


Fixes #6389