### PR TITLE
Remove unnecessary lines from components' tests.

### DIFF
--- a/src/tribler-core/tribler_core/components/bandwidth_accounting/tests/test_bandwidth_accounting_component.py
+++ b/src/tribler-core/tribler_core/components/bandwidth_accounting/tests/test_bandwidth_accounting_component.py
@@ -11,7 +11,6 @@ from tribler_core.components.restapi import RESTComponent
 
 @pytest.mark.asyncio
 async def test_bandwidth_accounting_component(tribler_config):
-    tribler_config.ipv8.enabled = True
     components = [RESTComponent(), MasterKeyComponent(), Ipv8Component(), BandwidthAccountingComponent()]
     session = Session(tribler_config, components)
     with session:

--- a/src/tribler-core/tribler_core/components/gigachannel/tests/test_gigachannel_component.py
+++ b/src/tribler-core/tribler_core/components/gigachannel/tests/test_gigachannel_component.py
@@ -12,9 +12,6 @@ from tribler_core.components.restapi import RESTComponent
 
 @pytest.mark.asyncio
 async def test_giga_channel_component(tribler_config):
-    tribler_config.ipv8.enabled = True
-    tribler_config.libtorrent.enabled = True
-    tribler_config.chant.enabled = True
     components = [MetadataStoreComponent(), RESTComponent(), MasterKeyComponent(), Ipv8Component(),
                   GigaChannelComponent()]
     session = Session(tribler_config, components)

--- a/src/tribler-core/tribler_core/components/gigachannel_manager/tests/test_gigachannel_manager_component.py
+++ b/src/tribler-core/tribler_core/components/gigachannel_manager/tests/test_gigachannel_manager_component.py
@@ -13,9 +13,6 @@ from tribler_core.components.socks_configurator import SocksServersComponent
 
 @pytest.mark.asyncio
 async def test_gigachannel_manager_component(tribler_config):
-    tribler_config.ipv8.enabled = True
-    tribler_config.libtorrent.enabled = True
-    tribler_config.chant.enabled = True
     components = [SocksServersComponent(), MasterKeyComponent(), RESTComponent(), MetadataStoreComponent(),
                   LibtorrentComponent(), GigachannelManagerComponent()]
     session = Session(tribler_config, components)

--- a/src/tribler-core/tribler_core/components/ipv8/tests/test_ipv8_component.py
+++ b/src/tribler-core/tribler_core/components/ipv8/tests/test_ipv8_component.py
@@ -10,7 +10,6 @@ pytestmark = pytest.mark.asyncio
 
 # pylint: disable=protected-access
 async def test_ipv8_component(tribler_config):
-    tribler_config.ipv8.enabled = True
     session = Session(tribler_config, [MasterKeyComponent(), RESTComponent(), Ipv8Component()])
     with session:
         await session.start()

--- a/src/tribler-core/tribler_core/components/metadata_store/tests/test_metadata_store_component.py
+++ b/src/tribler-core/tribler_core/components/metadata_store/tests/test_metadata_store_component.py
@@ -13,8 +13,6 @@ from tribler_core.restapi.rest_manager import RESTManager
 
 @pytest.mark.asyncio
 async def test_metadata_store_component(tribler_config):
-    tribler_config.libtorrent.enabled = True
-    tribler_config.chant.enabled = True
     components = [MasterKeyComponent(), RESTComponent(), MetadataStoreComponent()]
     session = Session(tribler_config, components)
     with session:

--- a/src/tribler-core/tribler_core/components/tests/test_tribler_components.py
+++ b/src/tribler-core/tribler_core/components/tests/test_tribler_components.py
@@ -70,8 +70,6 @@ async def test_socks_servers_component(tribler_config):
 
 
 async def test_torrent_checker_component(tribler_config):
-    tribler_config.libtorrent.enabled = True
-    tribler_config.chant.enabled = True
     components = [SocksServersComponent(), LibtorrentComponent(), MasterKeyComponent(), RESTComponent(),
                   MetadataStoreComponent(), TorrentCheckerComponent()]
     session = Session(tribler_config, components)
@@ -86,9 +84,6 @@ async def test_torrent_checker_component(tribler_config):
 
 
 async def test_tunnels_component(tribler_config):
-    tribler_config.ipv8.enabled = True
-    tribler_config.libtorrent.enabled = True
-    tribler_config.chant.enabled = True
     components = [Ipv8Component(), MasterKeyComponent(), RESTComponent(), TunnelsComponent()]
     session = Session(tribler_config, components)
     with session:
@@ -129,8 +124,6 @@ async def test_version_check_component(tribler_config):
 
 
 async def test_watch_folder_component(tribler_config):
-    tribler_config.libtorrent.enabled = True
-    tribler_config.chant.enabled = True
     components = [MasterKeyComponent(), RESTComponent(), SocksServersComponent(), LibtorrentComponent(),
                   WatchFolderComponent()]
     session = Session(tribler_config, components)


### PR DESCRIPTION
This PR is an addition to the https://github.com/Tribler/tribler/pull/6418. It removes unnecessary lines from components' tests.

Addresses https://github.com/Tribler/tribler/issues/6407