### PR TITLE
Escape non-ASCII symbols when writing the tag value to the log

### DIFF
--- a/src/tribler/core/components/tag/community/tag_community.py
+++ b/src/tribler/core/components/tag/community/tag_community.py
@@ -75,7 +75,7 @@ class TagCommunity(TriblerCommunity):
             with db_session():
                 is_added = self.db.add_tag_operation(operation, signature.signature)
                 if is_added:
-                    self.logger.info(f'+ tag added ({operation.tag} ,{operation.infohash.hex()})')
+                    self.logger.info(f'+ tag added ({operation.tag!r}, {operation.infohash.hex()})')
 
         except PeerValidationError as e:  # peer has exhausted his response count
             self.logger.warning(e)


### PR DESCRIPTION
Fixes #6811