### PR TITLE
GUI settings should store api_key as bytes for compatibility with previous versions of Tribler

### DIFF
--- a/src/tribler-gui/tribler_gui/tests/test_util.py
+++ b/src/tribler-gui/tribler_gui/tests/test_util.py
@@ -1,6 +1,10 @@
+from unittest.mock import MagicMock
 from urllib.parse import unquote_plus
 
-from tribler_gui.utilities import compose_magnetlink, dict_item_is_any_of, quote_plus_unicode, unicode_quoter
+import pytest
+
+from tribler_gui.utilities import compose_magnetlink, create_api_key, dict_item_is_any_of, format_api_key, \
+    quote_plus_unicode, set_api_key, unicode_quoter
 
 
 def test_quoter_char():
@@ -124,3 +128,29 @@ def test_is_dict_has():
     assert dict_item_is_any_of(d, 'k', ['v'])
     assert dict_item_is_any_of(d, 'k', ['v', 'a'])
     assert dict_item_is_any_of(d, 'k', ['a', 'v'])
+
+
+def test_create_api_key():
+    x = create_api_key()
+    assert len(x) == 32 and bytes.fromhex(x).hex() == x
+
+
+def test_format_api_key():
+    api_key = "abcdef"
+    x = format_api_key(api_key)
+    assert x == "abcdef"
+
+    api_key = b"abcdef"
+    x = format_api_key(api_key)
+    assert x == "abcdef"
+
+    api_key = 123
+    match_str = r"^Got unexpected value type of api_key from gui settings \(should be str or bytes\): int$"
+    with pytest.raises(ValueError, match=match_str):
+        format_api_key(api_key)
+
+
+def test_set_api_key():
+    gui_settings = MagicMock()
+    set_api_key(gui_settings, "abcdef")
+    gui_settings.setValue.assert_called_once_with("api_key", b"abcdef")

--- a/src/tribler-gui/tribler_gui/tribler_window.py
+++ b/src/tribler-gui/tribler_gui/tribler_window.py
@@ -77,12 +77,15 @@ from tribler_gui.tribler_request_manager import TriblerNetworkRequest, TriblerRe
 from tribler_gui.upgrade_manager import UpgradeManager
 from tribler_gui.utilities import (
     connect,
+    create_api_key,
     disconnect,
+    format_api_key,
     get_font_path,
     get_gui_setting,
     get_image_path,
     get_ui_file_path,
     is_dir_writable,
+    set_api_key,
     tr,
 )
 from tribler_gui.widgets.channelsmenulistwidget import ChannelsMenuListWidget
@@ -147,11 +150,8 @@ class TriblerWindow(QMainWindow):
         self.root_state_dir = Path(root_state_dir)
         self.gui_settings = settings
         api_port = api_port or int(get_gui_setting(self.gui_settings, "api_port", DEFAULT_API_PORT))
-        api_key = api_key or get_gui_setting(self.gui_settings, "api_key", hexlify(os.urandom(16)))
-        if isinstance(api_key, bytes):
-            # in QSettings, api_key can be stored as bytes, then we decode it to str
-            api_key = api_key.decode('ascii')
-        self.gui_settings.setValue("api_key", api_key)
+        api_key = format_api_key(api_key or get_gui_setting(self.gui_settings, "api_key", None) or create_api_key())
+        set_api_key(self.gui_settings, api_key)
 
         api_port = NetworkUtils().get_first_free_port(start=api_port)
         request_manager.port, request_manager.key = api_port, api_key


### PR DESCRIPTION
In #6608 and #6611 `api_key` value type was changed from bytes to str. As it turns out, it can break previous releases, as previous releases expect that the value of `api_key` in GUI settings is stored as bytes. So, if a user installs the next release of Tribler (7.12+), or run Tribler from the `main` branch, and then attempts to run a previous version of Tribler (for example, release 7.11), the Tribler will crash on reading `api_key` value from settings.

The PR fixes this problem: `api_key` is now stored in GUI settings as bytes. New function `set_api_key` should correctly handle all possible scenarios when `api_key` was set in bytes or str, or not set at all.