### PR TITLE
Rename QtSingleApplication.activation_window() to tribler_window

### DIFF
--- a/src/tribler/gui/start_gui.py
+++ b/src/tribler/gui/start_gui.py
@@ -72,7 +72,7 @@ def run_gui(api_port, api_key, root_state_dir, parsed_args):
         logger.info('Start Tribler Window')
         window = TriblerWindow(app_manager, settings, root_state_dir, api_port=api_port, api_key=api_key)
         window.setWindowTitle("Tribler")
-        app.set_activation_window(window)
+        app.tribler_window = window
         app.parse_sys_args(sys.argv)
         sys.exit(app.exec_())
 

--- a/src/tribler/gui/tests/test_gui.py
+++ b/src/tribler/gui/tests/test_gui.py
@@ -51,7 +51,7 @@ def fixture_window(tmpdir_factory):
         api_key=api_key,
         core_args=[str(RUN_TRIBLER_PY.absolute()), '--core', '--gui-test-mode'],
     )
-    app.set_activation_window(window)
+    app.tribler_window = window
     QTest.qWaitForWindowExposed(window)
 
     screenshot(window, name="tribler_loading")

--- a/src/tribler/gui/tribler_app.py
+++ b/src/tribler/gui/tribler_app.py
@@ -33,12 +33,8 @@ class TriblerApplication(QtSingleApplication):
             self.handle_uri(msg)
 
     def handle_uri(self, uri):
-        if not self.activation_window():
-            return
-
-        self.activation_window().pending_uri_requests.append(uri)
-        if self.activation_window().tribler_started and not self.activation_window().start_download_dialog_active:
-            self.activation_window().process_uri_request()
+        if self.tribler_window:
+            self.tribler_window.handle_uri(uri)
 
     def parse_sys_args(self, args):
         for arg in args[1:]:
@@ -52,9 +48,9 @@ class TriblerApplication(QtSingleApplication):
         if '--allow-code-injection' in sys.argv[1:]:
             variables = globals().copy()
             variables.update(locals())
-            variables['window'] = self.activation_window()
+            variables['window'] = self.tribler_window
             self.code_executor = CodeExecutor(5500, shell_variables=variables)
-            connect(self.activation_window().tribler_crashed, self.code_executor.on_crash)
+            connect(self.tribler_window.tribler_crashed, self.code_executor.on_crash)
 
         if '--testnet' in sys.argv[1:]:
             os.environ['TESTNET'] = "YES"

--- a/src/tribler/gui/tribler_window.py
+++ b/src/tribler/gui/tribler_window.py
@@ -21,7 +21,14 @@ from PyQt5.QtCore import (
     pyqtSignal,
     pyqtSlot,
 )
-from PyQt5.QtGui import QDesktopServices, QFontDatabase, QIcon, QKeyEvent, QKeySequence, QPixmap
+from PyQt5.QtGui import (
+    QDesktopServices,
+    QFontDatabase,
+    QIcon,
+    QKeyEvent,
+    QKeySequence,
+    QPixmap,
+)
 from PyQt5.QtWidgets import (
     QAction,
     QApplication,
@@ -80,7 +87,11 @@ from tribler.gui.dialogs.startdownloaddialog import StartDownloadDialog
 from tribler.gui.error_handler import ErrorHandler
 from tribler.gui.event_request_manager import EventRequestManager
 from tribler.gui.tribler_action_menu import TriblerActionMenu
-from tribler.gui.tribler_request_manager import TriblerNetworkRequest, TriblerRequestManager, request_manager
+from tribler.gui.tribler_request_manager import (
+    TriblerNetworkRequest,
+    TriblerRequestManager,
+    request_manager,
+)
 from tribler.gui.upgrade_manager import UpgradeManager
 from tribler.gui.utilities import (
     connect,
@@ -97,8 +108,15 @@ from tribler.gui.utilities import (
 )
 from tribler.gui.widgets.channelsmenulistwidget import ChannelsMenuListWidget
 from tribler.gui.widgets.instanttooltipstyle import InstantTooltipStyle
-from tribler.gui.widgets.tablecontentmodel import DiscoveredChannelsModel, PopularTorrentsModel
-from tribler.gui.widgets.triblertablecontrollers import PopularContentTableViewController
+from tribler.gui.widgets.tablecontentmodel import (
+    DiscoveredChannelsModel,
+    PopularTorrentsModel,
+)
+from tribler.gui.widgets.triblertablecontrollers import (
+    PopularContentTableViewController,
+)
+
+# fmt: off
 
 fc_loading_list_item, _ = uic.loadUiType(get_ui_file_path('loading_list_item.ui'))
 
@@ -135,15 +153,15 @@ class TriblerWindow(QMainWindow):
     received_search_completions = pyqtSignal(object)
 
     def __init__(
-        self,
-        app_manager: AppManager,
-        settings,
-        root_state_dir,
-        core_args=None,
-        core_env=None,
-        api_port=None,
-        api_key=None,
-        run_core=True,
+            self,
+            app_manager: AppManager,
+            settings,
+            root_state_dir,
+            core_args=None,
+            core_env=None,
+            api_port=None,
+            api_key=None,
+            run_core=True,
     ):
         QMainWindow.__init__(self)
         self._logger = logging.getLogger(self.__class__.__name__)
@@ -598,14 +616,14 @@ class TriblerWindow(QMainWindow):
         self.gui_settings.setValue("recent_download_locations", ','.join(recent_locations))
 
     def perform_start_download_request(
-        self,
-        uri,
-        anon_download,
-        safe_seeding,
-        destination,
-        selected_files,
-        add_to_channel=False,
-        callback=None,
+            self,
+            uri,
+            anon_download,
+            safe_seeding,
+            destination,
+            selected_files,
+            add_to_channel=False,
+            callback=None,
     ):
         # Check if destination directory is writable
         is_writable, error = is_dir_writable(destination)
@@ -1134,10 +1152,10 @@ class TriblerWindow(QMainWindow):
     def event(self, event):
         # Minimize to tray
         if (
-            not DARWIN
-            and event.type() == QtCore.QEvent.WindowStateChange
-            and self.window().isMinimized()
-            and get_gui_setting(self.gui_settings, "minimize_to_tray", False, is_bool=True)
+                not DARWIN
+                and event.type() == QtCore.QEvent.WindowStateChange
+                and self.window().isMinimized()
+                and get_gui_setting(self.gui_settings, "minimize_to_tray", False, is_bool=True)
         ):
             self.window().hide()
             return True
@@ -1275,3 +1293,12 @@ class TriblerWindow(QMainWindow):
     def keyPressEvent(self, event: QKeyEvent) -> None:
         if event.key() == Qt.Key_Escape:
             self.escape_pressed.emit()
+
+    def restore_from_minimised(self):
+        self.setWindowState(self.windowState() & ~Qt.WindowMinimized)
+        self.raise_()
+
+    def handle_uri(self, uri):
+        self.pending_uri_requests.append(uri)
+        if self.tribler_started and not self.start_download_dialog_active:
+            self.process_uri_request()


### PR DESCRIPTION
This is a PR with refactoring requested by @kozlovsky in #6829