### PR TITLE
Add CoreRuntimeError to the error list that causes Tribler shutdown

### DIFF
--- a/src/tribler-gui/tribler_gui/core_manager.py
+++ b/src/tribler-gui/tribler_gui/core_manager.py
@@ -20,6 +20,10 @@ START_FAKE_API = False
 SKIP_VERSION_CLEANUP = os.environ.get("SKIP_VERSION_CLEANUP", "FALSE").lower() == "true"
 
 
+class CoreRuntimeError(Exception):
+    """This error raises in case of tribler core finished with error"""
+
+
 class CoreManager(QObject):
     """
     The CoreManager is responsible for managing the Tribler core (starting/stopping). When we are running the GUI tests,
@@ -83,7 +87,7 @@ class CoreManager(QObject):
                     self.core_traceback_timestamp,
                 )
 
-            raise RuntimeError(exception_msg)
+            raise CoreRuntimeError(exception_msg)
 
     def start(self, core_args=None, core_env=None):
         """

--- a/src/tribler-gui/tribler_gui/error_handler.py
+++ b/src/tribler-gui/tribler_gui/error_handler.py
@@ -5,6 +5,7 @@ import traceback
 from tribler_common.reported_error import ReportedError
 from tribler_common.sentry_reporter.sentry_reporter import SentryReporter
 
+from tribler_gui.core_manager import CoreRuntimeError
 from tribler_gui.dialogs.feedbackdialog import FeedbackDialog
 from tribler_gui.event_request_manager import CoreConnectTimeoutError
 
@@ -32,8 +33,8 @@ class ErrorHandler:
 
         text = "".join(traceback.format_exception(info_type, info_error, tb))
 
-        is_core_timeout_exception = info_type is CoreConnectTimeoutError
-        if is_core_timeout_exception:
+        is_core_exception = info_type in (CoreConnectTimeoutError, CoreRuntimeError)
+        if is_core_exception:
             text = text + self.tribler_window.core_manager.core_traceback
             self._stop_tribler(text)
 
@@ -51,7 +52,7 @@ class ErrorHandler:
             start_time=self.tribler_window.start_time,
             stop_application_on_close=self._tribler_stopped,
             additional_tags={'source': 'gui'},
-            retrieve_error_message_from_stacktrace=is_core_timeout_exception
+            retrieve_error_message_from_stacktrace=is_core_exception
         ).show()
 
     def core_error(self, reported_error: ReportedError):

--- a/src/tribler-gui/tribler_gui/tests/test_core_manager.py
+++ b/src/tribler-gui/tribler_gui/tests/test_core_manager.py
@@ -1,0 +1,35 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tribler_gui.core_manager import CoreManager, CoreRuntimeError
+
+pytestmark = pytest.mark.asyncio
+
+
+# pylint: disable=
+# fmt: off
+
+@patch.object(CoreManager, 'on_finished')
+@patch('tribler_gui.core_manager.EventRequestManager', new=MagicMock())
+async def test_on_core_finished_call_on_finished(mocked_on_finished: MagicMock):
+    # test that in case of `shutting_down` and `should_stop_on_shutdown` flags have been set to True
+    # then `on_finished` function will be called and Exception will not be raised
+
+    core_manager = CoreManager(MagicMock(), MagicMock(), MagicMock())
+    core_manager.shutting_down = True
+    core_manager.should_stop_on_shutdown = True
+
+    core_manager.on_core_finished(exit_code=1, exit_status='exit status')
+    mocked_on_finished.assert_called_once()
+
+
+@patch('tribler_gui.core_manager.EventRequestManager', new=MagicMock())
+async def test_on_core_finished_raises_error():
+    # test that in case of flag `shutting_down` has been set to True and
+    # exit_code is not equal to 0, then CoreRuntimeError should be raised
+
+    core_manager = CoreManager(MagicMock(), MagicMock(), MagicMock())
+
+    with pytest.raises(CoreRuntimeError):
+        core_manager.on_core_finished(exit_code=1, exit_status='exit status')

--- a/src/tribler-gui/tribler_gui/tests/test_error_handler.py
+++ b/src/tribler-gui/tribler_gui/tests/test_error_handler.py
@@ -4,6 +4,7 @@ import pytest
 
 from tribler_common.reported_error import ReportedError
 
+from tribler_gui.core_manager import CoreRuntimeError
 from tribler_gui.error_handler import ErrorHandler
 from tribler_gui.event_request_manager import CoreConnectTimeoutError
 
@@ -41,18 +42,33 @@ async def test_gui_info_type_in_handled_exceptions(mocked_feedback_dialog: Magic
 
 
 @patch('tribler_gui.error_handler.FeedbackDialog')
-async def test_gui_is_core_timeout_exception(mocked_feedback_dialog: MagicMock, error_handler: ErrorHandler):
+@patch.object(ErrorHandler, '_stop_tribler')
+async def test_gui_core_connect_timeout_error(mocked_stop_tribler, mocked_feedback_dialog: MagicMock,
+                                              error_handler: ErrorHandler):
     # test that in case of CoreConnectTimeoutError Tribler should stop it's work
-    error_handler._stop_tribler = MagicMock()
     error_handler.gui_error(CoreConnectTimeoutError, None, None)
-    error_handler._stop_tribler.assert_called_once()
+    mocked_stop_tribler.assert_called_once()
 
 
 @patch('tribler_gui.error_handler.FeedbackDialog')
-async def test_gui_is_core_timeout_exception(mocked_feedback_dialog: MagicMock, error_handler: ErrorHandler):
-    # test that gui_error creates FeedbackDialog
+@patch.object(ErrorHandler, '_stop_tribler')
+async def test_gui_core_connect_timeout_error(mocked_stop_tribler: MagicMock, mocked_feedback_dialog: MagicMock,
+                                              error_handler: ErrorHandler):
+    # test that in case of CoreRuntimeError Tribler should stop it's work
+    error_handler.gui_error(CoreRuntimeError, None, None)
+
+    mocked_stop_tribler.assert_called_once()
+
+
+@patch('tribler_gui.error_handler.FeedbackDialog')
+@patch.object(ErrorHandler, '_stop_tribler')
+async def test_gui_is_not_core_exception(mocked_stop_tribler: MagicMock, mocked_feedback_dialog: MagicMock,
+                                         error_handler: ErrorHandler):
+    # test that gui_error creates FeedbackDialog without stopping the Tribler's work
     error_handler.gui_error(Exception, None, None)
+
     mocked_feedback_dialog.assert_called_once()
+    mocked_stop_tribler.assert_not_called()
 
 
 @patch('tribler_gui.error_handler.FeedbackDialog')


### PR DESCRIPTION
This PR fixes #6521 by introducing `CoreRuntimeError` and adding this error to the list that causes Tribler shutdown.