### PR TITLE
Avoid modifying global category/filters in tests

### DIFF
--- a/src/tribler-core/tribler_core/components/metadata_store/category_filter/category.py
+++ b/src/tribler-core/tribler_core/components/metadata_store/category_filter/category.py
@@ -35,15 +35,17 @@ class Category:
     __size_change = 1024 * 1024
     _logger = logging.getLogger("Category")
 
-    category_info = getCategoryInfo(CATEGORY_CONFIG_FILE)
-    category_info.sort(key=cmp_to_key(cmp_rank))
+    def __init__(self, xxx_filter=default_xxx_filter):
+        self.category_info = getCategoryInfo(CATEGORY_CONFIG_FILE)
+        self.category_info.sort(key=cmp_to_key(cmp_rank))
+        self.xxx_filter = xxx_filter
 
     def calculateCategory(self, torrent_dict, display_name):
         """
         Calculate the category for a given torrent_dict of a torrent file.
         :return a list of categories this torrent belongs to.
         """
-        is_xxx = default_xxx_filter.isXXXTorrent(
+        is_xxx = self.xxx_filter.isXXXTorrent(
             files_list=recursive_unicode(torrent_dict[b'info']["files"] if "files" in torrent_dict[b'info'] else []),
             torrent_name=torrent_dict[b'info'].get(b"name", b'').decode('utf-8'),
             tracker=torrent_dict[b'info'].get(b"announce", b'').decode('utf-8'))

--- a/src/tribler-core/tribler_core/components/metadata_store/category_filter/family_filter.py
+++ b/src/tribler-core/tribler_core/components/metadata_store/category_filter/family_filter.py
@@ -35,7 +35,8 @@ def initTerms(filename):
 class XXXFilter:
     _logger = logging.getLogger("XXXFilter")
 
-    xxx_terms, xxx_searchterms = initTerms(termfilename)
+    def __init__(self):
+        self.xxx_terms, self.xxx_searchterms = initTerms(termfilename)
 
     def _getWords(self, string):
         return [a.lower() for a in WORDS_REGEXP.findall(string)]

--- a/src/tribler-core/tribler_core/components/metadata_store/category_filter/tests/test_category.py
+++ b/src/tribler-core/tribler_core/components/metadata_store/category_filter/tests/test_category.py
@@ -1,36 +1,47 @@
-from tribler_core.components.metadata_store.category_filter.category import cmp_rank, default_category_filter
-from tribler_core.components.metadata_store.category_filter.family_filter import default_xxx_filter
+import pytest
+
+from tribler_core.components.metadata_store.category_filter.category import Category, cmp_rank
+from tribler_core.components.metadata_store.category_filter.family_filter import XXXFilter
 
 
-default_xxx_filter.xxx_terms.add("term1")
+@pytest.fixture(name="xxx_filter")
+def fixture_xxx_filter():
+    return XXXFilter()
 
 
-def test_get_category_names():
-    assert len(default_category_filter.category_info) == 10
+@pytest.fixture(name="category_filter")
+def fixture_category_filter(xxx_filter):
+    return Category(xxx_filter=xxx_filter)
 
 
-def test_calculate_category_multi_file():
+def test_get_category_names(category_filter):
+    assert len(category_filter.category_info) == 10
+
+
+def test_calculate_category_multi_file(category_filter):
     torrent_info = {b"info": {b"files": [{b"path": [b"my", b"path", b"video.avi"], b"length": 1234}]},
                     b"announce": b"http://tracker.org", b"comment": b"lorem ipsum"}
-    assert default_category_filter.calculateCategory(torrent_info, "my torrent") == "VideoClips"
+    assert category_filter.calculateCategory(torrent_info, "my torrent") == "VideoClips"
 
 
-def test_calculate_category_single_file():
+def test_calculate_category_single_file(category_filter):
     torrent_info = {b"info": {b"name": b"my_torrent", b"length": 1234},
                     b"announce-list": [[b"http://tracker.org"]], b"comment": b"lorem ipsum"}
-    assert default_category_filter.calculateCategory(torrent_info, "my torrent"), "other"
+    assert category_filter.calculateCategory(torrent_info, "my torrent"), "other"
 
 
-def test_calculate_category_xxx():
+def test_calculate_category_xxx(category_filter, xxx_filter):
+    xxx_filter.xxx_terms.add("term1")
     torrent_info = {b"info": {b"name": b"term1", b"length": 1234},
                     b"announce-list": [[b"http://tracker.org"]], b"comment": b"lorem ipsum"}
-    assert default_category_filter.calculateCategory(torrent_info, "my torrent") == "xxx"
+    assert category_filter.calculateCategory(torrent_info, "my torrent") == "xxx"
 
 
-def test_calculate_category_invalid_announce_list():
+def test_calculate_category_invalid_announce_list(category_filter, xxx_filter):
+    xxx_filter.xxx_terms.add("term1")
     torrent_info = {b"info": {b"name": b"term1", b"length": 1234},
                     b"announce-list": [[]], b"comment": b"lorem ipsum"}
-    assert default_category_filter.calculateCategory(torrent_info, "my torrent") == "xxx"
+    assert category_filter.calculateCategory(torrent_info, "my torrent") == "xxx"
 
 
 def test_cmp_rank():


### PR DESCRIPTION
In the metadata store tests, we are modifying `default_xxx_filter` and add a term to it. This change is persistent across different tests, potentially leading to test failures. This PR modifies the tests and increases flexibility by creating separate instances of `Category` and `XXXFilter`. These objects are manipulated without affecting `default_category_filter` or `default_xxx_filter`.

Fixes #6500 (hopefully)