### PR TITLE
Remove spam in pytest output

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,6 +2,12 @@
 timeout = 5
 log_level = DEBUG
 log_cli_format = %(asctime)s %(levelname)s %(message)s
+markers =
+    guitest:Tests for GUI. Skipped by default, use --guitests option to enable them
+    tunneltest:Slow tests for tunnels. Skipped by default, use --tunneltests option to enable them
+    enable_https:Use HTTPS instead of HTTP in marked tests
+    api_key:Used by rest_manager fixture to inject api_key value
+
 filterwarnings =
     ignore:Passing field metadata as a keyword arg is deprecated:DeprecationWarning:marshmallow
     ignore:Passing field metadata as keyword arguments is deprecated:DeprecationWarning:marshmallow

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 timeout = 5
-log_level = DEBUG
+log_level = INFO
 log_cli_format = %(asctime)s %(levelname)s %(message)s
 markers =
     guitest:Tests for GUI. Skipped by default, use --guitests option to enable them

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,16 @@
 timeout = 5
 log_level = DEBUG
 log_cli_format = %(asctime)s %(levelname)s %(message)s
+filterwarnings =
+    ignore:Passing field metadata as a keyword arg is deprecated:DeprecationWarning:marshmallow
+    ignore:Passing field metadata as keyword arguments is deprecated:DeprecationWarning:marshmallow
+    ignore:The 'default' argument to fields is deprecated:DeprecationWarning:marshmallow
+    ignore:The 'missing' attribute of fields is deprecated:DeprecationWarning:marshmallow
+    ignore:"@coroutine" decorator is deprecated since Python 3.8, use "async def" instead:DeprecationWarning:asynctest
+    ignore:Bare functions are deprecated, use async ones:DeprecationWarning:aiohttp
+    ignore:returning HTTPException object is deprecated:DeprecationWarning:aiohttp
+    ignore:Flags not at the start of the expression:DeprecationWarning:pyqtgraph
+    ignore:Parsing of hex strings that do not start with:DeprecationWarning:pyqtgraph
+    ignore:The parser module is deprecated:DeprecationWarning:pony
+    ignore:The symbol module is deprecated:DeprecationWarning:pony
+    ignore:the imp module is deprecated in favour of importlib:DeprecationWarning:pywintypes

--- a/src/tribler-core/tribler_core/components/metadata_store/db/tests/test_store.py
+++ b/src/tribler-core/tribler_core/components/metadata_store/db/tests/test_store.py
@@ -453,7 +453,7 @@ def test_process_payload_update_type(metadata_store):
     assert updated_node2.metadata_type == CHANNEL_TORRENT
 
 
-class TestException(Exception):
+class ThreadedTestException(Exception):
     pass
 
 
@@ -464,10 +464,10 @@ async def test_run_threaded(metadata_store):
     def f1(a, b, *, c, d):
         if a == 1 and b == 2 and c == 3 and d == 4:
             return threading.get_ident()
-        raise TestException('test exception')
+        raise ThreadedTestException('test exception')
 
     result = await metadata_store.run_threaded(f1, 1, 2, c=3, d=4)
     assert result != thread_id
 
-    with pytest.raises(TestException, match='^test exception$'):
+    with pytest.raises(ThreadedTestException, match='^test exception$'):
         await metadata_store.run_threaded(f1, 1, 2, c=5, d=6)

--- a/src/tribler-core/tribler_core/components/popularity/community/popularity_community.py
+++ b/src/tribler-core/tribler_core/components/popularity/community/popularity_community.py
@@ -6,9 +6,9 @@ from ipv8.lazy_community import lazy_wrapper
 
 from pony.orm import db_session
 
+from tribler_core.components.metadata_store.remote_query_community.remote_query_community import RemoteQueryCommunity
 from tribler_core.components.popularity.community.payload import TorrentsHealthPayload
 from tribler_core.components.popularity.community.version_community_mixin import VersionCommunityMixin
-from tribler_core.components.metadata_store.remote_query_community.remote_query_community import RemoteQueryCommunity
 from tribler_core.utilities.unicode import hexlify
 
 

--- a/src/tribler-core/tribler_core/components/popularity/community/popularity_community.py
+++ b/src/tribler-core/tribler_core/components/popularity/community/popularity_community.py
@@ -78,7 +78,7 @@ class PopularityCommunity(RemoteQueryCommunity, VersionCommunityMixin):
         if include_random:
             rest = alive - popular
             count = min(PopularityCommunity.GOSSIP_RANDOM_TORRENT_COUNT, len(rest))
-            rand = set(random.sample(rest, count))
+            rand = set(random.sample(list(rest), count))
 
         return popular, rand
 

--- a/src/tribler-core/tribler_core/components/tests/test_base_component.py
+++ b/src/tribler-core/tribler_core/components/tests/test_base_component.py
@@ -5,7 +5,7 @@ from tribler_core.components.base import Component, MissedDependency, NoneCompon
 pytestmark = pytest.mark.asyncio
 
 
-class TestException(Exception):
+class ComponentTestException(Exception):
     pass
 
 
@@ -125,7 +125,7 @@ async def test_component_shutdown_failure(tribler_config):
             await self.require_component(ComponentA)
 
         async def shutdown(self):
-            raise TestException
+            raise ComponentTestException
 
     session = Session(tribler_config, [ComponentA(), ComponentB()])
     with session:
@@ -136,7 +136,7 @@ async def test_component_shutdown_failure(tribler_config):
 
         assert not a.unused_event.is_set()
 
-        with pytest.raises(TestException):
+        with pytest.raises(ComponentTestException):
             await session.shutdown()
 
         for component in a, b:

--- a/src/tribler-core/tribler_core/components/tunnel/community/discovery.py
+++ b/src/tribler-core/tribler_core/components/tunnel/community/discovery.py
@@ -1,5 +1,5 @@
 import time
-from random import sample
+from random import choice
 
 from ipv8.messaging.anonymization.tunnel import PEER_FLAG_EXIT_BT
 from ipv8.peerdiscovery.discovery import DiscoveryStrategy
@@ -63,6 +63,6 @@ class GoldenRatioStrategy(DiscoveryStrategy):
                 exit_count = len(exit_peers)
                 ratio = 1.0 - exit_count / peer_count  # Peer count is > 0 per definition
                 if ratio < self.golden_ratio:
-                    self.overlay.network.remove_peer(sample(exit_peers, 1)[0])
+                    self.overlay.network.remove_peer(choice(list(exit_peers)))
                 elif ratio > self.golden_ratio:
-                    self.overlay.network.remove_peer(sample(set(self.overlay.get_peers()) - exit_peers, 1)[0])
+                    self.overlay.network.remove_peer(choice(list(set(self.overlay.get_peers()) - exit_peers)))

--- a/src/tribler-core/tribler_core/components/tunnel/community/tunnel_community.py
+++ b/src/tribler-core/tribler_core/components/tunnel/community/tunnel_community.py
@@ -586,7 +586,7 @@ class TriblerTunnelCommunity(HiddenTunnelCommunity):
 
         writer = None
         try:
-            with async_timeout.timeout(10):
+            async with async_timeout.timeout(10):
                 self.logger.debug("Opening TCP connection to %s", payload.target)
                 reader, writer = await open_connection(*payload.target)
                 writer.write(payload.request)

--- a/src/tribler-gui/tribler_gui/dialogs/dialogcontainer.py
+++ b/src/tribler-gui/tribler_gui/dialogs/dialogcontainer.py
@@ -49,8 +49,8 @@ class DialogContainer(AddBreadcrumbOnShowMixin, QWidget):
             self.dialog_widget.setFixedWidth(self.width() - self.left_right_margin)
             self.dialog_widget.move(
                 QPoint(
-                    self.geometry().center().x() - self.dialog_widget.geometry().width() / 2,
-                    self.geometry().center().y() - self.dialog_widget.geometry().height() / 2,
+                    int(self.geometry().center().x() - self.dialog_widget.geometry().width() / 2),
+                    int(self.geometry().center().y() - self.dialog_widget.geometry().height() / 2),
                 )
             )
         except RuntimeError:

--- a/src/tribler-gui/tribler_gui/tribler_window.py
+++ b/src/tribler-gui/tribler_gui/tribler_window.py
@@ -321,7 +321,7 @@ class TriblerWindow(QMainWindow):
         self.resize(size)
 
         center = QApplication.desktop().availableGeometry(self).center()
-        screen_center_pos = QPoint(center.x() - self.width() / 2, center.y() - self.height() / 2)
+        screen_center_pos = QPoint(int(center.x() - self.width() / 2), int(center.y() - self.height() / 2))
         pos = self.gui_settings.value("pos", screen_center_pos)
 
         if not QApplication.desktop().availableGeometry(self).intersects(QRect(pos, self.size())):

--- a/src/tribler-gui/tribler_gui/widgets/lazytableview.py
+++ b/src/tribler-gui/tribler_gui/widgets/lazytableview.py
@@ -36,7 +36,7 @@ class FloatingAnimationWidget(QLabel):
 
         x = parent_rect.width() / 2 - self.width() / 2
         y = parent_rect.height() / 2 - self.height() / 2
-        self.setGeometry(x, y, self.width(), self.height())
+        self.setGeometry(int(x), int(y), self.width(), self.height())
 
     def resizeEvent(self, event):
         super().resizeEvent(event)

--- a/src/tribler-gui/tribler_gui/widgets/tablecontentdelegate.py
+++ b/src/tribler-gui/tribler_gui/widgets/tablecontentdelegate.py
@@ -281,7 +281,7 @@ class ChannelStateMixin:
         r = rect
         indicator_border = 1
         indicator_side = (r.height() if r.width() > r.height() else r.width()) - indicator_border * 2
-        y = r.top() + (r.height() - indicator_side) / 2
+        y = int(r.top() + (r.height() - indicator_side) / 2)
         x = r.left() + indicator_border
         w = indicator_side
         h = indicator_side
@@ -401,7 +401,7 @@ class TagsMixin:
             cur_tag_x = option.rect.x() + 6
             cur_tag_y += TAG_HEIGHT + 10
 
-        edit_rect = QRect(cur_tag_x + 4, cur_tag_y, TAG_HEIGHT, TAG_HEIGHT)
+        edit_rect = QRect(int(cur_tag_x + 4), int(cur_tag_y), int(TAG_HEIGHT), int(TAG_HEIGHT))
         index.model().edit_tags_rects[index] = edit_rect
 
         if edit_tags_button_hovered:
@@ -624,8 +624,8 @@ class SubscribeToggleControl(QObject, CheckClickedMixin):
 
         painter.save()
 
-        x = rect.x() + (rect.width() - self._width) / 2
-        y = rect.y() + (rect.height() - self._height) / 2
+        x = int(rect.x() + (rect.width() - self._width) / 2)
+        y = int(rect.y() + (rect.height() - self._height) / 2)
 
         offset = self._end_offset[toggled]()
         p = painter
@@ -664,7 +664,7 @@ class SubscribeToggleControl(QObject, CheckClickedMixin):
         p.setPen(text_color)
         p.setOpacity(text_opacity)
         font = p.font()
-        font.setPixelSize(1.5 * self._thumb_radius)
+        font.setPixelSize(int(1.5 * self._thumb_radius))
         p.setFont(font)
         p.drawText(
             QRectF(
@@ -760,7 +760,7 @@ class HealthStatusDisplay(QObject):
         painter.save()
 
         # Indicator ellipse rectangle
-        y = r.top() + (r.height() - self.indicator_side) / 2
+        y = int(r.top() + (r.height() - self.indicator_side) / 2)
         x = r.left() + self.indicator_border
         w = self.indicator_side
         h = self.indicator_side

--- a/src/tribler-gui/tribler_gui/widgets/tagslineedit.py
+++ b/src/tribler-gui/tribler_gui/widgets/tagslineedit.py
@@ -108,7 +108,7 @@ class TagsLineEdit(QLineEdit):
         if visible:
             flashTime = QGuiApplication.styleHints().cursorFlashTime()
             if flashTime >= 2:
-                self.blink_timer = self.startTimer(flashTime / 2)
+                self.blink_timer = self.startTimer(int(flashTime / 2))
         else:
             self.blink_status = False
 
@@ -246,7 +246,7 @@ class TagsLineEdit(QLineEdit):
                 i_r.setRect(input_rect.x(), i_r.y() + TAG_HEIGHT + TAG_VERTICAL_MARGIN, i_r.width(), i_r.height())
                 lt.setY(lt.y() + TAG_HEIGHT + TAG_VERTICAL_MARGIN)
 
-            lt.setX(i_r.right() + TAG_HORIZONTAL_MARGIN)
+            lt.setX(int(i_r.right() + TAG_HORIZONTAL_MARGIN))
             self.tags[tag_index].rect = i_r
 
     def has_selection_active(self) -> bool:

--- a/src/tribler-gui/tribler_gui/widgets/togglebutton.py
+++ b/src/tribler-gui/tribler_gui/widgets/togglebutton.py
@@ -109,7 +109,7 @@ class ToggleButton(QAbstractButton):
         p.setPen(text_color)
         p.setOpacity(text_opacity)
         font = p.font()
-        font.setPixelSize(1.5 * self._thumb_radius)
+        font.setPixelSize(int(1.5 * self._thumb_radius))
         p.setFont(font)
         p.drawText(
             QRectF(

--- a/src/tribler-gui/tribler_gui/widgets/torrentfiletreewidget.py
+++ b/src/tribler-gui/tribler_gui/widgets/torrentfiletreewidget.py
@@ -161,7 +161,7 @@ class TorrentFileTreeWidget(QTreeWidget):
         self.blockSignals(True)
         self.clear()
 
-        self.header().setResizeMode(QHeaderView.ResizeToContents)
+        self.header().setSectionResizeMode(QHeaderView.ResizeToContents)
         single_item_torrent = len(files) == 1
 
         # !!! ACHTUNG !!!


### PR DESCRIPTION
Currently, pytest output has many unimportant warnings from third-party libraries. We can safely ignore all of them. Displaying all these warnings makes understanding pytest results more complex than necessary. It is essential that if we get some new and important warning one day, we can easily miss it in this wall of existing warnings.

In this PR, I update the `pytest.ini` config file to suppress all unimportant warnings and also I suppress warnings in code when necessary.

Also, I switched the default logging level in tests from DEBUG to INFO. In most cases, DEBUG output is not helpful, as it mainly consists of spam generated by internal PyQt modules. So, most of the time, it makes test results harder to understand. If necessary, we can always switch it back to DEBUG level later when analyzing some specific test failure.