### PR TITLE
Fix popular torrents

### DIFF
--- a/src/tribler-core/tribler_core/components/metadata_store/db/store.py
+++ b/src/tribler-core/tribler_core/components/metadata_store/db/store.py
@@ -636,7 +636,9 @@ class MetadataStore:
                     health
                     for health in self.TorrentState
                     if health.last_check >= t and (health.seeders > 0 or health.leechers > 0)
-                ).order_by(lambda health: (health.seeders, health.leechers, health.last_check))[:POPULAR_TORRENTS_COUNT]
+                ).order_by(
+                    lambda health: (desc(health.seeders), desc(health.leechers), desc(health.last_check))
+                )[:POPULAR_TORRENTS_COUNT]
             )
             pony_query = pony_query.where(lambda g: g.health in health_list)
 


### PR DESCRIPTION
Popular torrents of last 24 hours are now sorted on descending order of seeders, leechers and the last health check timestamp.