### PR TITLE
Add CoreRuntimeError to the error list that causes Tribler shutdown 

### DIFF
--- a/src/tribler-gui/tribler_gui/__init__.py
+++ b/src/tribler-gui/tribler_gui/__init__.py
@@ -9,6 +9,11 @@ from tribler_common.logger import setup_logging
 
 logger = logging.getLogger(__name__)
 
+
+class CoreError(Exception):
+    """This is the base class for exceptions that causes GUI shutdown"""
+
+
 def load_logger_config(log_dir):
     """
     Loads tribler-gui module logger configuration. Note that this function should be called explicitly to

--- a/src/tribler-gui/tribler_gui/__init__.py
+++ b/src/tribler-gui/tribler_gui/__init__.py
@@ -10,10 +10,6 @@ from tribler_common.logger import setup_logging
 logger = logging.getLogger(__name__)
 
 
-class CoreError(Exception):
-    """This is the base class for exceptions that causes GUI shutdown"""
-
-
 def load_logger_config(log_dir):
     """
     Loads tribler-gui module logger configuration. Note that this function should be called explicitly to

--- a/src/tribler-gui/tribler_gui/core_manager.py
+++ b/src/tribler-gui/tribler_gui/core_manager.py
@@ -21,8 +21,7 @@ START_FAKE_API = False
 SKIP_VERSION_CLEANUP = os.environ.get("SKIP_VERSION_CLEANUP", "FALSE").lower() == "true"
 
 
-class CoreCrashedError(CoreError):
-    """This error raises in case of tribler core finished with error"""
+
 
 
 class CoreManager(QObject):

--- a/src/tribler-gui/tribler_gui/core_manager.py
+++ b/src/tribler-gui/tribler_gui/core_manager.py
@@ -12,12 +12,17 @@ from tribler_common.osutils import get_root_state_directory
 from tribler_common.utilities import is_frozen
 from tribler_common.version_manager import TriblerVersion, VersionHistory
 
+from tribler_gui import CoreError
 from tribler_gui.event_request_manager import EventRequestManager
 from tribler_gui.tribler_request_manager import TriblerNetworkRequest
 from tribler_gui.utilities import connect, format_size, get_base_path, tr
 
 START_FAKE_API = False
 SKIP_VERSION_CLEANUP = os.environ.get("SKIP_VERSION_CLEANUP", "FALSE").lower() == "true"
+
+
+class CoreCrashedError(CoreError):
+    """This error raises in case of tribler core finished with error"""
 
 
 class CoreManager(QObject):
@@ -83,7 +88,7 @@ class CoreManager(QObject):
                     self.core_traceback_timestamp,
                 )
 
-            raise RuntimeError(exception_msg)
+            raise CoreCrashedError(exception_msg)
 
     def start(self, core_args=None, core_env=None):
         """

--- a/src/tribler-gui/tribler_gui/core_manager.py
+++ b/src/tribler-gui/tribler_gui/core_manager.py
@@ -12,16 +12,13 @@ from tribler_common.osutils import get_root_state_directory
 from tribler_common.utilities import is_frozen
 from tribler_common.version_manager import TriblerVersion, VersionHistory
 
-from tribler_gui import CoreError
 from tribler_gui.event_request_manager import EventRequestManager
+from tribler_gui.exceptions import CoreCrashedError
 from tribler_gui.tribler_request_manager import TriblerNetworkRequest
 from tribler_gui.utilities import connect, format_size, get_base_path, tr
 
 START_FAKE_API = False
 SKIP_VERSION_CLEANUP = os.environ.get("SKIP_VERSION_CLEANUP", "FALSE").lower() == "true"
-
-
-
 
 
 class CoreManager(QObject):

--- a/src/tribler-gui/tribler_gui/error_handler.py
+++ b/src/tribler-gui/tribler_gui/error_handler.py
@@ -5,10 +5,10 @@ import traceback
 from tribler_common.reported_error import ReportedError
 from tribler_common.sentry_reporter.sentry_reporter import SentryReporter
 
-from tribler_gui import CoreError
-from tribler_gui.dialogs.feedbackdialog import FeedbackDialog
-
 # fmt: off
+from tribler_gui.dialogs.feedbackdialog import FeedbackDialog
+from tribler_gui.exceptions import CoreError
+
 
 class ErrorHandler:
     def __init__(self, tribler_window):

--- a/src/tribler-gui/tribler_gui/error_handler.py
+++ b/src/tribler-gui/tribler_gui/error_handler.py
@@ -5,8 +5,8 @@ import traceback
 from tribler_common.reported_error import ReportedError
 from tribler_common.sentry_reporter.sentry_reporter import SentryReporter
 
+from tribler_gui import CoreError
 from tribler_gui.dialogs.feedbackdialog import FeedbackDialog
-from tribler_gui.event_request_manager import CoreConnectTimeoutError
 
 # fmt: off
 
@@ -32,8 +32,8 @@ class ErrorHandler:
 
         text = "".join(traceback.format_exception(info_type, info_error, tb))
 
-        is_core_timeout_exception = info_type is CoreConnectTimeoutError
-        if is_core_timeout_exception:
+        is_core_exception = issubclass(info_type, CoreError)
+        if is_core_exception:
             text = text + self.tribler_window.core_manager.core_traceback
             self._stop_tribler(text)
 
@@ -51,7 +51,7 @@ class ErrorHandler:
             start_time=self.tribler_window.start_time,
             stop_application_on_close=self._tribler_stopped,
             additional_tags={'source': 'gui'},
-            retrieve_error_message_from_stacktrace=is_core_timeout_exception
+            retrieve_error_message_from_stacktrace=is_core_exception
         ).show()
 
     def core_error(self, reported_error: ReportedError):

--- a/src/tribler-gui/tribler_gui/event_request_manager.py
+++ b/src/tribler-gui/tribler_gui/event_request_manager.py
@@ -9,16 +9,12 @@ from tribler_common.reported_error import ReportedError
 from tribler_common.sentry_reporter.sentry_reporter import SentryReporter
 from tribler_common.simpledefs import NTFY
 
-from tribler_gui import CoreError
+from tribler_gui.exceptions import CoreConnectTimeoutError
 from tribler_gui.utilities import connect
 
 received_events = []
 
 CORE_CONNECTION_ATTEMPTS_LIMIT = 120
-
-
-class CoreConnectTimeoutError(CoreError):
-    pass
 
 
 class EventRequestManager(QNetworkAccessManager):

--- a/src/tribler-gui/tribler_gui/event_request_manager.py
+++ b/src/tribler-gui/tribler_gui/event_request_manager.py
@@ -9,15 +9,15 @@ from tribler_common.reported_error import ReportedError
 from tribler_common.sentry_reporter.sentry_reporter import SentryReporter
 from tribler_common.simpledefs import NTFY
 
+from tribler_gui import CoreError
 from tribler_gui.utilities import connect
 
 received_events = []
 
-
 CORE_CONNECTION_ATTEMPTS_LIMIT = 120
 
 
-class CoreConnectTimeoutError(RuntimeError):
+class CoreConnectTimeoutError(CoreError):
     pass
 
 
@@ -64,7 +64,7 @@ class EventRequestManager(QNetworkAccessManager):
             NTFY.EVENTS_START.value: self.events_start_received,
             NTFY.TRIBLER_STARTED.value: self.tribler_started_event,
             NTFY.REPORT_CONFIG_ERROR.value: self.config_error_signal.emit,
-            NTFY.TRIBLER_EXCEPTION.value: lambda data: self.error_handler.core_error(ReportedError(**data))
+            NTFY.TRIBLER_EXCEPTION.value: lambda data: self.error_handler.core_error(ReportedError(**data)),
         }
 
     def events_start_received(self, event_dict):

--- a/src/tribler-gui/tribler_gui/exceptions.py
+++ b/src/tribler-gui/tribler_gui/exceptions.py
@@ -1,0 +1,10 @@
+class CoreError(Exception):
+    """This is the base class for exceptions that causes GUI shutdown"""
+
+
+class CoreConnectTimeoutError(CoreError):
+    ...
+
+
+class CoreCrashedError(CoreError):
+    """This error raises in case of tribler core finished with error"""

--- a/src/tribler-gui/tribler_gui/tests/test_core_manager.py
+++ b/src/tribler-gui/tribler_gui/tests/test_core_manager.py
@@ -1,0 +1,35 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tribler_gui.core_manager import CoreCrashedError, CoreManager
+
+pytestmark = pytest.mark.asyncio
+
+
+# pylint: disable=
+# fmt: off
+
+@patch.object(CoreManager, 'on_finished')
+@patch('tribler_gui.core_manager.EventRequestManager', new=MagicMock())
+async def test_on_core_finished_call_on_finished(mocked_on_finished: MagicMock):
+    # test that in case of `shutting_down` and `should_stop_on_shutdown` flags have been set to True
+    # then `on_finished` function will be called and Exception will not be raised
+
+    core_manager = CoreManager(MagicMock(), MagicMock(), MagicMock())
+    core_manager.shutting_down = True
+    core_manager.should_stop_on_shutdown = True
+
+    core_manager.on_core_finished(exit_code=1, exit_status='exit status')
+    mocked_on_finished.assert_called_once()
+
+
+@patch('tribler_gui.core_manager.EventRequestManager', new=MagicMock())
+async def test_on_core_finished_raises_error():
+    # test that in case of flag `shutting_down` has been set to True and
+    # exit_code is not equal to 0, then CoreRuntimeError should be raised
+
+    core_manager = CoreManager(MagicMock(), MagicMock(), MagicMock())
+
+    with pytest.raises(CoreCrashedError):
+        core_manager.on_core_finished(exit_code=1, exit_status='exit status')

--- a/src/tribler-gui/tribler_gui/tests/test_error_handler.py
+++ b/src/tribler-gui/tribler_gui/tests/test_error_handler.py
@@ -4,6 +4,7 @@ import pytest
 
 from tribler_common.reported_error import ReportedError
 
+from tribler_gui.core_manager import CoreCrashedError
 from tribler_gui.error_handler import ErrorHandler
 from tribler_gui.event_request_manager import CoreConnectTimeoutError
 
@@ -41,18 +42,33 @@ async def test_gui_info_type_in_handled_exceptions(mocked_feedback_dialog: Magic
 
 
 @patch('tribler_gui.error_handler.FeedbackDialog')
-async def test_gui_is_core_timeout_exception(mocked_feedback_dialog: MagicMock, error_handler: ErrorHandler):
+@patch.object(ErrorHandler, '_stop_tribler')
+async def test_gui_core_connect_timeout_error(mocked_stop_tribler, mocked_feedback_dialog: MagicMock,
+                                              error_handler: ErrorHandler):
     # test that in case of CoreConnectTimeoutError Tribler should stop it's work
-    error_handler._stop_tribler = MagicMock()
     error_handler.gui_error(CoreConnectTimeoutError, None, None)
-    error_handler._stop_tribler.assert_called_once()
+    mocked_stop_tribler.assert_called_once()
 
 
 @patch('tribler_gui.error_handler.FeedbackDialog')
-async def test_gui_is_core_timeout_exception(mocked_feedback_dialog: MagicMock, error_handler: ErrorHandler):
-    # test that gui_error creates FeedbackDialog
+@patch.object(ErrorHandler, '_stop_tribler')
+async def test_gui_core_connect_timeout_error(mocked_stop_tribler: MagicMock, mocked_feedback_dialog: MagicMock,
+                                              error_handler: ErrorHandler):
+    # test that in case of CoreRuntimeError Tribler should stop it's work
+    error_handler.gui_error(CoreCrashedError, None, None)
+
+    mocked_stop_tribler.assert_called_once()
+
+
+@patch('tribler_gui.error_handler.FeedbackDialog')
+@patch.object(ErrorHandler, '_stop_tribler')
+async def test_gui_is_not_core_exception(mocked_stop_tribler: MagicMock, mocked_feedback_dialog: MagicMock,
+                                         error_handler: ErrorHandler):
+    # test that gui_error creates FeedbackDialog without stopping the Tribler's work
     error_handler.gui_error(Exception, None, None)
+
     mocked_feedback_dialog.assert_called_once()
+    mocked_stop_tribler.assert_not_called()
 
 
 @patch('tribler_gui.error_handler.FeedbackDialog')

--- a/src/tribler-gui/tribler_gui/tests/test_error_handler.py
+++ b/src/tribler-gui/tribler_gui/tests/test_error_handler.py
@@ -4,9 +4,8 @@ import pytest
 
 from tribler_common.reported_error import ReportedError
 
-from tribler_gui.core_manager import CoreCrashedError
 from tribler_gui.error_handler import ErrorHandler
-from tribler_gui.event_request_manager import CoreConnectTimeoutError
+from tribler_gui.exceptions import CoreConnectTimeoutError, CoreCrashedError
 
 pytestmark = pytest.mark.asyncio
 


### PR DESCRIPTION
This PR fixes #6521 by introducing CoreRuntimeError and adding this error to the list that causes Tribler shutdown.