### PR TITLE
Change tag search condition from `or` to `and`

### DIFF
--- a/src/tribler-core/tribler_core/components/metadata_store/remote_query_community/tests/test_remote_search_by_tags.py
+++ b/src/tribler-core/tribler_core/components/metadata_store/remote_query_community/tests/test_remote_search_by_tags.py
@@ -91,7 +91,7 @@ class TestRemoteSearchByTags(TestBase):
                         Tag(name='tag1', count=SHOW_THRESHOLD),
                     ],
                     b'infohash2': [
-                        Tag(name='tag2', count=SHOW_THRESHOLD - 1),
+                        Tag(name='tag1', count=SHOW_THRESHOLD - 1),
                     ]
                 })
 
@@ -110,7 +110,7 @@ class TestRemoteSearchByTags(TestBase):
         fill_mds()
 
         # Then we try to query search for three tags: 'tag1', 'tag2', 'tag3'
-        parameters = {'first': 0, 'infohash_set': None, 'last': 100, 'tags': ['tag1', 'tag2', 'tag3']}
+        parameters = {'first': 0, 'infohash_set': None, 'last': 100, 'tags': ['tag1']}
         json = dumps(parameters).encode('utf-8')
 
         with db_session:


### PR DESCRIPTION
This PR is related to #6708 and introduces a bit different logic for tag search than it was before.

As @kozlovsky suggested earlier, we should return 'intersection' of search results instead of 'union' in the case that more than one tag is specified in the search query.

This test that should clarify what I mean:

```python
    @db_session
    async def test_get_infohashes(self):
        self.add_operation_set(
            self.db,
            {
                b'infohash1': [
                    Tag(name='tag1', count=SHOW_THRESHOLD),
                    Tag(name='tag2', count=SHOW_THRESHOLD)
                ],
                b'infohash2': [
                    Tag(name='tag1', count=SHOW_THRESHOLD)
                ],
                b'infohash3': [
                    Tag(name='tag2', count=SHOW_THRESHOLD)
                ]
            }
        )

        assert self.db.get_infohashes({'tag1', 'tag2'}) == [b'infohash1']
```