### PR TITLE
Handle ValueError "Data is not a bencoded string" in TorrentInfoEndpoint.get_torrent_info()

### DIFF
--- a/src/tribler/core/components/libtorrent/restapi/torrentinfo_endpoint.py
+++ b/src/tribler/core/components/libtorrent/restapi/torrentinfo_endpoint.py
@@ -95,7 +95,7 @@ class TorrentInfoEndpoint(RESTEndpoint):
             try:
                 tdef = TorrentDef.load(file)
                 metainfo = tdef.metainfo
-            except (TypeError, RuntimeError):
+            except (TypeError, ValueError, RuntimeError):
                 return RESTResponse({"error": f"error while decoding torrent file: {file}"},
                                     status=HTTP_INTERNAL_SERVER_ERROR)
         elif scheme in (HTTP_SCHEME, HTTPS_SCHEME):


### PR DESCRIPTION
Fixes #6813