### PR TITLE
Add python 3.9 and python 3.9 badges

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,10 +2,15 @@
 Tribler
 *******
 
-|jenkins_build| |docs| |contributors| |pr_closed| |issues_closed| |downloads_7_0|
-|downloads_7_1| |downloads_7_2| |downloads_7_3| |downloads_7_4| |downloads_7_5|
-|downloads_7_6| |downloads_7_7| |downloads_7_8| |downloads_7_9| |downloads_7_10|
-|downloads_7_11| |doi| |openhub| |discord|
+|jenkins_build| |docs| |contributors| |pr_closed| |issues_closed|
+
+|python_3_8| |python_3_9|
+
+|downloads_7_0| |downloads_7_1| |downloads_7_2| |downloads_7_3| |downloads_7_4|
+|downloads_7_5| |downloads_7_6| |downloads_7_7| |downloads_7_8| |downloads_7_9|
+|downloads_7_10| |downloads_7_11|
+
+|doi| |openhub| |discord|
 
 *Towards making Bittorrent anonymous and impossible to shut down.*
 
@@ -191,3 +196,9 @@ We like to hear your feedback and suggestions. To reach out to us, you can join 
 .. |discord| image:: https://img.shields.io/badge/discord-join%20chat-blue.svg
     :target: https://discord.gg/UpPUcVGESe
     :alt: Join Discord chat
+
+.. |python_3_8| image:: https://img.shields.io/badge/python-3.8-blue.svg
+    :target: https://www.python.org/
+
+.. |python_3_9| image:: https://img.shields.io/badge/python-3.9-blue.svg
+    :target: https://www.python.org/


### PR DESCRIPTION
This PR adds two new badges to the readme:
* python 3.8
* python 3.9

Also, this PR splits the badge set on sections divided by `<br>`.

How it looks:

<img width="470" alt="image" src="https://user-images.githubusercontent.com/13798583/156400156-c1c935df-48fb-4742-9a30-307e2c078908.png">

Closes #6794