### PR TITLE
Use ipv8 as an external dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "py-ipv8"]
-	path = src/pyipv8
-	url = https://github.com/Tribler/py-ipv8.git

--- a/doc/build-docs.sh
+++ b/doc/build-docs.sh
@@ -9,10 +9,6 @@ then
   echo "Please run this script from project root as:\n./doc/build-docs.sh"
 fi
 
-# Update git modules if necessary
-git submodule sync
-git submodule update --init --force --recursive src/pyipv8
-
 # all commands are executed from the doc directory
 cd doc
 

--- a/doc/building/building_on_osx.rst
+++ b/doc/building/building_on_osx.rst
@@ -13,7 +13,7 @@ Required packages
 
 Building Tribler on macOS
 -------------------------
-Start by checking out the directory you want to clone (using ``git clone --recursive``). Open a terminal and ``cd`` to this new cloned directory (referenced to as ``tribler_source`` in this guide).
+Start by checking out the directory you want to clone (using ``git clone``). Open a terminal and ``cd`` to this new cloned directory (referenced to as ``tribler_source`` in this guide).
 
 Next, we should inject version information into the files about the latest release. This is done by the ``update_version_from_git.py`` script found in ``Tribler/Main/Build``. Invoke it from the ``tribler_source`` directory by executing:
 

--- a/doc/building/building_on_windows.rst
+++ b/doc/building/building_on_windows.rst
@@ -21,7 +21,7 @@ To build a Tribler installer, you'll need some additional scripts and packages. 
 Building & Packaging Tribler
 ----------------------------
 
-Start by cloning Tribler if you haven't done already (using the ``git clone --recursive`` command).
+Start by cloning Tribler if you haven't done already (using the ``git clone`` command).
 Next, create a ``build`` folder directly on your ``C:\`` drive.
 Inside the ``build`` folder, put the following items:
 

--- a/doc/development/development_on_linux.rst
+++ b/doc/development/development_on_linux.rst
@@ -13,7 +13,7 @@ Clone the Tribler repo:
 
 .. code-block:: bash
 
-    git clone https://github.com/tribler/tribler --recursive
+    git clone https://github.com/tribler/tribler
 
 
 Install python packages:
@@ -51,7 +51,7 @@ Clone the Tribler repo:
 
 .. code-block:: bash
 
-    git clone https://github.com/tribler/tribler --recursive
+    git clone https://github.com/tribler/tribler
 
 
 Install python packages:

--- a/doc/development/development_on_osx.rst
+++ b/doc/development/development_on_osx.rst
@@ -83,7 +83,7 @@ The best solution to this problem is to link or copy ``libsodium.dylib`` into th
 
 .. code-block:: bash
 
-    git clone --recursive  https://github.com/Tribler/tribler.git
+    git clone  https://github.com/Tribler/tribler.git
     cd tribler
     cp /usr/local/lib/libsodium.dylib ./ || cp /opt/local/lib/libsodium.dylib ./
 

--- a/src/seedbox/README.md
+++ b/src/seedbox/README.md
@@ -11,7 +11,7 @@ The seedbox consists of two parts:
 
 1. Clone the tribler repo include sub modules:
     ```shell
-    git clone --recursive https://github.com/Tribler/tribler.git
+    git clone https://github.com/Tribler/tribler.git
     ```
 1. Install requirements:
     ```bash

--- a/src/tribler-core/tribler_core/requirements.txt
+++ b/src/tribler-core/tribler_core/requirements.txt
@@ -23,3 +23,4 @@ yappi==1.3.3
 yarl==1.7.2 # keep this dependency higher than 1.6.3. See: https://github.com/aio-libs/yarl/issues/517
 Faker==9.8.2
 sentry-sdk==1.5.0
+pyipv8==2.8.0


### PR DESCRIPTION
This PR is a part of #6505.

It changes the way the `ipv8` module is used in Tribler from "sub-module" to "external dependency".

I've requested a review from the involved participants. In case, the participants agree with the change, I will continue with the implementation.

The future steps will be:
1. Merging this branch into the main
2. Changing corresponding Jenkins jobs

**The question**: I'm not sure about the ordering of the future steps. Should I merge the branch first, and change the corresponding Jenkins jobs second, or the opposite?
