### PR TITLE
Remove allow_exit_node_checkbox

### DIFF
--- a/src/tribler-gui/tribler_gui/qt_resources/mainwindow.ui
+++ b/src/tribler-gui/tribler_gui/qt_resources/mainwindow.ui
@@ -2234,55 +2234,6 @@ color: white;</string>
                    <number>12</number>
                   </property>
                   <item>
-                   <widget class="QLabel" name="tribler_profile_header_label">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="styleSheet">
-                     <string notr="true">font-weight: bold;
-color: white;</string>
-                    </property>
-                    <property name="text">
-                     <string>Anonymity</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QCheckBox" name="allow_exit_node_checkbox">
-                    <property name="styleSheet">
-                     <string notr="true"/>
-                    </property>
-                    <property name="text">
-                     <string>Allow Tribler to be an exit node</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QLabel" name="label_19">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="MinimumExpanding" vsizetype="Minimum">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="styleSheet">
-                     <string notr="true"/>
-                    </property>
-                    <property name="text">
-                     <string>By allowing Tribler to be an exit node, your computer will act as a proxy for other Tribler users' bittorrent traffic, be it seeding or downloading. Check your local laws and make sure you are aware of the implications of enabling this checkbox.</string>
-                    </property>
-                    <property name="alignment">
-                     <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-                    </property>
-                    <property name="wordWrap">
-                     <bool>true</bool>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
                    <spacer name="verticalSpacer_6">
                     <property name="orientation">
                      <enum>Qt::Vertical</enum>

--- a/src/tribler-gui/tribler_gui/widgets/settingspage.py
+++ b/src/tribler-gui/tribler_gui/widgets/settingspage.py
@@ -220,7 +220,6 @@ class SettingsPage(AddBreadcrumbOnShowMixin, QWidget):
             self.window().seeding_ratio_combobox.setCurrentIndex(ind)
 
         # Anonymity settings
-        self.window().allow_exit_node_checkbox.setChecked(settings['tunnel_community']['exitnode_enabled'])
         self.window().number_hops_slider.setValue(int(settings['download_defaults']['number_hops']))
         connect(self.window().number_hops_slider.valueChanged, self.update_anonymity_cost_label)
         self.update_anonymity_cost_label(int(settings['download_defaults']['number_hops']))
@@ -505,7 +504,7 @@ class SettingsPage(AddBreadcrumbOnShowMixin, QWidget):
             )
             return
 
-        settings_data['tunnel_community']['exitnode_enabled'] = self.window().allow_exit_node_checkbox.isChecked()
+        settings_data['tunnel_community']['exitnode_enabled'] = False
         settings_data['download_defaults']['number_hops'] = self.window().number_hops_slider.value()
         settings_data['download_defaults'][
             'anonymity_enabled'


### PR DESCRIPTION
Based on yesterday's discussion, this PR removes allow_exit_node_checkbox from UI as potentially dangerous for a user.

![image](https://user-images.githubusercontent.com/13798583/150321635-6a5e4938-0eea-419c-a166-852dab8d49f3.png)
