### PR TITLE
Improved GUI dialog logic

### DIFF
--- a/src/tribler-gui/tribler_gui/dialog_manager.py
+++ b/src/tribler-gui/tribler_gui/dialog_manager.py
@@ -6,14 +6,14 @@ class DialogManager:
     This class manages all dialogs that are created in the GUI.
     The only exception is the feedback dialog that is raised when an error occurs in the GUI.
     """
-    dialogs: List["DialogContainer"] = []  # Stack of open dialogs - recent dialogs are at the end of this list
+    dialogs: List["DialogContainer"] = []  # noqa: F821
 
     @staticmethod
-    def add_dialog(dialog: "DialogContainer") -> None:
+    def add_dialog(dialog: "DialogContainer") -> None:  # noqa: F821
         DialogManager.dialogs.append(dialog)
 
     @staticmethod
-    def remove_dialog(dialog: "DialogContainer") -> None:
+    def remove_dialog(dialog: "DialogContainer") -> None:  # noqa: F821
         if dialog in DialogManager.dialogs:
             DialogManager.dialogs.remove(dialog)
 

--- a/src/tribler-gui/tribler_gui/dialog_manager.py
+++ b/src/tribler-gui/tribler_gui/dialog_manager.py
@@ -1,0 +1,36 @@
+from typing import List, Optional, Type
+
+
+class DialogManager:
+    """
+    This class manages all dialogs that are created in the GUI.
+    The only exception is the feedback dialog that is raised when an error occurs in the GUI.
+    """
+    dialogs: List["DialogContainer"] = []  # Stack of open dialogs - recent dialogs are at the end of this list
+
+    @staticmethod
+    def add_dialog(dialog: "DialogContainer") -> None:
+        DialogManager.dialogs.append(dialog)
+
+    @staticmethod
+    def remove_dialog(dialog: "DialogContainer") -> None:
+        if dialog in DialogManager.dialogs:
+            DialogManager.dialogs.remove(dialog)
+
+    @staticmethod
+    def get_dialogs(diag_cls: Optional[Type]):
+        """
+        Return either all dialogs or dialogs with a specific type.
+        """
+        if not diag_cls:
+            return DialogManager.dialogs
+        return [dialog for dialog in DialogManager.dialogs if isinstance(dialog, diag_cls)]
+
+    @staticmethod
+    def close_all_dialogs(diag_cls: Optional[Type] = None) -> None:
+        """
+        Close all open dialogs or dialogs with a specific type.
+        """
+        to_close = DialogManager.get_dialogs(diag_cls) if diag_cls else DialogManager.dialogs
+        for dialog in to_close:
+            dialog.close_dialog()

--- a/src/tribler-gui/tribler_gui/dialog_manager.py
+++ b/src/tribler-gui/tribler_gui/dialog_manager.py
@@ -6,14 +6,14 @@ class DialogManager:
     This class manages all dialogs that are created in the GUI.
     The only exception is the feedback dialog that is raised when an error occurs in the GUI.
     """
-    dialogs: List["DialogContainer"] = []  # noqa: F821
+    dialogs: List["TriblerDialog"] = []  # noqa: F821
 
     @staticmethod
-    def add_dialog(dialog: "DialogContainer") -> None:  # noqa: F821
+    def add_dialog(dialog: "TriblerDialog") -> None:  # noqa: F821
         DialogManager.dialogs.append(dialog)
 
     @staticmethod
-    def remove_dialog(dialog: "DialogContainer") -> None:  # noqa: F821
+    def remove_dialog(dialog: "TriblerDialog") -> None:  # noqa: F821
         if dialog in DialogManager.dialogs:
             DialogManager.dialogs.remove(dialog)
 

--- a/src/tribler-gui/tribler_gui/dialogs/addtagsdialog.py
+++ b/src/tribler-gui/tribler_gui/dialogs/addtagsdialog.py
@@ -7,22 +7,22 @@ from PyQt5.QtWidgets import QSizePolicy, QWidget
 from tribler_common.tag_constants import MAX_TAG_LENGTH, MIN_TAG_LENGTH
 
 from tribler_gui.defs import TAG_HORIZONTAL_MARGIN
-from tribler_gui.dialogs.dialogcontainer import DialogContainer
+from tribler_gui.dialogs.triblerdialog import TriblerDialog
 from tribler_gui.tribler_request_manager import TriblerNetworkRequest
 from tribler_gui.utilities import connect, get_ui_file_path, tr
 from tribler_gui.widgets.tagbutton import TagButton
 
 
-class AddTagsDialog(DialogContainer):
+class AddTagsDialog(TriblerDialog):
     """
     This dialog enables a user to add new tags to/remove existing tags from content.
     """
 
-    save_button_clicked = pyqtSignal(DialogContainer, QModelIndex, list)
+    save_button_clicked = pyqtSignal(TriblerDialog, QModelIndex, list)
     suggestions_loaded = pyqtSignal()
 
     def __init__(self, parent: QWidget, infohash: str) -> None:
-        DialogContainer.__init__(self, parent, left_right_margin=400)
+        TriblerDialog.__init__(self, parent, left_right_margin=400)
         self.index: Optional[QModelIndex] = None
         self.infohash = infohash
 

--- a/src/tribler-gui/tribler_gui/dialogs/addtagsdialog.py
+++ b/src/tribler-gui/tribler_gui/dialogs/addtagsdialog.py
@@ -18,7 +18,7 @@ class AddTagsDialog(DialogContainer):
     This dialog enables a user to add new tags to/remove existing tags from content.
     """
 
-    save_button_clicked = pyqtSignal(QModelIndex, list)
+    save_button_clicked = pyqtSignal(DialogContainer, QModelIndex, list)
     suggestions_loaded = pyqtSignal()
 
     def __init__(self, parent: QWidget, infohash: str) -> None:
@@ -57,7 +57,7 @@ class AddTagsDialog(DialogContainer):
                 self.dialog_widget.error_text_label.setHidden(False)
                 return
 
-        self.save_button_clicked.emit(self.index, entered_tags)
+        self.save_button_clicked.emit(self, self.index, entered_tags)
 
     def on_received_suggestions(self, data: Dict) -> None:
         self.suggestions_loaded.emit()

--- a/src/tribler-gui/tribler_gui/dialogs/addtopersonalchanneldialog.py
+++ b/src/tribler-gui/tribler_gui/dialogs/addtopersonalchanneldialog.py
@@ -5,8 +5,8 @@ from PyQt5.QtCore import pyqtSignal
 
 from tribler_core.components.metadata_store.db.serialization import CHANNEL_TORRENT, COLLECTION_NODE
 
-from tribler_gui.dialogs.dialogcontainer import DialogContainer
 from tribler_gui.dialogs.new_channel_dialog import NewChannelDialog
+from tribler_gui.dialogs.triblerdialog import TriblerDialog
 from tribler_gui.tribler_request_manager import TriblerNetworkRequest
 from tribler_gui.utilities import connect, get_ui_file_path
 
@@ -17,11 +17,11 @@ class ChannelQTreeWidgetItem(QtWidgets.QTreeWidgetItem):
         QtWidgets.QTreeWidgetItem.__init__(self, *args, **kwargs)
 
 
-class AddToChannelDialog(DialogContainer):
+class AddToChannelDialog(TriblerDialog):
     create_torrent_notification = pyqtSignal(dict)
 
     def __init__(self, parent):
-        DialogContainer.__init__(self, parent)
+        TriblerDialog.__init__(self, parent)
         uic.loadUi(get_ui_file_path('addtochanneldialog.ui'), self.dialog_widget)
         connect(self.dialog_widget.btn_cancel.clicked, self.close_dialog)
         connect(self.dialog_widget.btn_confirm.clicked, self.on_confirm_clicked)

--- a/src/tribler-gui/tribler_gui/dialogs/confirmationdialog.py
+++ b/src/tribler-gui/tribler_gui/dialogs/confirmationdialog.py
@@ -10,7 +10,7 @@ from tribler_gui.widgets.ellipsebutton import EllipseButton
 
 
 class ConfirmationDialog(DialogContainer):
-    button_clicked = pyqtSignal(int)
+    button_clicked = pyqtSignal(DialogContainer, int)
 
     def __init__(self, parent, title, main_text, buttons, show_input=False, checkbox_text=None):
         DialogContainer.__init__(self, parent)
@@ -28,7 +28,7 @@ class ConfirmationDialog(DialogContainer):
         if not show_input:
             self.dialog_widget.dialog_input.setHidden(True)
         else:
-            connect(self.dialog_widget.dialog_input.returnPressed, lambda: self.button_clicked.emit(0))
+            connect(self.dialog_widget.dialog_input.returnPressed, lambda: self.button_clicked.emit(self, 0))
 
         if not checkbox_text:
             self.dialog_widget.checkbox.setHidden(True)
@@ -51,7 +51,7 @@ class ConfirmationDialog(DialogContainer):
     def show_error(cls, window, title, error_text):
         error_dialog = ConfirmationDialog(window, title, error_text, [(tr("CLOSE"), BUTTON_TYPE_NORMAL)])
 
-        def on_close(checked):
+        def on_close(_, __):
             error_dialog.close_dialog()
 
         connect(error_dialog.button_clicked, on_close)
@@ -62,7 +62,7 @@ class ConfirmationDialog(DialogContainer):
     def show_message(cls, window, title, message_text, button_text):
         error_dialog = ConfirmationDialog(window, title, message_text, [(button_text, BUTTON_TYPE_NORMAL)])
 
-        def on_close(checked):
+        def on_close(_, __):
             error_dialog.close_dialog()
 
         connect(error_dialog.button_clicked, on_close)
@@ -94,4 +94,4 @@ class ConfirmationDialog(DialogContainer):
         )
 
         self.dialog_widget.dialog_button_container.layout().addWidget(button)
-        connect(button.clicked, lambda _: self.button_clicked.emit(index))
+        connect(button.clicked, lambda _: self.button_clicked.emit(self, index))

--- a/src/tribler-gui/tribler_gui/dialogs/confirmationdialog.py
+++ b/src/tribler-gui/tribler_gui/dialogs/confirmationdialog.py
@@ -4,16 +4,16 @@ from PyQt5.QtGui import QCursor
 from PyQt5.QtWidgets import QSizePolicy, QSpacerItem
 
 from tribler_gui.defs import BUTTON_TYPE_NORMAL
-from tribler_gui.dialogs.dialogcontainer import DialogContainer
+from tribler_gui.dialogs.triblerdialog import TriblerDialog
 from tribler_gui.utilities import connect, get_ui_file_path, tr
 from tribler_gui.widgets.ellipsebutton import EllipseButton
 
 
-class ConfirmationDialog(DialogContainer):
-    button_clicked = pyqtSignal(DialogContainer, int)
+class ConfirmationDialog(TriblerDialog):
+    button_clicked = pyqtSignal(TriblerDialog, int)
 
     def __init__(self, parent, title, main_text, buttons, show_input=False, checkbox_text=None):
-        DialogContainer.__init__(self, parent)
+        TriblerDialog.__init__(self, parent)
 
         uic.loadUi(get_ui_file_path('buttonsdialog.ui'), self.dialog_widget)
 

--- a/src/tribler-gui/tribler_gui/dialogs/confirmationdialog.py
+++ b/src/tribler-gui/tribler_gui/dialogs/confirmationdialog.py
@@ -50,22 +50,14 @@ class ConfirmationDialog(DialogContainer):
     @classmethod
     def show_error(cls, window, title, error_text):
         error_dialog = ConfirmationDialog(window, title, error_text, [(tr("CLOSE"), BUTTON_TYPE_NORMAL)])
-
-        def on_close(_, __):
-            error_dialog.close_dialog()
-
-        connect(error_dialog.button_clicked, on_close)
+        connect(error_dialog.button_clicked, lambda _, __: error_dialog.close_dialog())
         error_dialog.show()
         return error_dialog
 
     @classmethod
     def show_message(cls, window, title, message_text, button_text):
         error_dialog = ConfirmationDialog(window, title, message_text, [(button_text, BUTTON_TYPE_NORMAL)])
-
-        def on_close(_, __):
-            error_dialog.close_dialog()
-
-        connect(error_dialog.button_clicked, on_close)
+        connect(error_dialog.button_clicked, lambda _, __: error_dialog.close_dialog())
         error_dialog.show()
         return error_dialog
 

--- a/src/tribler-gui/tribler_gui/dialogs/createtorrentdialog.py
+++ b/src/tribler-gui/tribler_gui/dialogs/createtorrentdialog.py
@@ -6,7 +6,7 @@ from PyQt5.QtWidgets import QAction, QFileDialog, QSizePolicy, QTreeWidgetItem
 
 from tribler_gui.defs import BUTTON_TYPE_NORMAL
 from tribler_gui.dialogs.confirmationdialog import ConfirmationDialog
-from tribler_gui.dialogs.dialogcontainer import DialogContainer
+from tribler_gui.dialogs.triblerdialog import TriblerDialog
 from tribler_gui.tribler_action_menu import TriblerActionMenu
 from tribler_gui.tribler_request_manager import TriblerNetworkRequest
 from tribler_gui.utilities import connect, get_ui_file_path, is_dir_writable, tr
@@ -17,13 +17,13 @@ class DownloadFileTreeWidgetItem(QTreeWidgetItem):
         QTreeWidgetItem.__init__(self, parent)
 
 
-class CreateTorrentDialog(DialogContainer):
+class CreateTorrentDialog(TriblerDialog):
 
     create_torrent_notification = pyqtSignal(dict)
     add_to_channel_selected = pyqtSignal(str)
 
     def __init__(self, parent):
-        DialogContainer.__init__(self, parent)
+        TriblerDialog.__init__(self, parent)
 
         uic.loadUi(get_ui_file_path('createtorrentdialog.ui'), self.dialog_widget)
 

--- a/src/tribler-gui/tribler_gui/dialogs/createtorrentdialog.py
+++ b/src/tribler-gui/tribler_gui/dialogs/createtorrentdialog.py
@@ -85,7 +85,7 @@ class CreateTorrentDialog(DialogContainer):
                 [(tr("CLOSE"), BUTTON_TYPE_NORMAL)],
             )
 
-            connect(dialog.button_clicked, dialog.close_dialog)
+            connect(dialog.button_clicked, lambda _, __: dialog.close_dialog())
             dialog.show()
             return
 

--- a/src/tribler-gui/tribler_gui/dialogs/dialogcontainer.py
+++ b/src/tribler-gui/tribler_gui/dialogs/dialogcontainer.py
@@ -3,8 +3,8 @@ from PyQt5.QtGui import QPainter
 from PyQt5.QtWidgets import QStyle, QStyleOption, QWidget
 
 from tribler_common.sentry_reporter.sentry_mixin import AddBreadcrumbOnShowMixin
-from tribler_gui.dialog_manager import DialogManager
 
+from tribler_gui.dialog_manager import DialogManager
 from tribler_gui.utilities import connect
 
 

--- a/src/tribler-gui/tribler_gui/dialogs/dialogcontainer.py
+++ b/src/tribler-gui/tribler_gui/dialogs/dialogcontainer.py
@@ -3,6 +3,7 @@ from PyQt5.QtGui import QPainter
 from PyQt5.QtWidgets import QStyle, QStyleOption, QWidget
 
 from tribler_common.sentry_reporter.sentry_mixin import AddBreadcrumbOnShowMixin
+from tribler_gui.dialog_manager import DialogManager
 
 from tribler_gui.utilities import connect
 
@@ -16,6 +17,7 @@ class DialogContainer(AddBreadcrumbOnShowMixin, QWidget):
         self.left_right_margin = left_right_margin  # The margin at the left and right of the dialog window
         self.closed = False
         connect(self.window().resize_event, self.on_main_window_resize)
+        DialogManager.add_dialog(self)
 
     def paintEvent(self, _):
         opt = QStyleOption()
@@ -28,6 +30,7 @@ class DialogContainer(AddBreadcrumbOnShowMixin, QWidget):
             self.setParent(None)
             self.deleteLater()
             self.closed = True
+            DialogManager.remove_dialog(self)
         except RuntimeError:
             pass
 

--- a/src/tribler-gui/tribler_gui/dialogs/new_channel_dialog.py
+++ b/src/tribler-gui/tribler_gui/dialogs/new_channel_dialog.py
@@ -23,7 +23,7 @@ class NewChannelDialog(ConfirmationDialog):
         connect(self.button_clicked, self.on_channel_name_dialog_done)
         self.show()
 
-    def on_channel_name_dialog_done(self, action):
+    def on_channel_name_dialog_done(self, _, action):
         if action == 0:
             text = self.dialog_widget.dialog_input.text()
             if text:

--- a/src/tribler-gui/tribler_gui/dialogs/new_version_dialog.py
+++ b/src/tribler-gui/tribler_gui/dialogs/new_version_dialog.py
@@ -1,0 +1,21 @@
+from PyQt5.QtGui import QWindow
+
+from tribler_gui.defs import BUTTON_TYPE_NORMAL
+from tribler_gui.dialogs.confirmationdialog import ConfirmationDialog
+from tribler_gui.utilities import tr
+
+
+class NewVersionDialog(ConfirmationDialog):
+
+    @classmethod
+    def show_dialog(cls, window: QWindow, version: str):
+        dialog = cls(
+            window,
+            tr("New version available"),
+            tr("Version %s of Tribler is available. Do you want to visit the "
+               "website to download the newest version?")
+            % version,
+            [(tr("IGNORE"), BUTTON_TYPE_NORMAL), (tr("LATER"), BUTTON_TYPE_NORMAL), (tr("OK"), BUTTON_TYPE_NORMAL)],
+        )
+        dialog.show()
+        return dialog

--- a/src/tribler-gui/tribler_gui/dialogs/startdownloaddialog.py
+++ b/src/tribler-gui/tribler_gui/dialogs/startdownloaddialog.py
@@ -28,7 +28,7 @@ from tribler_gui.widgets.torrentfiletreewidget import TORRENT_FILES_TREE_STYLESH
 
 class StartDownloadDialog(DialogContainer):
 
-    button_clicked = pyqtSignal(int)
+    button_clicked = pyqtSignal(DialogContainer, int)
     received_metainfo = pyqtSignal(dict)
 
     def __init__(self, parent, download_uri):
@@ -50,7 +50,7 @@ class StartDownloadDialog(DialogContainer):
         self.dialog_widget.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Expanding)
 
         connect(self.dialog_widget.browse_dir_button.clicked, self.on_browse_dir_clicked)
-        connect(self.dialog_widget.cancel_button.clicked, lambda _: self.button_clicked.emit(0))
+        connect(self.dialog_widget.cancel_button.clicked, lambda _: self.button_clicked.emit(self, 0))
         connect(self.dialog_widget.download_button.clicked, self.on_download_clicked)
         connect(self.dialog_widget.loading_files_label.clicked, self.on_reload_torrent_info)
         connect(self.dialog_widget.anon_download_checkbox.clicked, self.on_reload_torrent_info)
@@ -284,4 +284,4 @@ class StartDownloadDialog(DialogContainer):
                     self.dialog_widget, tr("Insufficient Permissions"), gui_error_message, "OK"
                 )
             else:
-                self.button_clicked.emit(1)
+                self.button_clicked.emit(self, 1)

--- a/src/tribler-gui/tribler_gui/dialogs/startdownloaddialog.py
+++ b/src/tribler-gui/tribler_gui/dialogs/startdownloaddialog.py
@@ -11,7 +11,7 @@ from tribler_common.utilities import uri_to_path
 
 from tribler_gui.defs import METAINFO_MAX_RETRIES, METAINFO_TIMEOUT
 from tribler_gui.dialogs.confirmationdialog import ConfirmationDialog
-from tribler_gui.dialogs.dialogcontainer import DialogContainer
+from tribler_gui.dialogs.triblerdialog import TriblerDialog
 from tribler_gui.tribler_request_manager import TriblerNetworkRequest
 from tribler_gui.utilities import (
     connect,
@@ -26,13 +26,13 @@ from tribler_gui.utilities import (
 from tribler_gui.widgets.torrentfiletreewidget import TORRENT_FILES_TREE_STYLESHEET
 
 
-class StartDownloadDialog(DialogContainer):
+class StartDownloadDialog(TriblerDialog):
 
-    button_clicked = pyqtSignal(DialogContainer, int)
+    button_clicked = pyqtSignal(TriblerDialog, int)
     received_metainfo = pyqtSignal(dict)
 
     def __init__(self, parent, download_uri):
-        DialogContainer.__init__(self, parent)
+        TriblerDialog.__init__(self, parent)
 
         torrent_name = download_uri
         if torrent_name.startswith('file:'):

--- a/src/tribler-gui/tribler_gui/dialogs/triblerdialog.py
+++ b/src/tribler-gui/tribler_gui/dialogs/triblerdialog.py
@@ -8,7 +8,7 @@ from tribler_gui.dialog_manager import DialogManager
 from tribler_gui.utilities import connect
 
 
-class DialogContainer(AddBreadcrumbOnShowMixin, QWidget):
+class TriblerDialog(AddBreadcrumbOnShowMixin, QWidget):
     def __init__(self, parent, left_right_margin=100):
         QWidget.__init__(self, parent)
         self.setStyleSheet("background-color: rgba(30, 30, 30, 0.75);")

--- a/src/tribler-gui/tribler_gui/dialogs/trustexplanationdialog.py
+++ b/src/tribler-gui/tribler_gui/dialogs/trustexplanationdialog.py
@@ -1,13 +1,13 @@
 from PyQt5 import uic
 from PyQt5.QtWidgets import QSizePolicy
 
-from tribler_gui.dialogs.dialogcontainer import DialogContainer
+from tribler_gui.dialogs.triblerdialog import TriblerDialog
 from tribler_gui.utilities import connect, get_ui_file_path
 
 
-class TrustExplanationDialog(DialogContainer):
+class TrustExplanationDialog(TriblerDialog):
     def __init__(self, parent):
-        DialogContainer.__init__(self, parent)
+        TriblerDialog.__init__(self, parent)
 
         uic.loadUi(get_ui_file_path('trustexplanation.ui'), self.dialog_widget)
 

--- a/src/tribler-gui/tribler_gui/tests/test_gui.py
+++ b/src/tribler-gui/tribler_gui/tests/test_gui.py
@@ -22,11 +22,11 @@ from tribler_gui.dialog_manager import DialogManager
 from tribler_gui.dialogs.addtagsdialog import AddTagsDialog
 from tribler_gui.dialogs.confirmationdialog import ConfirmationDialog
 from tribler_gui.dialogs.createtorrentdialog import CreateTorrentDialog
-from tribler_gui.dialogs.dialogcontainer import DialogContainer
 from tribler_gui.dialogs.feedbackdialog import FeedbackDialog
 from tribler_gui.dialogs.new_channel_dialog import NewChannelDialog
 from tribler_gui.dialogs.new_version_dialog import NewVersionDialog
 from tribler_gui.dialogs.startdownloaddialog import StartDownloadDialog
+from tribler_gui.dialogs.triblerdialog import TriblerDialog
 from tribler_gui.dialogs.trustexplanationdialog import TrustExplanationDialog
 from tribler_gui.tribler_app import TriblerApplication
 from tribler_gui.tribler_request_manager import TriblerNetworkRequest
@@ -121,7 +121,7 @@ def wait_for_variable(window, var, timeout=10, cmp_var=None):
     raise TimeoutException(f"Variable {var} within 10 seconds")
 
 
-def wait_for_dialog(dialog_cls: Type, timeout: int = 10, wait_for_close=False) -> Optional[DialogContainer]:
+def wait_for_dialog(dialog_cls: Type, timeout: int = 10, wait_for_close=False) -> Optional[TriblerDialog]:
     """
     Wait for a dialog to appear.
     Raises a TimeoutException if the dialog does not appear within the timeout.

--- a/src/tribler-gui/tribler_gui/tribler_app.py
+++ b/src/tribler-gui/tribler_gui/tribler_app.py
@@ -31,7 +31,7 @@ class TriblerApplication(QtSingleApplication):
 
     def handle_uri(self, uri):
         self.activation_window().pending_uri_requests.append(uri)
-        if self.activation_window().tribler_started and not self.activation_window().start_download_dialog_active:
+        if self.activation_window().tribler_started:
             self.activation_window().process_uri_request()
 
     def parse_sys_args(self, args):

--- a/src/tribler-gui/tribler_gui/tribler_request_manager.py
+++ b/src/tribler-gui/tribler_gui/tribler_request_manager.py
@@ -72,18 +72,6 @@ class TriblerRequestManager(QNetworkAccessManager):
             return json.dumps(error)  # Just print the json object
         return return_error
 
-    def show_error(self, error_text):
-        main_text = f"An error occurred during the request:\n\n{error_text}"
-        error_dialog = ConfirmationDialog(
-            TriblerRequestManager.window, "Request error", main_text, [('CLOSE', BUTTON_TYPE_NORMAL)]
-        )
-
-        def on_close(checked):
-            error_dialog.close_dialog()
-
-        connect(error_dialog.button_clicked, on_close)
-        error_dialog.show()
-
     def clear(self):
         for req in list(self.requests_in_flight.values()):
             req.cancel_request()
@@ -214,7 +202,9 @@ class TriblerNetworkRequest(QObject):
                 and not TriblerRequestManager.window.core_manager.shutting_down
             ):
                 # TODO: Report REST API errors to Sentry
-                request_manager.show_error(TriblerRequestManager.get_message_from_error(json_result))
+                error_text = TriblerRequestManager.get_message_from_error(json_result)
+                main_text = f"An error occurred during the request:\n\n{error_text}"
+                ConfirmationDialog.show_error(TriblerRequestManager.window, "Request error", main_text)
             else:
                 self.received_json.emit(json_result)
         except ValueError:

--- a/src/tribler-gui/tribler_gui/widgets/channelcontentswidget.py
+++ b/src/tribler-gui/tribler_gui/widgets/channelcontentswidget.py
@@ -61,7 +61,6 @@ class ChannelContentsWidget(AddBreadcrumbOnShowMixin, widget_form, widget_class)
 
         self.initialized = False
         self.chosen_dir = None
-        self.dialog = None
         self.controller = None
         self.commit_timer = None
         self.autocommit_enabled = None
@@ -488,23 +487,22 @@ class ChannelContentsWidget(AddBreadcrumbOnShowMixin, widget_form, widget_class)
             return
 
         self.chosen_dir = chosen_dir
-        self.dialog = ConfirmationDialog(
+        dialog = ConfirmationDialog(
             self,
             tr("Add torrents from directory"),
             tr("Add all torrent files from the following directory to your Tribler channel: \n\n %s") % chosen_dir,
             [('ADD', BUTTON_TYPE_NORMAL), ('CANCEL', BUTTON_TYPE_CONFIRM)],
             checkbox_text=tr("Include subdirectories (recursive mode)"),
         )
-        connect(self.dialog.button_clicked, self.on_confirm_add_directory_dialog)
-        self.dialog.show()
+        connect(dialog.button_clicked, self.on_confirm_add_directory_dialog)
+        dialog.show()
 
-    def on_confirm_add_directory_dialog(self, action):
+    def on_confirm_add_directory_dialog(self, dialog, action):
         if action == 0:
-            self.add_dir_to_channel(self.chosen_dir, recursive=self.dialog.checkbox.isChecked())
+            self.add_dir_to_channel(self.chosen_dir, recursive=dialog.checkbox.isChecked())
 
-        if self.dialog:
-            self.dialog.close_dialog()
-            self.dialog = None
+        if dialog:
+            dialog.close_dialog()
             self.chosen_dir = None
 
     def on_add_torrent_browse_file(self, checked):  # pylint: disable=W0613
@@ -518,22 +516,22 @@ class ChannelContentsWidget(AddBreadcrumbOnShowMixin, widget_form, widget_class)
             self.add_torrent_to_channel(filename)
 
     def on_add_torrent_from_url(self, checked):  # pylint: disable=W0613
-        self.dialog = ConfirmationDialog(
+        dialog = ConfirmationDialog(
             self,
             tr("Add torrent from URL/magnet link"),
             tr("Please enter the URL/magnet link in the field below:"),
             [(tr("ADD"), BUTTON_TYPE_NORMAL), (tr("CANCEL"), BUTTON_TYPE_CONFIRM)],
             show_input=True,
         )
-        self.dialog.dialog_widget.dialog_input.setPlaceholderText(tr("URL/magnet link"))
-        connect(self.dialog.button_clicked, self.on_torrent_from_url_dialog_done)
-        self.dialog.show()
+        dialog.dialog_widget.dialog_input.setPlaceholderText(tr("URL/magnet link"))
+        connect(dialog.button_clicked, self.on_torrent_from_url_dialog_done)
+        dialog.show()
 
-    def on_torrent_from_url_dialog_done(self, action):
+    def on_torrent_from_url_dialog_done(self, dialog, action):
         if action == 0:
-            self.add_torrent_url_to_channel(self.dialog.dialog_widget.dialog_input.text())
-        self.dialog.close_dialog()
-        self.dialog = None
+            self.add_torrent_url_to_channel(dialog.dialog_widget.dialog_input.text())
+        dialog.close_dialog()
+        dialog = None
 
     def _on_torrent_to_channel_added(self, result):
         if not result:

--- a/src/tribler-gui/tribler_gui/widgets/channeldescriptionwidget.py
+++ b/src/tribler-gui/tribler_gui/widgets/channeldescriptionwidget.py
@@ -91,8 +91,6 @@ class ChannelDescriptionWidget(AddBreadcrumbOnShowMixin, widget_form, widget_cla
 
         self.initialized = False
 
-        self.dialog = None
-
         self.floating_edit_button = FloatingButtonWidget(parent=self.description_text_preview)
         self.floating_edit_button.setHidden(True)
         connect(self.floating_edit_button.pressed, self.on_start_editing)
@@ -193,7 +191,7 @@ class ChannelDescriptionWidget(AddBreadcrumbOnShowMixin, widget_form, widget_cla
             data = f.read()
 
         if len(data) > 1024 ** 2:
-            self.dialog = ConfirmationDialog.show_error(
+            ConfirmationDialog.show_error(
                 self,
                 tr(tr("Image too large error")),
                 tr(tr("Image file you're trying to upload is too large.")),

--- a/src/tribler-gui/tribler_gui/widgets/channeldescriptionwidget.py
+++ b/src/tribler-gui/tribler_gui/widgets/channeldescriptionwidget.py
@@ -191,16 +191,19 @@ class ChannelDescriptionWidget(AddBreadcrumbOnShowMixin, widget_form, widget_cla
             data = f.read()
 
         if len(data) > 1024 ** 2:
-            ConfirmationDialog.show_error(
-                self,
-                tr(tr("Image too large error")),
-                tr(tr("Image file you're trying to upload is too large.")),
-            )
+            self.show_image_too_large_error()
             return
 
         self.channel_thumbnail_bytes = data
         self.channel_thumbnail_type = content_type
         self.update_channel_thumbnail(data, content_type)
+
+    def show_image_too_large_error(self):
+        ConfirmationDialog.show_error(
+            self.window(),
+            tr(tr("Image too large error")),
+            tr(tr("Image file you're trying to upload is too large.")),
+        )
 
     @pyqtSlot()
     def on_cancel_button_clicked(self):

--- a/src/tribler-gui/tribler_gui/widgets/createtorrentpage.py
+++ b/src/tribler-gui/tribler_gui/widgets/createtorrentpage.py
@@ -22,7 +22,6 @@ class CreateTorrentPage(AddBreadcrumbOnShowMixin, QWidget):
         QWidget.__init__(self)
 
         self.channel_identifier = None
-        self.dialog = None
         self.selected_item_index = -1
         self.initialized = False
 
@@ -73,11 +72,7 @@ class CreateTorrentPage(AddBreadcrumbOnShowMixin, QWidget):
 
     def on_create_clicked(self, checked):
         if self.window().create_torrent_files_list.count() == 0:
-            self.dialog = ConfirmationDialog(
-                self, "Notice", "You should add at least one file to your torrent.", [('CLOSE', BUTTON_TYPE_NORMAL)]
-            )
-            connect(self.dialog.button_clicked, self.on_dialog_ok_clicked)
-            self.dialog.show()
+            ConfirmationDialog.show_error(self, "Notice", "You should add at least one file to your torrent.")
             return
 
         self.window().edit_channel_create_torrent_button.setEnabled(False)
@@ -94,10 +89,6 @@ class CreateTorrentPage(AddBreadcrumbOnShowMixin, QWidget):
         TriblerNetworkRequest(url, self.on_torrent_created, data=post_data, method='POST')
         # Show creating torrent text
         self.window().edit_channel_create_torrent_progress_label.show()
-
-    def on_dialog_ok_clicked(self, _):
-        self.dialog.close_dialog()
-        self.dialog = None
 
     def on_torrent_created(self, result):
         if not result:

--- a/src/tribler-gui/tribler_gui/widgets/downloadspage.py
+++ b/src/tribler-gui/tribler_gui/widgets/downloadspage.py
@@ -420,7 +420,9 @@ class DownloadsPage(AddBreadcrumbOnShowMixin, QWidget):
         self.export_dir = QFileDialog.getExistingDirectory(
             self, tr("Please select the destination directory"), "", QFileDialog.ShowDirsOnly
         )
+        self.show_export_download_dialog()
 
+    def show_export_download_dialog(self) -> None:
         selected_item = self.selected_items[:1]
         if len(self.export_dir) > 0 and selected_item:
             # Show confirmation dialog where we specify the name of the file

--- a/src/tribler-gui/tribler_gui/widgets/trustpage.py
+++ b/src/tribler-gui/tribler_gui/widgets/trustpage.py
@@ -31,7 +31,6 @@ class TrustPage(AddBreadcrumbOnShowMixin, QWidget):
         self.trust_plot = None
         self.history = None
         self.byte_scale = 1024 * 1024
-        self.dialog = None
 
     def initialize_trust_page(self):
         vlayout = self.window().plot_widget.layout()
@@ -42,8 +41,8 @@ class TrustPage(AddBreadcrumbOnShowMixin, QWidget):
         connect(self.window().trust_explain_button.clicked, self.on_info_button_clicked)
 
     def on_info_button_clicked(self, checked):
-        self.dialog = TrustExplanationDialog(self.window())
-        self.dialog.show()
+        dialog = TrustExplanationDialog(self.window())
+        dialog.show()
 
     def received_bandwidth_statistics(self, statistics: Dict) -> None:
         """


### PR DESCRIPTION
This PR improves how dialogs in the GUI are managed. Our logic to create, close and hide dialogs is quite inconsistent across the code base, leading to errors and hard-coded timeouts, e.g., in the GUI tests. Specifically, this PR makes the following changes:
- Introduces the static `DialogManager` class. When a dialog (a subclass of `DialogContainer`) is created, the dialog is automatically added to the `DialogManager`, and removed when the `close_dialog` method is called. This central approach removes the need to bind dialog objects to `QWidget` and allows us to close all open dialogs when closing Tribler (with the exception of the feedback dialog which is not a subclass of `DialogContainer`).
- Removed the binding of various widgets to `QWidget` classes.
- Improved the GUI tests by implementing a `wait_for_dialog` method that waits for the appearance/disappearance of a dialog with a specific class type. This removes the need for various `QWait` calls in the GUI tests and should make the GUI tests more robust.
- Extended the GUI tests with several tests that test the various dialogs we have in Tribler.

Feedback is welcome!

Fixes #6597 