### PR TITLE
Fix Search results page resetting unexpectedly

### DIFF
--- a/src/tribler-gui/tribler_gui/tribler_window.py
+++ b/src/tribler-gui/tribler_gui/tribler_window.py
@@ -1013,8 +1013,6 @@ class TriblerWindow(QMainWindow):
         query = self.top_search_bar.text()
         if query and self.search_results_page.has_results:
             self.deselect_all_menu_buttons()
-            if self.stackedWidget.currentIndex() == PAGE_SEARCH_RESULTS:
-                self.search_results_page.reset()
             self.stackedWidget.setCurrentIndex(PAGE_SEARCH_RESULTS)
 
     def on_top_search_bar_return_pressed(self):

--- a/src/tribler-gui/tribler_gui/widgets/searchresultswidget.py
+++ b/src/tribler-gui/tribler_gui/widgets/searchresultswidget.py
@@ -130,7 +130,11 @@ class SearchResultsWidget(AddBreadcrumbOnShowMixin, widget_form, widget_class):
             self.results_page.go_back_to_level(0)
 
     def update_loading_page(self, remote_results):
-        if not self.search_request or remote_results.get("uuid") != self.search_request.uuid:
+        if (
+            not self.search_request
+            or remote_results.get("uuid") != self.search_request.uuid
+            or self.currentWidget() == self.results_page
+        ):
             return
         peer = remote_results["peer"]
         self.search_request.peers_complete.add(peer)


### PR DESCRIPTION
This fixes the problem with unexpected resets of the Search results page that happen when one uses "show immediately" button.