### PR TITLE
Fixes #6665 - Graph can now go higher than TB. New PB Definition added.

### DIFF
--- a/src/tribler-gui/tribler_gui/defs.py
+++ b/src/tribler-gui/tribler_gui/defs.py
@@ -192,6 +192,7 @@ KB = 1024
 MB = 1024 * KB
 GB = 1024 * MB
 TB = 1024 * GB
+PB = 1024 * TB
 
 DARWIN = sys.platform == 'darwin'
 WINDOWS = sys.platform == 'win32'

--- a/src/tribler-gui/tribler_gui/widgets/trustpage.py
+++ b/src/tribler-gui/tribler_gui/widgets/trustpage.py
@@ -4,7 +4,7 @@ from PyQt5.QtWidgets import QWidget
 
 from tribler_common.sentry_reporter.sentry_mixin import AddBreadcrumbOnShowMixin
 
-from tribler_gui.defs import GB, TB
+from tribler_gui.defs import GB, PB
 from tribler_gui.dialogs.trustexplanationdialog import TrustExplanationDialog
 from tribler_gui.tribler_request_manager import TriblerNetworkRequest
 from tribler_gui.utilities import connect
@@ -18,7 +18,7 @@ class TrustSeriesPlot(TimeSeriesDataPlot):
         ]
         super().__init__(parent, 'Token balance over time', series, **kargs)
         self.setLabel('left', 'Data', units='B')
-        self.setLimits(yMin=-GB, yMax=TB)
+        self.setLimits(yMin=-GB, yMax=PB)
 
 
 class TrustPage(AddBreadcrumbOnShowMixin, QWidget):


### PR DESCRIPTION
First proper PR so do bare with me.
Raises the "Token Balance over time" graph maximum from 1 Terabyte to 1 Petabyte. This is achieved by making a new "PB" GUI definition for the graph
![2021-12-19-065155_1007x427_scrot](https://user-images.githubusercontent.com/32282125/146676013-a1e419c5-b83a-428f-80c9-410b6017dcf0.png)
.