### PR TITLE
Remove .coveragerc

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,0 @@
-# .coveragerc to control coverage.py
-[run]
-branch = True


### PR DESCRIPTION
`.coveragerc` is a config file for [coverage.py](https://coverage.readthedocs.io/en/6.1.1/config.html).

Now we don't use `coverage.py`and using [diff-cover](https://diff-cover.readthedocs.io/en/latest/README.html) instead (for creating coverage reports during [Coverage Check](https://jenkins-ci.tribler.org/job/GH_Tribler_PR_Tests/job/PR_coverage_check/configure)).

Therefore there is no longer a need for `.coveragerc`.