### PR TITLE
Reserve ports to prevent accidental ports capture

### DIFF
--- a/src/tribler-core/tribler_core/components/base.py
+++ b/src/tribler-core/tribler_core/components/base.py
@@ -8,6 +8,7 @@ from itertools import count
 from pathlib import Path
 from typing import Dict, List, Optional, Set, Type, TypeVar
 
+from tribler_common.network_utils import default_network_utils
 from tribler_common.simpledefs import STATEDIR_CHANNELS_DIR, STATEDIR_DB_DIR
 
 from tribler_core.config.tribler_config import TriblerConfig
@@ -46,6 +47,12 @@ def create_state_directory_structure(state_dir: Path):
     (state_dir / STATEDIR_CHANNELS_DIR).mkdir(exist_ok=True)
 
 
+def reserve_ports(ports_list: List[None, int]):
+    for port in ports_list:
+        if port is not None:
+            default_network_utils.remember(port)
+
+
 class Session:
     _next_session_id = count(1)
     _default: Optional[Session] = None
@@ -64,6 +71,13 @@ class Session:
         self.components: Dict[Type[Component], Component] = {}
         for component in components:
             self.register(component.__class__, component)
+
+        # Reserve various (possibly) fixed ports to prevent
+        # components from occupying those accidentally
+        reserve_ports([config.libtorrent.port,
+                       config.api.http_port,
+                       config.api.https_port,
+                       config.ipv8.port])
 
     def __repr__(self):
         return f'<{self.__class__.__name__}:{self.id}>'

--- a/src/tribler-core/tribler_core/components/libtorrent/download_manager/download_manager.py
+++ b/src/tribler-core/tribler_core/components/libtorrent/download_manager/download_manager.py
@@ -15,7 +15,7 @@ from typing import List, Optional
 
 from ipv8.taskmanager import TaskManager, task
 
-from tribler_common.network_utils import NetworkUtils
+from tribler_common.network_utils import default_network_utils
 from tribler_common.simpledefs import DLSTATUS_SEEDING, MAX_LIBTORRENT_RATE_LIMIT, NTFY, STATEDIR_CHECKPOINT_DIR
 from tribler_common.utilities import uri_to_path
 
@@ -221,7 +221,7 @@ class DownloadManager(TaskManager):
         else:
             ltsession = lt.session(lt.fingerprint(*fingerprint), flags=0) if hops == 0 else lt.session(flags=0)
 
-        libtorrent_port = self.config.port or NetworkUtils().get_random_free_port()
+        libtorrent_port = self.config.port or default_network_utils.get_random_free_port()
         self._libtorrent_port = libtorrent_port
         self._logger.info(f'Libtorrent port: {libtorrent_port}')
         if hops == 0:

--- a/src/tribler-core/tribler_core/components/restapi/rest/settings_endpoint.py
+++ b/src/tribler-core/tribler_core/components/restapi/rest/settings_endpoint.py
@@ -6,7 +6,7 @@ from ipv8.REST.schema import schema
 
 from marshmallow.fields import Boolean
 
-from tribler_common.network_utils import NetworkUtils
+from tribler_common.network_utils import default_network_utils
 
 from tribler_core.components.restapi.rest.rest_endpoint import RESTEndpoint, RESTResponse
 from tribler_core.utilities.utilities import froze_it
@@ -42,7 +42,7 @@ class SettingsEndpoint(RESTEndpoint):
         self._logger.info(f'Get settings. Request: {request}')
         return RESTResponse({
             "settings": self.tribler_config.dict(),
-            "ports": list(NetworkUtils.ports_in_use)
+            "ports": list(default_network_utils.ports_in_use)
         })
 
     @docs(

--- a/src/tribler-core/tribler_core/components/socks_servers/socks_servers_component.py
+++ b/src/tribler-core/tribler_core/components/socks_servers/socks_servers_component.py
@@ -1,5 +1,7 @@
 from typing import List
 
+from tribler_common.network_utils import default_network_utils
+
 from tribler_core.components.base import Component
 from tribler_core.components.reporter.reporter_component import ReporterComponent
 from tribler_core.components.socks_servers.socks5.server import Socks5Server
@@ -17,7 +19,10 @@ class SocksServersComponent(Component):
         self.socks_ports = []
         # Start the SOCKS5 servers
         for _ in range(NUM_SOCKS_PROXIES):
-            socks_server = Socks5Server()
+            # To prevent a once-in-a-blue-moon situation when SOCKS server accidentally occupy
+            # a port reserved by other services (e.g. REST API), we track our ports usage and assign
+            # ports through a single, default NetworkUtils instance
+            socks_server = Socks5Server(port=default_network_utils.get_random_free_port())
             self.socks_servers.append(socks_server)
             await socks_server.start()
             self.socks_ports.append(socks_server.port)

--- a/src/tribler-core/tribler_core/conftest.py
+++ b/src/tribler-core/tribler_core/conftest.py
@@ -10,7 +10,7 @@ from ipv8.util import succeed
 
 import pytest
 
-from tribler_common.network_utils import NetworkUtils
+from tribler_common.network_utils import default_network_utils
 from tribler_common.simpledefs import DLSTATUS_SEEDING
 
 from tribler_core.components.libtorrent.download_manager.download import Download
@@ -59,20 +59,6 @@ def _tribler_config(tribler_state_dir, tribler_download_dir) -> TriblerConfig:
     config.chant.enabled = False
     config.resource_monitor.enabled = False
     config.bootstrap.enabled = False
-    return config
-
-
-def get_free_port():
-    return NetworkUtils(remember_checked_ports_enabled=True).get_random_free_port()
-
-
-@pytest.fixture
-def seed_config(tribler_config, tmp_path_factory):
-    config = tribler_config.copy(deep=True)
-    config.set_state_dir(tmp_path_factory.mktemp("seeder"))
-    config.libtorrent.enabled = True
-    config.libtorrent.port = get_free_port()
-
     return config
 
 
@@ -143,7 +129,7 @@ selected_ports = set()
 
 @pytest.fixture(name="free_port")
 def fixture_free_port():
-    return NetworkUtils(remember_checked_ports_enabled=True).get_random_free_port(start=1024, stop=50000)
+    return default_network_utils.get_random_free_port(start=1024, stop=50000)
 
 
 @pytest.fixture

--- a/src/tribler-gui/tribler_gui/tests/test_gui.py
+++ b/src/tribler-gui/tribler_gui/tests/test_gui.py
@@ -11,7 +11,7 @@ from PyQt5.QtWidgets import QApplication, QListWidget, QTableView, QTextEdit, QT
 import pytest
 
 import tribler_common
-from tribler_common.network_utils import NetworkUtils
+from tribler_common.network_utils import default_network_utils
 from tribler_common.reported_error import ReportedError
 from tribler_common.tag_constants import MIN_TAG_LENGTH
 
@@ -34,7 +34,7 @@ TORRENT_WITH_DIRS = COMMON_DATA_DIR / "multi_entries.torrent"
 
 @pytest.fixture(scope="module")
 def api_port():
-    return NetworkUtils(remember_checked_ports_enabled=False).get_random_free_port()
+    return default_network_utils.get_random_free_port()
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
fixes #6650 by creating a default instance of NetworkUtils, reserving ports through its `remember` method, and using its `get_random_free_port` method to get free ports for SOCKS servers.