### PR TITLE
Feature/report endpoint errors

### DIFF
--- a/src/tribler-core/tribler_core/components/reporter/exception_handler.py
+++ b/src/tribler-core/tribler_core/components/reporter/exception_handler.py
@@ -75,8 +75,8 @@ class CoreExceptionHandler:
         try:
             SentryReporter.ignore_logger(self.logger.name)
 
-            should_stop = True
             context = context.copy()
+            should_stop = context.pop('should_stop', True)
             message = context.pop('message', 'no message')
             exception = context.pop('exception', None) or self._create_exception_from(message)
             # Exception

--- a/src/tribler-core/tribler_core/components/reporter/tests/test_exception_handler.py
+++ b/src/tribler-core/tribler_core/components/reporter/tests/test_exception_handler.py
@@ -102,6 +102,13 @@ async def test_unhandled_error_observer_store_unreported_error(exception_handler
     assert exception_handler.unreported_error
 
 
+async def test_unhandled_error_observer_false_should_stop(exception_handler):
+    # Test passing negative value for should_stop flag through the context dict
+    context = {'message': 'Any', 'should_stop': False}
+    exception_handler.unhandled_error_observer(None, context)
+    assert exception_handler.unreported_error.should_stop is False
+
+
 async def test_unhandled_error_observer_ignored(exception_handler):
     # test that exception from list IGNORED_ERRORS_BY_CODE never sends to the GUI
     context = {'exception': OSError(113, '')}

--- a/src/tribler-core/tribler_core/components/reporter/tests/test_exception_handler.py
+++ b/src/tribler-core/tribler_core/components/reporter/tests/test_exception_handler.py
@@ -8,9 +8,6 @@ from tribler_common.sentry_reporter.sentry_reporter import SentryReporter
 
 from tribler_core.components.reporter.exception_handler import CoreExceptionHandler
 
-pytestmark = pytest.mark.asyncio
-
-
 # pylint: disable=protected-access, redefined-outer-name
 # fmt: off
 
@@ -26,7 +23,7 @@ def raise_error(error):  # pylint: disable=inconsistent-return-statements
         return e
 
 
-async def test_is_ignored(exception_handler):
+def test_is_ignored(exception_handler):
     # test that CoreExceptionHandler ignores specific exceptions
 
     # by type
@@ -40,7 +37,7 @@ async def test_is_ignored(exception_handler):
     assert exception_handler._is_ignored(RuntimeError('Message that contains invalid info-hash'))
 
 
-async def test_is_not_ignored(exception_handler):
+def test_is_not_ignored(exception_handler):
     # test that CoreExceptionHandler do not ignore exceptions out of
     # IGNORED_ERRORS_BY_CODE and IGNORED_ERRORS_BY_SUBSTRING
     assert not exception_handler._is_ignored(OSError(1, 'Any'))
@@ -48,12 +45,12 @@ async def test_is_not_ignored(exception_handler):
     assert not exception_handler._is_ignored(AttributeError())
 
 
-async def test_create_exception_from(exception_handler):
+def test_create_exception_from(exception_handler):
     # test that CoreExceptionHandler can create an Exception from a string
     assert isinstance(exception_handler._create_exception_from('Any'), Exception)
 
 
-async def test_get_long_text_from(exception_handler):
+def test_get_long_text_from(exception_handler):
     # test that CoreExceptionHandler can generate stacktrace from an Exception
     error = raise_error(AttributeError('Any'))
     actual_string = exception_handler._get_long_text_from(error)
@@ -62,7 +59,7 @@ async def test_get_long_text_from(exception_handler):
 
 @patch(f'{sentry_reporter.__name__}.{SentryReporter.__name__}.{SentryReporter.event_from_exception.__name__}',
        new=MagicMock(return_value={'sentry': 'event'}))
-async def test_unhandled_error_observer_exception(exception_handler):
+def test_unhandled_error_observer_exception(exception_handler):
     # test that unhandled exception, represented by Exception, reported to the GUI
     context = {'exception': raise_error(AttributeError('Any')), 'Any key': 'Any value'}
     exception_handler.report_callback = MagicMock()
@@ -79,7 +76,7 @@ async def test_unhandled_error_observer_exception(exception_handler):
     assert reported_error.should_stop
 
 
-async def test_unhandled_error_observer_only_message(exception_handler):
+def test_unhandled_error_observer_only_message(exception_handler):
     # test that unhandled exception, represented by message, reported to the GUI
     context = {'message': 'Any'}
     exception_handler.report_callback = MagicMock()
@@ -96,20 +93,20 @@ async def test_unhandled_error_observer_only_message(exception_handler):
     assert reported_error.should_stop
 
 
-async def test_unhandled_error_observer_store_unreported_error(exception_handler):
+def test_unhandled_error_observer_store_unreported_error(exception_handler):
     context = {'message': 'Any'}
     exception_handler.unhandled_error_observer(None, context)
     assert exception_handler.unreported_error
 
 
-async def test_unhandled_error_observer_false_should_stop(exception_handler):
+def test_unhandled_error_observer_false_should_stop(exception_handler):
     # Test passing negative value for should_stop flag through the context dict
     context = {'message': 'Any', 'should_stop': False}
     exception_handler.unhandled_error_observer(None, context)
     assert exception_handler.unreported_error.should_stop is False
 
 
-async def test_unhandled_error_observer_ignored(exception_handler):
+def test_unhandled_error_observer_ignored(exception_handler):
     # test that exception from list IGNORED_ERRORS_BY_CODE never sends to the GUI
     context = {'exception': OSError(113, '')}
     exception_handler.report_callback = MagicMock()

--- a/src/tribler-core/tribler_core/components/restapi/rest/rest_manager.py
+++ b/src/tribler-core/tribler_core/components/restapi/rest/rest_manager.py
@@ -9,6 +9,7 @@ from aiohttp_apispec import AiohttpApiSpec
 
 from apispec.core import VALID_METHODS_OPENAPI_V2
 
+from tribler_core.components.reporter.exception_handler import default_core_exception_handler
 from tribler_core.components.restapi.rest.rest_endpoint import (
     HTTP_INTERNAL_SERVER_ERROR,
     HTTP_NOT_FOUND,
@@ -55,6 +56,9 @@ async def error_middleware(request, handler):
     except Exception as e:
         logger.exception(e)
         full_exception = traceback.format_exc()
+
+        default_core_exception_handler.unhandled_error_observer(None, {'exception': e, 'should_stop': False})
+
         return RESTResponse({"error": {
             "handled": False,
             "code": e.__class__.__name__,


### PR DESCRIPTION
This PR enables reporting REST errors through Events mechanism. The reported errors do not shutdown Tribler.