### PR TITLE
Fix run_bandwidth_crawler script

### DIFF
--- a/src/tribler-core/tribler_core/components/bandwidth_accounting/bandwidth_accounting_component.py
+++ b/src/tribler-core/tribler_core/components/bandwidth_accounting/bandwidth_accounting_component.py
@@ -14,6 +14,10 @@ class BandwidthAccountingComponent(Component):
     _ipv8_component: Ipv8Component = None
     database: BandwidthDatabase = None
 
+    def __init__(self, crawler_mode=False):
+        super().__init__()
+        self.crawler_mode = crawler_mode
+
     async def run(self):
         await super().run()
         self._ipv8_component = await self.require_component(Ipv8Component)
@@ -24,14 +28,25 @@ class BandwidthAccountingComponent(Component):
         else:
             bandwidth_cls = BandwidthAccountingCommunity
 
+        if self.crawler_mode:
+            store_all_transactions = True
+            unlimited_peers = True
+        else:
+            store_all_transactions = False
+            unlimited_peers = False
+
         db_name = "bandwidth_gui_test.db" if config.gui_test_mode else f"{bandwidth_cls.DB_NAME}.db"
         database_path = config.state_dir / STATEDIR_DB_DIR / db_name
-        self.database = BandwidthDatabase(database_path, self._ipv8_component.peer.public_key.key_to_bin())
+        self.database = BandwidthDatabase(database_path, self._ipv8_component.peer.public_key.key_to_bin(),
+                                          store_all_transactions=store_all_transactions)
+
+        kwargs = {"max_peers": -1} if unlimited_peers else {}
         self.community = bandwidth_cls(self._ipv8_component.peer,
                                        self._ipv8_component.ipv8.endpoint,
                                        self._ipv8_component.ipv8.network,
                                        settings=config.bandwidth_accounting,
-                                       database=self.database)
+                                       database=self.database,
+                                       **kwargs)
 
         self._ipv8_component.initialise_community_by_default(self.community)
 


### PR DESCRIPTION
In this PR I fix the script to run bandwidth crawler. It initializes BandwidthDatabase and BandwidthAccountingCommunity in a bit different way comparing to Tribler itself, so I added `crawler_mode` flag to `BandwidthAccountingComponent`. Another options was to add an option to BandwidthAccounting section of TriblerConfig, but the option does not look important enough to complicate the general config.