### PR TITLE
Fix/6854

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.8']
-        os: [macos-10.15, windows-latest, ubuntu-latest]
+        os: [macos-latest, windows-latest, ubuntu-latest]
 
     steps:
       - uses: actions/checkout@v3
@@ -33,6 +33,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r ./requirements-test.txt
+
+      - name: Override PYTEST_TIMEOUT
+        if: matrix.os == 'macos-latest'
+        run: |
+          echo "PYTEST_TIMEOUT=300" >> $GITHUB_ENV
 
       - name: Run Pytest
         run: |

--- a/src/tribler/core/components/ipv8/tests/test_eva_protocol.py
+++ b/src/tribler/core/components/ipv8/tests/test_eva_protocol.py
@@ -7,10 +7,9 @@ from itertools import permutations
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
+import pytest
 from ipv8.community import Community
 from ipv8.test.base import TestBase
-
-import pytest
 
 from tribler.core.components.ipv8.eva_protocol import (
     Acknowledgement,
@@ -133,7 +132,6 @@ class TestEVA(TestBase):
         assert len(self.overlay(0).sent_data[self.peer(1)]) == 0
         assert len(self.overlay(1).received_data[self.peer(0)]) == 0
 
-    @pytest.mark.timeout(PYTEST_TIMEOUT_IN_SEC)
     async def test_one_megabyte_transfer(self):
         data_size = 1024 * 1024
         data = os.urandom(1), os.urandom(data_size), random.randrange(0, 256)
@@ -145,7 +143,6 @@ class TestEVA(TestBase):
         assert len(self.overlay(1).most_recent_received_data[1]) == data_size
         assert self.overlay(1).most_recent_received_data == data
 
-    @pytest.mark.timeout(PYTEST_TIMEOUT_IN_SEC)
     async def test_termination_by_timeout(self):
         self.overlay(0).eva_protocol.terminate_by_timeout_enabled = True
         self.overlay(1).eva_protocol.terminate_by_timeout_enabled = True
@@ -241,7 +238,6 @@ class TestEVA(TestBase):
         assert not self.overlay(2).eva_protocol.outgoing
         assert len(self.overlay(0).sent_data[self.peer(2)]) == 0
 
-    @pytest.mark.timeout(PYTEST_TIMEOUT_IN_SEC)
     async def test_duplex(self):
         count = 100
         block_size = 10
@@ -269,7 +265,6 @@ class TestEVA(TestBase):
         assert len(self.overlay(1).sent_data[self.peer(0)]) == 1
         assert len(self.overlay(1).received_data[self.peer(0)]) == 1
 
-    @pytest.mark.timeout(PYTEST_TIMEOUT_IN_SEC)
     async def test_multiply_send(self):
         data_set_count = 10
         data_size = 1024
@@ -283,7 +278,6 @@ class TestEVA(TestBase):
         assert self.overlay(1).received_data[self.peer(0)] == data_list
         assert not self.overlay(0).eva_protocol.scheduled
 
-    @pytest.mark.timeout(PYTEST_TIMEOUT_IN_SEC)
     async def test_multiply_duplex(self):
         data_set_count = 5
 
@@ -322,7 +316,6 @@ class TestEVA(TestBase):
 
         assert data_sets_checked == 6
 
-    @pytest.mark.timeout(PYTEST_TIMEOUT_IN_SEC)
     async def test_survive_when_multiply_packets_lost(self):
         self.overlay(0).eva_protocol.retransmit_interval_in_sec = 0
         self.overlay(1).eva_protocol.retransmit_interval_in_sec = 0
@@ -377,7 +370,6 @@ class TestEVA(TestBase):
         assert len(self.overlay(1).received_data[self.peer(0)]) == data_set_count
         assert self.overlay(1).received_data[self.peer(0)] == data
 
-    @pytest.mark.timeout(PYTEST_TIMEOUT_IN_SEC)
     async def test_dynamically_changed_window_size(self):
         window_size = 5
 
@@ -431,7 +423,6 @@ class TestEVA(TestBase):
         assert isinstance(self.overlay(0).most_recent_received_exception, TransferException)
         assert isinstance(self.overlay(1).most_recent_received_exception, SizeException)
 
-    @pytest.mark.timeout(PYTEST_TIMEOUT_IN_SEC)
     async def test_wrong_message_order_and_wrong_nonce(self):
         self.overlay(0).eva_protocol.retransmit_interval_in_sec = 0
         self.overlay(1).eva_protocol.retransmit_interval_in_sec = 0

--- a/src/tribler/core/components/libtorrent/tests/test_download_api.py
+++ b/src/tribler/core/components/libtorrent/tests/test_download_api.py
@@ -8,7 +8,6 @@ from tribler.core.utilities.simpledefs import DLSTATUS_DOWNLOADING
 
 
 @pytest.mark.asyncio
-@pytest.mark.timeout(10)
 async def test_download_torrent_from_url(tmp_path, file_server, download_manager):
     # Setup file server to serve torrent file
     shutil.copyfile(TORRENT_UBUNTU_FILE, tmp_path / "ubuntu.torrent")
@@ -17,7 +16,6 @@ async def test_download_torrent_from_url(tmp_path, file_server, download_manager
 
 
 @pytest.mark.asyncio
-@pytest.mark.timeout(10)
 async def test_download_torrent_from_file(download_manager):
     uri = path_to_url(TORRENT_UBUNTU_FILE)
     d = await download_manager.start_download_from_uri(uri)
@@ -25,7 +23,6 @@ async def test_download_torrent_from_file(download_manager):
 
 
 @pytest.mark.asyncio
-@pytest.mark.timeout(10)
 async def test_download_torrent_from_file_with_escaped_characters(download_manager, tmp_path):
     destination = tmp_path / 'ubuntu%20%21 15.04.torrent'
     shutil.copyfile(TORRENT_UBUNTU_FILE, destination)

--- a/src/tribler/core/components/libtorrent/tests/test_seeding.py
+++ b/src/tribler/core/components/libtorrent/tests/test_seeding.py
@@ -11,7 +11,6 @@ from tribler.core.utilities.simpledefs import DLSTATUS_SEEDING
 
 
 @pytest.mark.asyncio
-@pytest.mark.timeout(20)
 async def test_seeding(download_manager, video_seeder, video_tdef, tmp_path):
     """
     Test whether a torrent is correctly seeded

--- a/src/tribler/core/components/metadata_store/remote_query_community/tests/test_remote_query_community.py
+++ b/src/tribler/core/components/metadata_store/remote_query_community/tests/test_remote_query_community.py
@@ -436,7 +436,6 @@ class TestRemoteQueryCommunity(TestBase):
             torrents1 = mds1.get_entries(**kwargs_dict)
             self.assertEqual(len(torrents0), len(torrents1))
 
-    @pytest.mark.timeout(15)
     async def test_remote_select_query_back_thumbs_and_descriptions(self):
         """
         Test querying back preview thumbnail and description for previously unknown and updated channels.

--- a/src/tribler/core/components/metadata_store/tests/test_channel_download.py
+++ b/src/tribler/core/components/metadata_store/tests/test_channel_download.py
@@ -1,10 +1,7 @@
-from asynctest import MagicMock
-
-from ipv8.util import succeed
-
-from pony.orm import db_session
-
 import pytest
+from asynctest import MagicMock
+from ipv8.util import succeed
+from pony.orm import db_session
 
 from tribler.core.components.gigachannel_manager.gigachannel_manager import GigaChannelManager
 from tribler.core.components.libtorrent.download_manager.download_config import DownloadConfig
@@ -59,7 +56,6 @@ async def gigachannel_manager(metadata_store, download_manager):
 
 
 @pytest.mark.asyncio
-@pytest.mark.timeout(20)
 async def test_channel_update_and_download(
     channel_tdef, channel_seeder, metadata_store, download_manager, gigachannel_manager
 ):

--- a/src/tribler/core/components/metadata_store/tests/test_channel_metadata.py
+++ b/src/tribler/core/components/metadata_store/tests/test_channel_metadata.py
@@ -378,7 +378,6 @@ def test_commit_channel_torrent(metadata_store):
     assert not channel.commit_channel_torrent()
 
 
-@pytest.mark.timeout(20)
 @db_session
 def test_recursive_commit_channel_torrent(metadata_store):
     status_types = [NEW, UPDATED, TODELETE, COMMITTED]

--- a/src/tribler/core/components/tunnel/tests/test_full_session/conftest.py
+++ b/src/tribler/core/components/tunnel/tests/test_full_session/conftest.py
@@ -15,9 +15,6 @@ def pytest_addoption(parser):
 
 
 def pytest_collection_modifyitems(config, items):
-    for item in items:
-        item.add_marker(pytest.mark.timeout(30))
-
     if config.getoption("--tunneltests"):
         # --tunneltests given in cli: do not skip GUI tests
         return


### PR DESCRIPTION
This PR fixes #6854

There are three main changes in this PR:
1. All `@pytest.mark.timeout` have been removed to derive global timeout settings
2. For the `macos` pytest's run added a particular timeout `PYTEST_TIMEOUT=300`
3. Tunnels tests have been refactored (mostly cosmetic changes)