### PR TITLE
Tag System: Verify tag doesn't contain any spaces

### DIFF
--- a/src/tribler-core/tribler_core/components/tag/community/tag_payload.py
+++ b/src/tribler-core/tribler_core/components/tag/community/tag_payload.py
@@ -25,6 +25,7 @@ class TagOperation:
     def validate(self):
         assert MIN_TAG_LENGTH <= len(self.tag) <= MAX_TAG_LENGTH, 'Tag length should be in range [3..50]'
         assert not any(ch.isupper() for ch in self.tag), 'Tag should not contain upper-case letters'
+        assert ' ' not in self.tag, 'Tag should not contain any spaces'
 
         # try to convert operation into Enum
         assert TagOperationEnum(self.operation)

--- a/src/tribler-core/tribler_core/components/tag/community/tests/test_tag_payload.py
+++ b/src/tribler-core/tribler_core/components/tag/community/tests/test_tag_payload.py
@@ -49,3 +49,8 @@ async def test_contain_upper_case():
 async def test_contain_upper_case_not_latin():
     with pytest.raises(AssertionError):
         create_message(tag='Тэг').validate()
+
+
+async def test_contain_any_space():
+    with pytest.raises(AssertionError):
+        create_message(tag="tag with space").validate()


### PR DESCRIPTION
This PR extends the verification of a tag to ensure that the tag doesn't contain any spaces.

Related to #6214