### PR TITLE
Make CoreExceptionHandler scope-dependent

### DIFF
--- a/src/tribler-core/tribler_core/components/restapi/restapi_component.py
+++ b/src/tribler-core/tribler_core/components/restapi/restapi_component.py
@@ -7,7 +7,7 @@ from tribler_common.reported_error import ReportedError
 from tribler_common.simpledefs import STATE_START_API
 
 from tribler_core.components.base import Component
-from tribler_core.components.reporter.exception_handler import CoreExceptionHandler
+from tribler_core.components.reporter.exception_handler import CoreExceptionHandler, default_core_exception_handler
 from tribler_core.components.reporter.reporter_component import ReporterComponent
 from tribler_core.components.restapi.rest.debug_endpoint import DebugEndpoint
 from tribler_core.components.restapi.rest.events_endpoint import EventsEndpoint
@@ -75,6 +75,7 @@ class RESTComponent(Component):
 
     _events_endpoint: EventsEndpoint
     _state_endpoint: StateEndpoint
+    _core_exception_handler: CoreExceptionHandler = default_core_exception_handler
 
     async def run(self):
         await super().run()
@@ -115,10 +116,13 @@ class RESTComponent(Component):
             self._events_endpoint.on_tribler_exception(reported_error)
             self._state_endpoint.on_tribler_exception(reported_error.text)
 
-        CoreExceptionHandler.report_callback = report_callback
+        self._core_exception_handler.report_callback = report_callback
 
     async def shutdown(self):
         await super().shutdown()
-        CoreExceptionHandler.report_callback = None
+
+        if self._core_exception_handler:
+            self._core_exception_handler.report_callback = None
+
         if self.rest_manager:
             await self.rest_manager.stop()

--- a/src/tribler-core/tribler_core/components/restapi/tests/test_restapi_component.py
+++ b/src/tribler-core/tribler_core/components/restapi/tests/test_restapi_component.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -7,23 +7,13 @@ from tribler_common.reported_error import ReportedError
 from tribler_core.components.base import Session
 from tribler_core.components.key.key_component import KeyComponent
 from tribler_core.components.reporter.exception_handler import CoreExceptionHandler
+from tribler_core.components.restapi.rest.rest_manager import RESTManager
 from tribler_core.components.restapi.restapi_component import RESTComponent
 
 pytestmark = pytest.mark.asyncio
 
 
 # pylint: disable=protected-access, not-callable
-
-def assert_report_callback_is_correct(component: RESTComponent):
-    assert CoreExceptionHandler.report_callback
-    component._events_endpoint.on_tribler_exception = MagicMock()
-    component._state_endpoint.on_tribler_exception = MagicMock()
-
-    error = ReportedError(type='', text='text', event={})
-    CoreExceptionHandler.report_callback(error)
-
-    component._events_endpoint.on_tribler_exception.assert_called_with(error)
-    component._state_endpoint.on_tribler_exception.assert_called_with(error.text)
 
 
 async def test_restful_component(tribler_config):
@@ -35,5 +25,27 @@ async def test_restful_component(tribler_config):
         comp = RESTComponent.instance()
         assert comp.started_event.is_set() and not comp.failed
         assert comp.rest_manager
-        assert_report_callback_is_correct(comp)
         await session.shutdown()
+
+
+@patch.object(RESTComponent, 'get_component', new=AsyncMock())
+@patch.object(RESTManager, 'start', new=AsyncMock())
+async def test_report_callback_set_up_correct():
+    component = RESTComponent()
+    component.session = MagicMock()
+
+    component._core_exception_handler = CoreExceptionHandler()
+
+    await component.run()
+
+    # mock callbacks
+    component._events_endpoint.on_tribler_exception = MagicMock()
+    component._state_endpoint.on_tribler_exception = MagicMock()
+
+    # try to call report_callback from core_exception_handler and assert
+    # that corresponding methods in events_endpoint and state_endpoint have been called
+
+    error = ReportedError(type='', text='text', event={})
+    component._core_exception_handler.report_callback(error)
+    component._events_endpoint.on_tribler_exception.assert_called_with(error)
+    component._state_endpoint.on_tribler_exception.assert_called_with(error.text)

--- a/src/tribler-core/tribler_core/start_core.py
+++ b/src/tribler-core/tribler_core/start_core.py
@@ -23,7 +23,7 @@ from tribler_core.components.libtorrent.libtorrent_component import LibtorrentCo
 from tribler_core.components.metadata_store.metadata_store_component import MetadataStoreComponent
 from tribler_core.components.payout.payout_component import PayoutComponent
 from tribler_core.components.popularity.popularity_component import PopularityComponent
-from tribler_core.components.reporter.exception_handler import CoreExceptionHandler
+from tribler_core.components.reporter.exception_handler import default_core_exception_handler
 from tribler_core.components.reporter.reporter_component import ReporterComponent
 from tribler_core.components.resource_monitor.resource_monitor_component import ResourceMonitorComponent
 from tribler_core.components.restapi.restapi_component import RESTComponent
@@ -172,7 +172,8 @@ def start_tribler_core(base_path, api_port, api_key, root_state_dir, gui_test_mo
         asyncio.set_event_loop(asyncio.SelectorEventLoop())
 
     loop = asyncio.get_event_loop()
-    loop.set_exception_handler(CoreExceptionHandler.unhandled_error_observer)
+    exception_handler = default_core_exception_handler
+    loop.set_exception_handler(exception_handler.unhandled_error_observer)
 
     loop.run_until_complete(core_session(config, components=list(components_gen(config))))
 


### PR DESCRIPTION
This PR fixes #6542 by making CoreExceptionHandler just an instance class (instead of singleton). It will allow us to test `CoreExceptionHandler` properly and will increase the stability of tests.