### PR TITLE
Fix unstable test_channels_peers_mapping_drop_excess_peers

### DIFF
--- a/src/tribler-core/tribler_core/components/gigachannel/community/tests/test_gigachannel_community.py
+++ b/src/tribler-core/tribler_core/components/gigachannel/community/tests/test_gigachannel_community.py
@@ -237,10 +237,12 @@ class TestGigaChannelUnits(TestBase):
         chan_id = 123
 
         num_excess_peers = 20
-        first_peer_timestamp = None
+        t = time.time() - 1000
+        first_peer_timestamp = t
         for k in range(0, mapping.max_peers_per_channel + num_excess_peers):
             peer = Peer(default_eccrypto.generate_key("very-low"), ("1.2.3.4", 5))
-            peer.last_response = time.time()
+            peer.last_response = t
+            t += 1.0
             mapping.add(peer, chan_pk, chan_id)
             if k == 0:
                 first_peer_timestamp = peer.last_response


### PR DESCRIPTION
On fast machine, the test `[test_channels_peers_mapping_drop_excess_peers](https://github.com/Tribler/tribler/blob/0ee609e142956b7d0c47054e1d9259450a1a20cc/src/tribler-core/tribler_core/components/gigachannel/community/tests/test_gigachannel_community.py#L231)` sometimes sets `peer.last_response` time to the same value for all peers, and fails after that. In this fix, I explicitly set a different time for each peer to avoid this type of failure.