### PR TITLE
Swapped 'cancel' and 'download' buttons

### DIFF
--- a/src/tribler-gui/tribler_gui/qt_resources/startdownloaddialog.ui
+++ b/src/tribler-gui/tribler_gui/qt_resources/startdownloaddialog.ui
@@ -486,31 +486,6 @@ background: yellow;
        </spacer>
       </item>
       <item>
-       <widget class="QToolButton" name="cancel_button">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>24</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>16777215</width>
-          <height>24</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>CANCEL</string>
-        </property>
-       </widget>
-      </item>
-      <item>
        <widget class="QToolButton" name="download_button">
         <property name="minimumSize">
          <size>
@@ -532,6 +507,34 @@ background: yellow;
         </property>
         <property name="text">
          <string>DOWNLOAD</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QToolButton" name="cancel_button">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>24</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>16777215</width>
+          <height>24</height>
+         </size>
+        </property>
+        <property name="cursor">
+         <cursorShape>PointingHandCursor</cursorShape>
+        </property>
+        <property name="text">
+         <string>CANCEL</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
Fixes #6712. The order of the buttons in the start download dialog is now consistent with the button order in other dialogs.

Before:
![Schermafbeelding 2022-01-17 om 09 23 28](https://user-images.githubusercontent.com/1707075/149734093-ff18073d-a61e-40d6-acf3-78baa0b7d9d2.png)

After:
![Schermafbeelding 2022-01-17 om 09 25 51](https://user-images.githubusercontent.com/1707075/149734101-f233f677-d1f8-4e56-933d-565c35f83aab.png)


