### PR TITLE
Improve the EVA protocol: devos50 edition

### DIFF
--- a/src/tribler/core/components/ipv8/eva_protocol.py
+++ b/src/tribler/core/components/ipv8/eva_protocol.py
@@ -1,41 +1,48 @@
-# EVA protocol: a protocol for transferring big binary data over ipv8.
-#
-# Limitations and other useful information described in the corresponding class.
-# Example of use:
-#
-# class MyCommunity(EVAProtocolMixin, Community):
-#     community_id = os.urandom(20)
-#
-#     def __init__(self, *args, **kwargs):
-#         super().__init__(*args, **kwargs)
-#         self.eva_init()
-#
-#         self.eva_register_receive_callback(self.on_receive)
-#         self.eva_register_send_complete_callback(self.on_send_complete)
-#         self.eva_register_error_callback(self.on_error)
-#
-#     def my_function(self, peer):
-#         self.eva_send_binary(peer, b'info1', b'data1')
-#         self.eva_send_binary(peer, b'info2', b'data2')
-#         self.eva_send_binary(peer, b'info3', b'data3')
-#
-#     def on_receive(self, peer, binary_info, binary_data, nonce):
-#         logger.info(f'Data has been received: {binary_info}')
-#
-#     def on_send_complete(self, peer, binary_info, binary_data, nonce):
-#         logger.info(f'Transfer has been completed: {binary_info}')
-#
-#     def on_error(self, peer, exception):
-#         logger.error(f'Error has been occurred: {exception}')
+"""EVA protocol: a protocol for transferring big binary data over ipv8.
 
+    Limitations and other useful information described in the corresponding class.
+    An example of use:
+
+    >>> import os
+    >>> from ipv8.community import Community
+    >>> class MyCommunity(EVAProtocolMixin, Community):
+    ...     community_id = os.urandom(20)
+    ...
+    >>>     def __init__(self, *args, **kwargs):
+    ...         super().__init__(*args, **kwargs)
+    ...         self.eva_init()
+    ...
+    ...         self.eva.register_receive_callback(self.on_receive)
+    ...         self.eva.register_send_complete_callback(self.on_send_complete)
+    ...         self.eva.register_error_callback(self.on_error)
+    ...
+    >>>     async def my_function(self, peer):
+    ...         await self.eva.send_binary(peer, b'info1', b'data1')
+    ...         await self.eva.send_binary(peer, b'info2', b'data2')
+    ...         await self.eva.send_binary(peer, b'info3', b'data3')
+    ...
+    >>>     async def on_receive(self, result):
+    ...         self.logger.info(f'Data has been received: {result}')
+    ...
+    >>>     async def on_send_complete(self, result):
+    ...         self.logger.info(f'Transfer has been completed: {result}')
+    ...
+    >>>     async def on_error(self, peer, exception):
+    ...         self.logger.error(f'Error has been occurred: {exception}')
+
+"""
+__version__ = '2.0.0'
+
+import asyncio
 import logging
 import math
 import time
+from asyncio import Future
 from collections import defaultdict, deque
+from dataclasses import dataclass
 from enum import Enum, auto
 from random import randint
-from types import SimpleNamespace
-from typing import Dict, Optional
+from typing import Awaitable, Callable, Dict, Optional, Type
 
 from ipv8.lazy_community import lazy_wrapper
 from ipv8.messaging.lazy_payload import VariablePayload, vp_compile
@@ -46,12 +53,10 @@ logger = logging.getLogger('EVA')
 MAX_U64 = 0xFFFFFFFF
 
 
-# fmt: off
-
 @vp_compile
 class WriteRequest(VariablePayload):
     format_list = ['I', 'I', 'raw']
-    names = ['data_size', 'nonce', 'info_binary']
+    names = ['data_size', 'nonce', 'info']
 
 
 @vp_compile
@@ -63,73 +68,36 @@ class Acknowledgement(VariablePayload):
 @vp_compile
 class Data(VariablePayload):
     format_list = ['I', 'I', 'raw']
-    names = ['block_number', 'nonce', 'data_binary']
+    names = ['block_number', 'nonce', 'data']
 
 
 @vp_compile
 class Error(VariablePayload):
-    format_list = ['raw']
-    names = ['message']
+    format_list = ['I', 'raw']
+    names = ['nonce', 'message']
 
 
 class EVAProtocolMixin:
     """This mixin makes it possible to transfer big binary data over ipv8.
 
-    The protocol based on TFTP with windowsize (RFC 7440).
-    Features:
-        * timeout
-        * retransmit
-        * dynamic window size
+        The protocol based on TFTP with windowsize (RFC 7440).
+        Features:
+            * timeout
+            * retransmit
+            * dynamic window size
 
-    The maximum data size that can be transferred through the protocol can be
-    calculated as "block_size * 4294967295" where 4294967295 is the max segment
-    number (4B unsigned int).
+        The maximum data size that can be transferred through the protocol can be
+        calculated as "block_size * 4294967295" where 4294967295 is the max segment
+        number (4B unsigned int).
     """
 
-    def eva_init(  # pylint: disable=too-many-arguments
-            self,
-            block_size=1000,
-            window_size_in_blocks=16,
-            start_message_id=186,
-            retransmit_interval_in_sec=3,
-            retransmit_attempt_count=3,
-            timeout_interval_in_sec=10,
-            binary_size_limit=1024 * 1024 * 1024,
-            terminate_by_timeout_enabled=True
-    ):
+    def eva_init(self, start_message_id: int = 186, **kwargs):
         """Init should be called manually within his parent class.
-
-        Args:
-            block_size: a single block size in bytes. Please keep in mind that
-                ipv8 adds approx. 177 bytes to each packet.
-            window_size_in_blocks: size of consecutive blocks to send
-            start_message_id: a started id that will be used to assigning
-                protocol's messages ids
-            retransmit_interval_in_sec: an interval until the next attempt
-                to retransmit will be made
-            retransmit_attempt_count: a limit for retransmit attempts
-            timeout_interval_in_sec: an interval after which the transfer will
-                be considered as "dead" and will be terminated
-            binary_size_limit: limit for binary data size. If this limit will be
-                exceeded, the exception will be returned through a registered
-                error handler
-            terminate_by_timeout_enabled: the flag indicating is termination-by-timeout
-                mechanism enabled or not
+        For the arguments description see `EVAProtocol` class.
         """
+        self.eva = EVAProtocol(community=self, **kwargs)
         self.last_message_id = start_message_id
-        self.eva_messages = dict()
-
-        self.eva_protocol = EVAProtocol(
-            community=self,
-            block_size=block_size,
-            window_size_in_blocks=window_size_in_blocks,
-            retransmit_interval_in_sec=retransmit_interval_in_sec,
-            retransmit_attempt_count=retransmit_attempt_count,
-            scheduled_send_interval_in_sec=5,
-            timeout_interval_in_sec=timeout_interval_in_sec,
-            binary_size_limit=binary_size_limit,
-            terminate_by_timeout_enabled=terminate_by_timeout_enabled,
-        )
+        self.eva_messages: Dict[Type[VariablePayload], int] = {}
 
         # note:
         # The order in which _eva_register_message_handler is called defines
@@ -139,88 +107,26 @@ class EVAProtocolMixin:
         self._eva_register_message_handler(Data, self.on_eva_data)
         self._eva_register_message_handler(Error, self.on_eva_error)
 
-    def eva_send_binary(self, peer, info_binary, data_binary, nonce=None):
-        """Send a big binary data.
-
-        Due to ipv8 specifics, we can use only one socket port per one peer.
-        Therefore, at one point in time, the protocol can only transmit one particular
-        piece of data for one particular peer.
-
-        In case "eva_send_binary" is invoked multiply times for a single peer, the data
-        transfer will be scheduled and performed when the current sending session is finished.
-
-        An example:
-
-        self.eva_send_binary(peer, b'binary_data0', b'binary_info0')
-        self.eva_send_binary(peer, b'binary_data1', b'binary_info1')
-        self.eva_send_binary(peer, b'binary_data2', b'binary_info2')
-
-        Args:
-            peer: the target peer
-            info_binary: a binary info, limited by <block_size> bytes
-            data_binary: binary data that will be sent to the target.
-                It is limited by several GB, but the protocol is slow by design, so
-                try to send less rather than more.
-            nonce: a unique number for identifying the session. If not specified, generated randomly
-        """
-        self.eva_protocol.send_binary(peer, info_binary, data_binary, nonce)
-
-    def eva_register_receive_callback(self, callback):
-        """Register callback that will be invoked when a data receiving is complete.
-
-        An example:
-
-        def on_receive(peer, info, data, nonce):
-            pass
-
-        self.eva_register_receive_callback(on_receive)
-        """
-        self.eva_protocol.receive_callbacks.add(callback)
-
-    def eva_register_send_complete_callback(self, callback):
-        """Register callback that will be invoked when a data sending is complete.
-
-        An example:
-
-        def on_send_complete(peer, info, data, nonce):
-            pass
-
-        self.eva_register_send_complete_callback(on_receive)
-        """
-        self.eva_protocol.send_complete_callbacks.add(callback)
-
-    def eva_register_error_callback(self, callback):
-        """Register callback that will be invoked in case of an error.
-
-        An example:
-
-        def on_error(self, peer, exception):
-            pass
-
-        self.eva_register_error_callback(on_error)
-        """
-        self.eva_protocol.error_callbacks.add(callback)
-
-    def eva_send_message(self, peer, message):
+    def eva_send_message(self, peer: Peer, message: VariablePayload):
         self.endpoint.send(peer.address, self.ezr_pack(self.eva_messages[type(message)], message))
 
     @lazy_wrapper(WriteRequest)
-    async def on_eva_write_request(self, peer, payload):
-        await self.eva_protocol.on_write_request(peer, payload)
+    async def on_eva_write_request(self, peer: Peer, payload: WriteRequest):
+        await self.eva.on_write_request(peer, payload)
 
     @lazy_wrapper(Acknowledgement)
-    async def on_eva_acknowledgement(self, peer, payload):
-        await self.eva_protocol.on_acknowledgement(peer, payload)
+    async def on_eva_acknowledgement(self, peer: Peer, payload: Acknowledgement):
+        await self.eva.on_acknowledgement(peer, payload)
 
     @lazy_wrapper(Data)
-    async def on_eva_data(self, peer, payload):
-        await self.eva_protocol.on_data(peer, payload)
+    async def on_eva_data(self, peer: Peer, payload: Data):
+        await self.eva.on_data(peer, payload)
 
     @lazy_wrapper(Error)
-    async def on_eva_error(self, peer, payload):
-        await self.eva_protocol.on_error(peer, payload)
+    async def on_eva_error(self, peer: Peer, payload: Error):
+        await self.eva.on_error(peer, payload)
 
-    def _eva_register_message_handler(self, message_class, handler):
+    def _eva_register_message_handler(self, message_class: Type[VariablePayload], handler: Callable):
         self.add_message_handler(self.last_message_id, handler)
         self.eva_messages[message_class] = self.last_message_id
         self.last_message_id += 1
@@ -231,32 +137,87 @@ class TransferType(Enum):
     OUTGOING = auto()
 
 
+@dataclass
+class TransferResult:
+    peer: Peer
+    info: bytes
+    data: bytes
+    nonce: int
+
+
 class Transfer:  # pylint: disable=too-many-instance-attributes
     """The class describes an incoming or an outgoing transfer"""
 
     NONE = -1
 
-    def __init__(self, transfer_type, info_binary, data_binary, nonce):
+    def __init__(self, transfer_type: TransferType, info: bytes, data: bytes, data_size: int, block_count: int,
+                 nonce: int, peer: Peer, protocol, future: Optional[Future] = None, window_size: int = 0,
+                 updated: float = 0):
         self.type = transfer_type
-        self.info_binary = info_binary
-        self.data_binary = data_binary
+        self.info = info
+        self.data = data
+        self.data_size = data_size
+        self.block_count = block_count
         self.block_number = Transfer.NONE
-        self.block_count = 0
-        self.attempt = 0
+        self.future = future
+        self.peer = peer
         self.nonce = nonce
-        self.window_size = 0
-        self.acknowledgement_number = 0
-        self.updated = time.time()
-        self.released = False
+        self.window_size = window_size
+        self.updated = updated
+        self.protocol = protocol
 
-    def release(self):
-        self.info_binary = None
-        self.data_binary = None
-        self.released = True
+        self.attempt = 0
+        self.acknowledgement_number = 0
+        self.terminated = False
+
+    def finish(self):
+        result = TransferResult(peer=self.peer, info=self.info, data=self.data, nonce=self.nonce)
+        self.terminate(result=result)
+
+    def terminate(self, result: Optional[TransferResult] = None, exception: Optional[Exception] = None):
+        if self.terminated:
+            return
+
+        logger.debug(f'Terminate. Peer: {self.peer}. Transfer: {self}')
+
+        container = self.protocol.incoming if self.type == TransferType.INCOMING else self.protocol.outgoing
+        container.pop(self.peer, None)
+
+        if result:
+            self._terminate_with_result(result)
+        if exception:
+            self._terminate_with_exception(exception)
+
+        self.info = None
+        self.data = None
+        self.peer = None
+        self.protocol = None
+        self.future = None
+
+        self.terminated = True
+
+    def _terminate_with_result(self, result: TransferResult):
+        if self.future:
+            self.future.set_result(result)
+
+        callbacks = self.protocol.receive_callbacks if self.type == TransferType.INCOMING \
+            else self.protocol.send_complete_callbacks
+
+        for callback in callbacks:
+            asyncio.create_task(callback(result))
+
+    def _terminate_with_exception(self, exception: Exception):
+        logger.warning(f'Peer hash: {self.peer}: "{exception.__class__.__name__}: {exception}".')
+
+        if self.future:
+            self.future.set_exception(exception)
+
+        for callback in self.protocol.error_callbacks:
+            asyncio.create_task(callback(self.peer, exception))
 
     def __str__(self):
         return (
-            f'Type: {self.type}. Info: {self.info_binary}. Block: {self.block_number}({self.block_count}). '
+            f'Type: {self.type}. Info: {self.info}. Block: {self.block_number}({self.block_count}). '
             f'Window size: {self.window_size}. Updated: {self.updated}'
         )
 
@@ -280,6 +241,10 @@ class ValueException(TransferException):
     pass
 
 
+class TransferLimitException(TransferException):
+    """Maximum simultaneous transfers limit exceeded"""
+
+
 class EVAProtocol:  # pylint: disable=too-many-instance-attributes
     MIN_WINDOWS_SIZE = 1
 
@@ -294,8 +259,31 @@ class EVAProtocol:  # pylint: disable=too-many-instance-attributes
             scheduled_send_interval_in_sec=5,
             timeout_interval_in_sec=10,
             binary_size_limit=1024 * 1024 * 1024,
-            terminate_by_timeout_enabled=True
+            terminate_by_timeout_enabled=True,
+            max_simultaneous_transfers=10
     ):
+        """Init should be called manually within his parent class.
+
+        Args:
+            block_size: a single block size in bytes. Please keep in mind that
+                ipv8 adds approx. 177 bytes to each packet.
+            window_size_in_blocks: size of consecutive blocks to send
+            start_message_id: a started id that will be used to assigning
+                protocol's messages ids
+            retransmit_interval_in_sec: an interval until the next attempt
+                to retransmit will be made
+            retransmit_attempt_count: a limit for retransmit attempts
+            timeout_interval_in_sec: an interval after which the transfer will
+                be considered as "dead" and will be terminated
+            binary_size_limit: limit for binary data size. If this limit will be
+                exceeded, the exception will be returned through a registered
+                error handler
+            terminate_by_timeout_enabled: the flag indicating is termination-by-timeout
+                mechanism enabled or not
+            max_simultaneous_transfers: an upper limit of simultaneously served peers.
+                The reason for introducing this parameter is to have a tool for
+                limiting socket load which could lead to packet loss.
+        """
         self.community = community
 
         self.scheduled = defaultdict(deque)
@@ -306,18 +294,18 @@ class EVAProtocol:  # pylint: disable=too-many-instance-attributes
         self.timeout_interval_in_sec = timeout_interval_in_sec
         self.scheduled_send_interval_in_sec = scheduled_send_interval_in_sec
         self.binary_size_limit = binary_size_limit
+        self.max_simultaneous_transfers = max_simultaneous_transfers
 
         self.send_complete_callbacks = set()
         self.receive_callbacks = set()
         self.error_callbacks = set()
 
-        self.incoming: Dict[Peer, Transfer] = dict()
-        self.outgoing: Dict[Peer, Transfer] = dict()
+        self.incoming: Dict[Peer, Transfer] = {}
+        self.outgoing: Dict[Peer, Transfer] = {}
 
         self.retransmit_enabled = True
         self.terminate_by_timeout_enabled = terminate_by_timeout_enabled
 
-        # register tasks
         community.register_task('scheduled send', self.send_scheduled, interval=scheduled_send_interval_in_sec)
 
         logger.debug(
@@ -328,81 +316,196 @@ class EVAProtocol:  # pylint: disable=too-many-instance-attributes
             f'Binary size limit: {binary_size_limit}.'
         )
 
-    def send_binary(self, peer, info_binary, data_binary, nonce=None):
-        if not data_binary:
-            return
+    def send_binary(self, peer: Peer, info: bytes, data: bytes, nonce: Optional[int] = None) -> Future:
+        """Send a big binary data.
+
+        Due to ipv8 specifics, we can use only one socket port per one peer.
+        Therefore, at one point in time, the protocol can only transmit one particular
+        piece of data for one particular peer.
+
+        In case "eva_send_binary" is invoked multiply times for a single peer, the data
+        transfer will be scheduled and performed when the current sending session is finished.
+
+        An example:
+        >>> from ipv8.community import Community
+        >>> class MyCommunity(EVAProtocolMixin, Community)
+        >>>     def __init__(self, *args, **kwargs):
+        ...         super().__init__(*args, **kwargs)
+        ...         self.eva_init()
+        ...
+        >>>     async def my_function(self, peer):
+        ...         await self.eva.send_binary(peer, b'binary_data0', b'binary_info0')
+        ...         await self.eva.send_binary(peer, b'binary_data1', b'binary_info1')
+        ...         await self.eva.send_binary(peer, b'binary_data2', b'binary_info2')
+
+        Args:
+            peer: the target peer
+            info: a binary info, limited by <block_size> bytes
+            data: binary data that will be sent to the target.
+                It is limited by several GB, but the protocol is slow by design, so
+                try to send less rather than more.
+            nonce: a unique number for identifying the session. If not specified, generated randomly
+        """
+        if not data:
+            raise ValueException('The empty data binary passed')
 
         if peer == self.community.my_peer:
-            return
+            raise ValueException('The receiver can not be equal to the sender')
 
-        if nonce is None:
-            nonce = randint(0, MAX_U64)
-
-        if peer in self.outgoing:
-            scheduled_transfer = SimpleNamespace(info_binary=info_binary, data_binary=data_binary, nonce=nonce)
-            self.scheduled[peer].append(scheduled_transfer)
-            return
-
-        self.start_outgoing_transfer(peer, info_binary, data_binary, nonce)
-
-    def start_outgoing_transfer(self, peer, info_binary, data_binary, nonce):
-        transfer = Transfer(TransferType.OUTGOING, info_binary, b'', nonce)
-
-        data_size = len(data_binary)
+        data_size = len(data)
         if data_size > self.binary_size_limit:
-            message = f'Current data size limit({self.binary_size_limit}) has been exceeded'
-            self._notify_error(peer, SizeException(message, transfer))
+            raise SizeException(f'Current data size limit({self.binary_size_limit}) has been exceeded')
+
+        transfer = Transfer(
+            transfer_type=TransferType.OUTGOING,
+            info=info,
+            data=data,
+            data_size=data_size,
+            block_count=math.ceil(data_size / self.block_size),
+            nonce=nonce if nonce is not None else randint(0, MAX_U64),
+            future=Future(),
+            peer=peer,
+            protocol=self
+        )
+
+        need_to_schedule = peer in self.outgoing or self._is_simultaneously_served_transfers_limit_exceeded()
+        if need_to_schedule:
+            self.scheduled[peer].append(transfer)
+            return transfer.future
+
+        self.start_outgoing_transfer(transfer)
+        return transfer.future
+
+    def register_receive_callback(self, callback: Callable[[TransferResult], Awaitable[None]]):
+        """Register callback that will be invoked when a data receiving is complete.
+
+        An example:
+        >>> import os
+        >>> from ipv8.community import Community
+        >>> class MyCommunity(EVAProtocolMixin, Community):
+        >>>     def __init__(self, *args, **kwargs):
+        ...         super().__init__(*args, **kwargs)
+        ...         self.eva_init()
+        ...         self.eva.register_receive_callback(self.on_receive)
+        ...
+        >>>     async def on_receive(self, result):
+        ...         self.logger.info(f'Data has been received: {result}')
+
+        """
+        self.receive_callbacks.add(callback)
+
+    def register_send_complete_callback(self, callback: Callable[[TransferResult], Awaitable[None]]):
+        """Register callback that will be invoked when a data sending is complete.
+
+        An example:
+        >>> import os
+        >>> from ipv8.community import Community
+        >>> class MyCommunity(EVAProtocolMixin, Community):
+        >>>     def __init__(self, *args, **kwargs):
+        ...         super().__init__(*args, **kwargs)
+        ...         self.eva_init()
+        ...         self.eva.register_send_complete_callback(self.on_send_complete)
+        ...
+        >>>     async def on_send_complete(self, result):
+        ...         self.logger.info(f'Transfer has been completed: {result}')
+
+        """
+        self.send_complete_callbacks.add(callback)
+
+    def register_error_callback(self, callback: Callable[[Peer, TransferException], Awaitable[None]]):
+        """Register callback that will be invoked in case of an error.
+
+        An example:
+
+        >>> import os
+        >>> from ipv8.community import Community
+        >>> class MyCommunity(EVAProtocolMixin, Community):
+        >>>     def __init__(self, *args, **kwargs):
+        ...         super().__init__(*args, **kwargs)
+        ...         self.eva_init()
+        ...         self.eva.register_error_callback(self.on_error)
+        ...
+        >>>     async def on_error(self, peer, exception):
+        ...         self.logger.error(f'Error has been occurred: {exception}')
+
+        """
+        self.error_callbacks.add(callback)
+
+    def start_outgoing_transfer(self, transfer: Transfer):
+        self.outgoing[transfer.peer] = transfer
+
+        self.community.register_anonymous_task('eva_terminate_by_timeout', self._terminate_by_timeout_task, transfer)
+        self.community.register_anonymous_task('eva_send_write_request', self._send_write_request_task, transfer)
+
+    def send_write_request(self, transfer: Transfer):
+        if transfer.terminated:
             return
-
-        transfer.block_count = math.ceil(data_size / self.block_size)
-        transfer.data_binary = data_binary
-
-        self.outgoing[peer] = transfer
-
-        self._schedule_terminate(self.outgoing, peer, transfer)
-
-        logger.debug(f'Write Request. Peer hash: {hash(peer)}. Transfer: {transfer}')
-        self.community.eva_send_message(peer, WriteRequest(data_size, nonce, info_binary))
+        transfer.updated = time.time()
+        write_request = WriteRequest(transfer.data_size, transfer.nonce, transfer.info)
+        logger.debug(f'Write Request. Peer: {transfer.peer}. Transfer: {transfer}')
+        self.community.eva_send_message(transfer.peer, write_request)
 
     async def on_write_request(self, peer: Peer, payload: WriteRequest):
-        logger.debug(f'On write request. Peer hash: {hash(peer)}. Info: {payload.info_binary}. '
-                     f'Size: {payload.data_size}')
+        logger.debug(f'On write request. Peer: {peer}. Info: {payload.info}. Size: {payload.data_size}')
 
-        if payload.data_size <= 0:
-            self._incoming_error(peer, None, ValueException('Data size can not be less or equal to 0'))
+        if peer in self.incoming:
             return
 
-        transfer = Transfer(TransferType.INCOMING, payload.info_binary, b'', payload.nonce)
-        transfer.window_size = self.window_size
-        transfer.attempt = 0
+        transfer = Transfer(
+            transfer_type=TransferType.INCOMING,
+            info=payload.info,
+            data=b'',
+            data_size=payload.data_size,
+            block_count=0,
+            nonce=payload.nonce,
+            future=None,
+            peer=peer,
+            window_size=self.window_size,
+            updated=time.time(),
+            protocol=self
+        )
+
+        if payload.data_size <= 0:
+            self._terminate_by_error(transfer, ValueException('Data size can not be less or equal to 0'))
+            return
+
+        if self._is_simultaneously_served_transfers_limit_exceeded():
+            exception = TransferLimitException('Maximum simultaneous transfers limit exceeded')
+            self._terminate_by_error(transfer, exception)
+            return
 
         if payload.data_size > self.binary_size_limit:
             e = SizeException(f'Current data size limit({self.binary_size_limit}) has been exceeded', transfer)
-            self._incoming_error(peer, transfer, e)
+            self._terminate_by_error(transfer, e)
             return
 
         self.incoming[peer] = transfer
 
-        self._schedule_terminate(self.incoming, peer, transfer)
-        self._schedule_resend_acknowledge(peer, transfer)
-
-        self.send_acknowledgement(peer, transfer)
+        self.community.register_anonymous_task('eva_terminate_by_timeout', self._terminate_by_timeout_task, transfer)
+        self.community.register_anonymous_task('eva_resend_acknowledge', self._resend_acknowledge_task, transfer)
+        self.send_acknowledgement(transfer)
 
     async def on_acknowledgement(self, peer: Peer, payload: Acknowledgement):
-        logger.debug(f'On acknowledgement({payload.number}). Window size: {payload.window_size}. '
-                     f'Peer hash: {hash(peer)}.')
+        logger.debug(f'On acknowledgement({payload.number}). Window size: {payload.window_size}. Peer: {peer}.')
 
-        transfer = self.outgoing.get(peer, None)
+        transfer = self.outgoing.get(peer)
         if not transfer:
+            logger.warning("No outgoing transfer found with peer %s associated with incoming ackowledgement.", peer)
             return
 
-        can_be_handled = transfer.block_number <= payload.number
-        if not can_be_handled or transfer.nonce != payload.nonce:
+        if transfer.block_number > payload.number:
+            logger.warning("Cannot handle incoming acknowledgement from peer %s - ack num mismatch (%d - %d)",
+                           peer, transfer.block_number, payload.number)
+            return
+
+        if transfer.nonce != payload.nonce:
+            logger.warning("Cannot handle incoming acknowledgement from peer %s - nonce mismatch", peer)
             return
 
         transfer.block_number = payload.number
         if transfer.block_number > transfer.block_count:
-            self.finish_outgoing_transfer(peer, transfer)
+            transfer.finish()
+            self.send_scheduled()
             return
 
         transfer.window_size = max(self.MIN_WINDOWS_SIZE, min(payload.window_size, self.binary_size_limit))
@@ -411,16 +514,15 @@ class EVAProtocol:  # pylint: disable=too-many-instance-attributes
         for block_number in range(transfer.block_number, transfer.block_number + transfer.window_size):
             start_position = block_number * self.block_size
             stop_position = start_position + self.block_size
-            data = transfer.data_binary[start_position:stop_position]
-            logger.debug(f'Transmit({block_number}). Peer hash: {hash(peer)}.')
+            data = transfer.data[start_position:stop_position]
+            logger.debug(f'Transmit({block_number}). Peer: {peer}.')
             self.community.eva_send_message(peer, Data(block_number, transfer.nonce, data))
             if len(data) == 0:
                 break
 
     async def on_data(self, peer, payload):
-        logger.debug(
-            f'On data({payload.block_number}). Peer hash: {hash(peer)}. Data hash: {hash(payload.data_binary)}')
-        transfer = self.incoming.get(peer, None)
+        logger.debug(f'On data({payload.block_number}). Peer: {peer}. Data hash: {hash(payload.data)}')
+        transfer = self.incoming.get(peer)
         if not transfer:
             return
 
@@ -430,67 +532,46 @@ class EVAProtocol:  # pylint: disable=too-many-instance-attributes
 
         transfer.block_number = payload.block_number
 
-        is_final_data_packet = len(payload.data_binary) == 0
+        is_final_data_packet = len(payload.data) == 0
         if is_final_data_packet:
-            self.send_acknowledgement(peer, transfer)
-            self.finish_incoming_transfer(peer, transfer)
+            self.send_acknowledgement(transfer)
+            transfer.finish()
+            self.send_scheduled()
             return
 
-        data_size = len(transfer.data_binary) + len(payload.data_binary)
+        data_size = len(transfer.data) + len(payload.data)
         if data_size > self.binary_size_limit:
             e = SizeException(f'Current data size limit({self.binary_size_limit}) has been exceeded', transfer)
-            self._incoming_error(peer, transfer, e)
+            self._terminate_by_error(transfer, e)
             return
 
-        transfer.data_binary += payload.data_binary
+        transfer.data += payload.data
+
         transfer.attempt = 0
         transfer.updated = time.time()
 
         time_to_acknowledge = transfer.acknowledgement_number + transfer.window_size <= transfer.block_number + 1
         if time_to_acknowledge:
-            self.send_acknowledgement(peer, transfer)
+            self.send_acknowledgement(transfer)
 
-    def send_acknowledgement(self, peer, transfer):
-        transfer.acknowledgement_number = transfer.block_number + 1
+    def send_acknowledgement(self, transfer: Transfer):
+        ack = transfer.block_number + 1
 
-        logger.debug(f'Acknowledgement ({transfer.acknowledgement_number}). Window size: {transfer.window_size}. '
-                     f'Peer hash: {hash(peer)}')
+        transfer.acknowledgement_number = ack
+        logger.debug(f'Ack ({ack}). Window size: {transfer.window_size}. Peer: {transfer.peer}')
 
-        acknowledgement = Acknowledgement(transfer.acknowledgement_number, transfer.window_size, transfer.nonce)
-        self.community.eva_send_message(peer, acknowledgement)
+        acknowledgement = Acknowledgement(ack, transfer.window_size, transfer.nonce)
+        self.community.eva_send_message(transfer.peer, acknowledgement)
 
-    async def on_error(self, peer, payload):
-        message = payload.message.decode('utf-8')
-        logger.debug(f'On error. Peer hash: {hash(peer)}. Message: "{message}"')
-        transfer = self.outgoing.get(peer, None)
-        if not transfer:
+    async def on_error(self, peer: Peer, error: Error):
+        message = error.message.decode('utf-8')
+        logger.debug(f'On error. Peer: {peer}. Message: "{message}"')
+
+        transfer = self.outgoing.get(peer)
+        if not transfer or transfer.nonce != error.nonce:
             return
 
-        EVAProtocol.terminate(self.outgoing, peer, transfer)
-
-        self._notify_error(peer, TransferException(message, transfer))
-        self.send_scheduled()
-
-    def finish_incoming_transfer(self, peer, transfer):
-        data = transfer.data_binary
-        info = transfer.info_binary
-        nonce = transfer.nonce
-
-        EVAProtocol.terminate(self.incoming, peer, transfer)
-
-        for callback in self.receive_callbacks:
-            callback(peer, info, data, nonce)
-
-    def finish_outgoing_transfer(self, peer, transfer):
-        data = transfer.data_binary
-        info = transfer.info_binary
-        nonce = transfer.nonce
-
-        EVAProtocol.terminate(self.outgoing, peer, transfer)
-
-        for callback in self.send_complete_callbacks:
-            callback(peer, info, data, nonce)
-
+        transfer.terminate(exception=TransferException(message, transfer))
         self.send_scheduled()
 
     def send_scheduled(self):
@@ -503,76 +584,77 @@ class EVAProtocol:  # pylint: disable=too-many-instance-attributes
                 self.scheduled.pop(peer, None)
                 continue
 
+            if self._is_simultaneously_served_transfers_limit_exceeded():
+                break
+
             transfer = self.scheduled[peer].popleft()
 
-            logger.debug(f'Scheduled send: {transfer.info_binary}')
-            self.start_outgoing_transfer(peer, transfer.info_binary, transfer.data_binary, transfer.nonce)
+            logger.debug(f'Scheduled send: {transfer}')
+            self.start_outgoing_transfer(transfer)
 
-    @staticmethod
-    def terminate(container, peer, transfer):
-        logger.debug(f'Finish. Peer hash: {hash(peer)}. Transfer: {transfer}')
+    def shutdown(self):
+        """ This method terminates all current transfers
+        """
+        logger.info('Shutting down...')
+        transfers = list(self.incoming.values()) + list(self.outgoing.values())
+        for transfer in transfers:
+            transfer.terminate(exception=TransferException('Terminated due to shutdown'))
+        logger.info('Shutting down completed')
 
-        transfer.release()
-        container.pop(peer, None)
+    def _terminate_by_error(self, transfer: Transfer, exception: TransferException):
+        self.community.eva_send_message(transfer.peer, Error(transfer.nonce, exception.message.encode('utf-8')))
+        transfer.terminate(exception=exception)
 
-    def _incoming_error(self, peer: Peer, transfer: Optional[Transfer], e: TransferException):
-        if transfer:
-            self.terminate(self.incoming, peer, transfer)
-        self.community.eva_send_message(peer, Error(e.message.encode('utf-8')))
-        self._notify_error(peer, e)
+    async def _terminate_by_timeout_task(self, transfer: Transfer):
+        remaining_time = self.timeout_interval_in_sec
 
-    def _notify_error(self, peer, exception):
-        logger.warning(f'Exception.Peer hash {hash(peer)}: "{exception}"')
+        while self.terminate_by_timeout_enabled:
+            await asyncio.sleep(remaining_time)
+            if transfer.terminated:
+                return
 
-        for callback in self.error_callbacks:
-            callback(peer, exception)
+            remaining_time = self.timeout_interval_in_sec - (time.time() - transfer.updated)
+            if remaining_time <= 0:  # it is time to terminate
+                exception = TimeoutException('Terminated by timeout', transfer)
+                transfer.terminate(exception=exception)
+                return
 
-    def _schedule_terminate(self, container, peer, transfer):
-        if not self.terminate_by_timeout_enabled:
-            return
+    async def _resend_acknowledge_task(self, transfer: Transfer):
+        remaining_time = self.retransmit_interval_in_sec
 
-        self.community.register_anonymous_task('eva_terminate_by_timeout', self._terminate_by_timout_task, container,
-                                               peer, transfer, delay=self.timeout_interval_in_sec, )
+        while self.retransmit_enabled:
+            await asyncio.sleep(remaining_time)
 
-    def _terminate_by_timout_task(self, container, peer, transfer):
-        if transfer.released or not self.terminate_by_timeout_enabled:
-            return
+            attempts_are_over = transfer.attempt >= self.retransmit_attempt_count
+            if attempts_are_over or transfer.terminated:
+                return
 
-        timeout = self.timeout_interval_in_sec
-        remaining_time = timeout - (time.time() - transfer.updated)
+            remaining_time = self.retransmit_interval_in_sec - (time.time() - transfer.updated)
+            if remaining_time <= 0:  # it is time to retransmit
+                transfer.attempt += 1
+                remaining_time = self.retransmit_interval_in_sec
 
-        if remaining_time > 0:
-            self.community.register_anonymous_task('eva_terminate_by_timeout', self._terminate_by_timout_task,
-                                                   container, peer, transfer, delay=remaining_time, )
-            return
+                current_attempt = f'{transfer.attempt + 1}/{self.retransmit_attempt_count}'
+                logger.debug(f'Re-ack ({transfer.acknowledgement_number}). '
+                             f'Attempt: {current_attempt} for peer: {transfer.peer}')
 
-        EVAProtocol.terminate(container, peer, transfer)
-        self._notify_error(peer, TimeoutException(f'Terminated by timeout. Timeout is: {timeout} sec', transfer))
+                self.send_acknowledgement(transfer)
 
-    def _schedule_resend_acknowledge(self, peer, transfer):
+    async def _send_write_request_task(self, transfer: Transfer):
+        self.send_write_request(transfer)
+
         if not self.retransmit_enabled:
             return
 
-        self.community.register_anonymous_task('eva_resend_acknowledge', self._resend_acknowledge_task,
-                                               peer, transfer, delay=self.retransmit_interval_in_sec, )
+        for attempt in range(self.retransmit_attempt_count):
+            await asyncio.sleep(self.retransmit_interval_in_sec)
 
-    def _resend_acknowledge_task(self, peer, transfer):
-        if transfer.released or not self.retransmit_enabled:
-            return
+            if transfer.terminated or transfer.block_number != Transfer.NONE:
+                return
+            current_attempt = f'{attempt + 1}/{self.retransmit_attempt_count}'
+            logger.debug(f'Re-write request. Attempt: {current_attempt} for peer: {transfer.peer}')
+            self.send_write_request(transfer)
 
-        attempts_are_over = transfer.attempt >= self.retransmit_attempt_count
-        if attempts_are_over:
-            return
-
-        resend_needed = time.time() - transfer.updated >= self.retransmit_interval_in_sec
-        if resend_needed:
-            transfer.acknowledgement_number = transfer.block_number + 1
-            transfer.attempt += 1
-
-            logger.debug(f'Re-acknowledgement({transfer.acknowledgement_number}). '
-                         f'Attempt: {transfer.attempt + 1}/{self.retransmit_attempt_count} for peer: {hash(peer)}')
-
-            self.send_acknowledgement(peer, transfer)
-
-        self.community.register_anonymous_task('eva_resend_acknowledge', self._resend_acknowledge_task, peer,
-                                               transfer, delay=self.retransmit_interval_in_sec, )
+    def _is_simultaneously_served_transfers_limit_exceeded(self) -> bool:
+        transfers_count = len(self.incoming) + len(self.outgoing)
+        return transfers_count >= self.max_simultaneous_transfers

--- a/src/tribler/core/components/ipv8/tests/test_eva_protocol.py
+++ b/src/tribler/core/components/ipv8/tests/test_eva_protocol.py
@@ -1,33 +1,34 @@
 import asyncio
+import collections
 import logging
 import os
 import random
+from asyncio import AbstractEventLoop
 from collections import defaultdict
 from itertools import permutations
 from types import SimpleNamespace
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from ipv8.community import Community
+from ipv8.messaging.lazy_payload import VariablePayload
 from ipv8.test.base import TestBase
 
 from tribler.core.components.ipv8.eva_protocol import (
     Acknowledgement,
-    EVAProtocol,
+    Data, EVAProtocol,
     EVAProtocolMixin,
-    Error,
-    SizeException,
+    Error, SizeException,
     TimeoutException,
-    Transfer,
-    TransferException,
-    TransferType,
+    Transfer, TransferException,
+    TransferLimitException,
+    TransferResult,
+    TransferType, ValueException,
     WriteRequest,
 )
 
-# fmt: off
-# pylint: disable=redefined-outer-name
+# pylint: disable=redefined-outer-name, protected-access, attribute-defined-outside-init
 
-PYTEST_TIMEOUT_IN_SEC = 60
 
 TEST_DEFAULT_TERMINATE_INTERVAL_IN_SEC = 0.2
 TEST_DEFAULT_RETRANSMIT_INTERVAL_IN_SEC = 0.1
@@ -35,14 +36,7 @@ TEST_DEFAULT_SEGMENT_SIZE = 1200
 TEST_START_MESSAGE_ID = 100
 
 
-def create_transfer(block_count: int = 0, updated: int = 0) -> Transfer:
-    transfer = Transfer(TransferType.INCOMING, b'', b'', 0)
-    transfer.updated = updated
-    transfer.block_count = block_count
-    return transfer
-
-
-async def drain_loop(loop):
+async def drain_loop(loop: AbstractEventLoop):
     """Cool asyncio magic brewed by Vadim"""
     while True:
         if not loop._ready or not loop._scheduled:  # pylint: disable=protected-access
@@ -58,6 +52,8 @@ class MockCommunity(EVAProtocolMixin, Community):  # pylint: disable=too-many-an
         self.received_data = defaultdict(lambda: [])
         self.sent_data = defaultdict(lambda: [])
 
+        self.data_has_been_sent = asyncio.Event()
+
         self.most_recent_received_data = None
         self.most_recent_received_exception = None
         self.most_recent_sent_data = None
@@ -69,19 +65,20 @@ class MockCommunity(EVAProtocolMixin, Community):  # pylint: disable=too-many-an
             terminate_by_timeout_enabled=False  # by default disable the termination
         )
 
-        self.eva_register_receive_callback(self.on_receive)
-        self.eva_register_send_complete_callback(self.on_send_complete)
-        self.eva_register_error_callback(self.on_error)
+        self.eva.register_receive_callback(self.on_receive)
+        self.eva.register_send_complete_callback(self.on_send_complete)
+        self.eva.register_error_callback(self.on_error)
 
-    def on_receive(self, peer, info, data, nonce):
-        self.most_recent_received_data = info, data, nonce
-        self.received_data[peer].append(self.most_recent_received_data)
+    async def on_receive(self, result: TransferResult):
+        self.most_recent_received_data = result.info, result.data, result.nonce
+        self.received_data[result.peer].append(self.most_recent_received_data)
 
-    def on_send_complete(self, peer, info, data, nonce):
-        self.most_recent_sent_data = info, data, nonce
-        self.sent_data[peer].append(self.most_recent_sent_data)
+    async def on_send_complete(self, result: TransferResult):
+        self.most_recent_sent_data = result.info, result.data, result.nonce
+        self.sent_data[result.peer].append(self.most_recent_sent_data)
+        self.data_has_been_sent.set()
 
-    def on_error(self, peer, exception):
+    async def on_error(self, _, exception):
         self.most_recent_received_exception = exception
 
 
@@ -92,285 +89,334 @@ class TestEVA(TestBase):
 
         self.test_store = SimpleNamespace()
 
-    async def test_one_chunk_binary(self):
-        self.overlay(0).eva_send_binary(self.peer(1), b'test1', b'1234', 42)
+    @property
+    def alice(self) -> MockCommunity:
+        return self.overlay(0)
 
-        await drain_loop(asyncio.get_event_loop())
+    @property
+    def bob(self) -> MockCommunity:
+        return self.overlay(1)
 
-        assert self.overlay(1).most_recent_received_data == (b'test1', b'1234', 42)
-        assert len(self.overlay(0).sent_data[self.peer(1)]) == 1
-        assert len(self.overlay(1).received_data[self.peer(0)]) == 1
+    @property
+    def carol(self) -> MockCommunity:
+        return self.overlay(2)
+
+    async def send_sequence_from_alice_to_bob(self, *sequence: VariablePayload):
+        for message in sequence:
+            self.alice.eva_send_message(self.bob.my_peer, message)
+            await drain_loop(asyncio.get_event_loop())
+
+    async def test_one_block_binary(self):
+        # In this test we send a single transfer from Alice to Bob.
+        # The transfer size is less than and `block_size` and therefore it
+        # could be send as a single packet.
+        data = (b'test1', b'1234', 42)
+
+        await self.alice.eva.send_binary(self.bob.my_peer, *data)
+
+        assert self.bob.most_recent_received_data == data
+
+        await self.alice.data_has_been_sent.wait()
+        assert self.alice.most_recent_sent_data == data
 
     async def test_self_send(self):
-        self.overlay(0).eva_send_binary(self.peer(0), b'test1', b'1234')
+        # In this test we send a single transfer from Alice to Alice.
+        # `ValueException` should be raised.
+        with pytest.raises(ValueException):
+            await self.alice.eva.send_binary(self.alice.my_peer, b'test1', b'1234')
 
-        await drain_loop(asyncio.get_event_loop())
-
-        assert not self.overlay(0).most_recent_received_data
-        assert len(self.overlay(0).sent_data[self.peer(1)]) == 0
-
-    async def test_two_chunk_binary(self):
+    async def test_two_blocks_binary(self):
+        # In this test we send a single transfer from Alice to Bob.
+        # The transfer size is equal to and `block_size * 2` and therefore it
+        # could be send as a two packets.
         data = b'test2', b'4321', 42
-        self.overlay(0).block_size = 2
-        self.overlay(0).eva_send_binary(self.peer(1), *data)
+        self.alice.block_size = 2
+        await self.alice.eva.send_binary(self.bob.my_peer, *data)
+        assert self.bob.most_recent_received_data == data
 
-        await drain_loop(asyncio.get_event_loop())
-
-        assert self.overlay(1).most_recent_received_data == data
-        assert len(self.overlay(0).sent_data[self.peer(1)]) == 1
-        assert len(self.overlay(1).received_data[self.peer(0)]) == 1
+        await self.alice.data_has_been_sent.wait()
+        assert self.alice.most_recent_sent_data == data
 
     async def test_zero_transfer(self):
-        self.overlay(0).eva_send_binary(self.peer(1), b'', b'')
-
-        await drain_loop(asyncio.get_event_loop())
-
-        assert self.overlay(1).most_recent_received_data is None
-        assert len(self.overlay(0).eva_protocol.outgoing) == 0
-        assert len(self.overlay(1).eva_protocol.incoming) == 0
-
-        assert len(self.overlay(0).sent_data[self.peer(1)]) == 0
-        assert len(self.overlay(1).received_data[self.peer(0)]) == 0
+        # In this test we send a single transfer from Alice to Bob.
+        # The transfer size is equal to zero and the transfer attempt should
+        # lead to `ValueException`.
+        with pytest.raises(ValueException):
+            await self.alice.eva.send_binary(self.bob.my_peer, b'', b'')
 
     async def test_one_megabyte_transfer(self):
+        # In this test we send `1Mb` transfer from Alice to Bob.
         data_size = 1024 * 1024
         data = os.urandom(1), os.urandom(data_size), random.randrange(0, 256)
 
-        self.overlay(0).eva_send_binary(self.peer(1), *data)
+        await self.alice.eva.send_binary(self.bob.my_peer, *data)
 
-        await drain_loop(asyncio.get_event_loop())
+        assert self.bob.most_recent_received_data == data
 
-        assert len(self.overlay(1).most_recent_received_data[1]) == data_size
-        assert self.overlay(1).most_recent_received_data == data
+        await self.alice.data_has_been_sent.wait()
+        assert self.alice.most_recent_sent_data == data
 
     async def test_termination_by_timeout(self):
-        self.overlay(0).eva_protocol.terminate_by_timeout_enabled = True
-        self.overlay(1).eva_protocol.terminate_by_timeout_enabled = True
+        # In this test we send a single transfer from Alice to Bob.
+        # To invoke a termination by timeout we should do the following:
+        # 1. Set Alice's `timeout == TEST_DEFAULT_TERMINATE_INTERVAL_IN_SEC`
+        # 2. Set Bob's `timeout == TEST_DEFAULT_TERMINATE_INTERVAL_IN_SEC / 2`
+        # 3. On Bob's instance we should replace `on_data` function by AsyncMock().
+        #
+        # After a failed sending attempt from Alice to Bob we should see that both
+        # instances had terminated their transfers by timeout.
+        for participant in [self.alice, self.bob]:
+            participant.eva.terminate_by_timeout_enabled = True
 
-        # breaks "on_data" function in community2 to make this community silent
+        self.bob.eva.timeout_interval_in_sec = TEST_DEFAULT_TERMINATE_INTERVAL_IN_SEC / 2
 
-        self.overlay(0).eva_protocol.window_size = 10
-        self.overlay(1).eva_protocol.window_size = 20
+        # replace `on_data` function to make this community silent
+        self.bob.eva.on_data = AsyncMock()
 
-        async def void(*_):
-            await asyncio.sleep(0)
+        with pytest.raises(TimeoutException):
+            await self.alice.eva.send_binary(self.bob.my_peer, b'info', b'data')
 
-        self.overlay(1).eva_protocol.on_data = void
+        assert len(self.alice.eva.outgoing) == 0
+        assert len(self.bob.eva.incoming) == 0
 
-        self.overlay(0).eva_send_binary(self.peer(1), b'info', b'data')
+        assert isinstance(self.bob.most_recent_received_exception, TimeoutException)
 
-        await self.deliver_messages(timeout=TEST_DEFAULT_TERMINATE_INTERVAL_IN_SEC * 3)
+    async def test_retransmit_enabled(self):
+        # In this test we send a single transfer from Alice to Bob.
+        # To invoke retransmit by timeout feature we should:
+        # 1. Replace `send_acknowledgement` by Mock() on Bob's instance
+        #
+        # EVA should make `retransmit_attempt_count + 1` failed attempts to
+        # send an acknowledgement.
 
-        assert len(self.overlay(1).eva_protocol.incoming) == 0
-        assert isinstance(self.overlay(1).most_recent_received_exception, TimeoutException)
+        self.alice.eva.terminate_by_timeout_enabled = True
+        self.bob.eva.retransmit_interval_in_sec = 0
 
-        await self.deliver_messages(timeout=TEST_DEFAULT_TERMINATE_INTERVAL_IN_SEC * 3)
+        self.bob.eva.send_acknowledgement = Mock()
 
-        assert len(self.overlay(0).eva_protocol.outgoing) == 0
-        assert isinstance(self.overlay(0).most_recent_received_exception, TimeoutException)
+        with pytest.raises(TimeoutException):
+            await self.alice.eva.send_binary(self.bob.my_peer, b'info', b'data')
 
-    async def test_retransmit(self):
-        attempts = 2
-
-        self.overlay(0).eva_protocol.retransmit_interval_in_sec = 0
-        self.overlay(1).eva_protocol.retransmit_interval_in_sec = 0
-        self.overlay(1).eva_protocol.retransmit_attempt_count = attempts
-
-        # breaks "acknowledgement" function in community0 to make this community silent
-        async def void(*_):
-            await asyncio.sleep(0)
-
-        self.overlay(0).eva_protocol.on_acknowledgement = void
-
-        self.overlay(0).eva_send_binary(self.peer(1), b'info', b'data')
-        await drain_loop(asyncio.get_event_loop())
-
-        assert len(self.overlay(0).eva_protocol.outgoing) == 1
-        assert len(self.overlay(1).eva_protocol.incoming) == 1
-
-        assert self.overlay(1).eva_protocol.incoming[self.peer(0)].attempt == attempts
+        expected = self.bob.eva.retransmit_attempt_count + 1
+        assert self.bob.eva.send_acknowledgement.call_count == expected
 
     async def test_retransmit_disabled(self):
-        self.overlay(0).eva_protocol.retransmit_enabled = False
-        self.overlay(1).eva_protocol.retransmit_enabled = False
-        self.overlay(0).eva_protocol.retransmit_interval_in_sec = 0
-        self.overlay(1).eva_protocol.retransmit_interval_in_sec = 0
+        # In this test we send a single transfer from Alice to Bob.
+        # To test disabled retransmit feature we should:
+        # 1. Replace `send_acknowledgement` by Mock() on Bob's side
+        # 2. Disable the retransmit feature on Bob's side
+        #
+        # Bob should make a single attempt to send an acknowledgement.
 
-        # breaks "acknowledgement" function in community0 to make this community silent
-        async def void(*_):
-            await asyncio.sleep(0)
+        self.alice.eva.terminate_by_timeout_enabled = True
+        self.bob.eva.retransmit_enabled = False
 
-        self.overlay(0).eva_protocol.on_acknowledgement = void
+        self.bob.eva.send_acknowledgement = Mock()
 
-        self.overlay(0).eva_send_binary(self.peer(1), b'info', b'data')
-        await drain_loop(asyncio.get_event_loop())
+        with pytest.raises(TimeoutException):
+            await self.alice.eva.send_binary(self.bob.my_peer, b'info', b'data')
 
-        assert len(self.overlay(0).eva_protocol.outgoing) == 1
-        assert len(self.overlay(1).eva_protocol.incoming) == 1
-
-        assert self.overlay(1).eva_protocol.incoming[self.peer(0)].attempt == 0
+        assert self.bob.eva.send_acknowledgement.call_count == 1
 
     async def test_size_limit(self):
-        # test on a sender side
-        self.overlay(2).eva_protocol.binary_size_limit = 4
+        # In this test we send a single transfer from Alice to Bob.
+        # TransferException and SizeException should be raised in the case of
+        # exceeded binary size limit.
 
-        self.overlay(2).eva_send_binary(self.peer(0), b'info', b'12345')
+        # First, try to exceed size limit on a receiver (bob) side.
+        self.bob.eva.binary_size_limit = 4
+        with pytest.raises(TransferException):
+            await self.alice.eva.send_binary(self.bob.my_peer, b'info', b'12345')
 
-        await drain_loop(asyncio.get_event_loop())
+        # Second, try to exceed size limit on a sender (alice) side.
+        self.alice.eva.binary_size_limit = 4
+        with pytest.raises(SizeException):
+            await self.alice.eva.send_binary(self.bob.my_peer, b'info', b'12345')
 
-        assert isinstance(self.overlay(2).most_recent_received_exception, SizeException)
-        assert not self.overlay(2).eva_protocol.outgoing
-        assert not self.overlay(0).eva_protocol.incoming
-        assert len(self.overlay(0).received_data[self.peer(1)]) == 0
-        assert len(self.overlay(2).sent_data[self.peer(1)]) == 0
+    async def test_duplex_transfer(self):
+        # In this test we send a single transfer from Alice to Bob and `1 transfer
+        # from Bob to Alice at the same time.
 
-        # test on a receiver side
-        self.overlay(0).most_recent_received_exception = None
-        self.overlay(2).most_recent_received_exception = None
-
-        self.overlay(0).eva_send_binary(self.peer(2), b'info', b'54321')
-
-        await drain_loop(asyncio.get_event_loop())
-
-        assert isinstance(self.overlay(0).most_recent_received_exception, TransferException)
-        assert isinstance(self.overlay(2).most_recent_received_exception, SizeException)
-        assert not self.overlay(2).eva_protocol.incoming
-        assert not self.overlay(2).eva_protocol.outgoing
-        assert len(self.overlay(0).sent_data[self.peer(2)]) == 0
-
-    async def test_duplex(self):
-        count = 100
+        block_count = 100
         block_size = 10
 
-        self.overlay(0).eva_protocol.block_size = block_size
-        self.overlay(1).eva_protocol.block_size = block_size
+        self.alice.eva.block_size = block_size
+        self.bob.eva.block_size = block_size
 
-        data0 = os.urandom(1), os.urandom(block_size * count), random.randrange(0, 256)
-        data1 = os.urandom(1), os.urandom(block_size * count), random.randrange(0, 256)
+        alice_data = os.urandom(1), os.urandom(block_size * block_count), random.randrange(0, 256)
+        bob_data = os.urandom(1), os.urandom(block_size * block_count), random.randrange(0, 256)
 
-        self.overlay(0).eva_send_binary(self.peer(1), *data0)
-        self.overlay(1).eva_send_binary(self.peer(0), *data1)
+        alice_feature = self.alice.eva.send_binary(self.bob.my_peer, *alice_data)
+        bob_feature = self.bob.eva.send_binary(self.alice.my_peer, *bob_data)
 
         await drain_loop(asyncio.get_event_loop())
 
-        assert self.overlay(0).most_recent_received_data == data1
-        assert self.overlay(1).most_recent_received_data == data0
+        assert alice_feature.done()
+        assert bob_feature.done()
+        assert self.alice.most_recent_received_data == bob_data
+        assert self.bob.most_recent_received_data == alice_data
 
-        assert not self.overlay(0).eva_protocol.incoming
-        assert not self.overlay(0).eva_protocol.outgoing
-        assert not self.overlay(1).eva_protocol.incoming
-        assert not self.overlay(1).eva_protocol.outgoing
-        assert len(self.overlay(0).sent_data[self.peer(1)]) == 1
-        assert len(self.overlay(0).received_data[self.peer(1)]) == 1
-        assert len(self.overlay(1).sent_data[self.peer(0)]) == 1
-        assert len(self.overlay(1).received_data[self.peer(0)]) == 1
+        assert not self.alice.eva.incoming
+        assert not self.alice.eva.outgoing
+        assert not self.bob.eva.incoming
+        assert not self.bob.eva.outgoing
 
-    async def test_multiply_send(self):
+    async def test_scheduled_send(self):
+        # In this test we will send `10` transfers from Alice to Bob
+        # at the same time.
+        # `9` transfers should be scheduled by Alice and then sent one by one to Bob.
+
         data_set_count = 10
         data_size = 1024
 
-        data_list = [(os.urandom(1), os.urandom(data_size), random.randrange(0, 256)) for _ in range(data_set_count)]
-        for data in data_list:
-            self.overlay(0).eva_send_binary(self.peer(1), *data)
+        alice_data_list = [(os.urandom(1), os.urandom(data_size), random.randrange(0, 256)) for _ in
+                           range(data_set_count)]
+        futures = []
+        for data in alice_data_list:
+            futures.append(self.alice.eva.send_binary(self.bob.my_peer, *data))
+        assert len(self.alice.eva.scheduled[self.bob.my_peer]) == data_set_count - 1
 
-        await drain_loop(asyncio.get_event_loop())
+        await drain_loop(asyncio.get_event_loop())  # wait for transfer's complete
 
-        assert self.overlay(1).received_data[self.peer(0)] == data_list
-        assert not self.overlay(0).eva_protocol.scheduled
+        for future in futures:
+            assert future.done()
+
+        assert self.bob.received_data[self.alice.my_peer] == alice_data_list
+        assert not self.alice.eva.scheduled
 
     async def test_multiply_duplex(self):
+        # In this test we will send `5` transfers in the following directions
+        # at the same time:
+
+        # Alice->Bob
+        # Alice->Carol
+
+        # Bob->Alice
+        # Bob->Carol
+
+        # Carol->Alice
+        # Carol->Bob
+
         data_set_count = 5
-
-        self.overlay(2).eva_protocol.terminate_by_timeout_enabled = False
-
-        self.overlay(0).eva_protocol.block_size = 10
-        self.overlay(1).eva_protocol.block_size = 10
-        self.overlay(2).eva_protocol.block_size = 10
 
         # create 10 different data sets for each direction (0->1, 0->2, 1->0, 1->2, 2->0, 2->1)
         participants = [
-            (self.peer(0), self.overlay(0)),
-            (self.peer(1), self.overlay(1)),
-            (self.peer(2), self.overlay(2)),
+            (self.alice.my_peer, self.alice),
+            (self.bob.my_peer, self.bob),
+            (self.carol.my_peer, self.carol),
         ]
+
+        for _, community in participants:
+            community.eva.block_size = 10
 
         data = [
             (p, list((os.urandom(1), os.urandom(50), random.randrange(0, 256)) for _ in range(data_set_count)))
             for p in permutations(participants, 2)
         ]
 
+        futures = []
         for ((_, community), (peer, _)), data_set in data:
             for d in data_set:
-                community.eva_send_binary(peer, *d)
+                futures.append(community.eva.send_binary(peer, *d))
 
         await drain_loop(asyncio.get_event_loop())
 
-        assert len(self.overlay(0).received_data) == 2
-        assert len(self.overlay(1).received_data) == 2
-        assert len(self.overlay(2).received_data) == 2
+        for _, community in participants:
+            assert len(community.received_data) == 2
 
         data_sets_checked = 0
         for ((peer, _), (_, community)), data_set in data:
             assert community.received_data[peer] == data_set
             data_sets_checked += 1
 
-        assert data_sets_checked == 6
+        assert data_sets_checked == len(data)
 
     async def test_survive_when_multiply_packets_lost(self):
-        self.overlay(0).eva_protocol.retransmit_interval_in_sec = 0
-        self.overlay(1).eva_protocol.retransmit_interval_in_sec = 0
-
+        # In this test we send `3` transfers from Alice to Bob.
+        # On bob's side we replace `on_data` function by `fake_on_data` in
+        # which some packets will be ignored (dropped).
+        # The EVA protocol should handle this situation by retransmitting
+        # dropped packets.
         lost_packets_count_estimation = 5
         data_set_count = 3
 
         block_count = 15
         block_size = 3
-        window_size = 10
 
         packet_loss_probability = lost_packets_count_estimation / (block_count * data_set_count)
 
-        self.overlay(0).eva_protocol.block_size = block_size
-        self.overlay(1).eva_protocol.window_size = window_size
+        self.bob.eva.retransmit_attempt_count = lost_packets_count_estimation
 
-        self.overlay(1).eva_protocol.retransmit_attempt_count = lost_packets_count_estimation
+        for participant in [self.alice, self.bob]:
+            participant.eva.retransmit_interval_in_sec = 0
+            participant.eva.block_size = 3
+            participant.eva.window_size = 10
 
         data = [(os.urandom(1), os.urandom(block_size * block_count), 0) for _ in range(data_set_count)]
 
-        real_on_data1 = self.overlay(1).eva_protocol.on_data
-
-        # store for the fake function
+        # a storage for the fake function
         self.test_store.actual_packets_lost = 0
         self.test_store.lost_packets_count_estimation = lost_packets_count_estimation
         self.test_store.packet_loss_probability = packet_loss_probability
 
         # modify "on_data" function to proxying all calls and to add a probability
         # to a packet loss
-        async def fake_on_data1(peer, payload):
+        bob_on_data = self.bob.eva.on_data
+
+        async def fake_bob_on_data(peer, payload):
             chance_to_fake = random.random() < self.test_store.packet_loss_probability
-            is_last_packet = len(payload.data_binary) == 0
+            is_last_packet = len(payload.data) == 0
             max_count_reached = self.test_store.actual_packets_lost >= self.test_store.lost_packets_count_estimation
 
             if chance_to_fake and not max_count_reached and not is_last_packet:
                 self.test_store.actual_packets_lost += 1
                 return
 
-            await real_on_data1(peer, payload)
+            await bob_on_data(peer, payload)
 
-        self.overlay(1).eva_protocol.on_data = fake_on_data1
+        self.bob.eva.on_data = fake_bob_on_data
 
         for d in data:
-            self.overlay(0).eva_send_binary(self.peer(1), *d)
-
-        await drain_loop(asyncio.get_event_loop())
+            await self.alice.eva.send_binary(self.bob.my_peer, *d)
 
         logging.info(f'Estimated packet lost block_count/probability: '
                      f'{lost_packets_count_estimation}/{packet_loss_probability}')
         logging.info(f'Actual packet lost: {self.test_store.actual_packets_lost}')
+        assert self.bob.received_data[self.alice.my_peer] == data
+        assert self.test_store.actual_packets_lost > 0
 
-        assert len(self.overlay(1).received_data[self.peer(0)]) == data_set_count
-        assert self.overlay(1).received_data[self.peer(0)] == data
+    async def test_write_request_packets_lost(self):
+        # In this test we send a single transfer from Alice to Bob.
+        # On Alice's side we replace `send_write_request` function by
+        # `fake_send_write_request` in which first `2` packets will be dropped.
+        # The EVA protocol should handle this situation by retransmitting
+        # dropped packets.
+
+        self.alice.eva.retransmit_interval_in_sec = 0
+        self.lost_packet_count = 2
+
+        # replace `real_send_writerequest` function by `fake_write_request` which
+        # ignores (drops) first `lost_packet_count` messages
+        alice_send_write_request = self.alice.eva.send_write_request
+
+        def fake_write_request(transfer):
+            self.lost_packet_count -= 1
+            if self.lost_packet_count < 0:
+                alice_send_write_request(transfer)
+
+        self.alice.eva.send_write_request = fake_write_request
+
+        data = b'info', b'data', 0
+        await self.alice.eva.send_binary(self.bob.my_peer, *data)
+
+        assert self.bob.most_recent_received_data == data
 
     async def test_dynamically_changed_window_size(self):
+        # In this test we send a single transfer from Alice to Bob with dynamically
+        # changed windows size.
+        # Window size changes with the following progression:
+        # 5, 4, 3, 2, 1, 3, 5, ..., N
+
         window_size = 5
 
         self.test_store.window_size_increment = -1
@@ -378,14 +424,14 @@ class TestEVA(TestBase):
 
         block_size = 2
 
-        self.overlay(0).eva_protocol.block_size = block_size
-        self.overlay(1).eva_protocol.window_size = window_size
+        self.alice.eva.block_size = block_size
+        self.bob.eva.window_size = window_size
 
         data = os.urandom(1), os.urandom(block_size * 100), 42
 
-        real_on_send_acknowledgement1 = self.overlay(1).eva_protocol.send_acknowledgement
+        bob_send_acknowledgement = self.bob.eva.send_acknowledgement
 
-        def fake_eva_send_acknowledgement1(peer, transfer):
+        def bob_fake_send_acknowledgement(transfer):
             if transfer.window_size == 1:
                 # go up
                 self.test_store.window_size_increment = 2
@@ -393,117 +439,83 @@ class TestEVA(TestBase):
             transfer.window_size += self.test_store.window_size_increment
 
             self.test_store.actual_window_size = transfer.window_size
-            real_on_send_acknowledgement1(peer, transfer)
+            bob_send_acknowledgement(transfer)
 
-        self.overlay(1).eva_protocol.send_acknowledgement = fake_eva_send_acknowledgement1
+        self.bob.eva.send_acknowledgement = bob_fake_send_acknowledgement
 
-        self.overlay(0).eva_send_binary(self.peer(1), *data)
-        await drain_loop(asyncio.get_event_loop())
-
-        assert self.overlay(1).received_data[self.peer(0)][0] == data
+        await self.alice.eva.send_binary(self.bob.my_peer, *data)
+        assert self.bob.received_data[self.alice.my_peer][0] == data
 
     async def test_cheating_send_over_size(self):
-        self.overlay(1).eva_protocol.binary_size_limit = 4
-        acknowledgement_message_id = TEST_START_MESSAGE_ID + 1
+        # In this test we send a single transfer from Alice to Bob.
+        # Alice will try to send b`extra` binary data over the original size.
 
-        real_on_acknowledgement0 = self.overlay(0).decode_map[acknowledgement_message_id]
+        self.bob.eva.binary_size_limit = 5
 
-        def fake_on_acknowledgement0(peer, payload):
-            transfer = self.overlay(0).eva_protocol.outgoing[self.peer(1)]
-            transfer.data_binary = b'1' * 100
-            transfer.count = 100
-            return real_on_acknowledgement0(peer, payload)
+        await self.send_sequence_from_alice_to_bob(
+            WriteRequest(4, 1, b'info'),
+            Data(0, 1, b'data'),
+            Data(1, 1, b'extra')
+        )
 
-        self.overlay(0).decode_map[acknowledgement_message_id] = fake_on_acknowledgement0
+        assert isinstance(self.bob.most_recent_received_exception, SizeException)
 
-        self.overlay(0).eva_send_binary(self.peer(1), b'', b'12')
+    async def test_wrong_message_order(self):
+        # In this test we send a single transfer from Alice to Bob.
+        # Alice will try to send packets in invalid order. These packets
+        # should be dropped
 
-        await drain_loop(asyncio.get_event_loop())
+        self.bob.eva.block_size = 2
 
-        assert isinstance(self.overlay(0).most_recent_received_exception, TransferException)
-        assert isinstance(self.overlay(1).most_recent_received_exception, SizeException)
+        await self.send_sequence_from_alice_to_bob(
+            WriteRequest(4, 1, b'info'),
+            Data(0, 1, b'da'),
+            Data(2, 1, b'xx'),  # should be dropped
+            Data(1, 1, b'ta'),
+            Data(2, 1, b''),
+        )
+
+        assert self.bob.most_recent_received_data == (b'info', b'data', 1)
 
     async def test_wrong_message_order_and_wrong_nonce(self):
-        self.overlay(0).eva_protocol.retransmit_interval_in_sec = 0
-        self.overlay(1).eva_protocol.retransmit_interval_in_sec = 0
-        self.overlay(1).eva_protocol.retransmit_attempt_count = 5
+        # In this test we send a single transfer from Alice to Bob.
+        # Alice will try to send packets with invalid nonce. These packets
+        # should be dropped
 
-        data_set_count = 1
+        # In this test we send a single transfer from Alice to Bob.
+        # Alice will try to send packets in invalid order. These packets
+        # should be dropped
 
-        block_count = 20
-        block_size = 3
-        window_size = 2
+        self.bob.eva.block_size = 2
 
-        self.overlay(0).eva_protocol.block_size = block_size
-        self.overlay(1).eva_protocol.window_size = window_size
+        await self.send_sequence_from_alice_to_bob(
+            WriteRequest(4, 1, b'info'),
+            Data(0, 1, b'da'),
+            Data(1, 43, b'xx'),  # should be dropped
+            Data(1, 1, b'ta'),
+            Data(2, 1, b''),
+        )
 
-        data = [(os.urandom(1), os.urandom(block_size * block_count), 0) for _ in range(data_set_count)]
-
-        real_on_acknowledgement = self.overlay(0).eva_protocol.on_acknowledgement
-
-        self.test_store.acknowledgement_count_before_start = 2
-        self.test_store.wrong_order_attempted = False
-        self.test_store.wrong_nonce_attempted = False
-
-        # test wrong message order and wrong nonce
-        async def fake_on_acknowledgement(peer, payload):
-            if self.test_store.acknowledgement_count_before_start > 0:
-                self.test_store.acknowledgement_count_before_start -= 1
-                await real_on_acknowledgement(peer, payload)
-            elif not self.test_store.wrong_order_attempted:
-                self.test_store.wrong_order_attempted = True
-                payload.number = 0
-                await real_on_acknowledgement(peer, payload)
-            elif not self.test_store.wrong_nonce_attempted:
-                self.test_store.wrong_nonce_attempted = True
-                payload.nonce = 100
-                await real_on_acknowledgement(peer, payload)
-            else:
-                await real_on_acknowledgement(peer, payload)
-
-        self.overlay(0).eva_protocol.on_acknowledgement = fake_on_acknowledgement
-
-        for d in data:
-            self.overlay(0).eva_send_binary(self.peer(1), *d)
-        await drain_loop(asyncio.get_event_loop())
-
-        assert len(self.overlay(1).received_data[self.peer(0)]) == data_set_count
-        assert self.overlay(1).received_data[self.peer(0)] == data
+        assert self.bob.most_recent_received_data == (b'info', b'data', 1)
 
     async def test_received_packet_that_have_no_transfer(self):
-        self.overlay(0).eva_protocol.terminate_by_timeout_enabled = True
-        self.overlay(1).eva_protocol.terminate_by_timeout_enabled = True
+        # In this test we send a single transfer from Alice to Bob.
+        # Alice will try to send packets without requesting WriteRequest
 
-        self.overlay(0).eva_protocol.timeout_interval_in_sec = 0
-        self.overlay(1).eva_protocol.timeout_interval_in_sec = 0
+        await self.send_sequence_from_alice_to_bob(
+            Data(0, 1, b'da'),
+            Acknowledgement(0, 1, 0),
+        )
 
-        # wait to new timeout will be set up
-        await self.deliver_messages(timeout=TEST_DEFAULT_TERMINATE_INTERVAL_IN_SEC * 3)
-
-        # try to send data with 0 timeout
-        # it should lead to packet's send without presented transfer
-        self.overlay(0).eva_send_binary(self.peer(1), b'', os.urandom(1000))
-        await self.deliver_messages(timeout=TEST_DEFAULT_TERMINATE_INTERVAL_IN_SEC * 3)
-
-        assert len(self.overlay(0).eva_protocol.outgoing) == 0
-        assert isinstance(self.overlay(0).most_recent_received_exception, TimeoutException)
-        assert len(self.overlay(1).eva_protocol.incoming) == 0
-        assert isinstance(self.overlay(1).most_recent_received_exception, TimeoutException)
-
-        # then try to send an error message without corresponding transfer
-        self.overlay(0).most_recent_received_exception = None
-        self.overlay(1).most_recent_received_exception = None
-
-        self.overlay(0).eva_send_message(self.peer(1), Error('message'.encode('utf-8')))
-        await self.deliver_messages(timeout=TEST_DEFAULT_TERMINATE_INTERVAL_IN_SEC * 3)
-
-        assert not self.overlay(0).most_recent_received_exception
-        assert not self.overlay(1).most_recent_received_exception
+        assert not self.alice.most_recent_received_exception
+        assert not self.bob.most_recent_received_exception
 
 
 @pytest.fixture
 def eva():
-    return EVAProtocol(Mock())
+    protocol = EVAProtocol(Mock())
+    yield protocol
+    protocol.shutdown()
 
 
 @pytest.fixture
@@ -514,7 +526,7 @@ def peer():
 @pytest.mark.asyncio
 async def test_on_write_request_data_size_le0(eva: EVAProtocol, peer):
     # validate that data_size can not be less or equal to 0
-    with patch.object(EVAProtocol, '_incoming_error') as method_mock:
+    with patch.object(EVAProtocol, '_terminate_by_error') as method_mock:
         await eva.on_write_request(peer, WriteRequest(0, 0, b''))
         await eva.on_write_request(peer, WriteRequest(-1, 0, b''))
         assert peer not in eva.incoming
@@ -523,15 +535,139 @@ async def test_on_write_request_data_size_le0(eva: EVAProtocol, peer):
 
 @pytest.mark.asyncio
 async def test_on_acknowledgement_window_size_attr(eva: EVAProtocol, peer):
-    transfer = create_transfer(block_count=10)
+    # This test ensures that `window_size` will be always within the limits:
+    # 0 < window_size < binary_size_limit
+    nonce = 1
+    transfer = Transfer(
+        transfer_type=TransferType.OUTGOING,
+        info=b'',
+        data=b'',
+        data_size=0,
+        block_count=10,
+        nonce=nonce,
+        future=None,
+        peer=Mock(),
+        window_size=0,
+        protocol=eva
+    )
+
     eva.outgoing[peer] = transfer
     window_size = 0
 
     # validate that window_size can not be less or equal to 0
-    await eva.on_acknowledgement(peer, Acknowledgement(1, window_size, 0))
+    await eva.on_acknowledgement(peer, Acknowledgement(1, window_size, nonce))
     assert transfer.window_size == eva.MIN_WINDOWS_SIZE
 
     # validate that window_size can not be greater than binary_size_limit
     window_size = eva.binary_size_limit + 1
-    await eva.on_acknowledgement(peer, Acknowledgement(1, window_size, 0))
+    await eva.on_acknowledgement(peer, Acknowledgement(1, window_size, nonce))
     assert transfer.window_size == eva.binary_size_limit
+
+
+def test_is_simultaneously_served_transfers_limit_exceeded(eva: EVAProtocol):
+    # In this test we will try to exceed `max_simultaneous_transfers` limit.
+    eva.max_simultaneous_transfers = 3
+
+    assert not eva._is_simultaneously_served_transfers_limit_exceeded()
+
+    eva.incoming['peer1'] = Mock()
+    eva.outgoing['peer2'] = Mock()
+
+    assert not eva._is_simultaneously_served_transfers_limit_exceeded()
+
+    eva.outgoing['peer3'] = Mock()
+    assert eva._is_simultaneously_served_transfers_limit_exceeded()
+
+
+@pytest.mark.asyncio
+async def test_send_binary_with_transfers_limit(eva: EVAProtocol):
+    # Test that in case `max_simultaneous_transfers` limit exceeded, call of
+    # `send_binary` function will lead to schedule a transfer
+    eva.max_simultaneous_transfers = 2
+    assert eva.send_binary(peer=Mock(), info=b'info', data=b'data')
+    assert not eva.scheduled
+
+    assert eva.send_binary(peer=Mock(), info=b'info', data=b'data')
+    assert not eva.scheduled
+
+    assert eva.send_binary(peer=Mock(), info=b'info', data=b'data')
+    assert eva._is_simultaneously_served_transfers_limit_exceeded()
+    assert eva.scheduled
+
+
+@pytest.mark.asyncio
+async def test_on_write_request_with_transfers_limit(eva: EVAProtocol):
+    # Test that in case of exceeded incoming transfers limit, TransferLimitException
+    # will be returned
+    eva.max_simultaneous_transfers = 1
+    eva._terminate_by_error = Mock()
+
+    await eva.on_write_request(Mock(), WriteRequest(10, 0, b''))
+    eva._terminate_by_error.assert_not_called()
+
+    await eva.on_write_request(Mock(), WriteRequest(10, 0, b''))
+    actual_exception = eva._terminate_by_error.call_args[0][-1]
+    assert isinstance(actual_exception, TransferLimitException)
+
+
+def test_send_scheduled_with_transfers_limit(eva: EVAProtocol):
+    # Test that `max_simultaneous_transfers` limit uses during `send_scheduled`
+    eva.max_simultaneous_transfers = 2
+    eva.scheduled['peer1'] = collections.deque([Mock()])
+    eva.scheduled['peer2'] = collections.deque([Mock()])
+    eva.scheduled['peer3'] = collections.deque([Mock()])
+    eva.send_scheduled()
+
+    assert len(eva.scheduled['peer1']) == 0
+    assert len(eva.scheduled['peer2']) == 0
+    assert len(eva.scheduled['peer3']) == 1
+
+
+def test_send_write_request_released_transfer(eva: EVAProtocol, peer):
+    transfer = Mock()
+    transfer.released = True
+    assert not eva.send_write_request(transfer)
+
+
+@pytest.mark.asyncio
+async def test_on_error_correct_nonce(eva: EVAProtocol):
+    # In this test we call `eva.on_error` and ensure that the corresponding transfer
+    # is terminated
+    peer = Mock()
+    nonce = 1
+    transfer = Mock(nonce=nonce)
+    eva.outgoing[peer] = transfer
+
+    await eva.on_error(peer, Error(nonce, b'error'))
+
+    transfer.terminate.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_on_error_wrong_nonce(eva: EVAProtocol):
+    # In this test we call `eva.on_error` with incorrect nonce and ensure that
+    # the corresponding transfer is not terminated
+    peer = Mock()
+    nonce = 1
+    transfer = Mock(nonce=nonce)
+    eva.outgoing[peer] = transfer
+
+    await eva.on_error(peer, Error(nonce + 1, b'error'))
+
+    transfer.terminate.assert_not_called()
+
+
+def test_shutdown(eva: EVAProtocol):
+    # Test that for all transfers will be called terminate in the case of a 'shutdown'
+    transfer1 = Mock()
+    transfer2 = Mock()
+    transfer3 = Mock()
+
+    eva.incoming['peer1'] = transfer1
+    eva.incoming['peer2'] = transfer2
+
+    eva.outgoing['peer3'] = transfer3
+
+    eva.shutdown()
+
+    assert all(t.terminate.called for t in [transfer1, transfer2, transfer3])

--- a/src/tribler/core/components/ipv8/tests/test_eva_protocol.py
+++ b/src/tribler/core/components/ipv8/tests/test_eva_protocol.py
@@ -623,7 +623,7 @@ def test_send_scheduled_with_transfers_limit(eva: EVAProtocol):
     assert len(eva.scheduled['peer3']) == 1
 
 
-def test_send_write_request_released_transfer(eva: EVAProtocol, peer):
+def test_send_write_request_released_transfer(eva: EVAProtocol):
     transfer = Mock()
     transfer.released = True
     assert not eva.send_write_request(transfer)

--- a/src/tribler/core/components/metadata_store/remote_query_community/tests/test_remote_query_community.py
+++ b/src/tribler/core/components/metadata_store/remote_query_community/tests/test_remote_query_community.py
@@ -570,9 +570,9 @@ class TestRemoteQueryCommunity(TestBase):
 
         kwargs_dict = {"metadata_type": [CHANNEL_THUMBNAIL]}
 
-        self.nodes[1].overlay.eva_send_binary = Mock()
+        self.nodes[1].overlay.eva.send_binary = Mock()
         self.nodes[0].overlay.send_remote_select(self.nodes[1].my_peer, **kwargs_dict, force_eva_response=True)
 
         await self.deliver_messages(timeout=0.5)
 
-        self.nodes[1].overlay.eva_send_binary.assert_called_once()
+        self.nodes[1].overlay.eva.send_binary.assert_called_once()

--- a/src/tribler/core/components/metadata_store/remote_query_community/tests/test_remote_query_community.py
+++ b/src/tribler/core/components/metadata_store/remote_query_community/tests/test_remote_query_community.py
@@ -2,7 +2,6 @@ import random
 import string
 from asyncio import sleep
 from binascii import unhexlify
-from datetime import datetime
 from json import dumps
 from operator import attrgetter
 from os import urandom
@@ -11,11 +10,8 @@ from unittest.mock import Mock, patch
 
 from ipv8.keyvault.crypto import default_eccrypto
 from ipv8.test.base import TestBase
-
 from pony.orm import db_session
 from pony.orm.dbapiprovider import OperationalError
-
-import pytest
 
 from tribler.core.components.metadata_store.db.orm_bindings.channel_node import NEW
 from tribler.core.components.metadata_store.db.serialization import CHANNEL_THUMBNAIL, CHANNEL_TORRENT, REGULAR_TORRENT
@@ -28,6 +24,7 @@ from tribler.core.components.metadata_store.remote_query_community.settings impo
 from tribler.core.utilities.path_util import Path
 from tribler.core.utilities.unicode import hexlify
 from tribler.core.utilities.utilities import random_infohash
+
 
 # pylint: disable=protected-access
 
@@ -550,6 +547,7 @@ class TestRemoteQueryCommunity(TestBase):
         self.nodes[1].overlay.rqc_settings.max_channel_query_back = 0
 
         was_called = []
+
         async def mock_on_remote_select_response(*_, **__):
             was_called.append(True)
             return []


### PR DESCRIPTION
During the ultimate stress test of the EVA protocol made by @devos50 we figured out some improvements that could be done to the EVA protocol.

### Packet loss

#### Problem

During massive use of binary transfers provided by EVA protocol, some packets seem to be dropped by a socket. 

#### Solution

EVA protocol has been designed as an abstract protocol, that uses ipv8 as a transport layer. That means EVA doesn't care much about balancing socket load. 
However, it seems like a good idea to add a tool to the protocol to have the ability to limit ipv8 and socket load.

This tool will be variable `max_simultaneous_transfers` and it will be set to `10` by default.

### Missed messages resending for WriteRequest

#### Problem

EVA doesn't support handling lost WriteRequest packets and performs only one attempt to send WriteRequest.

#### Solution

@devos50 added this support in https://github.com/devos50/accountable-dfl/blob/main/accdfl/util/eva_protocol.py in a similar way as it was implemented for resend_acknowledge. I've merged his changes to this PR.


### Future support for EVA protocol

@devos50 requested to add the `Future` object as a returned parameter to the`send_binary` function.
See the example of use: https://github.com/devos50/accountable-dfl/blob/main/accdfl/core/community.py#L230

### Shutdown method for EVA protocol

@devos50 requested to add this method because he has a necessity to fast shut down the entire EVA stack:

```python
task: <Task pending name='DFLCommunity:eva_terminate_by_timeout 11587' coro=<delay_runner() running at /home/spandey/venv3/lib/python3.9/site-packages/ipv8/taskmanager.py:23> wait_for=<Future pending cb=[<TaskWakeupMethWrapper object at 0x7f8508a060d0>()]> cb=[TaskManager.register_task.<locals>.done_cb() at /home/spandey/venv3/lib/python3.9/site-packages/ipv8/taskmanager.py:128]>
```