### PR TITLE
Add requirements.txt

### DIFF
--- a/build/win/makedist_win.bat
+++ b/build/win/makedist_win.bat
@@ -48,8 +48,8 @@ python3 -m pip install --upgrade -r src\requirements.txt
 REM Arno: When adding files here, make sure tribler.nsi actually
 REM packs them in the installer .EXE
 
-python3 -m pip install --upgrade --no-deps --force-reinstall pydantic --no-binary pydantic
-python3 -m pip install --upgrade --no-deps --force-reinstall typing_extensions==3.10.0.2 --no-binary typing_extensions
+ECHO Install pip dependencies for correct py-installer's work
+python3 -m pip install --upgrade build\win\requirements.txt
 
 %PYTHONHOME%\Scripts\pyinstaller.exe tribler.spec
 

--- a/build/win/makedist_win.bat
+++ b/build/win/makedist_win.bat
@@ -49,7 +49,7 @@ REM Arno: When adding files here, make sure tribler.nsi actually
 REM packs them in the installer .EXE
 
 ECHO Install pip dependencies for correct py-installer's work
-python3 -m pip install --upgrade build\win\requirements.txt
+python3 -m pip install --upgrade -r build\win\requirements.txt
 
 %PYTHONHOME%\Scripts\pyinstaller.exe tribler.spec
 

--- a/build/win/requirements.txt
+++ b/build/win/requirements.txt
@@ -1,0 +1,4 @@
+--no-binary :all:
+
+typing_extensions==3.10.0.2
+pydantic==1.8.2


### PR DESCRIPTION
This PR fixes #6569 by adding requrements.txt for the windows build.

The documentation about how to specify `--no-binary` for the requrements.txt: https://pip.pypa.io/en/latest/reference/requirements-file-format/#structure
