### PR TITLE
Add no_parallel to pytest.ini

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -7,6 +7,7 @@ markers =
     tunneltest:Slow tests for tunnels. Skipped by default, use --tunneltests option to enable them
     enable_https:Use HTTPS instead of HTTP in marked tests
     api_key:Used by rest_manager fixture to inject api_key value
+    no_parallel:Run tests that marked as "no_parallel".
 
 filterwarnings =
     ignore:Passing field metadata as a keyword arg is deprecated:DeprecationWarning:marshmallow

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -1,0 +1,19 @@
+import pytest
+
+
+def pytest_addoption(parser):
+    # Documentation on pytest, "how to skip a test":
+    # https://docs.pytest.org/en/6.2.x/example/simple.html#control-skipping-of-tests-according-to-command-line-option
+    parser.addoption('--no_parallel', action='store_true', dest="no_parallel",
+                     default=False, help="run no_parallel tests")
+
+
+def pytest_collection_modifyitems(config, items):
+    # Documentation on pytest, "how to skip a test":
+    # https://docs.pytest.org/en/6.2.x/example/simple.html#control-skipping-of-tests-according-to-command-line-option
+    if config.getoption("--no_parallel"):
+        return
+    skip = pytest.mark.skip(reason="need --no_parallel option to run")
+    for item in items:
+        if "no_parallel" in item.keywords:
+            item.add_marker(skip)

--- a/src/tribler-core/tribler_core/conftest.py
+++ b/src/tribler-core/tribler_core/conftest.py
@@ -310,21 +310,3 @@ async def download_manager(tmp_path_factory):
     download_manager.initialize()
     yield download_manager
     await download_manager.shutdown()
-
-
-def pytest_addoption(parser):
-    # Documentation on pytest, "how to skip a test":
-    # https://docs.pytest.org/en/6.2.x/example/simple.html#control-skipping-of-tests-according-to-command-line-option
-    parser.addoption('--no_parallel', action='store_true', dest="no_parallel",
-                     default=False, help="run no_parallel tests")
-
-
-def pytest_collection_modifyitems(config, items):
-    # Documentation on pytest, "how to skip a test":
-    # https://docs.pytest.org/en/6.2.x/example/simple.html#control-skipping-of-tests-according-to-command-line-option
-    if config.getoption("--no_parallel"):
-        return
-    skip = pytest.mark.skip(reason="need --no_parallel option to run")
-    for item in items:
-        if "no_parallel" in item.keywords:
-            item.add_marker(skip)


### PR DESCRIPTION
This PR should fix test run failures that happens in https://github.com/Tribler/tribler/pull/6716