### PR TITLE
Improvements to Tribler window initialization

### DIFF
--- a/src/tribler-gui/tribler_gui/tribler_window.py
+++ b/src/tribler-gui/tribler_gui/tribler_window.py
@@ -13,6 +13,7 @@ from PyQt5.QtCore import (
     QDir,
     QObject,
     QPoint,
+    QRect,
     QStringListModel,
     QTimer,
     QUrl,
@@ -293,7 +294,13 @@ class TriblerWindow(QMainWindow):
         self.resize(size)
 
         center = QApplication.desktop().availableGeometry(self).center()
-        pos = self.gui_settings.value("pos", QPoint(center.x() - self.width() / 2, center.y() - self.height() / 2))
+        screen_center_pos = QPoint(center.x() - self.width() / 2, center.y() - self.height() / 2)
+        pos = self.gui_settings.value("pos", screen_center_pos)
+
+        if not QApplication.desktop().availableGeometry(self).intersects(QRect(pos, self.size())):
+            self._logger.info("Resetting window position since it's outside the screen boundaries")
+            pos = screen_center_pos
+
         self.move(pos)
 
         self.show()


### PR DESCRIPTION
This PR makes the following two changes:
- Tribler now first resizes itself and then computes the desired position. Since computing the position depends on the window sizes, this should correctly put the Tribler screen in the center.
- Resetting the position when the Tribler window is outside the visible screen. Fixes #6243.