### PR TITLE
Refactor the error reporting chain

### DIFF
--- a/src/tribler-common/tribler_common/reported_error.py
+++ b/src/tribler-common/tribler_common/reported_error.py
@@ -1,0 +1,14 @@
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class ReportedError:
+    type: str
+    text: str
+    event: dict
+
+    long_text: str = ''
+    context: str = ''
+    should_stop: Optional[bool] = None
+    requires_user_consent: bool = True

--- a/src/tribler-common/tribler_common/sentry_reporter/sentry_tools.py
+++ b/src/tribler-common/tribler_common/sentry_reporter/sentry_tools.py
@@ -3,6 +3,9 @@ simplify work with several data structures.
 """
 import re
 
+LONG_TEXT_DELIMITER = '--LONG TEXT--'
+CONTEXT_DELIMITER = '--CONTEXT--'
+
 
 def parse_os_environ(array):
     """Parse os.environ field.
@@ -52,11 +55,10 @@ def parse_stacktrace(stacktrace, delimiters=None):
     Returns:
         The generator of stacktrace parts.
     """
-    if delimiters is None:
-        delimiters = ['--LONG TEXT--', '--CONTEXT--']
-
     if not stacktrace:
         return
+
+    delimiters = delimiters or [LONG_TEXT_DELIMITER, CONTEXT_DELIMITER]
 
     for part in re.split('|'.join(delimiters), stacktrace):
         yield [line for line in re.split(r'\\n|\n', part) if line]

--- a/src/tribler-core/tribler_core/components/reporter/exception_handler.py
+++ b/src/tribler-core/tribler_core/components/reporter/exception_handler.py
@@ -6,29 +6,28 @@ from socket import gaierror
 from traceback import print_exception
 from typing import Callable, Optional
 
+from tribler_common.reported_error import ReportedError
 from tribler_common.sentry_reporter.sentry_reporter import SentryReporter
 
 from tribler_core.components.base import ComponentStartupException
 from tribler_core.utilities.utilities import froze_it
 
-if sys.platform == 'win32':
-    SOCKET_BLOCK_ERRORCODE = 10035  # WSAEWOULDBLOCK
-else:
-    SOCKET_BLOCK_ERRORCODE = errno.EWOULDBLOCK
 # There are some errors that we are ignoring.
-IGNORED_ERRORS = {
-    # No route to host: this issue is non-critical since Tribler can still function when a request fails.
-    (OSError, 113): "Observed no route to host error (but ignoring)."
-                    "This might indicate a problem with your firewall.",
+IGNORED_ERRORS_BY_CODE = {
+    (OSError, 113),  # No route to host is non-critical since Tribler can still function when a request fails.
     # Socket block: this sometimes occurs on Windows and is non-critical.
-    (BlockingIOError, SOCKET_BLOCK_ERRORCODE): f"Unable to send data due to builtins.OSError {SOCKET_BLOCK_ERRORCODE}",
-    (OSError, 51): "Could not send data: network is unreachable.",
-    (ConnectionAbortedError, 10053): "An established connection was aborted by the software in your host machine.",
-    (ConnectionResetError, 10054): "Connection forcibly closed by the remote host.",
-    (OSError, 10022): "Failed to get address info. Error code: 10022",
-    (OSError, 16): "Socket error: Device or resource busy. Error code: 16",
-    (OSError, 0): "",
-    gaierror: "Unable to perform DNS lookup."
+    (BlockingIOError, 10035 if sys.platform == 'win32' else errno.EWOULDBLOCK),
+    (OSError, 51),  # Could not send data: network is unreachable.
+    (ConnectionAbortedError, 10053),  # An established connection was aborted by the software in your host machine.
+    (ConnectionResetError, 10054),  # Connection forcibly closed by the remote host.
+    (OSError, 10022),  # Failed to get address info.
+    (OSError, 16),  # Socket error: Device or resource busy.
+    (OSError, 0)
+}
+
+IGNORED_ERRORS_BY_SUBSTRING = {
+    gaierror: None,  # None means any gaierror is ignored
+    RuntimeError: 'invalid info-hash'
 }
 
 
@@ -41,6 +40,36 @@ class CoreExceptionHandler:
 
     _logger = logging.getLogger("CoreExceptionHandler")
     report_callback: Optional[Callable] = None
+    requires_user_consent: bool = True
+
+    @staticmethod
+    def _get_long_text_from(exception: Exception):
+        with StringIO() as buffer:
+            print_exception(type(exception), exception, exception.__traceback__, file=buffer)
+            return buffer.getvalue()
+
+    @classmethod
+    def _create_exception_from(cls, message: str):
+        text = f'Received error without exception: {message}'
+        cls._logger.warning(text)
+        return Exception(text)
+
+    @classmethod
+    def _is_ignored(cls, exception: Exception):
+        exception_class = exception.__class__
+        error_number = exception.errno if hasattr(exception, 'errno') else None
+
+        if (exception_class, error_number) in IGNORED_ERRORS_BY_CODE:
+            return True
+
+        if exception_class not in IGNORED_ERRORS_BY_SUBSTRING:
+            return False
+
+        substring = IGNORED_ERRORS_BY_SUBSTRING.get(exception_class)
+        if substring is None:
+            return True
+
+        return substring in str(exception)
 
     @classmethod
     def unhandled_error_observer(cls, loop, context):  # pylint: disable=unused-argument
@@ -52,42 +81,37 @@ class CoreExceptionHandler:
             SentryReporter.ignore_logger(cls._logger.name)
 
             should_stop = True
-            exception = context.get('exception')
+            message = context.get('message')
+            exception = context.get('exception') or cls._create_exception_from(message)
+            # Exception
+            text = str(exception)
             if isinstance(exception, ComponentStartupException):
                 should_stop = exception.component.tribler_should_stop_on_component_error
                 exception = exception.__cause__
 
-            ignored_message = None
-            try:
-                ignored_message = IGNORED_ERRORS.get(
-                    (exception.__class__, exception.errno),
-                    IGNORED_ERRORS.get(exception.__class__))
-            except (ValueError, AttributeError):
-                pass
-            if ignored_message is not None:
-                cls._logger.error(ignored_message if ignored_message != "" else context.get('message'))
+            if cls._is_ignored(exception):
+                cls._logger.warning(exception)
                 return
 
-            text = str(exception or context.get('message'))
-            # We already have a check for invalid infohash when adding a torrent, but if somehow we get this
-            # error then we simply log and ignore it.
-            if isinstance(exception, RuntimeError) and 'invalid info-hash' in text:
-                cls._logger.error("Invalid info-hash found")
-                return
+            long_text = cls._get_long_text_from(exception)
+            error_context = dict(context)
+            # remove duplicate fields
+            error_context.pop('message', None)
+            error_context.pop('exception', None)
 
-            exc_type_name = exc_long_text = text
-            if isinstance(exception, Exception):
-                exc_type_name = type(exception).__name__
-                with StringIO() as buffer:
-                    print_exception(type(exception), exception, exception.__traceback__, file=buffer)
-                    exc_long_text = exc_long_text + "\n--LONG TEXT--\n" + buffer.getvalue()
-            exc_long_text = exc_long_text + "\n--CONTEXT--\n" + str(context)
-            cls._logger.error("Unhandled exception occurred! %s", exc_long_text, exc_info=None)
+            cls._logger.error(f"Unhandled exception occurred! {exception}\n{long_text}")
 
-            sentry_event = SentryReporter.event_from_exception(exception)
-
-            if cls.report_callback is not None:
-                cls.report_callback(exc_type_name, exc_long_text, sentry_event, should_stop=should_stop)  # pylint: disable=not-callable
+            reported_error = ReportedError(
+                type=exception.__class__.__name__,
+                text=text,
+                long_text=long_text,
+                context=str(error_context),
+                event=SentryReporter.event_from_exception(exception) or {},
+                requires_user_consent=cls.requires_user_consent,
+                should_stop=should_stop
+            )
+            if cls.report_callback:
+                cls.report_callback(reported_error)  # pylint: disable=not-callable
 
         except Exception as ex:
             SentryReporter.capture_exception(ex)

--- a/src/tribler-core/tribler_core/components/reporter/tests/test_exception_handler.py
+++ b/src/tribler-core/tribler_core/components/reporter/tests/test_exception_handler.py
@@ -1,0 +1,103 @@
+from socket import gaierror
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tribler_common.sentry_reporter import sentry_reporter
+from tribler_common.sentry_reporter.sentry_reporter import SentryReporter
+
+from tribler_core.components.reporter.exception_handler import CoreExceptionHandler
+
+pytestmark = pytest.mark.asyncio
+
+
+# pylint: disable=protected-access
+# fmt: off
+
+def raise_error(error):  # pylint: disable=inconsistent-return-statements
+    try:
+        raise error
+    except error.__class__ as e:
+        return e
+
+
+async def test_is_ignored():
+    # test that CoreExceptionHandler ignores specific exceptions
+
+    # by type
+    assert CoreExceptionHandler._is_ignored(OSError(113, 'Any'))
+    assert CoreExceptionHandler._is_ignored(ConnectionResetError(10054, 'Any'))
+
+    # by class
+    assert CoreExceptionHandler._is_ignored(gaierror('Any'))
+
+    # by class and substring
+    assert CoreExceptionHandler._is_ignored(RuntimeError('Message that contains invalid info-hash'))
+
+
+async def test_is_not_ignored():
+    # test that CoreExceptionHandler do not ignore exceptions out of
+    # IGNORED_ERRORS_BY_CODE and IGNORED_ERRORS_BY_SUBSTRING
+    assert not CoreExceptionHandler._is_ignored(OSError(1, 'Any'))
+    assert not CoreExceptionHandler._is_ignored(RuntimeError('Any'))
+    assert not CoreExceptionHandler._is_ignored(AttributeError())
+
+
+async def test_create_exception_from():
+    # test that CoreExceptionHandler can create an Exception from a string
+    assert isinstance(CoreExceptionHandler._create_exception_from('Any'), Exception)
+
+
+async def test_get_long_text_from():
+    # test that CoreExceptionHandler can generate stacktrace from an Exception
+    error = raise_error(AttributeError('Any'))
+    actual_string = CoreExceptionHandler._get_long_text_from(error)
+    assert 'raise_error' in actual_string
+
+
+@patch(f'{sentry_reporter.__name__}.{SentryReporter.__name__}.{SentryReporter.event_from_exception.__name__}',
+       new=MagicMock(return_value={'sentry': 'event'}))
+async def test_unhandled_error_observer_exception():
+    # test that unhandled exception, represented by Exception, reported to the GUI
+    context = {'exception': raise_error(AttributeError('Any')), 'Any key': 'Any value'}
+    CoreExceptionHandler.report_callback = MagicMock()
+    CoreExceptionHandler.unhandled_error_observer(None, context)
+    CoreExceptionHandler.report_callback.assert_called()
+
+    # get the argument that has been passed to the report_callback
+    reported_error = CoreExceptionHandler.report_callback.call_args_list[-1][0][0]
+    assert reported_error.type == 'AttributeError'
+    assert reported_error.text == 'Any'
+    assert 'raise_error' in reported_error.long_text
+    assert reported_error.event == {'sentry': 'event'}
+    assert reported_error.context == "{'Any key': 'Any value'}"
+    assert reported_error.should_stop
+    assert reported_error.requires_user_consent
+
+
+async def test_unhandled_error_observer_only_message():
+    # test that unhandled exception, represented by message, reported to the GUI
+    context = {'message': 'Any'}
+    CoreExceptionHandler.report_callback = MagicMock()
+    CoreExceptionHandler.unhandled_error_observer(None, context)
+    CoreExceptionHandler.report_callback.assert_called()
+
+    # get the argument that has been passed to the report_callback
+    reported_error = CoreExceptionHandler.report_callback.call_args_list[-1][0][0]
+    assert reported_error.type == 'Exception'
+    assert reported_error.text == 'Received error without exception: Any'
+    assert reported_error.long_text == 'Exception: Received error without exception: Any\n'
+    assert not reported_error.event
+    assert reported_error.context == '{}'
+    assert reported_error.should_stop
+    assert reported_error.requires_user_consent
+
+
+async def test_unhandled_error_observer_ignored():
+    # test that exception from list IGNORED_ERRORS_BY_CODE never sends to the GUI
+    context = {'exception': OSError(113, '')}
+    CoreExceptionHandler.report_callback = MagicMock()
+    with patch.object(CoreExceptionHandler._logger, 'warning') as mocked_warning:
+        CoreExceptionHandler.unhandled_error_observer(None, context)
+        mocked_warning.assert_called_once()
+    CoreExceptionHandler.report_callback.assert_not_called()

--- a/src/tribler-core/tribler_core/components/restapi/rest/state_endpoint.py
+++ b/src/tribler-core/tribler_core/components/restapi/rest/state_endpoint.py
@@ -8,8 +8,8 @@ from marshmallow.fields import String
 
 from tribler_common.simpledefs import NTFY, STATE_EXCEPTION, STATE_STARTED, STATE_STARTING, STATE_UPGRADING
 
-from tribler_core.notifier import Notifier
 from tribler_core.components.restapi.rest.rest_endpoint import RESTEndpoint, RESTResponse
+from tribler_core.notifier import Notifier
 from tribler_core.utilities.utilities import froze_it
 
 
@@ -23,7 +23,6 @@ class StateEndpoint(RESTEndpoint):
         super().__init__()
         self.tribler_state = STATE_STARTING
         self.last_exception = None
-        self.sentry_event = None
         self.notifier = None
         self.readable_status = None
 
@@ -45,10 +44,9 @@ class StateEndpoint(RESTEndpoint):
     def on_tribler_started(self, *_):
         self.tribler_state = STATE_STARTED
 
-    def on_tribler_exception(self, exception_text, sentry_event):
+    def on_tribler_exception(self, exception_text):
         self.tribler_state = STATE_EXCEPTION
         self.last_exception = exception_text
-        self.sentry_event = sentry_event
 
     @docs(
         tags=["General"],

--- a/src/tribler-core/tribler_core/components/restapi/rest/tests/test_events_endpoint.py
+++ b/src/tribler-core/tribler_core/components/restapi/rest/tests/test_events_endpoint.py
@@ -8,6 +8,7 @@ from ipv8.messaging.anonymization.tunnel import Circuit
 
 import pytest
 
+from tribler_common.reported_error import ReportedError
 from tribler_common.simpledefs import NTFY
 
 from tribler_core.components.restapi.rest.rest_manager import ApiKeyMiddleware, RESTManager, error_middleware
@@ -96,7 +97,7 @@ async def test_events(rest_manager, notifier):
             notifier.notify(subject, *data)
         else:
             notifier.notify(subject)
-    rest_manager.root_endpoint.endpoints['/events'].on_tribler_exception("exc_type", "exc_text", None, False)
+    rest_manager.root_endpoint.endpoints['/events'].on_tribler_exception(ReportedError('', '', {}, False))
     await events_up.wait()
 
     event_socket_task.cancel()

--- a/src/tribler-core/tribler_core/components/restapi/rest/tests/test_state_endpoint.py
+++ b/src/tribler-core/tribler_core/components/restapi/rest/tests/test_state_endpoint.py
@@ -28,6 +28,6 @@ async def test_get_state(rest_api, endpoint):
     Testing whether the API returns a correct state when requested
     """
     endpoint.readable_status = "Started"
-    endpoint.on_tribler_exception("abcd", None)
+    endpoint.on_tribler_exception("abcd")
     expected_json = {"state": STATE_EXCEPTION, "last_exception": "abcd", "readable_state": "Started"}
     await do_request(rest_api, 'state', expected_code=200, expected_json=expected_json)

--- a/src/tribler-core/tribler_core/components/restapi/tests/test_restapi_component.py
+++ b/src/tribler-core/tribler_core/components/restapi/tests/test_restapi_component.py
@@ -1,13 +1,31 @@
+from unittest.mock import MagicMock
+
 import pytest
+
+from tribler_common.reported_error import ReportedError
 
 from tribler_core.components.base import Session
 from tribler_core.components.key.key_component import KeyComponent
+from tribler_core.components.reporter.exception_handler import CoreExceptionHandler
 from tribler_core.components.restapi.restapi_component import RESTComponent
 
 pytestmark = pytest.mark.asyncio
 
 
-# pylint: disable=protected-access
+# pylint: disable=protected-access, not-callable
+
+def assert_report_callback_is_correct(component: RESTComponent):
+    assert CoreExceptionHandler.report_callback
+    component._events_endpoint.on_tribler_exception = MagicMock()
+    component._state_endpoint.on_tribler_exception = MagicMock()
+
+    error = ReportedError(type='', text='text', event={})
+    CoreExceptionHandler.report_callback(error)
+
+    component._events_endpoint.on_tribler_exception.assert_called_with(error)
+    component._state_endpoint.on_tribler_exception.assert_called_with(error.text)
+
+
 async def test_restful_component(tribler_config):
     components = [KeyComponent(), RESTComponent()]
     session = Session(tribler_config, components)
@@ -17,5 +35,5 @@ async def test_restful_component(tribler_config):
         comp = RESTComponent.instance()
         assert comp.started_event.is_set() and not comp.failed
         assert comp.rest_manager
-
+        assert_report_callback_is_correct(comp)
         await session.shutdown()

--- a/src/tribler-core/tribler_core/start_core.py
+++ b/src/tribler-core/tribler_core/start_core.py
@@ -172,6 +172,7 @@ def start_tribler_core(base_path, api_port, api_key, root_state_dir, gui_test_mo
         asyncio.set_event_loop(asyncio.SelectorEventLoop())
 
     loop = asyncio.get_event_loop()
+    CoreExceptionHandler.requires_user_consent = config.error_handling.core_error_reporting_requires_user_consent
     loop.set_exception_handler(CoreExceptionHandler.unhandled_error_observer)
 
     loop.run_until_complete(core_session(config, components=list(components_gen(config))))

--- a/src/tribler-core/tribler_core/tests/test_start_core.py
+++ b/src/tribler-core/tribler_core/tests/test_start_core.py
@@ -1,0 +1,34 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tribler_core.components.reporter.exception_handler import CoreExceptionHandler
+from tribler_core.settings import ErrorHandlingSettings
+from tribler_core.start_core import start_tribler_core
+
+pytestmark = pytest.mark.asyncio
+
+
+# pylint: disable=
+# fmt: off
+
+class MockedProcessChecker(MagicMock):
+    already_running = False
+
+
+@patch('tribler_core.load_logger_config', new=MagicMock())
+@patch('tribler_core.start_core.VersionHistory', new=MagicMock())
+@patch('tribler_core.start_core.set_process_priority', new=MagicMock())
+@patch('tribler_core.start_core.check_and_enable_code_tracing', new=MagicMock())
+@patch('tribler_core.start_core.core_session', new=MagicMock())
+@patch('tribler_core.start_core.ProcessChecker', new=MockedProcessChecker())
+@patch('asyncio.get_event_loop', new=MagicMock())
+@patch('tribler_core.start_core.TriblerConfig.load')
+async def test_start_tribler_core_requires_user_consent(mocked_config):
+    # test that CoreExceptionHandler sets `requires_user_consent` in regarding the Tribler's config
+    class MockedTriblerConfig(MagicMock):
+        error_handling = ErrorHandlingSettings(core_error_reporting_requires_user_consent=False)
+
+    mocked_config.return_value = MockedTriblerConfig()
+    start_tribler_core('.', 1, 'key', '.', False)
+    assert not CoreExceptionHandler.requires_user_consent

--- a/src/tribler-gui/tribler_gui/dialogs/addtagsdialog.py
+++ b/src/tribler-gui/tribler_gui/dialogs/addtagsdialog.py
@@ -1,10 +1,11 @@
 from typing import Dict, Optional
 
 from PyQt5 import uic
-from PyQt5.QtCore import pyqtSignal, QModelIndex, QPoint
+from PyQt5.QtCore import QModelIndex, QPoint, pyqtSignal
 from PyQt5.QtWidgets import QSizePolicy, QWidget
 
-from tribler_common.tag_constants import MIN_TAG_LENGTH, MAX_TAG_LENGTH
+from tribler_common.tag_constants import MAX_TAG_LENGTH, MIN_TAG_LENGTH
+
 from tribler_gui.defs import TAG_HORIZONTAL_MARGIN
 from tribler_gui.dialogs.dialogcontainer import DialogContainer
 from tribler_gui.tribler_request_manager import TriblerNetworkRequest
@@ -16,12 +17,12 @@ class AddTagsDialog(DialogContainer):
     """
     This dialog enables a user to add new tags to/remove existing tags from content.
     """
+
     save_button_clicked = pyqtSignal(QModelIndex, list)
     suggestions_loaded = pyqtSignal()
 
     def __init__(self, parent: QWidget, infohash: str) -> None:
         DialogContainer.__init__(self, parent, left_right_margin=400)
-
         self.index: Optional[QModelIndex] = None
         self.infohash = infohash
 
@@ -47,9 +48,12 @@ class AddTagsDialog(DialogContainer):
         entered_tags = self.dialog_widget.edit_tags_input.get_entered_tags()
         for tag in entered_tags:
             if len(tag) < MIN_TAG_LENGTH or len(tag) > MAX_TAG_LENGTH:
-                self.dialog_widget.error_text_label.setText(tr(
-                    "Each tag should be at least %d characters and can be at most %d characters." %
-                    (MIN_TAG_LENGTH, MAX_TAG_LENGTH)))
+                self.dialog_widget.error_text_label.setText(
+                    tr(
+                        "Each tag should be at least %d characters and can be at most %d characters."
+                        % (MIN_TAG_LENGTH, MAX_TAG_LENGTH)
+                    )
+                )
                 self.dialog_widget.error_text_label.setHidden(False)
                 return
 

--- a/src/tribler-gui/tribler_gui/event_request_manager.py
+++ b/src/tribler-gui/tribler_gui/event_request_manager.py
@@ -5,6 +5,7 @@ import time
 from PyQt5.QtCore import QTimer, QUrl, pyqtSignal
 from PyQt5.QtNetwork import QNetworkAccessManager, QNetworkRequest
 
+from tribler_common.reported_error import ReportedError
 from tribler_common.sentry_reporter.sentry_reporter import SentryReporter
 from tribler_common.simpledefs import NTFY
 
@@ -120,11 +121,7 @@ class EventRequestManager(QNetworkAccessManager):
                         reaction()
                 elif event_type == NTFY.TRIBLER_EXCEPTION.value:
                     self.error_handler.core_error(
-                        exc_type_name=json_dict["exc_type_name"],
-                        exc_long_text=json_dict["exc_long_text"],
-                        sentry_event=json_dict['sentry_event'],
-                        error_reporting_requires_user_consent=json_dict['error_reporting_requires_user_consent'],
-                        should_stop=json_dict['should_stop'],
+                        reported_error=ReportedError(**json_dict["error"]),
                     )
             self.current_event_string = ""
 

--- a/src/tribler-gui/tribler_gui/tests/test_error_handler.py
+++ b/src/tribler-gui/tribler_gui/tests/test_error_handler.py
@@ -1,0 +1,83 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tribler_common.reported_error import ReportedError
+
+from tribler_gui.error_handler import ErrorHandler
+from tribler_gui.event_request_manager import CoreConnectTimeoutError
+
+pytestmark = pytest.mark.asyncio
+
+
+# pylint: disable=redefined-outer-name, protected-access, function-redefined, unused-argument
+# fmt: off
+
+@pytest.fixture
+def error_handler():
+    return ErrorHandler(MagicMock())
+
+
+@pytest.fixture
+def reported_error():
+    return ReportedError(type='Exception', text='text', event={})
+
+
+@patch('tribler_gui.error_handler.FeedbackDialog')
+async def test_gui_error_tribler_stopped(mocked_feedback_dialog: MagicMock, error_handler: ErrorHandler):
+    # test that while tribler_stopped is True FeedbackDialog is not called
+    error_handler._tribler_stopped = True
+    error_handler.gui_error()
+    mocked_feedback_dialog.assert_not_called()
+
+
+@patch('tribler_gui.error_handler.FeedbackDialog')
+async def test_gui_info_type_in_handled_exceptions(mocked_feedback_dialog: MagicMock, error_handler: ErrorHandler):
+    # test that if exception type in _handled_exceptions then FeedbackDialog is not called
+    error_handler._handled_exceptions = {AssertionError}
+    error_handler.gui_error(AssertionError, None, None)
+    mocked_feedback_dialog.assert_not_called()
+    assert len(error_handler._handled_exceptions) == 1
+
+
+@patch('tribler_gui.error_handler.FeedbackDialog')
+async def test_gui_is_core_timeout_exception(mocked_feedback_dialog: MagicMock, error_handler: ErrorHandler):
+    # test that in case of CoreConnectTimeoutError Tribler should stop it's work
+    error_handler._stop_tribler = MagicMock()
+    error_handler.gui_error(CoreConnectTimeoutError, None, None)
+    error_handler._stop_tribler.assert_called_once()
+
+
+@patch('tribler_gui.error_handler.FeedbackDialog')
+async def test_gui_is_core_timeout_exception(mocked_feedback_dialog: MagicMock, error_handler: ErrorHandler):
+    # test that gui_error creates FeedbackDialog
+    error_handler.gui_error(Exception, None, None)
+    mocked_feedback_dialog.assert_called_once()
+
+
+@patch('tribler_gui.error_handler.FeedbackDialog')
+async def test_core_info_type_in_handled_exceptions(mocked_feedback_dialog: MagicMock, error_handler: ErrorHandler,
+                                                    reported_error: ReportedError):
+    # test that if exception type in _handled_exceptions then FeedbackDialog is not called
+    error_handler._handled_exceptions = {reported_error.type}
+    error_handler.core_error(reported_error)
+    mocked_feedback_dialog.assert_not_called()
+    assert len(error_handler._handled_exceptions) == 1
+
+
+@patch('tribler_gui.error_handler.FeedbackDialog')
+async def test_core_should_stop(mocked_feedback_dialog: MagicMock, error_handler: ErrorHandler,
+                                reported_error: ReportedError):
+    # test that in case of "should_stop=True", Tribler should stop it's work
+    error_handler._stop_tribler = MagicMock()
+    reported_error.should_stop = True
+    error_handler.core_error(reported_error)
+    error_handler._stop_tribler.assert_called_once()
+
+
+@patch('tribler_gui.error_handler.FeedbackDialog')
+async def test_core_error(mocked_feedback_dialog: MagicMock, error_handler: ErrorHandler,
+                          reported_error: ReportedError):
+    # test that core_error creates FeedbackDialog
+    error_handler.core_error(reported_error)
+    mocked_feedback_dialog.assert_called_once()

--- a/src/tribler-gui/tribler_gui/tests/test_gui.py
+++ b/src/tribler-gui/tribler_gui/tests/test_gui.py
@@ -12,6 +12,7 @@ import pytest
 
 import tribler_common
 from tribler_common.network_utils import NetworkUtils
+from tribler_common.reported_error import ReportedError
 from tribler_common.tag_constants import MIN_TAG_LENGTH
 
 import tribler_gui
@@ -440,7 +441,8 @@ def test_feedback_dialog(window):
         screenshot(dialog, name="feedback_dialog")
         dialog.close()
 
-    dialog = FeedbackDialog(window, "test", "1.2.3", 23)
+    reported_error = ReportedError('type', 'text', {})
+    dialog = FeedbackDialog(window, reported_error, "1.2.3", 23)
     dialog.closeEvent = lambda _: None  # Otherwise, the application will stop
     QTimer.singleShot(1000, screenshot_dialog)
     dialog.exec_()
@@ -456,8 +458,8 @@ def test_feedback_dialog_report_sent(window):
         on_report_sent.did_send_report = True
 
     on_report_sent.did_send_report = False
-
-    dialog = FeedbackDialog(window, "Tribler GUI Test to test sending crash report works", "1.2.3", 23)
+    reported_error = ReportedError('', 'Tribler GUI Test to test sending crash report works', {})
+    dialog = FeedbackDialog(window, reported_error, "1.2.3", 23)
     dialog.closeEvent = lambda _: None  # Otherwise, the application will stop
     dialog.on_report_sent = on_report_sent
     QTest.mouseClick(dialog.send_report_button, Qt.LeftButton)


### PR DESCRIPTION
This PR fixes #6509 by refactoring the error reporting chain.

This PR introduces `ReportedError` class for sending errors from `core` to `gui` instead of using `dict`.

```python
@dataclass
class ReportedError:
    type: str
    text: str
    event: dict
    requires_user_consent: bool

    long_text: str = ''
    context: str = ''
    should_stop: Optional[bool] = None
```

It also adds missed `requires_user_consent` field that has been removed (probably) during #6206 