### PR TITLE
Swap download action by dawidd6/action-download-artifact@v2

### DIFF
--- a/.github/workflows/upload_coverage.yml
+++ b/.github/workflows/upload_coverage.yml
@@ -14,9 +14,11 @@ jobs:
 
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: dawidd6/action-download-artifact@v2
         with:
+          workflow: Coverage
           name: coverage_report
+
       - name: Upload codacy-coverage-report
         uses: codacy/codacy-coverage-reporter-action@v1
         with:


### PR DESCRIPTION
This PR fixes https://github.com/Tribler/tribler/runs/5988192162?check_suite_focus=true by swapping download action due to limitations of https://github.com/actions/download-artifact.

The `action-download-artifact@v2` action description: https://github.com/dawidd6/action-download-artifact