### PR TITLE
Fix for #6603

### DIFF
--- a/src/tribler-core/tribler_core/components/libtorrent/download_manager/download_manager.py
+++ b/src/tribler-core/tribler_core/components/libtorrent/download_manager/download_manager.py
@@ -140,7 +140,7 @@ class DownloadManager(TaskManager):
             self.dht_health_manager = DHTHealthManager(dht_health_session)
 
         # Make temporary directory for metadata collecting through DHT
-        self.metadata_tmpdir = Path.mkdtemp(suffix='tribler_metainfo_tmpdir')
+        self.metadata_tmpdir = self.metadata_tmpdir or Path.mkdtemp(suffix='tribler_metainfo_tmpdir')
 
         # Register tasks
         self.register_task("process_alerts", self._task_process_alerts, interval=1)
@@ -187,7 +187,7 @@ class DownloadManager(TaskManager):
 
         # Remove metadata temporary directory
         if self.metadata_tmpdir:
-            rmtree(self.metadata_tmpdir)
+            rmtree(self.metadata_tmpdir, ignore_errors=True)
             self.metadata_tmpdir = None
 
     def is_shutdown_ready(self):

--- a/src/tribler-core/tribler_core/components/libtorrent/tests/test_download_manager.py
+++ b/src/tribler-core/tribler_core/components/libtorrent/tests/test_download_manager.py
@@ -45,10 +45,10 @@ def create_fake_download_and_state():
 
 
 @pytest.fixture
-async def fake_dlmgr(tmp_path):
+async def fake_dlmgr(tmp_path_factory):
     config = LibtorrentSettings(dht_readiness_timeout=0)
-    dlmgr = DownloadManager(config=config, state_dir=tmp_path, notifier=Mock(), peer_mid=b"0000")
-    dlmgr.metadata_tmpdir = tmp_path
+    dlmgr = DownloadManager(config=config, state_dir=tmp_path_factory.mktemp('state_dir'), notifier=Mock(), peer_mid=b"0000")
+    dlmgr.metadata_tmpdir = tmp_path_factory.mktemp('metadata_tmpdir')
     dlmgr.get_session = lambda *_, **__: Mock()
     yield dlmgr
     await dlmgr.shutdown(timeout=0)

--- a/src/tribler-core/tribler_core/components/libtorrent/tests/test_download_manager.py
+++ b/src/tribler-core/tribler_core/components/libtorrent/tests/test_download_manager.py
@@ -47,7 +47,8 @@ def create_fake_download_and_state():
 @pytest.fixture
 async def fake_dlmgr(tmp_path_factory):
     config = LibtorrentSettings(dht_readiness_timeout=0)
-    dlmgr = DownloadManager(config=config, state_dir=tmp_path_factory.mktemp('state_dir'), notifier=Mock(), peer_mid=b"0000")
+    dlmgr = DownloadManager(config=config, state_dir=tmp_path_factory.mktemp('state_dir'), notifier=Mock(),
+                            peer_mid=b"0000")
     dlmgr.metadata_tmpdir = tmp_path_factory.mktemp('metadata_tmpdir')
     dlmgr.get_session = lambda *_, **__: Mock()
     yield dlmgr

--- a/src/tribler-core/tribler_core/components/metadata_store/tests/test_channel_download.py
+++ b/src/tribler-core/tribler_core/components/metadata_store/tests/test_channel_download.py
@@ -29,13 +29,15 @@ def channel_tdef():
 
 
 @pytest.fixture
-async def channel_seeder(channel_tdef, tmp_path, loop):
+async def channel_seeder(channel_tdef, loop, tmp_path_factory):
     config = LibtorrentSettings()
     config.dht = False
     config.upnp = False
     config.natpmp = False
     config.lsd = False
-    seeder_dlmgr = DownloadManager(state_dir=tmp_path, config=config, notifier=Mock(), peer_mid=b"0000")
+    seeder_dlmgr = DownloadManager(state_dir=tmp_path_factory.mktemp('state_dir'), config=config, notifier=Mock(),
+                                   peer_mid=b"0000")
+    seeder_dlmgr.metadata_tmpdir = tmp_path_factory.mktemp('metadata_tmpdir')
     seeder_dlmgr.initialize()
     dscfg_seed = DownloadConfig()
     dscfg_seed.set_dest_dir(TESTS_DATA_DIR / 'sample_channel')

--- a/src/tribler-core/tribler_core/components/metadata_store/tests/test_channel_download.py
+++ b/src/tribler-core/tribler_core/components/metadata_store/tests/test_channel_download.py
@@ -8,11 +8,11 @@ import pytest
 
 from tribler_common.simpledefs import DLSTATUS_SEEDING
 
+from tribler_core.components.gigachannel_manager.gigachannel_manager import GigaChannelManager
 from tribler_core.components.libtorrent.download_manager.download_config import DownloadConfig
 from tribler_core.components.libtorrent.download_manager.download_manager import DownloadManager
 from tribler_core.components.libtorrent.settings import LibtorrentSettings
 from tribler_core.components.libtorrent.torrentdef import TorrentDef
-from tribler_core.components.gigachannel_manager.gigachannel_manager import GigaChannelManager
 from tribler_core.components.metadata_store.db.serialization import ChannelMetadataPayload
 from tribler_core.tests.tools.common import TESTS_DATA_DIR
 
@@ -29,7 +29,7 @@ def channel_tdef():
 
 
 @pytest.fixture
-async def channel_seeder(channel_tdef, loop, tmp_path_factory):
+async def channel_seeder(channel_tdef, loop, tmp_path_factory):  # pylint: disable=unused-argument, redefined-outer-name
     config = LibtorrentSettings()
     config.dht = False
     config.upnp = False

--- a/src/tribler-core/tribler_core/conftest.py
+++ b/src/tribler-core/tribler_core/conftest.py
@@ -123,12 +123,13 @@ async def video_seeder(tmp_path_factory, video_tdef):
     config.upnp = False
     config.natpmp = False
     config.lsd = False
-    seeder_state_dir = tmp_path_factory.mktemp('video_seeder_state_dir', numbered=True)
+    seeder_state_dir = tmp_path_factory.mktemp('video_seeder_state_dir')
     dlmgr = DownloadManager(
         config=config,
         state_dir=seeder_state_dir,
         notifier=Mock(),
         peer_mid=b"0000")
+    dlmgr.metadata_tmpdir = tmp_path_factory.mktemp('metadata_tmpdir')
     dlmgr.initialize()
     dscfg_seed = DownloadConfig()
     dscfg_seed.set_dest_dir(TESTS_DATA_DIR)
@@ -301,7 +302,7 @@ def peer_key():
 
 
 @pytest.fixture
-async def download_manager(tmp_path):
+async def download_manager(tmp_path_factory):
     config = LibtorrentSettings()
     config.dht = False
     config.upnp = False
@@ -309,9 +310,10 @@ async def download_manager(tmp_path):
     config.lsd = False
     download_manager = DownloadManager(
         config=config,
-        state_dir=tmp_path,
+        state_dir=tmp_path_factory.mktemp('state_dir'),
         notifier=Mock(),
         peer_mid=b"0000")
+    download_manager.metadata_tmpdir = tmp_path_factory.mktemp('metadata_tmpdir')
     download_manager.initialize()
     yield download_manager
     await download_manager.shutdown()


### PR DESCRIPTION
This PR fixes #6603.

`metadata_tmpdir` now passes through the constructor of `DownloadManager` for each test.