### PR TITLE
Improve tests for patch_import.py

### DIFF
--- a/src/tribler-common/tribler_common/tests/test_patch_import.py
+++ b/src/tribler-common/tribler_common/tests/test_patch_import.py
@@ -15,11 +15,20 @@ async def test_mock_import_mocked_lib():
     import library_that_does_not_exist
     assert library_that_does_not_exist
 
+    # test that mocks for inner inner function are presented
+    assert library_that_does_not_exist.inner_function
+
+    # test that magic methods of objects from patched library works correctly
+    assert len(library_that_does_not_exist.inner_set) == 0
+
 
 @patch_import([])
 async def test_mock_import_import_real_lib():
     with pytest.raises(ImportError):
         import library_that_does_not_exist
+        # `library_that_does_not_exist.inner_function()` call is unnecessary for the test itself, but it prevents
+        # removing "unused" `import library_that_does_not_exist` during IDE autoformat procedure.
+        library_that_does_not_exist.inner_function()
 
 
 @patch_import(['time'])
@@ -38,3 +47,6 @@ async def test_mock_import_strict():
 async def test_mock_import_always_raise_exception_on_import():
     with pytest.raises(ImportError):
         import time
+        # `time.gmtime(0)` call is unnecessary for the test itself, but it prevents removing "unused"
+        # `import time` during IDE autoformat procedure.
+        time.gmtime(0)


### PR DESCRIPTION
This PR introduces two improvements for `patch_import.py`:

1. It adds a test for Magic methods usage inside a patched library
2. It adds (unnecessary) calls for tested libraries to prevent removing them during IDE autoformatting.