### PR TITLE
Fix api_key encoding/decoding

### DIFF
--- a/src/tribler-gui/tribler_gui/core_manager.py
+++ b/src/tribler-gui/tribler_gui/core_manager.py
@@ -105,7 +105,7 @@ class CoreManager(QObject):
         if not core_env:
             core_env = QProcessEnvironment.systemEnvironment()
             core_env.insert("CORE_API_PORT", f"{self.api_port}")
-            core_env.insert("CORE_API_KEY", self.api_key.decode('utf-8'))
+            core_env.insert("CORE_API_KEY", self.api_key)
             core_env.insert("TSTATEDIR", str(self.root_state_dir))
         if not core_args:
             core_args = sys.argv + ['--core']

--- a/src/tribler-gui/tribler_gui/event_request_manager.py
+++ b/src/tribler-gui/tribler_gui/event_request_manager.py
@@ -37,7 +37,7 @@ class EventRequestManager(QNetworkAccessManager):
         QNetworkAccessManager.__init__(self)
         url = QUrl("http://localhost:%d/events" % api_port)
         self.request = QNetworkRequest(url)
-        self.request.setRawHeader(b'X-Api-Key', api_key)
+        self.request.setRawHeader(b'X-Api-Key', api_key.encode('ascii'))
         self.remaining_connection_attempts = CORE_CONNECTION_ATTEMPTS_LIMIT
         self.connect_timer = QTimer()
         self.current_event_string = ""

--- a/src/tribler-gui/tribler_gui/tests/test_gui.py
+++ b/src/tribler-gui/tribler_gui/tests/test_gui.py
@@ -34,7 +34,7 @@ TORRENT_WITH_DIRS = COMMON_DATA_DIR / "multi_entries.torrent"
 
 @pytest.fixture(scope="module")
 def window(tmpdir_factory):
-    api_key = hexlify(os.urandom(16)).encode('utf-8')
+    api_key = hexlify(os.urandom(16))
     root_state_dir = str(tmpdir_factory.mktemp('tribler_state_dir'))
 
     app = TriblerApplication("triblerapp-guitest", sys.argv)

--- a/src/tribler-gui/tribler_gui/tribler_request_manager.py
+++ b/src/tribler-gui/tribler_gui/tribler_request_manager.py
@@ -106,7 +106,7 @@ class TriblerRequestManager(QNetworkAccessManager):
         qt_request = QNetworkRequest(QUrl(request.url))
         qt_request.setPriority(request.priority)
         qt_request.setHeader(QNetworkRequest.ContentTypeHeader, request.content_type_header)
-        qt_request.setRawHeader(b'X-Api-Key', self.key)
+        qt_request.setRawHeader(b'X-Api-Key', self.key.encode('ascii'))
 
         buf = QBuffer()
         if request.raw_data:

--- a/src/tribler-gui/tribler_gui/tribler_window.py
+++ b/src/tribler-gui/tribler_gui/tribler_window.py
@@ -147,7 +147,7 @@ class TriblerWindow(QMainWindow):
         self.root_state_dir = Path(root_state_dir)
         self.gui_settings = settings
         api_port = api_port or int(get_gui_setting(self.gui_settings, "api_port", DEFAULT_API_PORT))
-        api_key = api_key or get_gui_setting(self.gui_settings, "api_key", hexlify(os.urandom(16)).encode('utf-8'))
+        api_key = api_key or get_gui_setting(self.gui_settings, "api_key", hexlify(os.urandom(16)))
         self.gui_settings.setValue("api_key", api_key)
 
         api_port = NetworkUtils().get_first_free_port(start=api_port)


### PR DESCRIPTION
This PR fixes #6607 by fixing encoding/decoding of `api_key`.