### PR TITLE
Remove SOCKS component from GUI test mode requirements

### DIFF
--- a/src/tribler-core/tribler_core/components/libtorrent/libtorrent_component.py
+++ b/src/tribler-core/tribler_core/components/libtorrent/libtorrent_component.py
@@ -9,10 +9,14 @@ class LibtorrentComponent(Component):
 
     async def run(self):
         await super().run()
-        socks_servers_component = await self.require_component(SocksServersComponent)
+        config = self.session.config
+
         key_component = await self.require_component(KeyComponent)
 
-        config = self.session.config
+        socks_ports = []
+        if not config.gui_test_mode:
+            socks_servers_component = await self.require_component(SocksServersComponent)
+            socks_ports = socks_servers_component.socks_ports
 
         self.download_manager = DownloadManager(
             config=config.libtorrent,
@@ -21,7 +25,7 @@ class LibtorrentComponent(Component):
             peer_mid=key_component.primary_key.key_to_hash(),
             download_defaults=config.download_defaults,
             bootstrap_infohash=config.bootstrap.infohash,
-            socks_listen_ports=socks_servers_component.socks_ports,
+            socks_listen_ports=socks_ports,
             dummy_mode=config.gui_test_mode)
         self.download_manager.initialize()
 

--- a/src/tribler-core/tribler_core/start_core.py
+++ b/src/tribler-core/tribler_core/start_core.py
@@ -54,8 +54,6 @@ def components_gen(config: TriblerConfig):
     yield TagComponent()
 
     if config.libtorrent.enabled:
-        yield SocksServersComponent()
-    if config.libtorrent.enabled:
         yield LibtorrentComponent()
     if config.ipv8.enabled and config.chant.enabled:
         yield GigaChannelComponent()
@@ -67,6 +65,9 @@ def components_gen(config: TriblerConfig):
     # The components below are skipped if config.gui_test_mode == True
     if config.gui_test_mode:
         return
+
+    if config.libtorrent.enabled:
+        yield SocksServersComponent()
 
     if config.torrent_checking.enabled:
         yield TorrentCheckerComponent()


### PR DESCRIPTION
Should fix once-in-a-blue-moon flapping tests, such as #6650 