### PR TITLE
Fixes #6633 UnicodeEncodeError "ascii codec can't encode characters in position" when saving TriblerConfig with non-ascii symbols

### DIFF
--- a/src/tribler-core/tribler_core/config/tests/test_tribler_config.py
+++ b/src/tribler-core/tribler_core/config/tests/test_tribler_config.py
@@ -11,9 +11,6 @@ from tribler_core.utilities.path_util import Path
 CONFIG_PATH = TESTS_DATA_DIR / "config_files"
 
 
-# fmt: off
-
-
 @pytest.mark.asyncio
 async def test_create(tmpdir):
     config = TriblerConfig(state_dir=tmpdir)
@@ -49,6 +46,23 @@ async def test_load_write(tmpdir):
     assert config.general.version_checker_enabled is False
     assert config.libtorrent.port is None
     assert config.libtorrent.proxy_type == 2
+    assert config.file == tmpdir / filename
+
+
+@pytest.mark.asyncio
+async def test_load_write_nonascii(tmpdir):
+    config = TriblerConfig(state_dir=tmpdir)
+    filename = 'test_read_write.ini'
+
+    config.download_defaults.saveas = 'ыюя'
+
+    assert not config.file
+    config.write(tmpdir / filename)
+    assert config.file == tmpdir / filename
+
+    config = TriblerConfig.load(file=tmpdir / filename, state_dir=tmpdir)
+
+    assert config.download_defaults.saveas == 'ыюя'
     assert config.file == tmpdir / filename
 
 

--- a/src/tribler-core/tribler_core/config/tribler_config.py
+++ b/src/tribler-core/tribler_core/config/tribler_config.py
@@ -107,7 +107,7 @@ class TriblerConfig(TriblerConfigSections):
                                                        'anon_proxy_auth': ...,
                                                        'anon_listen_port': ...,
                                                        'anon_proxy_server_ip': ...}})
-        conf = configobj.ConfigObj(dictionary)
+        conf = configobj.ConfigObj(dictionary, encoding='utf-8')
         conf.filename = str(file)
         conf.write()
 


### PR DESCRIPTION
Some fields of TriblerConfig can contain non-ASCII symbols. For example, the name of the directory to save downloads. For this, we need to specify `utf-8` encoding for the `ConfigObj` instance.

This encoding will only affect the writing of config data to the file. Reading of `utf-8`-encoded data is supported even without specifying the `utf-8` encoding.