### PR TITLE
Fix torrent file path not split properly on Windows

### DIFF
--- a/src/tribler-core/tribler_core/components/libtorrent/restapi/downloads_endpoint.py
+++ b/src/tribler-core/tribler_core/components/libtorrent/restapi/downloads_endpoint.py
@@ -1,6 +1,7 @@
 from asyncio import CancelledError, TimeoutError as AsyncTimeoutError, wait_for
 from binascii import unhexlify
 from contextlib import suppress
+from pathlib import PurePosixPath
 
 from aiohttp import web
 
@@ -24,9 +25,14 @@ from tribler_core.components.libtorrent.download_manager.download_config import 
 from tribler_core.components.libtorrent.download_manager.download_manager import DownloadManager
 from tribler_core.components.libtorrent.download_manager.stream import STREAM_PAUSE_TIME, StreamChunk
 from tribler_core.components.libtorrent.utils.libtorrent_helper import libtorrent as lt
-from tribler_core.components.restapi.rest.rest_endpoint import HTTP_BAD_REQUEST, HTTP_INTERNAL_SERVER_ERROR, \
-    HTTP_NOT_FOUND, RESTEndpoint, \
-    RESTResponse, RESTStreamResponse
+from tribler_core.components.restapi.rest.rest_endpoint import (
+    HTTP_BAD_REQUEST,
+    HTTP_INTERNAL_SERVER_ERROR,
+    HTTP_NOT_FOUND,
+    RESTEndpoint,
+    RESTResponse,
+    RESTStreamResponse,
+)
 from tribler_core.components.restapi.rest.util import return_handled_exception
 from tribler_core.utilities.path_util import Path
 from tribler_core.utilities.unicode import ensure_unicode, hexlify
@@ -148,7 +154,8 @@ class DownloadsEndpoint(RESTEndpoint):
         for fn, size in download.get_def().get_files_with_length():
             files_json.append({
                 "index": file_index,
-                "name": str(Path(fn)),
+                # We always return files in Posix format to make GUI independent of Core and simplify testing
+                "name": str(PurePosixPath(fn)),
                 "size": size,
                 "included": (file_index in selected_files or not selected_files),
                 "progress": files_completion.get(fn, 0.0)

--- a/src/tribler-gui/tribler_gui/dialogs/startdownloaddialog.py
+++ b/src/tribler-gui/tribler_gui/dialogs/startdownloaddialog.py
@@ -1,6 +1,7 @@
 import json
 import logging
 from binascii import unhexlify
+from pathlib import PurePosixPath
 from urllib.parse import unquote_plus
 
 from PyQt5 import uic
@@ -191,7 +192,7 @@ class StartDownloadDialog(DialogContainer):
                 for file in metainfo['info']['files']
             ]
         else:
-            files = [{'path': metainfo['info']['name'].split('/'), 'length': metainfo['info']['length']}]
+            files = [{'path': PurePosixPath(metainfo['info']['name']).parts, 'length': metainfo['info']['length']}]
 
         self.dialog_widget.files_list_view.fill_entries(files)
         # Add a bit of space between the rows

--- a/src/tribler-gui/tribler_gui/widgets/downloadsdetailstabwidget.py
+++ b/src/tribler-gui/tribler_gui/widgets/downloadsdetailstabwidget.py
@@ -1,3 +1,5 @@
+from pathlib import PurePosixPath
+
 from PyQt5.QtCore import QTimer, Qt
 from PyQt5.QtWidgets import QTabWidget, QTreeWidgetItem
 
@@ -15,7 +17,7 @@ def convert_to_files_tree_format(download_info):
     files = download_info['files']
     out = []
     for file in sorted(files, key=lambda x: x['index']):
-        file_path_parts = file['name'].split('/')
+        file_path_parts = PurePosixPath(file['name']).parts
         file_path = [download_info['name'], *file_path_parts]
         if len(files) == 1:
             # Special case of a torrent consisting of a single file


### PR DESCRIPTION
fixes #6642 