### PR TITLE
Make --core and --gui-test-mode separate flags with all combinations possible

### DIFF
--- a/src/tribler-gui/tribler_gui/tests/test_gui.py
+++ b/src/tribler-gui/tribler_gui/tests/test_gui.py
@@ -42,7 +42,7 @@ def window(tmpdir_factory):
         QSettings(),
         root_state_dir,
         api_key=api_key,
-        core_args=[str(RUN_TRIBLER_PY.absolute()), '--gui-test-mode'],
+        core_args=[str(RUN_TRIBLER_PY.absolute()), '--core', '--gui-test-mode'],
     )  # pylint: disable=W0621
     app.set_activation_window(window)
     QTest.qWaitForWindowExposed(window)


### PR DESCRIPTION
Fixes #6601

Both GUI and Core processes should receive `--gui-test-mode` flag to handle it correctly