### PR TITLE
Add Faker and sentry as common dependency

### DIFF
--- a/src/tribler-common/tribler_common/requirements.txt
+++ b/src/tribler-common/tribler_common/requirements.txt
@@ -1,0 +1,2 @@
+Faker==9.8.2
+sentry-sdk==1.5.0

--- a/src/tribler-common/tribler_common/tests/test_dependencies.py
+++ b/src/tribler-common/tribler_common/tests/test_dependencies.py
@@ -37,6 +37,7 @@ async def test_get_dependencies():
     # assert that in each scope dependencies are exist
     assert list(get_dependencies(Scope.gui))
     assert list(get_dependencies(Scope.core))
+    assert list(get_dependencies(Scope.common))
 
 
 async def test_get_dependencies_wrong_scope():


### PR DESCRIPTION
Fixes https://github.com/Tribler/tribler/issues/6655

Additional to `faker`, `sentry-sdk` is required.

Tested buid here: https://jenkins-ci.tribler.org/job/pers/job/TRIBLER-PR-JOBS/job/PR_build_docs/9/