### PR TITLE
Add "no_parallel" pytest's mark

### DIFF
--- a/src/tribler-core/tribler_core/components/bandwidth_accounting/tests/test_bandwidth_accounting_component.py
+++ b/src/tribler-core/tribler_core/components/bandwidth_accounting/tests/test_bandwidth_accounting_component.py
@@ -7,7 +7,9 @@ from tribler_core.components.key.key_component import KeyComponent
 
 # pylint: disable=protected-access
 
+
 @pytest.mark.asyncio
+@pytest.mark.no_parallel
 async def test_bandwidth_accounting_component(tribler_config):
     components = [KeyComponent(), Ipv8Component(), BandwidthAccountingComponent()]
     async with Session(tribler_config, components).start():

--- a/src/tribler-core/tribler_core/components/gigachannel/tests/test_gigachannel_component.py
+++ b/src/tribler-core/tribler_core/components/gigachannel/tests/test_gigachannel_component.py
@@ -9,7 +9,9 @@ from tribler_core.components.tag.tag_component import TagComponent
 
 # pylint: disable=protected-access
 
+
 @pytest.mark.asyncio
+@pytest.mark.no_parallel
 async def test_giga_channel_component(tribler_config):
     tribler_config.ipv8.enabled = True
     tribler_config.libtorrent.enabled = True

--- a/src/tribler-core/tribler_core/components/gigachannel_manager/tests/test_gigachannel_manager_component.py
+++ b/src/tribler-core/tribler_core/components/gigachannel_manager/tests/test_gigachannel_manager_component.py
@@ -13,6 +13,7 @@ from tribler_core.components.tag.tag_component import TagComponent
 
 
 @pytest.mark.asyncio
+@pytest.mark.no_parallel
 async def test_gigachannel_manager_component(tribler_config):
     components = [Ipv8Component(), TagComponent(), SocksServersComponent(), KeyComponent(), MetadataStoreComponent(),
                   LibtorrentComponent(), GigachannelManagerComponent()]

--- a/src/tribler-core/tribler_core/components/ipv8/tests/test_ipv8_component.py
+++ b/src/tribler-core/tribler_core/components/ipv8/tests/test_ipv8_component.py
@@ -4,10 +4,10 @@ from tribler_core.components.base import Session
 from tribler_core.components.ipv8.ipv8_component import Ipv8Component
 from tribler_core.components.key.key_component import KeyComponent
 
-pytestmark = pytest.mark.asyncio
-
 
 # pylint: disable=protected-access
+@pytest.mark.asyncio
+@pytest.mark.no_parallel
 async def test_ipv8_component(tribler_config):
     async with Session(tribler_config, [KeyComponent(), Ipv8Component()]).start():
         comp = Ipv8Component.instance()
@@ -19,6 +19,8 @@ async def test_ipv8_component(tribler_config):
         assert not comp._peer_discovery_community
 
 
+@pytest.mark.asyncio
+@pytest.mark.no_parallel
 async def test_ipv8_component_dht_disabled(tribler_config):
     tribler_config.ipv8.enabled = True
     tribler_config.dht.enabled = True
@@ -27,6 +29,8 @@ async def test_ipv8_component_dht_disabled(tribler_config):
         assert comp.dht_discovery_community
 
 
+@pytest.mark.asyncio
+@pytest.mark.no_parallel
 async def test_ipv8_component_discovery_community_enabled(tribler_config):
     tribler_config.ipv8.enabled = True
     tribler_config.gui_test_mode = False

--- a/src/tribler-core/tribler_core/components/libtorrent/tests/test_libtorrent_component.py
+++ b/src/tribler-core/tribler_core/components/libtorrent/tests/test_libtorrent_component.py
@@ -5,11 +5,10 @@ from tribler_core.components.key.key_component import KeyComponent
 from tribler_core.components.libtorrent.libtorrent_component import LibtorrentComponent
 from tribler_core.components.socks_servers.socks_servers_component import SocksServersComponent
 
-pytestmark = pytest.mark.asyncio
-
 
 # pylint: disable=protected-access
-
+@pytest.mark.asyncio
+@pytest.mark.no_parallel
 async def test_libtorrent_component(tribler_config):
     components = [KeyComponent(), SocksServersComponent(), LibtorrentComponent()]
     async with Session(tribler_config, components).start():

--- a/src/tribler-core/tribler_core/components/metadata_store/tests/test_metadata_store_component.py
+++ b/src/tribler-core/tribler_core/components/metadata_store/tests/test_metadata_store_component.py
@@ -8,7 +8,9 @@ from tribler_core.components.tag.tag_component import TagComponent
 
 # pylint: disable=protected-access
 
+
 @pytest.mark.asyncio
+@pytest.mark.no_parallel
 async def test_metadata_store_component(tribler_config):
     components = [TagComponent(), Ipv8Component(), KeyComponent(), MetadataStoreComponent()]
     async with Session(tribler_config, components).start():

--- a/src/tribler-core/tribler_core/components/payout/tests/test_payout_component.py
+++ b/src/tribler-core/tribler_core/components/payout/tests/test_payout_component.py
@@ -9,6 +9,7 @@ from tribler_core.components.payout.payout_component import PayoutComponent
 
 
 @pytest.mark.asyncio
+@pytest.mark.no_parallel
 async def test_payout_component(tribler_config):
     components = [BandwidthAccountingComponent(), KeyComponent(), Ipv8Component(), PayoutComponent()]
     async with Session(tribler_config, components).start():

--- a/src/tribler-core/tribler_core/components/popularity/tests/test_popularity_component.py
+++ b/src/tribler-core/tribler_core/components/popularity/tests/test_popularity_component.py
@@ -14,6 +14,7 @@ from tribler_core.components.torrent_checker.torrent_checker_component import To
 
 
 @pytest.mark.asyncio
+@pytest.mark.no_parallel
 async def test_popularity_component(tribler_config):
     components = [SocksServersComponent(), LibtorrentComponent(), TorrentCheckerComponent(), TagComponent(),
                   MetadataStoreComponent(), KeyComponent(), Ipv8Component(), PopularityComponent()]

--- a/src/tribler-core/tribler_core/components/restapi/tests/test_restapi_component.py
+++ b/src/tribler-core/tribler_core/components/restapi/tests/test_restapi_component.py
@@ -16,11 +16,10 @@ from tribler_core.components.restapi.restapi_component import RESTComponent
 from tribler_core.components.socks_servers.socks_servers_component import SocksServersComponent
 from tribler_core.components.tag.tag_component import TagComponent
 
-pytestmark = pytest.mark.asyncio
-
 
 # pylint: disable=protected-access, not-callable, redefined-outer-name
-
+@pytest.mark.asyncio
+@pytest.mark.no_parallel
 async def test_rest_component(tribler_config):
     components = [KeyComponent(), RESTComponent(), Ipv8Component(), LibtorrentComponent(), ResourceMonitorComponent(),
                   BandwidthAccountingComponent(), GigaChannelComponent(), TagComponent(), SocksServersComponent(),
@@ -56,7 +55,7 @@ def rest_component():
     component.root_endpoint = MagicMock()
     return component
 
-
+@pytest.mark.asyncio
 async def test_maybe_add_check_args(rest_component, endpoint_cls):
     # test that in case `*args` in `maybe_add` function contains `NoneComponent` instance
     # no root_endpoint methods are called
@@ -67,6 +66,7 @@ async def test_maybe_add_check_args(rest_component, endpoint_cls):
     rest_component.root_endpoint.assert_not_called()
 
 
+@pytest.mark.asyncio
 async def test_maybe_add_check_kwargs(rest_component, endpoint_cls):
     # test that in case `**kwargs` in `maybe_add` function contains `NoneComponent` instance
     # no root_endpoint methods are called
@@ -77,6 +77,7 @@ async def test_maybe_add_check_kwargs(rest_component, endpoint_cls):
     rest_component.root_endpoint.assert_not_called()
 
 
+@pytest.mark.asyncio
 async def test_maybe_add(rest_component, endpoint_cls):
     # test that in case there are no `NoneComponent` instances in `**kwargs` or `*args`
     # root_endpoint methods are called

--- a/src/tribler-core/tribler_core/components/socks_servers/tests/test_socks_servers_component.py
+++ b/src/tribler-core/tribler_core/components/socks_servers/tests/test_socks_servers_component.py
@@ -3,11 +3,10 @@ import pytest
 from tribler_core.components.base import Session
 from tribler_core.components.socks_servers.socks_servers_component import SocksServersComponent
 
-pytestmark = pytest.mark.asyncio
-
 
 # pylint: disable=protected-access
-
+@pytest.mark.asyncio
+@pytest.mark.no_parallel
 async def test_socks_servers_component(tribler_config):
     components = [SocksServersComponent()]
     async with Session(tribler_config, components).start():

--- a/src/tribler-core/tribler_core/components/tag/tests/test_tag_component.py
+++ b/src/tribler-core/tribler_core/components/tag/tests/test_tag_component.py
@@ -10,6 +10,7 @@ from tribler_core.components.tag.tag_component import TagComponent
 
 
 @pytest.mark.asyncio
+@pytest.mark.no_parallel
 async def test_tag_component(tribler_config):
     components = [MetadataStoreComponent(), KeyComponent(), Ipv8Component(), TagComponent()]
     async with Session(tribler_config, components).start():

--- a/src/tribler-core/tribler_core/components/torrent_checker/tests/test_torrent_checker_component.py
+++ b/src/tribler-core/tribler_core/components/torrent_checker/tests/test_torrent_checker_component.py
@@ -9,12 +9,10 @@ from tribler_core.components.socks_servers.socks_servers_component import SocksS
 from tribler_core.components.tag.tag_component import TagComponent
 from tribler_core.components.torrent_checker.torrent_checker_component import TorrentCheckerComponent
 
-pytestmark = pytest.mark.asyncio
-
 
 # pylint: disable=protected-access
-
-
+@pytest.mark.asyncio
+@pytest.mark.no_parallel
 async def test_torrent_checker_component(tribler_config):
     components = [SocksServersComponent(), LibtorrentComponent(), KeyComponent(),
                   Ipv8Component(), TagComponent(), MetadataStoreComponent(), TorrentCheckerComponent()]

--- a/src/tribler-core/tribler_core/components/tunnel/tests/test_tunnel_component.py
+++ b/src/tribler-core/tribler_core/components/tunnel/tests/test_tunnel_component.py
@@ -5,10 +5,11 @@ from tribler_core.components.ipv8.ipv8_component import Ipv8Component
 from tribler_core.components.key.key_component import KeyComponent
 from tribler_core.components.tunnel.tunnel_component import TunnelsComponent
 
-pytestmark = pytest.mark.asyncio
-
 
 # pylint: disable=protected-access
+
+@pytest.mark.asyncio
+@pytest.mark.no_parallel
 async def test_tunnels_component(tribler_config):
     components = [Ipv8Component(), KeyComponent(), TunnelsComponent()]
     async with Session(tribler_config, components).start():

--- a/src/tribler-core/tribler_core/components/watch_folder/tests/test_watch_folder_component.py
+++ b/src/tribler-core/tribler_core/components/watch_folder/tests/test_watch_folder_component.py
@@ -6,11 +6,10 @@ from tribler_core.components.libtorrent.libtorrent_component import LibtorrentCo
 from tribler_core.components.socks_servers.socks_servers_component import SocksServersComponent
 from tribler_core.components.watch_folder.watch_folder_component import WatchFolderComponent
 
-pytestmark = pytest.mark.asyncio
-
 
 # pylint: disable=protected-access
-
+@pytest.mark.asyncio
+@pytest.mark.no_parallel
 async def test_watch_folder_component(tribler_config):
     components = [KeyComponent(), SocksServersComponent(), LibtorrentComponent(), WatchFolderComponent()]
     async with Session(tribler_config, components).start():

--- a/src/tribler-core/tribler_core/conftest.py
+++ b/src/tribler-core/tribler_core/conftest.py
@@ -310,3 +310,21 @@ async def download_manager(tmp_path_factory):
     download_manager.initialize()
     yield download_manager
     await download_manager.shutdown()
+
+
+def pytest_addoption(parser):
+    # Documentation on pytest, "how to skip a test":
+    # https://docs.pytest.org/en/6.2.x/example/simple.html#control-skipping-of-tests-according-to-command-line-option
+    parser.addoption('--no_parallel', action='store_true', dest="no_parallel",
+                     default=False, help="run no_parallel tests")
+
+
+def pytest_collection_modifyitems(config, items):
+    # Documentation on pytest, "how to skip a test":
+    # https://docs.pytest.org/en/6.2.x/example/simple.html#control-skipping-of-tests-according-to-command-line-option
+    if config.getoption("--no_parallel"):
+        return
+    skip = pytest.mark.skip(reason="need --no_parallel option to run")
+    for item in items:
+        if "no_parallel" in item.keywords:
+            item.add_marker(skip)


### PR DESCRIPTION
This PR fixes #6709 by introducing the `no_parallel` pytest's mark.

All tests that have this mark will be excluded from normal "parallel" Jenkins's run. But they will be run sequentially instead (like tunnel tests do).

In case this PR will be approved, I will merge it to the main and then modify corresponding Jenkins' jobs.