### PR TITLE
Revert changelog based on git commit

### DIFF
--- a/build/debian/makedist_debian.sh
+++ b/build/debian/makedist_debian.sh
@@ -30,11 +30,9 @@ TRIBLER_VERSION=$(cat .TriblerVersion)
 sed -i "s/__VERSION__/$TRIBLER_VERSION/g" build/debian/snap/snapcraft.yaml
 
 pushd build/debian/tribler || exit
-# Compose the changelog using git commits
-git log "$(git describe --tags --abbrev=0)"..HEAD --oneline |
-while IFS= read -r commit; do
-  dch -v $TRIBLER_VERSION "$commit"
-done
+# Compose the changelog
+dch -v $TRIBLER_VERSION "New release"
+dch -v $TRIBLER_VERSION "See https://github.com/Tribler/tribler/releases/tag/$TRIBLER_VERSION for more info"
 # Build the package afterwards
 dpkg-buildpackage -b -rfakeroot -us -uc
 popd || exit


### PR DESCRIPTION
The current changelog generation script does not work when the current tag and HEAD are the same. This PR reverts the git commit based changelog and uses a generic log pointing to Github tag URL.