### PR TITLE
Replace core_traceback by last_core_output

### DIFF
--- a/src/tribler-gui/tribler_gui/error_handler.py
+++ b/src/tribler-gui/tribler_gui/error_handler.py
@@ -34,7 +34,7 @@ class ErrorHandler:
 
         is_core_exception = issubclass(info_type, CoreError)
         if is_core_exception:
-            text = text + self.tribler_window.core_manager.core_traceback
+            text = text + self.tribler_window.core_manager.last_core_output
             self._stop_tribler(text)
 
         self._logger.error(text)

--- a/src/tribler-gui/tribler_gui/tests/test_core_manager.py
+++ b/src/tribler-gui/tribler_gui/tests/test_core_manager.py
@@ -7,7 +7,6 @@ from tribler_gui.core_manager import CoreCrashedError, CoreManager
 pytestmark = pytest.mark.asyncio
 
 
-# pylint: disable=
 # fmt: off
 
 @patch.object(CoreManager, 'on_finished')
@@ -15,7 +14,6 @@ pytestmark = pytest.mark.asyncio
 async def test_on_core_finished_call_on_finished(mocked_on_finished: MagicMock):
     # test that in case of `shutting_down` and `should_stop_on_shutdown` flags have been set to True
     # then `on_finished` function will be called and Exception will not be raised
-
     core_manager = CoreManager(MagicMock(), MagicMock(), MagicMock())
     core_manager.shutting_down = True
     core_manager.should_stop_on_shutdown = True
@@ -28,8 +26,19 @@ async def test_on_core_finished_call_on_finished(mocked_on_finished: MagicMock):
 async def test_on_core_finished_raises_error():
     # test that in case of flag `shutting_down` has been set to True and
     # exit_code is not equal to 0, then CoreRuntimeError should be raised
-
     core_manager = CoreManager(MagicMock(), MagicMock(), MagicMock())
 
     with pytest.raises(CoreCrashedError):
         core_manager.on_core_finished(exit_code=1, exit_status='exit status')
+
+
+@patch('tribler_gui.core_manager.print')
+@patch('tribler_gui.core_manager.EventRequestManager', new=MagicMock())
+async def test_on_core_read_ready(mocked_print: MagicMock):
+    # test that method `on_core_read_ready` converts byte output to a string and prints it
+    core_manager = CoreManager(MagicMock(), MagicMock(), MagicMock())
+    core_manager.core_process = MagicMock(readAll=MagicMock(return_value=b'binary string'))
+
+    core_manager.on_core_read_ready()
+
+    mocked_print.assert_called_with('\tbinary string')


### PR DESCRIPTION
This PR fixes #6566 by replacing attempting to `extract core_traceback` from the core output to saving just `last_core_output`.

Also, the way of printing a core output has been changed to the following:
```python
        print(f'\t{self.last_core_output}') 
```
It gives more visual hints while reading the output log (GUI output without tab, Core output with tab)

```python
[PID:80545] 2021-11-19 12:44:42,585 - INFO - TriblerGUI(80) - Got Tribler core error: 1
	INFO:__main__:Sentry has been initialised in normal mode
	INFO:__main__:Root state dir: /Users/<user>/.Tribler
INFO:__main__:Running in "core" mode
[PID:80545] 2021-11-19 12:44:43,061 - INFO - TriblerGUI(136) - Will connect to events endpoint
[PID:80545] 2021-11-19 12:44:43,062 - INFO - TriblerGUI(80) - Got Tribler core error: 1
	INFO:tribler_core.start_core:Start tribler core. Base path: "/Users/<user>/Projects/github.com/Tribler/tribler/src/tribler-gui/tribler_gui/..". API port: "52194". API key: "<key>". Root state dir: "/Users/<user>/.Tribler". Core test mode: "False"
	[PID:80547] 2021-11-19 12:44:43,176 - INFO - Tribler Config(59) - Load: /Users/<user>/.Tribler/7.10/triblerd.conf. State dir: /Users/<user>/.Tribler/7.10. Reset config on error: True
	[PID:80547] 2021-11-19 12:44:43,177 - INFO - Tribler Config(40) - Init. State dir: None. File: None
	[PID:80547] 2021-11-19 12:44:43,177 - INFO - tribler_core.check_os(225) - Check and enable code tracing. Process name: "core". Log dir: "/Users/<user>/.Tribler/7.10/log"
```


The reported issue after the fix: https://sentry.tribler.org/organizations/tribler/issues/958
The GUI output after the fix:
```python
[PID:80545] 2021-11-19 12:45:14,394 - ERROR <error_handler:40> ErrorHandler.gui_error(): tribler_gui.utilities.CreationTraceback: 
  File "/Users/<user>/Projects/github.com/Tribler/tribler/src/run_tribler.py", line 124, in <module>
    sys.exit(app.exec_())
  File "/Users/<user>/Projects/github.com/Tribler/tribler/src/tribler-gui/tribler_gui/utilities.py", line 370, in trackback_wrapper
    callback(*args, **kwargs)
  File "/Users/<user>/Projects/github.com/Tribler/tribler/src/tribler-gui/tribler_gui/core_manager.py", line 86, in on_request_error
    self.start_tribler_core(core_args=core_args, core_env=core_env)
  File "/Users/<user>/Projects/github.com/Tribler/tribler/src/tribler-gui/tribler_gui/core_manager.py", line 166, in start_tribler_core
    connect(self.core_process.finished, self.on_core_finished)


The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/<user>/Projects/github.com/Tribler/tribler/src/tribler-gui/tribler_gui/utilities.py", line 373, in trackback_wrapper
    raise exc from CreationTraceback(traceback_str)
  File "/Users/<user>/Projects/github.com/Tribler/tribler/src/tribler-gui/tribler_gui/utilities.py", line 370, in trackback_wrapper
    callback(*args, **kwargs)
  File "/Users/<user>/Projects/github.com/Tribler/tribler/src/tribler-gui/tribler_gui/core_manager.py", line 76, in on_core_finished
    raise CoreCrashedError(exception_message)
tribler_gui.exceptions.CoreCrashedError: The Tribler core has unexpectedly finished with exit code 9 and status: 1!
Last core output: 
 [PID:80547] 2021-11-19 12:45:13,608 - INFO - Socks5Connection(210) - Closing session, reason unspecified
[PID:80547] 2021-11-19 12:45:13,608 - INFO - Socks5Connection(210) - Closing session, reason unspecified
```
