### PR TITLE
Remove streaming related sentences from main README.md

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,12 +13,15 @@ Tribler
 
 *Towards making Bittorrent anonymous and impossible to shut down.*
 
-We use our own dedicated Tor-like network for anonymous torrent downloading. We implemented and enhanced the *Tor protocol specifications* plus merged them with Bittorrent streaming. More info: https://github.com/Tribler/tribler/wiki
-Tribler includes our own Tor-like onion routing network with hidden services based seeding and end-to-end encryption, detailed specs: https://github.com/Tribler/tribler/wiki/Anonymous-Downloading-and-Streaming-specifications
+We use our own dedicated Tor-like network for anonymous torrent downloading.
+We implemented and enhanced the `Tor protocol specifications <https://github.com/Tribler/tribler/wiki/Anonymous-Downloading-and-Streaming-specifications>`_.
+Tribler includes our own Tor-like onion routing network with hidden services based
+seeding and `end-to-end encryption <https://github.com/Tribler/tribler/wiki/Anonymous-Downloading-and-Streaming-specifications>`_.
 
-The aim of Tribler is giving anonymous access to online (streaming) videos. We are trying to make privacy, strong cryptography and authentication the Internet norm.
+Tribler aims to give anonymous access to content. We are trying to make privacy, strong cryptography, and authentication the Internet norm.
 
-Tribler currently offers a Youtube-style service. For instance, Bittorrent-compatible streaming, fast search, thumbnail previews and comments. For the past 11 years we have been building a very robust Peer-to-Peer system. Today Tribler is robust: "the only way to take Tribler down is to take The Internet down" (but a single software bug could end everything).
+For the past 11 years we have been building a very robust Peer-to-Peer system.
+Today Tribler is robust: "the only way to take Tribler down is to take The Internet down" (but a single software bug could end everything).
 
 Obtaining the latest release
 ============================


### PR DESCRIPTION
As we no longer provide streaming access to content (for a few years already), we should reflect this fact in `README.md`