### PR TITLE
Using SelectorEventLoop during tests

### DIFF
--- a/src/tribler-core/tribler_core/components/tunnel/tests/test_full_session/conftest.py
+++ b/src/tribler-core/tribler_core/components/tunnel/tests/test_full_session/conftest.py
@@ -1,4 +1,12 @@
+import asyncio
+
 import pytest
+
+
+@pytest.fixture
+def event_loop():
+    # We use a SelectorEventLoop on all platforms so our test suite should use a similar event loop.
+    return asyncio.SelectorEventLoop()
 
 
 def pytest_addoption(parser):

--- a/src/tribler-core/tribler_core/conftest.py
+++ b/src/tribler-core/tribler_core/conftest.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 from pathlib import Path
 from unittest.mock import Mock
@@ -243,6 +244,12 @@ def test_tdef(state_dir):
     torrentfn = state_dir / "gen.torrent"
     tdef.save(torrentfn)
     return tdef
+
+
+@pytest.fixture
+def event_loop():
+    # We use a SelectorEventLoop on all platforms so our test suite should use a similar event loop.
+    return asyncio.SelectorEventLoop()
 
 
 @pytest.fixture


### PR DESCRIPTION
We use a `SelectorEventLoop` on all platforms so our test suite should use a similar event loop.

Fixes #6456