### PR TITLE
Add exist_ok=True to mkdir

### DIFF
--- a/src/tribler-common/tribler_common/tests/test_patch_import.py
+++ b/src/tribler-common/tribler_common/tests/test_patch_import.py
@@ -1,13 +1,15 @@
+from mock.mock import MagicMock
+
 import pytest
 
 from tribler_common.patch_import import patch_import
+
 
 pytestmark = pytest.mark.asyncio
 
 
 # pylint: disable=import-outside-toplevel, import-error, unused-import
 # fmt: off
-
 
 @patch_import(['library_that_does_not_exist'])
 async def test_mock_import_mocked_lib():
@@ -19,3 +21,21 @@ async def test_mock_import_mocked_lib():
 async def test_mock_import_import_real_lib():
     with pytest.raises(ImportError):
         import library_that_does_not_exist
+
+
+@patch_import(['time'])
+async def test_mock_import_not_strict():
+    import time
+    assert not isinstance(time, MagicMock)
+
+
+@patch_import(['time'], strict=True)
+async def test_mock_import_strict():
+    import time
+    assert isinstance(time, MagicMock)
+
+
+@patch_import(['time'], always_raise_exception_on_import=True)
+async def test_mock_import_always_raise_exception_on_import():
+    with pytest.raises(ImportError):
+        import time

--- a/src/tribler-core/tribler_core/check_os.py
+++ b/src/tribler-core/tribler_core/check_os.py
@@ -209,7 +209,7 @@ def enable_fault_handler(log_dir):
         import faulthandler
 
         if not log_dir.exists():
-            log_dir.mkdir(parents=True)
+            log_dir.mkdir(parents=True, exist_ok=True)
         crash_file = log_dir / "crash-report.log"
         faulthandler.enable(file=open(str(crash_file), "w"), all_threads=True)
     except ImportError:

--- a/src/tribler-core/tribler_core/tests/test_check_os.py
+++ b/src/tribler-core/tribler_core/tests/test_check_os.py
@@ -1,16 +1,47 @@
-from unittest.mock import patch
+from logging import Logger
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from tribler_core.check_os import error_and_exit
+from tribler_common.patch_import import patch_import
+
+from tribler_core.check_os import enable_fault_handler, error_and_exit
+
+# pylint: disable=import-outside-toplevel
+# fmt: off
 
 pytestmark = pytest.mark.asyncio
 
 
-# fmt: off
 @patch('sys.exit')
 @patch('tribler_core.check_os.show_system_popup')
 async def test_error_and_exit(mocked_show_system_popup, mocked_sys_exit):
     error_and_exit('title', 'text')
     mocked_show_system_popup.assert_called_once_with('title', 'text')
     mocked_sys_exit.assert_called_once_with(1)
+
+
+@patch_import(['faulthandler'], strict=True, enable=MagicMock())
+@patch('tribler_core.check_os.open', new=MagicMock())
+async def test_enable_fault_handler():
+    import faulthandler
+    enable_fault_handler(log_dir=MagicMock())
+    faulthandler.enable.assert_called_once()
+
+
+@patch_import(['faulthandler'], strict=True, always_raise_exception_on_import=True)
+@patch.object(Logger, 'error')
+@patch('tribler_core.check_os.open', new=MagicMock())
+async def test_enable_fault_handler_import_error(mocked_log_error: MagicMock):
+    enable_fault_handler(log_dir=MagicMock())
+    mocked_log_error.assert_called_once()
+
+
+@patch_import(['faulthandler'], strict=True, enable=MagicMock())
+@patch('tribler_core.check_os.open', new=MagicMock())
+async def test_enable_fault_handler_log_dir_not_exists():
+    log_dir = MagicMock(exists=MagicMock(return_value=False),
+                        mkdir=MagicMock())
+
+    enable_fault_handler(log_dir=log_dir)
+    log_dir.mkdir.assert_called_once()


### PR DESCRIPTION
This PR fixes #6157

It also extends `patch_import` function by adding two new arguments:
* **strict:** If `strict` is equal to True, then whenever importing module exists or not, it will be replaced
        by MagicMock. If `strict` is equal to False, then the real module will be return in case it is exist, and
        MagicMock in case the module doesn't exist.
* **always_raise_exception_on_import:** if set to True, then the import of the particular module always will raise
        the ImportError

These improvements to the `patch_import` are necessary to properly test `enable_fault_handler` function.