### PR TITLE
Fix gui tests stability

### DIFF
--- a/src/run_tribler.py
+++ b/src/run_tribler.py
@@ -93,7 +93,7 @@ if __name__ == "__main__":
         version_history = VersionHistory(root_state_dir)
         state_dir = version_history.code_version.directory
         try:
-            start_core.start_tribler_core(api_port, api_key, state_dir, gui_test_mode=parsed_args.gui_test_mode)
+            start_core.run_tribler_core(api_port, api_key, state_dir, gui_test_mode=parsed_args.gui_test_mode)
         finally:
             logger.info('Remove lock file')
             process_checker.remove_lock_file()

--- a/src/tribler-core/tribler_core/start_core.py
+++ b/src/tribler-core/tribler_core/start_core.py
@@ -104,7 +104,7 @@ async def core_session(config: TriblerConfig, components: List[Component]):
         config.write()
 
 
-def start_tribler_core(api_port, api_key, state_dir, gui_test_mode=False):
+def run_tribler_core(api_port, api_key, state_dir, gui_test_mode=False):
     """
     This method will start a new Tribler session.
     Note that there is no direct communication between the GUI process and the core: all communication is performed

--- a/src/tribler-core/tribler_core/tests/test_start_core.py
+++ b/src/tribler-core/tribler_core/tests/test_start_core.py
@@ -1,6 +1,6 @@
 from unittest.mock import MagicMock, patch
 
-from tribler_core.start_core import start_tribler_core
+from tribler_core.start_core import run_tribler_core
 from tribler_core.utilities.path_util import Path
 
 # pylint: disable=
@@ -15,5 +15,5 @@ from tribler_core.utilities.path_util import Path
 @patch('tribler_core.start_core.core_session')
 def test_start_tribler_core_no_exceptions(mocked_core_session):
     # test that base logic of tribler core runs without exceptions
-    start_tribler_core(1, 'key', Path('.'), False)
+    run_tribler_core(1, 'key', Path('.'), False)
     mocked_core_session.assert_called_once()

--- a/src/tribler-gui/tribler_gui/core_manager.py
+++ b/src/tribler-gui/tribler_gui/core_manager.py
@@ -33,14 +33,14 @@ class CoreManager(QObject):
         self.shutting_down = False
         self.should_quit_app_on_core_finished = False
         self.use_existing_core = True
-        self.is_core_running = False
+        self.core_connected = False
         self.last_core_stdout_output: str = ''
         self.last_core_stderr_output: str = ''
 
-        connect(self.events_manager.tribler_started, self._set_core_running)
+        connect(self.events_manager.tribler_started, self._set_core_connected)
 
-    def _set_core_running(self, _):
-        self.is_core_running = True
+    def _set_core_connected(self, _):
+        self.core_connected = True
 
     def on_core_stdout_read_ready(self):
         raw_output = bytes(self.core_process.readAllStandardOutput())
@@ -120,7 +120,7 @@ class CoreManager(QObject):
 
     def stop(self, quit_app_on_core_finished=True):
         self._logger.info("Stopping Core manager")
-        if self.core_process or self.is_core_running:
+        if self.core_process or self.core_connected:
             self._logger.info("Sending shutdown request to Tribler Core")
             self.events_manager.shutting_down = True
             TriblerNetworkRequest("shutdown", lambda _: None, method="PUT", priority=QNetworkRequest.HighPriority)

--- a/src/tribler-gui/tribler_gui/error_handler.py
+++ b/src/tribler-gui/tribler_gui/error_handler.py
@@ -90,7 +90,7 @@ class ErrorHandler:
 
         # Add info about whether we are stopping Tribler or not
         if not self.tribler_window.core_manager.shutting_down:
-            self.tribler_window.core_manager.stop(stop_app_on_shutdown=False)
+            self.tribler_window.core_manager.stop(quit_app_on_core_finished=False)
 
         self.tribler_window.setHidden(True)
 

--- a/src/tribler-gui/tribler_gui/error_handler.py
+++ b/src/tribler-gui/tribler_gui/error_handler.py
@@ -89,8 +89,7 @@ class ErrorHandler:
         self.tribler_window.downloads_page.stop_loading_downloads()
 
         # Add info about whether we are stopping Tribler or not
-        if not self.tribler_window.core_manager.shutting_down:
-            self.tribler_window.core_manager.stop(quit_app_on_core_finished=False)
+        self.tribler_window.core_manager.stop(quit_app_on_core_finished=False)
 
         self.tribler_window.setHidden(True)
 

--- a/src/tribler-gui/tribler_gui/tests/test_core_manager.py
+++ b/src/tribler-gui/tribler_gui/tests/test_core_manager.py
@@ -61,13 +61,6 @@ def test_on_core_stdout_stderr_read_ready_os_error():
     core_manager = CoreManager(MagicMock(), MagicMock(), MagicMock(), MagicMock())
     core_manager.core_process = MagicMock(read_all=MagicMock(return_value=''))
 
-    with pytest.raises(OSError):
-        core_manager.on_core_stdout_read_ready()
-
-    with pytest.raises(OSError):
-        core_manager.on_core_stderr_read_ready()
-
-    core_manager.quitting_app = True
-    # no exception during shutting down
+    # check that OSError exception is suppressed when writing to stdout and stderr
     core_manager.on_core_stdout_read_ready()
     core_manager.on_core_stderr_read_ready()

--- a/src/tribler-gui/tribler_gui/tests/test_core_manager.py
+++ b/src/tribler-gui/tribler_gui/tests/test_core_manager.py
@@ -9,9 +9,9 @@ pytestmark = pytest.mark.asyncio
 
 # fmt: off
 
-@patch.object(CoreManager, 'on_finished')
+@patch.object(CoreManager, 'quit_application')
 @patch('tribler_gui.core_manager.EventRequestManager', new=MagicMock())
-async def test_on_core_finished_call_on_finished(mocked_on_finished: MagicMock):
+async def test_on_core_finished_call_on_finished(mocked_quit_application: MagicMock):
     # test that in case of `shutting_down` and `should_quit_app_on_core_finished` flags have been set to True
     # then `on_finished` function will be called and Exception will not be raised
     core_manager = CoreManager(MagicMock(), MagicMock(), MagicMock(), MagicMock())
@@ -19,7 +19,7 @@ async def test_on_core_finished_call_on_finished(mocked_on_finished: MagicMock):
     core_manager.should_quit_app_on_core_finished = True
 
     core_manager.on_core_finished(exit_code=1, exit_status='exit status')
-    mocked_on_finished.assert_called_once()
+    mocked_quit_application.assert_called_once()
 
 
 @patch('tribler_gui.core_manager.EventRequestManager', new=MagicMock())
@@ -56,7 +56,7 @@ async def test_on_core_stderr_read_ready(mocked_stderr, mocked_print: MagicMock)
 @patch('tribler_gui.core_manager.EventRequestManager', new=MagicMock())
 @patch('builtins.print', MagicMock(side_effect=OSError()))
 def test_on_core_stdout_stderr_read_ready_os_error():
-    # test that OSError on writing to stdout is suppressed during shutting down
+    # test that OSError on writing to stdout is suppressed when quitting the application
 
     core_manager = CoreManager(MagicMock(), MagicMock(), MagicMock(), MagicMock())
     core_manager.core_process = MagicMock(read_all=MagicMock(return_value=''))
@@ -67,7 +67,7 @@ def test_on_core_stdout_stderr_read_ready_os_error():
     with pytest.raises(OSError):
         core_manager.on_core_stderr_read_ready()
 
-    core_manager.shutting_down = True
+    core_manager.quitting_app = True
     # no exception during shutting down
     core_manager.on_core_stdout_read_ready()
     core_manager.on_core_stderr_read_ready()

--- a/src/tribler-gui/tribler_gui/tests/test_core_manager.py
+++ b/src/tribler-gui/tribler_gui/tests/test_core_manager.py
@@ -12,11 +12,11 @@ pytestmark = pytest.mark.asyncio
 @patch.object(CoreManager, 'on_finished')
 @patch('tribler_gui.core_manager.EventRequestManager', new=MagicMock())
 async def test_on_core_finished_call_on_finished(mocked_on_finished: MagicMock):
-    # test that in case of `shutting_down` and `should_stop_on_shutdown` flags have been set to True
+    # test that in case of `shutting_down` and `should_quit_app_on_core_finished` flags have been set to True
     # then `on_finished` function will be called and Exception will not be raised
     core_manager = CoreManager(MagicMock(), MagicMock(), MagicMock(), MagicMock())
     core_manager.shutting_down = True
-    core_manager.should_stop_on_shutdown = True
+    core_manager.should_quit_app_on_core_finished = True
 
     core_manager.on_core_finished(exit_code=1, exit_status='exit status')
     mocked_on_finished.assert_called_once()

--- a/src/tribler-gui/tribler_gui/tribler_window.py
+++ b/src/tribler-gui/tribler_gui/tribler_window.py
@@ -419,7 +419,7 @@ class TriblerWindow(QMainWindow):
                 QApplication.quit()
 
         self.downloads_page.stop_loading_downloads()
-        self.core_manager.stop(False)
+        self.core_manager.stop(quit_app_on_core_finished=False)
         close_dialog = ConfirmationDialog(
             self.window(),
             tr("<b>CRITICAL ERROR</b>"),
@@ -1099,7 +1099,6 @@ class TriblerWindow(QMainWindow):
             QApplication.quit()
 
         self.core_manager.stop()
-        self.core_manager.shutting_down = True
         self.downloads_page.stop_loading_downloads()
         request_manager.clear()
 


### PR DESCRIPTION
In this PR, I rewrote the logic of `CoreManager` to fix the shutdown process sequence and make the logic of `CoreManager` easier to understand.

With these changes, I was able to get completely stable GUI tests on my Windows machine. Previously I often got the following error (reported in #6039):

```python
Traceback (most recent call last):
  File "C:\dev\tribler\src\tribler-gui\tribler_gui\utilities.py", line 375, in trackback_wrapper
    raise exc from CreationTraceback(traceback_str)
  File "C:\dev\tribler\src\tribler-gui\tribler_gui\utilities.py", line 372, in trackback_wrapper
    callback(*args, **kwargs)
  File "C:\dev\tribler\src\tribler-gui\tribler_gui\core_manager.py", line 67, in on_core_finished
    self.on_finished()
  File "C:\dev\tribler\src\tribler-gui\tribler_gui\core_manager.py", line 132, in on_finished
    self.tribler_stopped.emit()
RuntimeError: wrapped C/C++ object of type CoreManager has been deleted
```

Now, this error is gone.

I don't know, will the PR fix crashes on Mac described in #6564 or not, but I hope it should also fix them as well.

The reason for the problem "wrapped C/C++ object of type CoreManager has been deleted" was emitting the `CoreManager.tribler_stopped` signal at the moment when the application had already quit, and Qt internal structures were partially destroyed. As it turns out, nobody actually uses this signal, so I removed it. If necessary, we can reintroduce it in the future, as now the improved logic of the CoreManager's shutdown process should track do we already call `QApplication.quit()` or not and set the corresponding flag `quitting_app` to True, preventing some actions at this stage.

I rewrote the logic of the `CoreManager` shutdown to make it easier to understand. During this process, I noticed that we potentially do not always process errors on the Core shutdown. This is the previous logic of error handling:

```python
def on_core_finished(self, exit_code, exit_status):
        if self.shutting_down and self.should_stop_on_shutdown:
            self.on_finished()
        elif not self.shutting_down and exit_code != 0:
            ...
            raise CoreCrashedError(exception_message)
```

Note that if `CoreManager` was not in the `shutting_down` state and the Core process suddenly finished with exit code 0, this situation was not processed. I don't know how often it can happen in practice, but in my opinion, if Core suddenly finished with exit code 0 when GUI did not expect it, it should be treated as an error, reported Sentry, and then GUI should stop. Before this PR, GUI hangs indefinitely in this situation.

Now the logic looks the following way:

```python
def on_core_finished(self, exit_code, exit_status):
        self.core_running = False
        self.core_finished = True
        if self.shutting_down:
            if self.should_quit_app_on_core_finished:
                self.quit_application()
        else:
            ...
            raise CoreCrashedError(error_message)
```

That is, now GUI handles any unexpected Core process termination.

I renamed `CoreManager` state flags because the previous names do not reflect the actual flag meaning. Also, I added some new flags to describe the CoreManager state completely.