### PR TITLE
For test run with '--no-parallel' argument, skip all "normal" tests

### DIFF
--- a/src/conftest.py
+++ b/src/conftest.py
@@ -12,8 +12,17 @@ def pytest_collection_modifyitems(config, items):
     # Documentation on pytest, "how to skip a test":
     # https://docs.pytest.org/en/6.2.x/example/simple.html#control-skipping-of-tests-according-to-command-line-option
     if config.getoption("--no_parallel"):
+        # if tests have been run with '--no_parallel' argument, then
+        # skip all tests that doesn't contain `no_parallel` mark
+        skip_marker = pytest.mark.skip(reason="skipped during --no_parallel run")
+        for item in items:
+            if "no_parallel" not in item.keywords:
+                item.add_marker(skip_marker)
         return
-    skip = pytest.mark.skip(reason="need --no_parallel option to run")
+
+    # if tests have been run without '--no_parallel' argument, then
+    # skip all tests that contain `no_parallel` mark
+    skip_marker = pytest.mark.skip(reason="need --no_parallel option to run")
     for item in items:
         if "no_parallel" in item.keywords:
-            item.add_marker(skip)
+            item.add_marker(skip_marker)


### PR DESCRIPTION
Tribler's tests have been executed in Jenkins by the following commands:

```shell
pytest src/tribler/core -v --tx '12*popen//execmodel=eventlet' --cov=tribler --cov-report=xml:../output/coverage.xml --junitxml=test_report.xml
pytest src/tribler/core -v --no_parallel --cov=tribler --cov-report=xml:../output/coverage.xml --cov-append
```

1. During the first run, all tests that have the `@no_parallel` mark should be excluded from the execution.
2. During the second run, all tests that don't have the `@no_parallel` mark should be excluded from the execution.

This PR makes the second statement correct.