### PR TITLE
Add install_requirements.r

### DIFF
--- a/scripts/experiments/tunnel_community/README.md
+++ b/scripts/experiments/tunnel_community/README.md
@@ -1,0 +1,12 @@
+## Install requirements
+
+### Install Tribler requirements
+
+* Export the `src` directory to `PYTHONPATH`
+* Install Tribler's requirements from `requirements-core.txt`
+
+### Install R requirements
+
+```shell
+R --no-save < install_requirements.r
+```

--- a/scripts/experiments/tunnel_community/install_requirements.r
+++ b/scripts/experiments/tunnel_community/install_requirements.r
@@ -1,0 +1,2 @@
+install.packages("ggplot2")
+install.packages("reshape2")


### PR DESCRIPTION
This PR is a part of https://github.com/Tribler/tribler/issues/6505

Now our [tunnel experiments](https://jenkins-ci.tribler.org/job/tunnel_experiments/) are broken because:

```python
R version 4.0.4 (2021-02-15) -- "Lost Library Book"

> library(ggplot2)
Error: package or namespace load failed for ‘ggplot2’:
 package ‘ggplot2’ was installed before R 4.0.0: please re-install it
Execution halted
```

See [full console output](https://jenkins-ci.tribler.org/job/tunnel_experiments/job/speed_test_exit/190/console)


The last successful build is: https://jenkins-ci.tribler.org/job/tunnel_experiments/job/speed_test_exit/177/ and regarding it's console output it has been run under R version `3.5.2`
```python
R version 3.5.2 (2018-12-20) -- "Eggshell Igloo"
```

So, to fix the run we have just to install the following packages:

```python
library(ggplot2)
library(reshape2)
```

But this error could happen again when the R version has been updated.

I propose to use the file `install_requirements.r` to automatically install all the necessary dependencies.

ref: https://datatofish.com/install-package-r/
