### PR TITLE
Moved tag rect metadata to a separate dictionary in model

### DIFF
--- a/src/tribler-gui/tribler_gui/widgets/lazytableview.py
+++ b/src/tribler-gui/tribler_gui/widgets/lazytableview.py
@@ -1,9 +1,9 @@
 import json
 from typing import List
 
-from PyQt5.QtCore import QModelIndex, QRect, QTimer, Qt, pyqtSignal, QEvent
+from PyQt5.QtCore import QEvent, QModelIndex, QRect, QTimer, Qt, pyqtSignal
 from PyQt5.QtGui import QGuiApplication, QMouseEvent, QMovie
-from PyQt5.QtWidgets import QAbstractItemView, QLabel, QTableView, QHeaderView, QApplication
+from PyQt5.QtWidgets import QAbstractItemView, QApplication, QHeaderView, QLabel, QTableView
 
 from tribler_core.components.metadata_store.db.orm_bindings.channel_node import LEGACY_ENTRY
 from tribler_core.components.metadata_store.db.serialization import CHANNEL_TORRENT, COLLECTION_NODE, REGULAR_TORRENT
@@ -117,11 +117,10 @@ class TriblerContentTableView(QTableView):
         should_select_row = True
         index = self.indexAt(event.pos())
         if index != self.delegate.no_index:
-            data_item = self.model().data_items[index.row()]
-
             # Check if we are clicking the 'edit tags' button
-            if data_item and "edit_tags_button_rect" in data_item:
-                if data_item["edit_tags_button_rect"].contains(event.pos()) and event.button() != Qt.RightButton:
+            if index in index.model().edit_tags_rects:
+                rect = index.model().edit_tags_rects[index]
+                if rect.contains(event.pos()) and event.button() != Qt.RightButton:
                     should_select_row = False
                     self.on_edit_tags_clicked(index)
 

--- a/src/tribler-gui/tribler_gui/widgets/tablecontentmodel.py
+++ b/src/tribler-gui/tribler_gui/widgets/tablecontentmodel.py
@@ -2,9 +2,9 @@ import json
 import uuid
 from dataclasses import dataclass, field
 from enum import Enum, auto
-from typing import Callable
+from typing import Callable, Dict
 
-from PyQt5.QtCore import QAbstractTableModel, QModelIndex, Qt, pyqtSignal, QSize
+from PyQt5.QtCore import QAbstractTableModel, QModelIndex, QRectF, QSize, Qt, pyqtSignal
 
 from tribler_common.simpledefs import CHANNELS_VIEW_UUID, CHANNEL_STATE
 
@@ -348,6 +348,9 @@ class ChannelContentModel(RemoteTableModel):
         self.type_filter = type_filter
         self.category_filter = None
 
+        # Stores metadata of the 'edit tags' button in each cell.
+        self.edit_tags_rects: Dict[QModelIndex, QRectF] = {}
+
         # Current channel attributes. This is intentionally NOT copied, so local changes
         # can propagate to the origin, e.g. parent channel.
         self.channel_info = channel_info or {"name": "My channels", "status": 123}
@@ -440,6 +443,7 @@ class ChannelContentModel(RemoteTableModel):
 
     def reset(self):
         self.item_uid_map.clear()
+        self.edit_tags_rects.clear()
         super().reset()
 
     def update_node_info(self, update_dict):


### PR DESCRIPTION
On hindsight, adding the `QRectF` data to the `data_items` is not the best strategy. These changes move the tag rectangle metadata outside `data_items` into a separate dictionary. This dictionary is also cleared when the model resets.

Fixes #6498