### PR TITLE
Fix terminated by timeout exception

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,8 @@
 [pytest]
-timeout = 5
+timeout = 60
 log_level = INFO
-log_cli_format = %(asctime)s %(levelname)s %(message)s
+log_format = %(asctime)s.%(msecs)03d %(levelname)s %(message)s
+log_cli_format = %(asctime)s.%(msecs)03d %(levelname)s %(message)s
 markers =
     guitest:Tests for GUI. Skipped by default, use --guitests option to enable them
     tunneltest:Slow tests for tunnels. Skipped by default, use --tunneltests option to enable them

--- a/src/tribler/core/components/libtorrent/libtorrent_component.py
+++ b/src/tribler/core/components/libtorrent/libtorrent_component.py
@@ -40,5 +40,5 @@ class LibtorrentComponent(Component):
     async def shutdown(self):
         await super().shutdown()
         if self.download_manager:
-            self.download_manager.stop_download_states_callback()
+            _ = self.download_manager.stop_download_states_callback()
             await self.download_manager.shutdown()

--- a/src/tribler/core/components/libtorrent/tests/test_download_manager.py
+++ b/src/tribler/core/components/libtorrent/tests/test_download_manager.py
@@ -1,11 +1,9 @@
 from asyncio import Future, gather, get_event_loop, sleep
 from unittest.mock import MagicMock
 
-from ipv8.util import succeed
-
-from libtorrent import bencode
-
 import pytest
+from ipv8.util import succeed
+from libtorrent import bencode
 
 from tribler.core.components.libtorrent.download_manager.download_manager import DownloadManager
 from tribler.core.components.libtorrent.settings import LibtorrentSettings
@@ -354,7 +352,7 @@ async def test_post_session_stats(fake_dlmgr):
     fake_dlmgr.ltsessions[0] = mock_lt_session
 
     # Check for status with session stats alert
-    fake_dlmgr.post_session_stats(hops=0)
+    fake_dlmgr.post_session_stats()
     mock_lt_session.post_session_stats.assert_called_once()
 
 


### PR DESCRIPTION
This PR fixes #6822 by increasing a default pytest timeout.

Also this PR:
1. Extends logging for base Component and Download Manager.
2. Refactors shutdown function of Download Manager.