### PR TITLE
Change mock type for encode_message

### DIFF
--- a/src/tribler-core/tribler_core/components/restapi/rest/tests/test_events_endpoint.py
+++ b/src/tribler-core/tribler_core/components/restapi/rest/tests/test_events_endpoint.py
@@ -161,7 +161,7 @@ async def test_on_tribler_exception_stores_only_first_error(endpoint, reported_e
 @patch.object(EventsEndpoint, 'register_anonymous_task', new=AsyncMock(side_effect=CancelledError))
 @patch.object(RESTStreamResponse, 'prepare', new=AsyncMock())
 @patch.object(RESTStreamResponse, 'write', new_callable=AsyncMock)
-@patch.object(EventsEndpoint, 'encode_message', new_callable=AsyncMock)
+@patch.object(EventsEndpoint, 'encode_message')
 async def test_get_events_has_undelivered_error(mocked_encode_message, mocked_write, endpoint):
     # test that in case `self.undelivered_error` is not None, then it will be sent
     endpoint.undelivered_error = {'undelivered': 'error'}


### PR DESCRIPTION
This PR fixes #6539 by removing `AsyncMock` from `encode_message` patch because `encode_message` uses only in synchronized calls.

As a consequence of doing this: removed warning and fixed `test_set_rate_settings` test. 
```python
sys:1: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
```

See full explanations here:  #6539 

