### PR TITLE
Fixes #6514: Move to_fts_query function from tribler_gui.utilities to tribler_common.utilities

### DIFF
--- a/src/tribler-common/tribler_common/tests/test_utils.py
+++ b/src/tribler-common/tribler_common/tests/test_utils.py
@@ -1,9 +1,16 @@
 from pathlib import Path
 
-from tribler_common.utilities import uri_to_path
+from tribler_common.utilities import to_fts_query, uri_to_path
 
 
 def test_uri_to_path():
     path = Path(__file__).parent / "bla%20foo.bar"
     uri = path.as_uri()
     assert uri_to_path(uri) == path
+
+
+def test_to_fts_query():
+    assert to_fts_query('') == ''
+    assert to_fts_query('abc') == '"abc"*'
+    assert to_fts_query('abc def') == '"abc" "def"*'
+    assert to_fts_query('[abc, def]: xyz?!') == '"abc" "def" "xyz"*'

--- a/src/tribler-common/tribler_common/utilities.py
+++ b/src/tribler-common/tribler_common/utilities.py
@@ -1,4 +1,5 @@
 import os
+import re
 import sys
 from pathlib import Path
 from urllib.parse import urlparse
@@ -21,3 +22,13 @@ def uri_to_path(uri):
     parsed = urlparse(uri)
     host = "{0}{0}{mnt}{0}".format(os.path.sep, mnt=parsed.netloc)
     return Path(host) / url2pathname(parsed.path)
+
+
+fts_query_re = re.compile(r'\w+', re.UNICODE)
+
+
+def to_fts_query(text):
+    if not text:
+        return ""
+    words = fts_query_re.findall(text)
+    return ' '.join(f'"{word}"' for word in words) + '*'

--- a/src/tribler-core/tribler_core/components/metadata_store/restapi/tests/test_search_endpoint.py
+++ b/src/tribler-core/tribler_core/components/metadata_store/restapi/tests/test_search_endpoint.py
@@ -4,11 +4,11 @@ from pony.orm import db_session
 
 import pytest
 
+from tribler_common.utilities import to_fts_query
+
 from tribler_core.components.metadata_store.restapi.search_endpoint import SearchEndpoint
 from tribler_core.components.restapi.rest.base_api_test import do_request
 from tribler_core.utilities.random_utils import random_infohash
-
-from tribler_gui.utilities import to_fts_query
 
 # pylint: disable=unused-argument, redefined-outer-name
 

--- a/src/tribler-gui/tribler_gui/utilities.py
+++ b/src/tribler-gui/tribler_gui/utilities.py
@@ -2,7 +2,6 @@ import inspect
 import logging
 import math
 import os
-import re
 import sys
 import traceback
 import types
@@ -435,11 +434,3 @@ def get_translator(language=None):
     filename = ""
     translator.load(locale, filename, directory=TRANSLATIONS_DIR)
     return translator
-
-fts_query_re = re.compile(r'\w+', re.UNICODE)
-
-def to_fts_query(text):
-    if not text:
-        return ""
-    words = fts_query_re.findall(text)
-    return ' '.join(f'"{word}"' for word in words) + '*'

--- a/src/tribler-gui/tribler_gui/widgets/searchresultswidget.py
+++ b/src/tribler-gui/tribler_gui/widgets/searchresultswidget.py
@@ -7,11 +7,12 @@ from PyQt5 import uic
 from PyQt5.QtCore import pyqtSignal
 
 from tribler_common.sentry_reporter.sentry_mixin import AddBreadcrumbOnShowMixin
+from tribler_common.utilities import to_fts_query
 
 from tribler_core.components.metadata_store.db.serialization import CHANNEL_TORRENT, COLLECTION_NODE, REGULAR_TORRENT
 
 from tribler_gui.tribler_request_manager import TriblerNetworkRequest
-from tribler_gui.utilities import connect, get_ui_file_path, to_fts_query, tr
+from tribler_gui.utilities import connect, get_ui_file_path, tr
 from tribler_gui.widgets.tablecontentmodel import SearchResultsModel
 
 widget_form, widget_class = uic.loadUiType(get_ui_file_path('search_results.ui'))

--- a/src/tribler-gui/tribler_gui/widgets/tablecontentmodel.py
+++ b/src/tribler-gui/tribler_gui/widgets/tablecontentmodel.py
@@ -7,6 +7,7 @@ from typing import Callable, Dict
 from PyQt5.QtCore import QAbstractTableModel, QModelIndex, QRectF, QSize, Qt, pyqtSignal
 
 from tribler_common.simpledefs import CHANNELS_VIEW_UUID, CHANNEL_STATE
+from tribler_common.utilities import to_fts_query
 
 from tribler_core.components.metadata_store.db.orm_bindings.channel_node import NEW
 from tribler_core.components.metadata_store.db.serialization import CHANNEL_TORRENT, COLLECTION_NODE, REGULAR_TORRENT
@@ -19,7 +20,6 @@ from tribler_gui.utilities import (
     format_votes,
     get_votes_rating_description,
     pretty_date,
-    to_fts_query,
     tr,
 )
 


### PR DESCRIPTION
This PR should fix failing test_tribler_main job by fixing incorrect imports