### PR TITLE
Feature/add local search for tags

### DIFF
--- a/src/tribler-common/tribler_common/tests/test_utils.py
+++ b/src/tribler-common/tribler_common/tests/test_utils.py
@@ -2,15 +2,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from tribler_common.patch_import import patch_import
-from tribler_common.utilities import (
-    Query,
-    extract_plain_fts_query_text,
-    extract_tags,
-    parse_query,
-    show_system_popup,
-    to_fts_query,
-    uri_to_path,
-)
+from tribler_common.utilities import Query, extract_tags, parse_query, show_system_popup, to_fts_query, uri_to_path
 
 # pylint: disable=import-outside-toplevel, import-error
 # fmt: off
@@ -32,45 +24,37 @@ def test_to_fts_query():
 
 def test_extract_tags():
     assert extract_tags('') == (set(), '')
-    assert extract_tags('text') == (set(), '')
-    assert extract_tags('[text') == (set(), '')
-    assert extract_tags('text]') == (set(), '')
-    assert extract_tags('[]') == (set(), '')
-    assert extract_tags('[ta]') == (set(), '')
-    assert extract_tags('[' + 't' * 51 + ']') == (set(), '')
-    assert extract_tags('[tag1[tag2]text]') == (set(), '')
-    assert extract_tags('[not a tag]') == (set(), '')
+    assert extract_tags('text') == (set(), 'text')
+    assert extract_tags('#') == (set(), '#')
+    assert extract_tags('# ') == (set(), '# ')
+    assert extract_tags('#t ') == (set(), '#t ')
+    assert extract_tags('#' + 't' * 51) == (set(), '#' + 't' * 51)
+    assert extract_tags('####') == (set(), '####')
 
-    assert extract_tags('[tag]') == ({'tag'}, '[tag]')
-    assert extract_tags('[tag1][tag2]') == ({'tag1', 'tag2'}, '[tag1][tag2]')
-    assert extract_tags('[tag_with_underscore][tag-with-dash]') == ({'tag_with_underscore', 'tag-with-dash'},
-                                                                    '[tag_with_underscore][tag-with-dash]')
-
-    assert extract_tags(' [tag][not tag]for complex query with [not tag at the end]') == ({'tag'}, ' [tag]')
-
-
-def test_extract_plain_fts_query_text():
-    assert not extract_plain_fts_query_text('', '')
-    assert extract_plain_fts_query_text('query', '') == 'query'
-    assert extract_plain_fts_query_text('[tag] query', '[tag]') == 'query'
+    assert extract_tags('#tag') == ({'tag'}, '')
+    assert extract_tags('a #tag in the middle') == ({'tag'}, 'a  in the middle')
+    assert extract_tags('at the end of the query #tag') == ({'tag'}, 'at the end of the query ')
+    assert extract_tags('multiple tags: #tag1 #tag2#tag3') == ({'tag1', 'tag2', 'tag3'}, 'multiple tags:  ')
+    assert extract_tags('#tag_with_underscores #tag-with-dashes') == ({'tag_with_underscores', 'tag-with-dashes'}, ' ')
 
 
 def test_parse_query():
     assert parse_query('') == Query(original_query='')
 
-    actual = parse_query('[tag1][tag2]')
-    expected = Query(original_query='[tag1][tag2]', tags={'tag1', 'tag2'})
+    actual = parse_query('#tag1 #tag2')
+    expected = Query(original_query='#tag1 #tag2', tags={'tag1', 'tag2'}, fts_text='')
     assert actual == expected
 
-    actual = parse_query('fts query  with potential [brackets]')
-    expected = Query(original_query='fts query  with potential [brackets]',
-                     fts_text='fts query  with potential [brackets]')
+    actual = parse_query('query without tags')
+    expected = Query(original_query='query without tags',
+                     tags=set(),
+                     fts_text='query without tags')
     assert actual == expected
 
-    actual = parse_query('[tag1][tag2] fts query with potential [brackets]')
-    expected = Query(original_query='[tag1][tag2] fts query with potential [brackets]',
+    actual = parse_query('query with #tag1 and #tag2')
+    expected = Query(original_query='query with #tag1 and #tag2',
                      tags={'tag1', 'tag2'},
-                     fts_text='fts query with potential [brackets]', )
+                     fts_text='query with  and')
     assert actual == expected
 
 

--- a/src/tribler-common/tribler_common/tests/test_utils.py
+++ b/src/tribler-common/tribler_common/tests/test_utils.py
@@ -2,13 +2,18 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from tribler_common.patch_import import patch_import
-from tribler_common.utilities import Query, extract_plain_fts_query_text, extract_tags, \
-    parse_query, show_system_popup, to_fts_query, \
-    uri_to_path
-
+from tribler_common.utilities import (
+    Query,
+    extract_plain_fts_query_text,
+    extract_tags,
+    parse_query,
+    show_system_popup,
+    to_fts_query,
+    uri_to_path,
+)
 
 # pylint: disable=import-outside-toplevel, import-error
-
+# fmt: off
 
 def test_uri_to_path():
     path = Path(__file__).parent / "bla%20foo.bar"
@@ -26,28 +31,31 @@ def test_to_fts_query():
 
 
 def test_extract_tags():
-    assert extract_tags(None) == (set(), '')
     assert extract_tags('') == (set(), '')
     assert extract_tags('text') == (set(), '')
     assert extract_tags('[text') == (set(), '')
     assert extract_tags('text]') == (set(), '')
     assert extract_tags('[]') == (set(), '')
+    assert extract_tags('[ta]') == (set(), '')
+    assert extract_tags('[' + 't' * 51 + ']') == (set(), '')
     assert extract_tags('[tag1[tag2]text]') == (set(), '')
+    assert extract_tags('[not a tag]') == (set(), '')
 
-    assert extract_tags('[tag]text') == ({'tag'}, '[tag]')
-    assert extract_tags('[tag1][tag2]text') == ({'tag1', 'tag2'}, '[tag1][tag2]')
-    assert extract_tags(' [tag]text[not_tag]') == ({'tag'}, ' [tag]')
+    assert extract_tags('[tag]') == ({'tag'}, '[tag]')
+    assert extract_tags('[tag1][tag2]') == ({'tag1', 'tag2'}, '[tag1][tag2]')
+    assert extract_tags('[tag_with_underscore][tag-with-dash]') == ({'tag_with_underscore', 'tag-with-dash'},
+                                                                    '[tag_with_underscore][tag-with-dash]')
+
+    assert extract_tags(' [tag][not tag]for complex query with [not tag at the end]') == ({'tag'}, ' [tag]')
 
 
 def test_extract_plain_fts_query_text():
-    assert not extract_plain_fts_query_text(None, '')
     assert not extract_plain_fts_query_text('', '')
     assert extract_plain_fts_query_text('query', '') == 'query'
     assert extract_plain_fts_query_text('[tag] query', '[tag]') == 'query'
 
 
 def test_parse_query():
-    assert parse_query(None) == Query(original_query=None)
     assert parse_query('') == Query(original_query='')
 
     actual = parse_query('[tag1][tag2]')
@@ -62,7 +70,7 @@ def test_parse_query():
     actual = parse_query('[tag1][tag2] fts query with potential [brackets]')
     expected = Query(original_query='[tag1][tag2] fts query with potential [brackets]',
                      tags={'tag1', 'tag2'},
-                     fts_text='fts query with potential [brackets]',)
+                     fts_text='fts query with potential [brackets]', )
     assert actual == expected
 
 

--- a/src/tribler-common/tribler_common/utilities.py
+++ b/src/tribler-common/tribler_common/utilities.py
@@ -3,7 +3,7 @@ import platform
 import re
 import sys
 from dataclasses import dataclass, field
-from typing import Optional, Set, Tuple
+from typing import Set, Tuple
 from urllib.parse import urlparse
 from urllib.request import url2pathname
 
@@ -29,17 +29,17 @@ def uri_to_path(uri):
 
 
 fts_query_re = re.compile(r'\w+', re.UNICODE)
-tags_re = re.compile(r'^\s*(?:\[\w+\]\s*)+')
+tags_re = re.compile(r'^\s*(?:\[[^\s\[\]]{3,50}\]\s*)+')
 
 
 @dataclass
 class Query:
-    original_query: Optional[str]
+    original_query: str
     tags: Set[str] = field(default_factory=set)
     fts_text: str = ''
 
 
-def parse_query(query: Optional[str]) -> Query:
+def parse_query(query: str) -> Query:
     """
     The query structure:
         query = [tag1][tag2] text
@@ -55,7 +55,7 @@ def parse_query(query: Optional[str]) -> Query:
     return Query(original_query=query, tags=tags, fts_text=fts_text)
 
 
-def extract_tags(text: Optional[str]) -> Tuple[Set[str], str]:
+def extract_tags(text: str) -> Tuple[Set[str], str]:
     if not text:
         return set(), ''
     if (m := tags_re.match(text)) is not None:
@@ -64,11 +64,8 @@ def extract_tags(text: Optional[str]) -> Tuple[Set[str], str]:
     return set(), ''
 
 
-def extract_plain_fts_query_text(query: Optional[str], tags_string: str) -> str:
-    if query is None:
-        return ''
-
-    return query[len(tags_string):].strip()
+def extract_plain_fts_query_text(query: str, tags_string: str) -> str:
+    return query[len(tags_string) :].strip()
 
 
 def to_fts_query(text):

--- a/src/tribler-core/tribler_core/components/metadata_store/db/store.py
+++ b/src/tribler-core/tribler_core/components/metadata_store/db/store.py
@@ -610,6 +610,7 @@ class MetadataStore:
         category=None,
         attribute_ranges=None,
         infohash=None,
+        infohash_set=None,
         id_=None,
         complete_channel=None,
         self_checked_torrent=None,
@@ -626,7 +627,7 @@ class MetadataStore:
         if cls is None:
             cls = self.ChannelNode
         pony_query = self.search_keyword(txt_filter, lim=1000) if txt_filter else left_join(g for g in cls)
-
+        infohash_set = infohash_set or ({infohash} if infohash else None)
         if popular:
             if metadata_type != REGULAR_TORRENT:
                 raise TypeError('With `popular=True`, only `metadata_type=REGULAR_TORRENT` is allowed')
@@ -678,7 +679,7 @@ class MetadataStore:
         pony_query = pony_query.where(lambda g: g.status != TODELETE) if exclude_deleted else pony_query
         pony_query = pony_query.where(lambda g: g.xxx == 0) if hide_xxx else pony_query
         pony_query = pony_query.where(lambda g: g.status != LEGACY_ENTRY) if exclude_legacy else pony_query
-        pony_query = pony_query.where(lambda g: g.infohash == infohash) if infohash else pony_query
+        pony_query = pony_query.where(lambda g: g.infohash in infohash_set) if infohash_set else pony_query
         pony_query = (
             pony_query.where(lambda g: g.health.self_checked == self_checked_torrent)
             if self_checked_torrent is not None

--- a/src/tribler-core/tribler_core/components/metadata_store/restapi/metadata_endpoint_base.py
+++ b/src/tribler-core/tribler_core/components/metadata_store/restapi/metadata_endpoint_base.py
@@ -57,6 +57,8 @@ class MetadataEndpointBase(RESTEndpoint):
             "category": parameters.get('category'),
             "exclude_deleted": bool(int(parameters.get('exclude_deleted', 0)) > 0),
         }
+        if 'tags' in parameters:
+            sanitized['tags'] = parameters.getall('tags')
         if "remote" in parameters:
             sanitized["remote"] = (bool(int(parameters.get('remote', 0)) > 0),)
         if 'metadata_type' in parameters:

--- a/src/tribler-core/tribler_core/components/metadata_store/restapi/search_endpoint.py
+++ b/src/tribler-core/tribler_core/components/metadata_store/restapi/search_endpoint.py
@@ -1,9 +1,13 @@
 from aiohttp import web
+
 from aiohttp_apispec import docs, querystring_schema
-from marshmallow.fields import Integer, String
-from pony.orm import db_session
 
 from ipv8.REST.schema import schema
+
+from marshmallow.fields import Integer, String
+
+from pony.orm import db_session
+
 from tribler_core.components.metadata_store.db.store import MetadataStore
 from tribler_core.components.metadata_store.restapi.metadata_endpoint import MetadataEndpointBase
 from tribler_core.components.metadata_store.restapi.metadata_schema import MetadataParameters, MetadataSchema

--- a/src/tribler-core/tribler_core/components/metadata_store/restapi/search_endpoint.py
+++ b/src/tribler-core/tribler_core/components/metadata_store/restapi/search_endpoint.py
@@ -1,13 +1,9 @@
 from aiohttp import web
-
 from aiohttp_apispec import docs, querystring_schema
-
-from ipv8.REST.schema import schema
-
 from marshmallow.fields import Integer, String
-
 from pony.orm import db_session
 
+from ipv8.REST.schema import schema
 from tribler_core.components.metadata_store.db.store import MetadataStore
 from tribler_core.components.metadata_store.restapi.metadata_endpoint import MetadataEndpointBase
 from tribler_core.components.metadata_store.restapi.metadata_schema import MetadataParameters, MetadataSchema
@@ -53,11 +49,9 @@ class SearchEndpoint(MetadataEndpointBase):
     async def search(self, request):
         try:
             sanitized = self.sanitize_parameters(request.query)
+            tags = sanitized.pop('tags', None)
         except (ValueError, KeyError):
             return RESTResponse({"error": "Error processing request parameters"}, status=HTTP_BAD_REQUEST)
-
-        if not sanitized["txt_filter"]:
-            return RESTResponse({"error": "Filter parameter missing"}, status=HTTP_BAD_REQUEST)
 
         include_total = request.query.get('include_total', '')
 
@@ -75,9 +69,15 @@ class SearchEndpoint(MetadataEndpointBase):
             return search_results, total, max_rowid
 
         try:
+            with db_session:
+                if tags:
+                    lower_tags = {tag.lower() for tag in tags}
+                    infohash_set = self.tags_db.get_infohashes(lower_tags)
+                    sanitized['infohash_set'] = infohash_set
+
             search_results, total, max_rowid = await mds.run_threaded(search_db)
         except Exception as e:  # pylint: disable=broad-except;  # pragma: no cover
-            self._logger.error("Error while performing DB search: %s: %s", type(e).__name__, e)
+            self._logger.exception("Error while performing DB search: %s: %s", type(e).__name__, e)
             return RESTResponse(status=HTTP_BAD_REQUEST)
 
         self.add_tags_to_metadata_list(search_results, hide_xxx=sanitized["hide_xxx"])

--- a/src/tribler-core/tribler_core/components/restapi/restapi_component.py
+++ b/src/tribler-core/tribler_core/components/restapi/restapi_component.py
@@ -2,7 +2,9 @@ from itertools import chain
 from typing import Type
 
 from ipv8.REST.root_endpoint import RootEndpoint as IPV8RootEndpoint
+
 from tribler_common.reported_error import ReportedError
+
 from tribler_core.components.bandwidth_accounting.bandwidth_accounting_component import BandwidthAccountingComponent
 from tribler_core.components.bandwidth_accounting.restapi.bandwidth_endpoint import BandwidthEndpoint
 from tribler_core.components.base import Component, NoneComponent
@@ -68,7 +70,6 @@ class RESTComponent(Component):
         log_dir = config.general.get_path_as_absolute('log_dir', config.state_dir)
         metadata_store_component = await self.get_component(MetadataStoreComponent)
 
-        # fmt: off
         # pylint: disable=C0301
         key_component = await self.require_component(KeyComponent)
         ipv8_component = await self.maybe_component(Ipv8Component)
@@ -119,7 +120,6 @@ class RESTComponent(Component):
         for _, endpoint in ipv8_root_endpoint.endpoints.items():
             endpoint.initialize(ipv8_component.ipv8)
         self.root_endpoint.add_endpoint('/ipv8', ipv8_root_endpoint)
-        # fmt: on
 
         # Note: AIOHTTP endpoints cannot be added after the app has been started!
         rest_manager = RESTManager(config=config.api, root_endpoint=self.root_endpoint, state_dir=config.state_dir)

--- a/src/tribler-core/tribler_core/components/restapi/restapi_component.py
+++ b/src/tribler-core/tribler_core/components/restapi/restapi_component.py
@@ -2,9 +2,7 @@ from itertools import chain
 from typing import Type
 
 from ipv8.REST.root_endpoint import RootEndpoint as IPV8RootEndpoint
-
 from tribler_common.reported_error import ReportedError
-
 from tribler_core.components.bandwidth_accounting.bandwidth_accounting_component import BandwidthAccountingComponent
 from tribler_core.components.bandwidth_accounting.restapi.bandwidth_endpoint import BandwidthEndpoint
 from tribler_core.components.base import Component, NoneComponent
@@ -72,16 +70,16 @@ class RESTComponent(Component):
 
         # fmt: off
         # pylint: disable=C0301
-        key_component                  = await self.require_component(KeyComponent)
-        ipv8_component                 = await self.maybe_component(Ipv8Component)
-        libtorrent_component           = await self.maybe_component(LibtorrentComponent)
-        resource_monitor_component     = await self.maybe_component(ResourceMonitorComponent)
+        key_component = await self.require_component(KeyComponent)
+        ipv8_component = await self.maybe_component(Ipv8Component)
+        libtorrent_component = await self.maybe_component(LibtorrentComponent)
+        resource_monitor_component = await self.maybe_component(ResourceMonitorComponent)
         bandwidth_accounting_component = await self.maybe_component(BandwidthAccountingComponent)
-        gigachannel_component          = await self.maybe_component(GigaChannelComponent)
-        tag_component                  = await self.maybe_component(TagComponent)
-        tunnel_component               = await self.maybe_component(TunnelsComponent)
-        torrent_checker_component      = await self.maybe_component(TorrentCheckerComponent)
-        gigachannel_manager_component  = await self.maybe_component(GigachannelManagerComponent)
+        gigachannel_component = await self.maybe_component(GigaChannelComponent)
+        tag_component = await self.maybe_component(TagComponent)
+        tunnel_component = await self.maybe_component(TunnelsComponent)
+        torrent_checker_component = await self.maybe_component(TorrentCheckerComponent)
+        gigachannel_manager_component = await self.maybe_component(GigachannelManagerComponent)
 
         self._events_endpoint = EventsEndpoint(notifier, public_key=hexlify(key_component.primary_key.key.pk))
         self.root_endpoint = RootEndpoint(middlewares=[ApiKeyMiddleware(config.api.key), error_middleware])
@@ -92,22 +90,29 @@ class RESTComponent(Component):
 
         # add endpoints
         self.root_endpoint.add_endpoint('/events', self._events_endpoint)
-        self.maybe_add('/settings',      SettingsEndpoint,      config, download_manager=libtorrent_component.download_manager)
-        self.maybe_add('/shutdown',      ShutdownEndpoint,      shutdown_event.set)
-        self.maybe_add('/debug',         DebugEndpoint,         config.state_dir, log_dir, tunnel_community=tunnel_community, resource_monitor=resource_monitor_component.resource_monitor)
-        self.maybe_add('/bandwidth',     BandwidthEndpoint,     bandwidth_accounting_component.community)
-        self.maybe_add('/trustview',     TrustViewEndpoint,     bandwidth_accounting_component.database)
-        self.maybe_add('/downloads',     DownloadsEndpoint,     libtorrent_component.download_manager, metadata_store=metadata_store_component.mds, tunnel_community=tunnel_community)
+        self.maybe_add('/settings', SettingsEndpoint, config, download_manager=libtorrent_component.download_manager)
+        self.maybe_add('/shutdown', ShutdownEndpoint, shutdown_event.set)
+        self.maybe_add('/debug', DebugEndpoint, config.state_dir, log_dir, tunnel_community=tunnel_community,
+                       resource_monitor=resource_monitor_component.resource_monitor)
+        self.maybe_add('/bandwidth', BandwidthEndpoint, bandwidth_accounting_component.community)
+        self.maybe_add('/trustview', TrustViewEndpoint, bandwidth_accounting_component.database)
+        self.maybe_add('/downloads', DownloadsEndpoint, libtorrent_component.download_manager,
+                       metadata_store=metadata_store_component.mds, tunnel_community=tunnel_community)
         self.maybe_add('/createtorrent', CreateTorrentEndpoint, libtorrent_component.download_manager)
-        self.maybe_add('/statistics',    StatisticsEndpoint,    ipv8=ipv8_component.ipv8, metadata_store=metadata_store_component.mds)
-        self.maybe_add('/libtorrent',    LibTorrentEndpoint,    libtorrent_component.download_manager)
-        self.maybe_add('/torrentinfo',   TorrentInfoEndpoint,   libtorrent_component.download_manager)
-        self.maybe_add('/metadata',      MetadataEndpoint,      torrent_checker, metadata_store_component.mds, tags_db=tag_component.tags_db)
-        self.maybe_add('/channels',      ChannelsEndpoint,      libtorrent_component.download_manager, gigachannel_manager, gigachannel_component.community, metadata_store_component.mds, tags_db=tag_component.tags_db)
-        self.maybe_add('/collections',   ChannelsEndpoint,      libtorrent_component.download_manager, gigachannel_manager, gigachannel_component.community, metadata_store_component.mds, tags_db=tag_component.tags_db)
-        self.maybe_add('/search',        SearchEndpoint,        metadata_store_component.mds, tags_db=tag_component.tags_db)
-        self.maybe_add('/remote_query',  RemoteQueryEndpoint,   gigachannel_component.community, metadata_store_component.mds)
-        self.maybe_add('/tags',          TagsEndpoint,          tag_component.tags_db, tag_component.community)
+        self.maybe_add('/statistics', StatisticsEndpoint, ipv8=ipv8_component.ipv8,
+                       metadata_store=metadata_store_component.mds)
+        self.maybe_add('/libtorrent', LibTorrentEndpoint, libtorrent_component.download_manager)
+        self.maybe_add('/torrentinfo', TorrentInfoEndpoint, libtorrent_component.download_manager)
+        self.maybe_add('/metadata', MetadataEndpoint, torrent_checker, metadata_store_component.mds,
+                       tags_db=tag_component.tags_db)
+        self.maybe_add('/channels', ChannelsEndpoint, libtorrent_component.download_manager, gigachannel_manager,
+                       gigachannel_component.community, metadata_store_component.mds, tags_db=tag_component.tags_db)
+        self.maybe_add('/collections', ChannelsEndpoint, libtorrent_component.download_manager, gigachannel_manager,
+                       gigachannel_component.community, metadata_store_component.mds, tags_db=tag_component.tags_db)
+        self.maybe_add('/search', SearchEndpoint, metadata_store_component.mds, tags_db=tag_component.tags_db)
+        self.maybe_add('/remote_query', RemoteQueryEndpoint, gigachannel_component.community,
+                       metadata_store_component.mds)
+        self.maybe_add('/tags', TagsEndpoint, db=tag_component.tags_db, community=tag_component.community)
 
         # pylint: enable=C0301
         ipv8_root_endpoint = IPV8RootEndpoint()
@@ -116,8 +121,7 @@ class RESTComponent(Component):
         self.root_endpoint.add_endpoint('/ipv8', ipv8_root_endpoint)
         # fmt: on
 
-        # ACHTUNG!
-        # AIOHTTP endpoints cannot be added after the app has been started!
+        # Note: AIOHTTP endpoints cannot be added after the app has been started!
         rest_manager = RESTManager(config=config.api, root_endpoint=self.root_endpoint, state_dir=config.state_dir)
         await rest_manager.start()
         self.rest_manager = rest_manager

--- a/src/tribler-gui/tribler_gui/tribler_window.py
+++ b/src/tribler-gui/tribler_gui/tribler_window.py
@@ -40,7 +40,7 @@ from psutil import LINUX
 
 from tribler_common.network_utils import NetworkUtils
 from tribler_common.process_checker import ProcessChecker
-from tribler_common.utilities import uri_to_path
+from tribler_common.utilities import parse_query, uri_to_path
 from tribler_common.version_manager import VersionHistory
 
 from tribler_core.utilities.unicode import hexlify
@@ -94,7 +94,6 @@ from tribler_gui.widgets.tablecontentmodel import DiscoveredChannelsModel, Popul
 from tribler_gui.widgets.triblertablecontrollers import PopularContentTableViewController
 
 fc_loading_list_item, _ = uic.loadUiType(get_ui_file_path('loading_list_item.ui'))
-
 
 CHECKBOX_STYLESHEET = """
     QCheckBox::indicator { width: 16px; height: 16px;}
@@ -1027,10 +1026,12 @@ class TriblerWindow(QMainWindow):
             self.stackedWidget.setCurrentIndex(PAGE_SEARCH_RESULTS)
 
     def on_top_search_bar_return_pressed(self):
-        # Initiate a new search query and switch to search loading/results page
-        query = self.top_search_bar.text()
-        if query:
-            self.search_results_page.search(query)
+        query = parse_query(self.top_search_bar.text())
+        if not query.original_query:
+            return
+
+        if self.search_results_page.search(query):
+            self._logger.info(f'Do search for query: {query}')
             self.deselect_all_menu_buttons()
             self.stackedWidget.setCurrentIndex(PAGE_SEARCH_RESULTS)
 

--- a/src/tribler-gui/tribler_gui/tribler_window.py
+++ b/src/tribler-gui/tribler_gui/tribler_window.py
@@ -1026,10 +1026,11 @@ class TriblerWindow(QMainWindow):
             self.stackedWidget.setCurrentIndex(PAGE_SEARCH_RESULTS)
 
     def on_top_search_bar_return_pressed(self):
-        query = parse_query(self.top_search_bar.text())
-        if not query.original_query:
+        query_text = self.top_search_bar.text()
+        if not query_text:
             return
 
+        query = parse_query(query_text)
         if self.search_results_page.search(query):
             self._logger.info(f'Do search for query: {query}')
             self.deselect_all_menu_buttons()

--- a/src/tribler-gui/tribler_gui/widgets/searchresultswidget.py
+++ b/src/tribler-gui/tribler_gui/widgets/searchresultswidget.py
@@ -7,7 +7,9 @@ from PyQt5 import uic
 
 from tribler_common.sentry_reporter.sentry_mixin import AddBreadcrumbOnShowMixin
 from tribler_common.utilities import Query, to_fts_query
+
 from tribler_core.components.metadata_store.db.serialization import CHANNEL_TORRENT, COLLECTION_NODE, REGULAR_TORRENT
+
 from tribler_gui.tribler_request_manager import TriblerNetworkRequest
 from tribler_gui.utilities import connect, get_ui_file_path, tr
 from tribler_gui.widgets.tablecontentmodel import SearchResultsModel
@@ -23,11 +25,11 @@ def format_search_loading_label(search_request):
     }
 
     return (
-            tr(
-                "Remote responses: %(num_complete_peers)i / %(total_peers)i"
-                "\nNew remote results received: %(num_remote_results)i"
-            )
-            % data
+        tr(
+            "Remote responses: %(num_complete_peers)i / %(total_peers)i"
+            "\nNew remote results received: %(num_remote_results)i"
+        )
+        % data
     )
 
 
@@ -79,8 +81,11 @@ class SearchResultsWidget(AddBreadcrumbOnShowMixin, widget_form, widget_class):
         query = self.search_request.query
         self.results_page.initialize_root_model(
             SearchResultsModel(
-                channel_info={"name": (tr("Search results for %s") % query.original_query) if len(
-                    query.original_query) < 50 else f"{query.original_query[:50]}..."},
+                channel_info={
+                    "name": (tr("Search results for %s") % query.original_query)
+                    if len(query.original_query) < 50
+                    else f"{query.original_query[:50]}..."
+                },
                 endpoint_url="search",
                 hide_xxx=self.results_page.hide_xxx,
                 text_filter=to_fts_query(query.fts_text),
@@ -92,9 +97,9 @@ class SearchResultsWidget(AddBreadcrumbOnShowMixin, widget_form, widget_class):
 
     def check_can_show(self, query):
         if (
-                self.last_search_query == query
-                and self.last_search_time is not None
-                and time.time() - self.last_search_time < 1
+            self.last_search_query == query
+            and self.last_search_time is not None
+            and time.time() - self.last_search_time < 1
         ):
             self._logger.info("Same search query already sent within 500ms so dropping this one")
             return False


### PR DESCRIPTION
This PR introduced search by tags. It partially solves #6551

![image](https://user-images.githubusercontent.com/13798583/146226888-54806895-99cc-4979-b8d7-e0ce25b91329.png)

Search by tags extends the current search endpoint by adding tags keywoard.
Tags within the search query should start from the `#` character.


As a side-effect, this PR fixes #6612