### PR TITLE
Docker support

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,27 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository and submodules
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: docker login
+      env:
+        DOCKER_USER: ${{secrets.DOCKER_USER}}
+        DOCKER_PASSWORD: ${{secrets.DOCKER_PASSWORD}}
+      run: |
+        docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag triblercore/triblercore:latest
+    - name: Push to Docker Hub
+      run: docker push ${{secrets.DOCKER_USER}}/triblercore:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,19 +6,23 @@ FROM triblercore/libtorrent:1.2.10-x
 RUN apt update && apt upgrade -y
 RUN apt install -y libsodium23 python3-pip git
 
+RUN useradd -ms /bin/bash user
+USER user
+WORKDIR /home/user
+
 # Then, install pip dependencies so that it can be cached and does not
 # need to be built every time the source code changes.
 # This reduces the docker build time.
-RUN mkdir /requirements
-COPY ./src/pyipv8/requirements.txt /requirements/pyipv8-requirements.txt
-RUN pip3 install -r /requirements/pyipv8-requirements.txt
+RUN mkdir requirements
+COPY ./src/pyipv8/requirements.txt requirements/pyipv8-requirements.txt
+RUN pip3 install -r requirements/pyipv8-requirements.txt
 
-COPY ./src/tribler-core/tribler_core/requirements.txt /requirements/core-requirements.txt
-RUN pip3 install -r /requirements/core-requirements.txt
+COPY ./src/tribler-core/tribler_core/requirements.txt requirements/core-requirements.txt
+RUN pip3 install -r requirements/core-requirements.txt
 
 # Copy the source code and set the working directory
-COPY ./ /tribler
-WORKDIR /tribler
+COPY ./ tribler
+WORKDIR tribler
 
 # Set the REST API port and expose it
 ENV CORE_API_PORT=52194

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     container_name: triblercore
     network_mode: "host"
     build: .
+    volumes:
+      - ~/.Tribler:/home/user/.Tribler
     environment:
       CORE_API_PORT: 52194
 


### PR DESCRIPTION
# Docker support

- Run docker as non-root user
- Map local `.Tribler` to docker container so that downloads runs inside the container.
- Add a Github action to build and publish docker container to docker registry whenever the `main` branch is updated. The built image is published to 
https://hub.docker.com/r/triblercore/triblercore

