### PR TITLE
Added small delay after mouse click in GUI test

### DIFF
--- a/src/tribler-gui/tribler_gui/tests/test_gui.py
+++ b/src/tribler-gui/tribler_gui/tests/test_gui.py
@@ -641,6 +641,7 @@ def test_tags_dialog(window):
     # Remove the second tag
     cross_rect = tags_input.compute_cross_rect(tags_input.tags[1].rect)
     QTest.mouseClick(tags_input, Qt.LeftButton, pos=cross_rect.center().toPoint())
+    QTest.qWait(100)  # It can take some time for the GUI to remove the tag after the click event
     assert len(tags_input.tags) == num_tags - 1
     screenshot(window, name="edit_tags_dialog_second_tags_removed")
 


### PR DESCRIPTION
It can take some time for the GUI to remove a tag after clicking the cross button, and this action is not instantly. Therefore, if the machine is busy, the tag could not have been removed correctly and the assert will fail. Adding a small timeout between the mouseclick and the assert should address this issue.

As much as I dislike hard-coded timeouts in tests, I believe this one is reasonable and necessary since Qt events are processed asynchronously.

Fixes #6541