### PR TITLE
Add session context manager

### DIFF
--- a/src/tribler-core/run_bandwidth_crawler.py
+++ b/src/tribler-core/run_bandwidth_crawler.py
@@ -9,10 +9,11 @@ from pathlib import Path
 from ipv8.loader import IPv8CommunityLoader
 
 from tribler_common.simpledefs import STATEDIR_DB_DIR
-from tribler_core.config.tribler_config import TriblerConfig
+
 from tribler_core.components.bandwidth_accounting.db.database import BandwidthDatabase
-from tribler_core.modules.bandwidth_accounting.launcher import BandwidthCommunityLauncher
 from tribler_core.components.bandwidth_accounting.settings import BandwidthAccountingSettings
+from tribler_core.config.tribler_config import TriblerConfig
+from tribler_core.modules.bandwidth_accounting.launcher import BandwidthCommunityLauncher
 from tribler_core.start_core import Session
 
 
@@ -45,7 +46,7 @@ async def start_crawler(tribler_config):
     loader.set_launcher(BandwidthCommunityCrawlerLauncher())
     session = Session(tribler_config, community_loader=loader)
 
-    await session.start()
+    await session.start_components()
 
 
 if __name__ == "__main__":

--- a/src/tribler-core/run_tribler_headless.py
+++ b/src/tribler-core/run_tribler_headless.py
@@ -104,7 +104,7 @@ class TriblerService:
 
         self.session = Session(config)
         try:
-            await self.session.start()
+            await self.session.start_components()
         except Exception as e:
             print(str(e))
             get_event_loop().stop()

--- a/src/tribler-core/run_tunnel_helper.py
+++ b/src/tribler-core/run_tunnel_helper.py
@@ -149,7 +149,7 @@ class TunnelHelperService(TaskManager):
         self.log_circuits = options.log_circuits
         session.notifier.add_observer(NTFY.TUNNEL_REMOVE, self.circuit_removed)
 
-        await session.start()
+        await session.start_components()
 
         with session:
             if options.log_rejects:

--- a/src/tribler-core/tribler_core/components/bandwidth_accounting/tests/test_bandwidth_accounting_component.py
+++ b/src/tribler-core/tribler_core/components/bandwidth_accounting/tests/test_bandwidth_accounting_component.py
@@ -10,13 +10,8 @@ from tribler_core.components.key.key_component import KeyComponent
 @pytest.mark.asyncio
 async def test_bandwidth_accounting_component(tribler_config):
     components = [KeyComponent(), Ipv8Component(), BandwidthAccountingComponent()]
-    session = Session(tribler_config, components)
-    with session:
-        await session.start()
-
+    async with Session(tribler_config, components).start():
         comp = BandwidthAccountingComponent.instance()
         assert comp.started_event.is_set() and not comp.failed
         assert comp.community
         assert comp._ipv8_component
-
-        await session.shutdown()

--- a/src/tribler-core/tribler_core/components/gigachannel/tests/test_gigachannel_component.py
+++ b/src/tribler-core/tribler_core/components/gigachannel/tests/test_gigachannel_component.py
@@ -15,13 +15,8 @@ async def test_giga_channel_component(tribler_config):
     tribler_config.libtorrent.enabled = True
     tribler_config.chant.enabled = True
     components = [TagComponent(), MetadataStoreComponent(), KeyComponent(), Ipv8Component(), GigaChannelComponent()]
-    session = Session(tribler_config, components)
-    with session:
-        await session.start()
-
+    async with Session(tribler_config, components).start():
         comp = GigaChannelComponent.instance()
         assert comp.started_event.is_set() and not comp.failed
         assert comp.community
         assert comp._ipv8_component
-
-        await session.shutdown()

--- a/src/tribler-core/tribler_core/components/gigachannel_manager/tests/test_gigachannel_manager_component.py
+++ b/src/tribler-core/tribler_core/components/gigachannel_manager/tests/test_gigachannel_manager_component.py
@@ -14,15 +14,9 @@ from tribler_core.components.tag.tag_component import TagComponent
 
 @pytest.mark.asyncio
 async def test_gigachannel_manager_component(tribler_config):
-    components = [Ipv8Component(), TagComponent(), SocksServersComponent(), KeyComponent(),
-                  MetadataStoreComponent(),
+    components = [Ipv8Component(), TagComponent(), SocksServersComponent(), KeyComponent(), MetadataStoreComponent(),
                   LibtorrentComponent(), GigachannelManagerComponent()]
-    session = Session(tribler_config, components)
-    with session:
+    async with Session(tribler_config, components).start():
         comp = GigachannelManagerComponent.instance()
-        await session.start()
-
         assert comp.started_event.is_set() and not comp.failed
         assert comp.gigachannel_manager
-
-        await session.shutdown()

--- a/src/tribler-core/tribler_core/components/ipv8/tests/test_ipv8_component.py
+++ b/src/tribler-core/tribler_core/components/ipv8/tests/test_ipv8_component.py
@@ -9,10 +9,7 @@ pytestmark = pytest.mark.asyncio
 
 # pylint: disable=protected-access
 async def test_ipv8_component(tribler_config):
-    session = Session(tribler_config, [KeyComponent(), Ipv8Component()])
-    with session:
-        await session.start()
-
+    async with Session(tribler_config, [KeyComponent(), Ipv8Component()]).start():
         comp = Ipv8Component.instance()
         assert comp.started_event.is_set() and not comp.failed
         assert comp.ipv8
@@ -21,16 +18,11 @@ async def test_ipv8_component(tribler_config):
         assert comp._task_manager
         assert not comp._peer_discovery_community
 
-        await session.shutdown()
-
 
 async def test_ipv8_component_dht_disabled(tribler_config):
     tribler_config.ipv8.enabled = True
     tribler_config.dht.enabled = True
-    session = Session(tribler_config, [KeyComponent(), Ipv8Component()])
-    with session:
-        await session.start()
-
+    async with Session(tribler_config, [KeyComponent(), Ipv8Component()]).start():
         comp = Ipv8Component.instance()
         assert comp.dht_discovery_community
 
@@ -39,9 +31,6 @@ async def test_ipv8_component_discovery_community_enabled(tribler_config):
     tribler_config.ipv8.enabled = True
     tribler_config.gui_test_mode = False
     tribler_config.discovery_community.enabled = True
-    session = Session(tribler_config, [KeyComponent(), Ipv8Component()])
-    with session:
-        await session.start()
-
+    async with Session(tribler_config, [KeyComponent(), Ipv8Component()]).start():
         comp = Ipv8Component.instance()
         assert comp._peer_discovery_community

--- a/src/tribler-core/tribler_core/components/key/tests/test_key_component.py
+++ b/src/tribler-core/tribler_core/components/key/tests/test_key_component.py
@@ -6,14 +6,9 @@ from tribler_core.components.key.key_component import KeyComponent
 
 @pytest.mark.asyncio
 async def test_masterkey_component(tribler_config):
-    session = Session(tribler_config, [KeyComponent()])
-    with session:
+    async with Session(tribler_config, [KeyComponent()]).start():
         comp = KeyComponent.instance()
-        await session.start()
-
         assert comp.primary_key
-
-        await session.shutdown()
 
 
 async def test_get_private_key_filename(tribler_config):

--- a/src/tribler-core/tribler_core/components/libtorrent/tests/test_libtorrent_component.py
+++ b/src/tribler-core/tribler_core/components/libtorrent/tests/test_libtorrent_component.py
@@ -12,12 +12,7 @@ pytestmark = pytest.mark.asyncio
 
 async def test_libtorrent_component(tribler_config):
     components = [KeyComponent(), SocksServersComponent(), LibtorrentComponent()]
-    session = Session(tribler_config, components)
-    with session:
-        await session.start()
-
+    async with Session(tribler_config, components).start():
         comp = LibtorrentComponent.instance()
         assert comp.started_event.is_set() and not comp.failed
         assert comp.download_manager
-
-        await session.shutdown()

--- a/src/tribler-core/tribler_core/components/metadata_store/tests/test_metadata_store_component.py
+++ b/src/tribler-core/tribler_core/components/metadata_store/tests/test_metadata_store_component.py
@@ -11,12 +11,7 @@ from tribler_core.components.tag.tag_component import TagComponent
 @pytest.mark.asyncio
 async def test_metadata_store_component(tribler_config):
     components = [TagComponent(), Ipv8Component(), KeyComponent(), MetadataStoreComponent()]
-    session = Session(tribler_config, components)
-    with session:
+    async with Session(tribler_config, components).start():
         comp = MetadataStoreComponent.instance()
-        await session.start()
-
         assert comp.started_event.is_set() and not comp.failed
         assert comp.mds
-
-        await session.shutdown()

--- a/src/tribler-core/tribler_core/components/payout/tests/test_payout_component.py
+++ b/src/tribler-core/tribler_core/components/payout/tests/test_payout_component.py
@@ -11,12 +11,7 @@ from tribler_core.components.payout.payout_component import PayoutComponent
 @pytest.mark.asyncio
 async def test_payout_component(tribler_config):
     components = [BandwidthAccountingComponent(), KeyComponent(), Ipv8Component(), PayoutComponent()]
-    session = Session(tribler_config, components)
-    with session:
-        await session.start()
-
+    async with Session(tribler_config, components).start():
         comp = PayoutComponent.instance()
         assert comp.started_event.is_set() and not comp.failed
         assert comp.payout_manager
-
-        await session.shutdown()

--- a/src/tribler-core/tribler_core/components/popularity/tests/test_popularity_component.py
+++ b/src/tribler-core/tribler_core/components/popularity/tests/test_popularity_component.py
@@ -17,12 +17,7 @@ from tribler_core.components.torrent_checker.torrent_checker_component import To
 async def test_popularity_component(tribler_config):
     components = [SocksServersComponent(), LibtorrentComponent(), TorrentCheckerComponent(), TagComponent(),
                   MetadataStoreComponent(), KeyComponent(), Ipv8Component(), PopularityComponent()]
-    session = Session(tribler_config, components)
-    with session:
-        await session.start()
-
+    async with Session(tribler_config, components).start():
         comp = PopularityComponent.instance()
         assert comp.community
         assert comp._ipv8_component
-
-        await session.shutdown()

--- a/src/tribler-core/tribler_core/components/reporter/tests/test_reporter_component.py
+++ b/src/tribler-core/tribler_core/components/reporter/tests/test_reporter_component.py
@@ -10,11 +10,6 @@ pytestmark = pytest.mark.asyncio
 # pylint: disable=protected-access
 async def test_reporter_component(tribler_config):
     components = [KeyComponent(), ReporterComponent()]
-    session = Session(tribler_config, components)
-    with session:
-        await session.start()
-
+    async with Session(tribler_config, components).start():
         comp = ReporterComponent.instance()
         assert comp.started_event.is_set() and not comp.failed
-
-        await session.shutdown()

--- a/src/tribler-core/tribler_core/components/resource_monitor/tests/test_resource_monitor_component.py
+++ b/src/tribler-core/tribler_core/components/resource_monitor/tests/test_resource_monitor_component.py
@@ -9,12 +9,7 @@ from tribler_core.components.resource_monitor.resource_monitor_component import 
 @pytest.mark.asyncio
 async def test_resource_monitor_component(tribler_config):
     components = [KeyComponent(), ResourceMonitorComponent()]
-    session = Session(tribler_config, components)
-    with session:
-        await session.start()
-
+    async with Session(tribler_config, components).start():
         comp = ResourceMonitorComponent.instance()
         assert comp.started_event.is_set() and not comp.failed
         assert comp.resource_monitor
-
-        await session.shutdown()

--- a/src/tribler-core/tribler_core/components/restapi/tests/test_restapi_component.py
+++ b/src/tribler-core/tribler_core/components/restapi/tests/test_restapi_component.py
@@ -26,10 +26,7 @@ async def test_rest_component(tribler_config):
     components = [KeyComponent(), RESTComponent(), Ipv8Component(), LibtorrentComponent(), ResourceMonitorComponent(),
                   BandwidthAccountingComponent(), GigaChannelComponent(), TagComponent(), SocksServersComponent(),
                   MetadataStoreComponent()]
-    session = Session(tribler_config, components)
-    with session:
-        await session.start()
-
+    async with Session(tribler_config, components).start():
         # Test REST component starts normally
         comp = RESTComponent.instance()
         assert comp.started_event.is_set() and not comp.failed
@@ -41,12 +38,9 @@ async def test_rest_component(tribler_config):
 
         # try to call report_callback from core_exception_handler and assert
         # that corresponding methods in events_endpoint and state_endpoint have been called
-
         error = ReportedError(type='', text='text', event={})
         comp._core_exception_handler.report_callback(error)
         comp._events_endpoint.on_tribler_exception.assert_called_with(error)
-
-        await session.shutdown()
 
 
 @pytest.fixture

--- a/src/tribler-core/tribler_core/components/socks_servers/tests/test_socks_servers_component.py
+++ b/src/tribler-core/tribler_core/components/socks_servers/tests/test_socks_servers_component.py
@@ -10,13 +10,8 @@ pytestmark = pytest.mark.asyncio
 
 async def test_socks_servers_component(tribler_config):
     components = [SocksServersComponent()]
-    session = Session(tribler_config, components)
-    with session:
-        await session.start()
-
+    async with Session(tribler_config, components).start():
         comp = SocksServersComponent.instance()
         assert comp.started_event.is_set() and not comp.failed
         assert comp.socks_ports
         assert comp.socks_servers
-
-        await session.shutdown()

--- a/src/tribler-core/tribler_core/components/tag/tests/test_tag_component.py
+++ b/src/tribler-core/tribler_core/components/tag/tests/test_tag_component.py
@@ -10,12 +10,8 @@ from tribler_core.components.tag.tag_component import TagComponent
 
 @pytest.mark.asyncio
 async def test_tag_component(tribler_config):
-    session = Session(tribler_config, [KeyComponent(), Ipv8Component(), TagComponent()])
-    with session:
+    components = [KeyComponent(), Ipv8Component(), TagComponent()]
+    async with Session(tribler_config, components).start():
         comp = TagComponent.instance()
-        await session.start()
-
         assert comp.started_event.is_set() and not comp.failed
         assert comp.community
-
-        await session.shutdown()

--- a/src/tribler-core/tribler_core/components/tests/test_base_component.py
+++ b/src/tribler-core/tribler_core/components/tests/test_base_component.py
@@ -38,7 +38,7 @@ async def test_session_start_shutdown(tribler_config):
             assert not component.shutdown_was_executed
             assert not component.stopped
 
-        await session.start()
+        await session.start_components()
 
         assert ComponentA.instance() is a and ComponentB.instance() is b
         for component in a, b:
@@ -75,7 +75,7 @@ async def test_required_dependency(tribler_config):
             assert not component.dependencies and not component.reverse_dependencies
             assert component.unused_event.is_set()
 
-        await session.start()
+        await session.start_components()
 
         assert a in b.dependencies and not b.reverse_dependencies
         assert not a.dependencies and b in a.reverse_dependencies
@@ -103,13 +103,13 @@ async def test_required_dependency_missed(tribler_config):
         b = ComponentB.instance()
 
         with pytest.raises(MissedDependency, match='^Missed dependency: ComponentB requires ComponentA to be active$'):
-            await session.start()
+            await session.start_components()
 
     session = Session(tribler_config, [ComponentB()], failfast=False)
     with session:
         b = ComponentB.instance()
 
-        await session.start()
+        await session.start_components()
 
         assert ComponentB.instance() is b
         assert b.started_event.is_set()
@@ -132,7 +132,7 @@ async def test_component_shutdown_failure(tribler_config):
         a = ComponentA.instance()
         b = ComponentB.instance()
 
-        await session.start()
+        await session.start_components()
 
         assert not a.unused_event.is_set()
 
@@ -179,7 +179,7 @@ async def test_maybe_component(loop, tribler_config):  # pylint: disable=unused-
 
     session = Session(tribler_config, [ComponentA()])
     with session:
-        await session.start()
+        await session.start_components()
         component_a = await ComponentA.instance().maybe_component(ComponentA)
         component_b = await ComponentA.instance().maybe_component(ComponentB)
 

--- a/src/tribler-core/tribler_core/components/torrent_checker/tests/test_torrent_checker_component.py
+++ b/src/tribler-core/tribler_core/components/torrent_checker/tests/test_torrent_checker_component.py
@@ -18,12 +18,7 @@ pytestmark = pytest.mark.asyncio
 async def test_torrent_checker_component(tribler_config):
     components = [SocksServersComponent(), LibtorrentComponent(), KeyComponent(),
                   Ipv8Component(), TagComponent(), MetadataStoreComponent(), TorrentCheckerComponent()]
-    session = Session(tribler_config, components)
-    with session:
-        await session.start()
-
+    async with Session(tribler_config, components).start():
         comp = TorrentCheckerComponent.instance()
         assert comp.started_event.is_set() and not comp.failed
         assert comp.torrent_checker
-
-        await session.shutdown()

--- a/src/tribler-core/tribler_core/components/tunnel/tests/test_tunnel_component.py
+++ b/src/tribler-core/tribler_core/components/tunnel/tests/test_tunnel_component.py
@@ -11,13 +11,8 @@ pytestmark = pytest.mark.asyncio
 # pylint: disable=protected-access
 async def test_tunnels_component(tribler_config):
     components = [Ipv8Component(), KeyComponent(), TunnelsComponent()]
-    session = Session(tribler_config, components)
-    with session:
-        await session.start()
-
+    async with Session(tribler_config, components).start():
         comp = TunnelsComponent.instance()
         assert comp.started_event.is_set() and not comp.failed
         assert comp.community
         assert comp._ipv8_component
-
-        await session.shutdown()

--- a/src/tribler-core/tribler_core/components/version_check/tests/test_version_check_component.py
+++ b/src/tribler-core/tribler_core/components/version_check/tests/test_version_check_component.py
@@ -10,12 +10,7 @@ pytestmark = pytest.mark.asyncio
 
 async def test_version_check_component(tribler_config):
     components = [VersionCheckComponent()]
-    session = Session(tribler_config, components)
-    with session:
-        await session.start()
-
+    async with Session(tribler_config, components).start():
         comp = VersionCheckComponent.instance()
         assert comp.started_event.is_set() and not comp.failed
         assert comp.version_check_manager
-
-        await session.shutdown()

--- a/src/tribler-core/tribler_core/components/watch_folder/tests/test_watch_folder_component.py
+++ b/src/tribler-core/tribler_core/components/watch_folder/tests/test_watch_folder_component.py
@@ -13,12 +13,7 @@ pytestmark = pytest.mark.asyncio
 
 async def test_watch_folder_component(tribler_config):
     components = [KeyComponent(), SocksServersComponent(), LibtorrentComponent(), WatchFolderComponent()]
-    session = Session(tribler_config, components)
-    with session:
-        await session.start()
-
+    async with Session(tribler_config, components).start():
         comp = WatchFolderComponent.instance()
         assert comp.started_event.is_set() and not comp.failed
         assert comp.watch_folder
-
-        await session.shutdown()

--- a/src/tribler-core/tribler_core/utilities/tiny_tribler_service.py
+++ b/src/tribler-core/tribler_core/utilities/tiny_tribler_service.py
@@ -6,6 +6,7 @@ from typing import List
 
 from tribler_common.osutils import get_root_state_directory
 from tribler_common.process_checker import ProcessChecker
+
 from tribler_core.components.base import Component
 from tribler_core.start_core import Session
 
@@ -48,7 +49,7 @@ class TinyTriblerService:
         self.logger.info(f"Starting Tribler session with config: {self.config}")
         self.session = Session(self.config, self.components)
         self.session.set_as_default()
-        await self.session.start()
+        await self.session.start_components()
 
         self.logger.info("Tribler session started")
 


### PR DESCRIPTION
During the implementation of #6718 I came up with the idea of simplification component's tests.

Instead of writing tests like 

```python
@pytest.mark.asyncio
async def test_bandwidth_accounting_component(tribler_config):
    components = [KeyComponent(), Ipv8Component(), BandwidthAccountingComponent()]
    session = Session(tribler_config, components)
    with session:
        await session.start()

        comp = BandwidthAccountingComponent.instance()
        assert comp.started_event.is_set() and not comp.failed
        assert comp.community
        assert comp._ipv8_component

        await session.shutdown()
```

We could write:

```python
@pytest.mark.asyncio
async def test_bandwidth_accounting_component(tribler_config):
    components = [KeyComponent(), Ipv8Component(), BandwidthAccountingComponent()]
    with Session(tribler_config, components) as session:
        async with in_session(session):
            comp = BandwidthAccountingComponent.instance()
            assert comp.started_event.is_set() and not comp.failed
            assert comp.community
            assert comp._ipv8_component
```

it becomes possible by introducing `in_session` context manager:
```python
@asynccontextmanager
async def in_session(session):
    try:
        yield await session.start()
    finally:
        await session.shutdown()
```