### PR TITLE
Enable origin tracking for coroutine objects

### DIFF
--- a/src/tribler-core/tribler_core/conftest.py
+++ b/src/tribler-core/tribler_core/conftest.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import sys
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -24,6 +25,13 @@ from tribler_core.tests.tools.tracker.udp_tracker import UDPTracker
 from tribler_core.utilities.network_utils import default_network_utils
 from tribler_core.utilities.simpledefs import DLSTATUS_SEEDING
 from tribler_core.utilities.unicode import hexlify
+
+
+# Enable origin tracking for coroutine objects in the current thread, so when a test does not handle
+# some coroutine properly, we can see a traceback with the name of the test which created the coroutine.
+# Note that the error can happen in an unrelated test where the unhandled task from the previous test
+# was garbage collected. Without the origin tracking, it may be hard to see the test that created the task.
+sys.set_coroutine_origin_tracking_depth(10)
 
 
 @pytest.fixture(name="tribler_root_dir")


### PR DESCRIPTION
Sometimes in tests, we have a situation when the task was created in one test or fixture and then crashed in a totally unrelated test during the garbage collection phase. In that case, we see the failed test, but not the test or fixture that was the originator of the unhandled task.

In this PR I enable the [origin tracking for coroutine objects](https://docs.python.org/3/library/sys.html#sys.get_coroutine_origin_tracking_depth) (a feature available in Python 3.7 and later).

As an example, right now I see the following error in a completely unrelated test:
```
RuntimeError: 1 Runtime Warning,
c:\dev\tribler\venv\lib\site-packages\aiohttp\test_utils.py:536:coroutine 'interval_runner' was never awaited
```

With this feature enabled, I can see the traceback and discover the fixture in which the unhandled task was created:

```python
RuntimeError: 1 Runtime Warning,
c:\dev\tribler\venv\lib\site-packages\aiohttp\test_utils.py:536:coroutine 'interval_runner' was never awaited
Coroutine created at (most recent call last)
  File "C:\dev\tribler\venv\lib\site-packages\pluggy\hooks.py", line 286, in __call__
    return self._hookexec(self, self.get_hookimpls(), kwargs)
  File "C:\dev\tribler\venv\lib\site-packages\pluggy\manager.py", line 93, in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
  File "C:\dev\tribler\venv\lib\site-packages\pluggy\manager.py", line 84, in <lambda>
    self._inner_hookexec = lambda hook, methods, kwargs: hook.multicall(
  File "C:\dev\tribler\venv\lib\site-packages\pluggy\callers.py", line 187, in _multicall
    res = hook_impl.function(*args)
  File "C:\dev\tribler\venv\lib\site-packages\_pytest\fixtures.py", line 1126, in pytest_fixture_setup
    result = call_fixture_func(fixturefunc, request, kwargs)
  File "C:\dev\tribler\venv\lib\site-packages\_pytest\fixtures.py", line 932, in call_fixture_func
    fixture_result = fixturefunc(**kwargs)
  File "C:\dev\tribler\src\tribler-core\tribler_core\components\tag\rules\tests\test_tag_rules_processor.py", line 16, in tag_rules_processor
    return TagRulesProcessor(notifier=MagicMock(), db=MagicMock(), mds=MagicMock(), batch_size=TEST_BATCH_SIZE,
  File "C:\dev\tribler\src\tribler-core\tribler_core\components\tag\rules\tag_rules_processor.py", line 31, in __init__
    super().__init__()
  File "C:\dev\tribler\src\pyipv8\ipv8\taskmanager.py", line 57, in __init__
    self._checker = self.register_task('_check_tasks', self._check_tasks,
  File "C:\dev\tribler\src\pyipv8\ipv8\taskmanager.py", line 110, in register_task
    task = ensure_future(interval_runner(delay, interval, task, *args))
```