### PR TITLE
Fix api_key conversion in DebugWindow

### DIFF
--- a/src/tribler-gui/tribler_gui/debug_window.py
+++ b/src/tribler-gui/tribler_gui/debug_window.py
@@ -302,7 +302,7 @@ class DebugWindow(QMainWindow):
         self.create_and_add_widget_item("Qt file", self.gui_settings.fileName(), self.window().general_tree_widget)
 
         selected_settings = {
-            "api_key": lambda val: val.decode('utf-8'),
+            "api_key": lambda val: val,
             "api_port": lambda val: val,
             "pos": lambda val: f"(x : {val.x()} px,  y : {val.y()} px)",
             "size": lambda val: f"(width : {val.width()} px,  height : {val.height()} px)",


### PR DESCRIPTION
Previously GUI process stores `api_key` value mostly as bytes (and sometimes as str, which caused problems), and now it after #6608 and #6611, it is always stored as str. When displaying `api_key` in DebugWindow, the conversion from bytes to str is not needed anymore, as `api_key` is already str.