### PR TITLE
Remove an unnecessary second connection to the `/events` endpoint from GUI

### DIFF
--- a/src/tribler-gui/tribler_gui/core_manager.py
+++ b/src/tribler-gui/tribler_gui/core_manager.py
@@ -191,7 +191,6 @@ class CoreManager(QObject):
         self.core_state_update.emit(state['readable_state'])
 
         if state['state'] == 'STARTED':
-            self.events_manager.connect(reschedule_on_err=False)
             self.is_core_running = True
         elif state['state'] == 'EXCEPTION':
             raise RuntimeError(state['last_exception'])


### PR DESCRIPTION
Currently, GUI accidentally opens two parallel connections to the `/events` endpoint when communicating with Core. The first connection is opened [here](https://github.com/Tribler/tribler/blob/c67298f5df0a89886a3e3bfa49788b36f915862c/src/tribler-gui/tribler_gui/core_manager.py#L104), and the second is [here](https://github.com/Tribler/tribler/blob/c67298f5df0a89886a3e3bfa49788b36f915862c/src/tribler-gui/tribler_gui/core_manager.py#L194). Only one connection is actually necessary. In this PR, I remove the second unnecessary connection.