### PR TITLE
Make TEST_SENTRY_URL the single source of sentry test mode information

### DIFF
--- a/src/run_tribler.py
+++ b/src/run_tribler.py
@@ -7,7 +7,6 @@ from PyQt5.QtCore import QSettings
 logger = logging.getLogger(__name__)
 CONFIG_FILE_NAME = 'triblerd.conf'
 
-
 # pylint: disable=import-outside-toplevel, ungrouped-imports
 
 def init_sentry_reporter():
@@ -16,12 +15,12 @@ def init_sentry_reporter():
 
     """ Initialise sentry reporter
 
-    We use `sentry_url` as a URL for normal tribler mode and TEST_SENTRY_URL
+    We use `sentry_url` as a URL for normal tribler mode and TRIBLER_TEST_SENTRY_URL
     as a URL for sending sentry's reports while a Tribler client running in
     test mode
     """
     from tribler_core.version import sentry_url, version_id
-    test_sentry_url = os.environ.get('TEST_SENTRY_URL', None)
+    test_sentry_url = SentryReporter.get_test_sentry_url()
 
     if not test_sentry_url:
         SentryReporter.init(sentry_url=sentry_url,

--- a/src/tribler-common/tribler_common/reported_error.py
+++ b/src/tribler-common/tribler_common/reported_error.py
@@ -11,4 +11,3 @@ class ReportedError:
     long_text: str = ''
     context: str = ''
     should_stop: Optional[bool] = None
-    requires_user_consent: bool = True

--- a/src/tribler-common/tribler_common/sentry_reporter/sentry_reporter.py
+++ b/src/tribler-common/tribler_common/sentry_reporter/sentry_reporter.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import sys
 from contextlib import contextmanager
 from contextvars import ContextVar
@@ -331,6 +332,14 @@ class SentryReporter:
         """
         strategy = SentryReporter.thread_strategy.get()
         return strategy if strategy else SentryReporter.global_strategy
+
+    @staticmethod
+    def get_test_sentry_url():
+        return os.environ.get('TRIBLER_TEST_SENTRY_URL', None)
+
+    @staticmethod
+    def is_in_test_mode():
+        return SentryReporter.get_test_sentry_url() is not None
 
     @staticmethod
     def _before_send(event, hint):

--- a/src/tribler-common/tribler_common/sentry_reporter/sentry_reporter.py
+++ b/src/tribler-common/tribler_common/sentry_reporter/sentry_reporter.py
@@ -339,7 +339,7 @@ class SentryReporter:
 
     @staticmethod
     def is_in_test_mode():
-        return SentryReporter.get_test_sentry_url() is not None
+        return bool(SentryReporter.get_test_sentry_url())
 
     @staticmethod
     def _before_send(event, hint):

--- a/src/tribler-core/tribler_core/components/reporter/exception_handler.py
+++ b/src/tribler-core/tribler_core/components/reporter/exception_handler.py
@@ -41,7 +41,6 @@ class CoreExceptionHandler:
 
     _logger = logging.getLogger("CoreExceptionHandler")
     report_callback: Optional[Callable[[ReportedError], None]] = None
-    requires_user_consent: bool = True
 
     @staticmethod
     def _get_long_text_from(exception: Exception):
@@ -101,7 +100,6 @@ class CoreExceptionHandler:
                 long_text=long_text,
                 context=str(context),
                 event=SentryReporter.event_from_exception(exception) or {},
-                requires_user_consent=cls.requires_user_consent,
                 should_stop=should_stop
             )
             if cls.report_callback:

--- a/src/tribler-core/tribler_core/components/reporter/tests/test_exception_handler.py
+++ b/src/tribler-core/tribler_core/components/reporter/tests/test_exception_handler.py
@@ -72,7 +72,6 @@ async def test_unhandled_error_observer_exception():
     assert reported_error.event == {'sentry': 'event'}
     assert reported_error.context == "{'Any key': 'Any value'}"
     assert reported_error.should_stop
-    assert reported_error.requires_user_consent
 
 
 async def test_unhandled_error_observer_only_message():
@@ -90,7 +89,6 @@ async def test_unhandled_error_observer_only_message():
     assert not reported_error.event
     assert reported_error.context == '{}'
     assert reported_error.should_stop
-    assert reported_error.requires_user_consent
 
 
 async def test_unhandled_error_observer_ignored():

--- a/src/tribler-core/tribler_core/config/tribler_config_sections.py
+++ b/src/tribler-core/tribler_core/config/tribler_config_sections.py
@@ -28,7 +28,6 @@ class TriblerConfigSections(BaseSettings):
         extra = Extra.ignore  # ignore extra attributes during model initialization
 
     general: GeneralSettings = GeneralSettings()
-    error_handling: ErrorHandlingSettings = ErrorHandlingSettings()
     tunnel_community: TunnelCommunitySettings = TunnelCommunitySettings()
     bandwidth_accounting: BandwidthAccountingSettings = BandwidthAccountingSettings()
     bootstrap: BootstrapSettings = BootstrapSettings()

--- a/src/tribler-core/tribler_core/start_core.py
+++ b/src/tribler-core/tribler_core/start_core.py
@@ -147,7 +147,7 @@ def start_tribler_core(base_path, api_port, api_key, root_state_dir, gui_test_mo
     config = TriblerConfig.load(file=state_dir / CONFIG_FILE_NAME, state_dir=state_dir, reset_config_on_error=True)
     config.gui_test_mode = gui_test_mode
 
-    if not config.error_handling.core_error_reporting_requires_user_consent:
+    if SentryReporter.is_in_test_mode():
         SentryReporter.global_strategy = SentryStrategy.SEND_ALLOWED
 
     config.api.http_port = int(api_port)
@@ -172,7 +172,6 @@ def start_tribler_core(base_path, api_port, api_key, root_state_dir, gui_test_mo
         asyncio.set_event_loop(asyncio.SelectorEventLoop())
 
     loop = asyncio.get_event_loop()
-    CoreExceptionHandler.requires_user_consent = config.error_handling.core_error_reporting_requires_user_consent
     loop.set_exception_handler(CoreExceptionHandler.unhandled_error_observer)
 
     loop.run_until_complete(core_session(config, components=list(components_gen(config))))

--- a/src/tribler-core/tribler_core/tests/test_start_core.py
+++ b/src/tribler-core/tribler_core/tests/test_start_core.py
@@ -2,8 +2,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from tribler_core.components.reporter.exception_handler import CoreExceptionHandler
-from tribler_core.settings import ErrorHandlingSettings
 from tribler_core.start_core import start_tribler_core
 
 pytestmark = pytest.mark.asyncio
@@ -23,12 +21,9 @@ class MockedProcessChecker(MagicMock):
 @patch('tribler_core.start_core.core_session', new=MagicMock())
 @patch('tribler_core.start_core.ProcessChecker', new=MockedProcessChecker())
 @patch('asyncio.get_event_loop', new=MagicMock())
-@patch('tribler_core.start_core.TriblerConfig.load')
-async def test_start_tribler_core_requires_user_consent(mocked_config):
-    # test that CoreExceptionHandler sets `requires_user_consent` in regarding the Tribler's config
-    class MockedTriblerConfig(MagicMock):
-        error_handling = ErrorHandlingSettings(core_error_reporting_requires_user_consent=False)
-
-    mocked_config.return_value = MockedTriblerConfig()
+@patch('tribler_core.start_core.TriblerConfig.load', new=MagicMock())
+@patch.object(MockedProcessChecker, 'remove_lock_file', create=True)
+async def test_start_tribler_core_no_exceptions(mocked_remove_lock_file):
+    # test that base logic of tribler core runs without exceptions
     start_tribler_core('.', 1, 'key', '.', False)
-    assert not CoreExceptionHandler.requires_user_consent
+    mocked_remove_lock_file.assert_called_once()

--- a/src/tribler-gui/tribler_gui/dialogs/feedbackdialog.py
+++ b/src/tribler-gui/tribler_gui/dialogs/feedbackdialog.py
@@ -113,15 +113,10 @@ class FeedbackDialog(AddBreadcrumbOnShowMixin, QDialog):
         # Users can remove specific lines in the report
         connect(self.env_variables_list.customContextMenuRequested, self.on_right_click_item)
 
-        self.send_automatically = FeedbackDialog.can_send_automatically(self.reported_error.requires_user_consent)
+        self.send_automatically = SentryReporter.is_in_test_mode()
         if self.send_automatically:
             self.stop_application_on_close = True
             self.on_send_clicked(True)
-
-    @staticmethod
-    def can_send_automatically(error_reporting_requires_user_consent):
-        test_sentry_url_is_defined = os.environ.get('TEST_SENTRY_URL', None) is not None
-        return test_sentry_url_is_defined and not error_reporting_requires_user_consent
 
     def on_remove_entry(self):
         self.env_variables_list.takeTopLevelItem(self.selected_item_index)

--- a/src/tribler-gui/tribler_gui/error_handler.py
+++ b/src/tribler-gui/tribler_gui/error_handler.py
@@ -42,7 +42,6 @@ class ErrorHandler:
             type=type(info_type).__name__,
             text=text,
             event=SentryReporter.event_from_exception(info_error),
-            requires_user_consent=True
         )
 
         FeedbackDialog(


### PR DESCRIPTION
The intention of this PR is to simplify the Application Tester's error reporting by removing `requires_user_consent` field.

Initially, `requires_user_consent` has been introduced to prevent mis-switching to the test mode, which sends error messages automatically (without user participation) and it works in tandem with `TEST_SENTRY_URL` like:

```python
@staticmethod
    def can_send_automatically(error_reporting_requires_user_consent):
        test_sentry_url_is_defined = os.environ.get('TEST_SENTRY_URL', None) is not None
        return test_sentry_url_is_defined and not error_reporting_requires_user_consent
```

This PR renames `TEST_SENTRY_URL` to `TRIBLER_TEST_SENTRY_URL` which should be enough for preventing mis-switching to test mode without specifying `error_reporting_requires_user_consent`.