### PR TITLE
Fix unstable tests

### DIFF
--- a/src/tribler-core/tribler_core/components/key/tests/test_key_component.py
+++ b/src/tribler-core/tribler_core/components/key/tests/test_key_component.py
@@ -11,15 +11,14 @@ async def test_masterkey_component(tribler_config):
         assert comp.primary_key
 
 
-async def test_get_private_key_filename(tribler_config):
+def test_get_private_key_filename(tribler_config):
     private_key_file_name = KeyComponent.get_private_key_filename(tribler_config)
     tribler_config.general.testnet = True
     testnet_private_key_file_name = KeyComponent.get_private_key_filename(tribler_config)
     assert private_key_file_name != testnet_private_key_file_name
 
 
-@pytest.mark.asyncio
-async def test_create(tmp_path):
+def test_create(tmp_path):
     private_key_path = tmp_path / 'private'
     public_key_path = tmp_path / 'public'
 
@@ -32,8 +31,7 @@ async def test_create(tmp_path):
     assert public_key_path.exists()
 
 
-@pytest.mark.asyncio
-async def test_create_no_public_key(tmp_path):
+def test_create_no_public_key(tmp_path):
     private_key_path = tmp_path / 'private'
 
     assert not private_key_path.exists()
@@ -43,8 +41,7 @@ async def test_create_no_public_key(tmp_path):
     assert private_key_path.exists()
 
 
-@pytest.mark.asyncio
-async def test_load(tmp_path):
+def test_load(tmp_path):
     private_key_path = tmp_path / 'private'
     public_key_path = tmp_path / 'public'
 

--- a/src/tribler-core/tribler_core/components/tag/rules/tag_rules_processor.py
+++ b/src/tribler-core/tribler_core/components/tag/rules/tag_rules_processor.py
@@ -52,6 +52,9 @@ class TagRulesProcessor(TaskManager):
                                interval=self.interval,
                                task=self.process_batch)
 
+    async def shutdown(self):
+        await self.shutdown_task_manager()
+
     @db_session
     def process_batch(self) -> int:
         def query(_start, _end):

--- a/src/tribler-core/tribler_core/components/tag/rules/tests/test_tag_rules_processor.py
+++ b/src/tribler-core/tribler_core/components/tag/rules/tests/test_tag_rules_processor.py
@@ -12,9 +12,11 @@ TEST_INTERVAL = 0.1
 
 # pylint: disable=redefined-outer-name, protected-access
 @pytest.fixture
-def tag_rules_processor():
-    return TagRulesProcessor(notifier=MagicMock(), db=MagicMock(), mds=MagicMock(), batch_size=TEST_BATCH_SIZE,
-                             interval=TEST_INTERVAL)
+async def tag_rules_processor():
+    processor = TagRulesProcessor(notifier=MagicMock(), db=MagicMock(), mds=MagicMock(), batch_size=TEST_BATCH_SIZE,
+                                  interval=TEST_INTERVAL)
+    yield processor
+    await processor.shutdown()
 
 
 def test_constructor(tag_rules_processor: TagRulesProcessor):


### PR DESCRIPTION
I discovered the reason for unstable tests. It was caused by an interaction between one broken fixture, one broken test, and the aiohttp async plugin. The fix is simple, but the actual sequence of events that led to the error was amazing.

Initially, there was no error on my local machine, as the error is unstable and caused by a specific order of tests. I added the following pytest option to my local configuration to reproduce the error: `--randomly-seed=1`. It created a stable pseudo-random test sequence that failed stably on my machine, and then I could debug the reason for the error.

The failed test looked pretty innocent, and the error does not seem to be related to the test code:
```python
async def test_get_private_key_filename(tribler_config):
    private_key_file_name = KeyComponent.get_private_key_filename(tribler_config)
    tribler_config.general.testnet = True
    testnet_private_key_file_name = KeyComponent.get_private_key_filename(tribler_config)
    assert private_key_file_name != testnet_private_key_file_name
```

The error was:
```
..\..\..\venv\lib\site-packages\aiohttp\pytest_plugin.py:138: RuntimeError
RuntimeError: 1 Runtime Warning,
c:\dev\tribler\venv\lib\site-packages\aiohttp\test_utils.py:536:coroutine 'interval_runner' was never awaited
```

As it turns out, the reason for the error was a completely unrelated fixture:
```python
@pytest.fixture
def tag_rules_processor():
    return TagRulesProcessor(...)
```

This is what happened:

`TagRulesProcessor` inherits from `TaskManager`, which `__init__` creates a task `_check_tasks`. We need to properly shutdown classes that inherit from the `TaskManager` so all their tasks are properly finished, including the `_check_tasks` task. So, the first part of the problem was skipping the `shutdown_task_manager()` call in the finalization part of the fixture.

[The tests](https://github.com/Tribler/tribler/blob/3565b57cb88f8a246e4e5348611cbbd9aecb0178/src/tribler-core/tribler_core/components/tag/rules/tests/test_tag_rules_processor.py#L20) in which the fixture is used are not async, and the unhandled task remained in the memory.

Then `test_get_private_key_filename` was executed if the order of tests were unlucky. The function was declared as `async`, but `@pytest.mark.asyncio` decorator was not applied to the test, which caused the function to be treated as an async test by the `aiohttp` plugin that we use in REST API tests.

The `aiohttp` plugin, when executing a test function, do two additional things: first, it runs garbage collection at the end of the test to b sure that all unfinished tasks created in the function generate warnings. Second, it converts warnings to RuntimeError to ensure that they will not be missed accidentally.

The garbage collection triggered the warning from the task created in a previous test, and the warning became converted to `RuntimeError`, leading to the failed test.

As a fix, I:
1) Removed `async` from the test functions that does not execute any async code, so the `aiohttp` plugin no longer tries to handle these tests;
2) Added the `shutdown` method to `TagRulesProcessor`;
3) Converted `tag_rules_processor` fixture code to a generator to be able to call `processor.shutdown()` at the end of the fixture.

In the future, we probably need to add some safety checks to be sure a coroutine created in one test cannot cause an error in the following test during the garbage collection phase. We can add a plugin that triggers garbage collection at the end of each test as an option. It may slow down test execution, but it should make tests more stable.



