### PR TITLE
Set asyncio_mode=auto

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,7 @@
 [pytest]
 timeout = 60
+;https://pypi.org/project/pytest-asyncio/
+asyncio_mode = auto
 log_level = INFO
 log_format = %(asctime)s.%(msecs)03d %(levelname)s %(message)s
 log_cli_format = %(asctime)s.%(msecs)03d %(levelname)s %(message)s

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,13 +1,13 @@
 -r requirements.txt
 
-pytest==6.2.5
-pytest-aiohttp==0.3.0
-pytest-asyncio==0.16.0
-pytest-mock==3.6.1
-pytest-randomly==3.10.2
-pytest-timeout==2.0.1
-pytest-xdist==2.4.0
+pytest==7.1.1
+pytest-aiohttp==1.0.4
+pytest-asyncio==0.18.3
+pytest-mock==3.7.0
+pytest-randomly==3.11.0
+pytest-timeout==2.1.0
 pytest-freezegun==0.4.2
-freezegun==1.1.0
-asynctest==0.13.0
+freezegun==1.2.1
 coverage==6.3.2
+
+asynctest==0.13.0 # this library has to be installed to properly work with ipv8 TestBase.

--- a/src/tribler/core/components/bandwidth_accounting/tests/test_bandwidth_accounting_component.py
+++ b/src/tribler/core/components/bandwidth_accounting/tests/test_bandwidth_accounting_component.py
@@ -8,7 +8,6 @@ from tribler.core.components.key.key_component import KeyComponent
 # pylint: disable=protected-access
 
 
-@pytest.mark.asyncio
 async def test_bandwidth_accounting_component(tribler_config):
     components = [KeyComponent(), Ipv8Component(), BandwidthAccountingComponent()]
     async with Session(tribler_config, components).start():

--- a/src/tribler/core/components/bandwidth_accounting/tests/test_bandwidth_endpoint.py
+++ b/src/tribler/core/components/bandwidth_accounting/tests/test_bandwidth_endpoint.py
@@ -14,7 +14,6 @@ from tribler.core.components.bandwidth_accounting.settings import BandwidthAccou
 from tribler.core.components.restapi.rest.base_api_test import do_request
 from tribler.core.utilities.unicode import hexlify
 
-pytestmark = pytest.mark.asyncio
 
 # pylint: disable=redefined-outer-name
 @pytest.fixture

--- a/src/tribler/core/components/bandwidth_accounting/tests/test_database.py
+++ b/src/tribler/core/components/bandwidth_accounting/tests/test_database.py
@@ -99,7 +99,6 @@ def test_store_large_transaction(bandwidth_db):
     assert latest_tx
 
 
-@pytest.mark.asyncio
 async def test_totals(bandwidth_db):
     with db_session:
         tx1 = BandwidthTransactionData(1, b"a", b"b", EMPTY_SIGNATURE, EMPTY_SIGNATURE, 3000)

--- a/src/tribler/core/components/gigachannel/tests/test_gigachannel_component.py
+++ b/src/tribler/core/components/gigachannel/tests/test_gigachannel_component.py
@@ -10,7 +10,6 @@ from tribler.core.components.tag.tag_component import TagComponent
 # pylint: disable=protected-access
 
 
-@pytest.mark.asyncio
 async def test_giga_channel_component(tribler_config):
     tribler_config.ipv8.enabled = True
     tribler_config.libtorrent.enabled = True

--- a/src/tribler/core/components/gigachannel_manager/tests/test_gigachannel_manager.py
+++ b/src/tribler/core/components/gigachannel_manager/tests/test_gigachannel_manager.py
@@ -49,7 +49,6 @@ async def gigachannel_manager(metadata_store):
     await chanman.shutdown()
 
 
-@pytest.mark.asyncio
 async def test_regen_personal_channel_no_torrent(personal_channel, gigachannel_manager):
     """
     Test regenerating a non-existing personal channel torrent at startup
@@ -60,7 +59,6 @@ async def test_regen_personal_channel_no_torrent(personal_channel, gigachannel_m
     gigachannel_manager.regenerate_channel_torrent.assert_called_once()
 
 
-@pytest.mark.asyncio
 async def test_regen_personal_channel_damaged_torrent(personal_channel, gigachannel_manager):
     """
     Test regenerating a damaged personal channel torrent at startup
@@ -75,7 +73,6 @@ async def test_regen_personal_channel_damaged_torrent(personal_channel, gigachan
     await complete
 
 
-@pytest.mark.asyncio
 async def test_regenerate_channel_torrent(personal_channel, metadata_store, gigachannel_manager):
     with db_session:
         chan_pk, chan_id = personal_channel.public_key, personal_channel.id_
@@ -116,7 +113,6 @@ def test_updated_my_channel(personal_channel, gigachannel_manager, tmpdir):
     gigachannel_manager.download_manager.start_download.assert_called_once()
 
 
-@pytest.mark.asyncio
 async def test_check_and_regen_personal_channel_torrent(personal_channel, gigachannel_manager):
     with db_session:
         chan_pk, chan_id = personal_channel.public_key, personal_channel.id_
@@ -145,7 +141,6 @@ async def test_check_and_regen_personal_channel_torrent(personal_channel, gigach
         f.assert_called_once()
 
 
-@pytest.mark.asyncio
 async def test_check_channels_updates(personal_channel, gigachannel_manager, metadata_store):
     torrents_added = 0
     # We add our personal channel in an inconsistent state to make sure the GigaChannel Manager will
@@ -231,7 +226,6 @@ async def test_check_channels_updates(personal_channel, gigachannel_manager, met
         assert not gigachannel_manager.channels_processing_queue
 
 
-@pytest.mark.asyncio
 async def test_remove_cruft_channels(torrent_template, personal_channel, gigachannel_manager, metadata_store):
     remove_list = []
     with db_session:
@@ -324,7 +318,6 @@ async def test_remove_cruft_channels(torrent_template, personal_channel, gigacha
 initiated_download = False
 
 
-@pytest.mark.asyncio
 async def test_reject_malformed_channel(
     gigachannel_manager, metadata_store
 ):  # pylint: disable=unused-argument, redefined-outer-name

--- a/src/tribler/core/components/gigachannel_manager/tests/test_gigachannel_manager_component.py
+++ b/src/tribler/core/components/gigachannel_manager/tests/test_gigachannel_manager_component.py
@@ -12,7 +12,6 @@ from tribler.core.components.tag.tag_component import TagComponent
 # pylint: disable=protected-access
 
 
-@pytest.mark.asyncio
 async def test_gigachannel_manager_component(tribler_config):
     components = [Ipv8Component(), TagComponent(), SocksServersComponent(), KeyComponent(), MetadataStoreComponent(),
                   LibtorrentComponent(), GigachannelManagerComponent()]

--- a/src/tribler/core/components/ipv8/eva/tests/test_protocol.py
+++ b/src/tribler/core/components/ipv8/eva/tests/test_protocol.py
@@ -523,7 +523,6 @@ def peer():
     return Mock()
 
 
-@pytest.mark.asyncio
 async def test_on_write_request_data_size_le0(eva: EVAProtocol, peer):
     # validate that data_size can not be less or equal to 0
     with patch.object(EVAProtocol, '_finish_with_error') as method_mock:
@@ -548,7 +547,6 @@ def test_is_simultaneously_served_transfers_limit_exceeded(eva: EVAProtocol):
     assert eva._is_simultaneously_served_transfers_limit_exceeded()
 
 
-@pytest.mark.asyncio
 async def test_send_binary_with_transfers_limit(eva: EVAProtocol):
     # Test that in case `max_simultaneous_transfers` limit exceeded, call of
     # `send_binary` function will lead to schedule a transfer
@@ -564,7 +562,6 @@ async def test_send_binary_with_transfers_limit(eva: EVAProtocol):
     assert eva.scheduled
 
 
-@pytest.mark.asyncio
 async def test_on_write_request_with_transfers_limit(eva: EVAProtocol):
     # Test that in case of exceeded incoming transfers limit, TransferLimitException
     # will be returned
@@ -598,7 +595,6 @@ def test_send_write_request_finished_transfer(eva: EVAProtocol):
     assert not eva.send_write_request(transfer)
 
 
-@pytest.mark.asyncio
 async def test_on_error_correct_nonce(eva: EVAProtocol):
     # In this test we call `eva.on_error` and ensure that the corresponding transfer
     # is terminated
@@ -612,7 +608,6 @@ async def test_on_error_correct_nonce(eva: EVAProtocol):
     assert isinstance(transfer.finish.call_args.kwargs['exception'], TransferException)
 
 
-@pytest.mark.asyncio
 async def test_on_error_wrong_nonce(eva: EVAProtocol):
     # In this test we call `eva.on_error` with incorrect nonce and ensure that
     # the corresponding transfer is not terminated

--- a/src/tribler/core/components/ipv8/tests/test_ipv8_component.py
+++ b/src/tribler/core/components/ipv8/tests/test_ipv8_component.py
@@ -6,7 +6,6 @@ from tribler.core.components.key.key_component import KeyComponent
 
 
 # pylint: disable=protected-access
-@pytest.mark.asyncio
 async def test_ipv8_component(tribler_config):
     async with Session(tribler_config, [KeyComponent(), Ipv8Component()]).start():
         comp = Ipv8Component.instance()
@@ -18,7 +17,6 @@ async def test_ipv8_component(tribler_config):
         assert not comp._peer_discovery_community
 
 
-@pytest.mark.asyncio
 async def test_ipv8_component_dht_disabled(tribler_config):
     tribler_config.ipv8.enabled = True
     tribler_config.dht.enabled = True
@@ -27,7 +25,6 @@ async def test_ipv8_component_dht_disabled(tribler_config):
         assert comp.dht_discovery_community
 
 
-@pytest.mark.asyncio
 async def test_ipv8_component_discovery_community_enabled(tribler_config):
     tribler_config.ipv8.enabled = True
     tribler_config.gui_test_mode = False

--- a/src/tribler/core/components/ipv8/tests/test_ipv8_health_manager.py
+++ b/src/tribler/core/components/ipv8/tests/test_ipv8_health_manager.py
@@ -37,7 +37,6 @@ def fixture_ipv8_health_monitor(ipv8):
     return IPv8Monitor(ipv8, DEFAULT_WALK_INTERVAL, 3.0, 0.01)
 
 
-@pytest.mark.asyncio
 async def test_start(task_manager, ipv8_health_monitor):
     mock_interval = 7.7
 

--- a/src/tribler/core/components/key/tests/test_key_component.py
+++ b/src/tribler/core/components/key/tests/test_key_component.py
@@ -4,7 +4,6 @@ from tribler.core.components.base import Session
 from tribler.core.components.key.key_component import KeyComponent
 
 
-@pytest.mark.asyncio
 async def test_masterkey_component(tribler_config):
     async with Session(tribler_config, [KeyComponent()]).start():
         comp = KeyComponent.instance()

--- a/src/tribler/core/components/libtorrent/tests/test_dht_health_manager.py
+++ b/src/tribler/core/components/libtorrent/tests/test_dht_health_manager.py
@@ -1,7 +1,6 @@
 from asyncio import Future
 from binascii import unhexlify
-
-from asynctest import Mock
+from unittest.mock import Mock
 
 import pytest
 
@@ -16,7 +15,6 @@ async def dht_health_manager():
     await manager.shutdown_task_manager()
 
 
-@pytest.mark.asyncio
 async def test_get_health(dht_health_manager):
     """
     Test fetching the health of a trackerless torrent.
@@ -27,14 +25,12 @@ async def test_get_health(dht_health_manager):
     assert response['DHT'][0]['infohash'] == hexlify(b'a' * 20)
 
 
-@pytest.mark.asyncio
 async def test_existing_get_health(dht_health_manager):
     lookup_future = dht_health_manager.get_health(b'a' * 20, timeout=0.1)
     assert dht_health_manager.get_health(b'a' * 20, timeout=0.1) == lookup_future
     await lookup_future
 
 
-@pytest.mark.asyncio
 async def test_combine_bloom_filters(dht_health_manager):
     """
     Test combining two bloom filters
@@ -48,7 +44,6 @@ async def test_combine_bloom_filters(dht_health_manager):
     assert dht_health_manager.combine_bloomfilters(bf1, bf2) == bf2
 
 
-@pytest.mark.asyncio
 async def test_get_size_from_bloom_filter(dht_health_manager):
     """
     Test whether we can successfully estimate the size from a bloom filter
@@ -69,7 +64,6 @@ async def test_get_size_from_bloom_filter(dht_health_manager):
     assert dht_health_manager.get_size_from_bloomfilter(bf) == 6000
 
 
-@pytest.mark.asyncio
 async def test_receive_bloomfilters(dht_health_manager):
     """
     Test whether the right operations happen when receiving a bloom filter

--- a/src/tribler/core/components/libtorrent/tests/test_download.py
+++ b/src/tribler/core/components/libtorrent/tests/test_download.py
@@ -32,14 +32,12 @@ def test_download_resume(mock_handle, mock_download_config, test_download):
     test_download.handle.resume.assert_called()
 
 
-@pytest.mark.asyncio
 async def test_download_resume_in_upload_mode(mock_handle, mock_download_config, test_download):
     await test_download.set_upload_mode(True)
     test_download.resume()
     test_download.handle.set_upload_mode.assert_called_with(test_download.get_upload_mode())
 
 
-@pytest.mark.asyncio
 async def test_save_resume(mock_handle, test_download, test_tdef):
     """
     testing call resume data alert
@@ -77,7 +75,6 @@ def test_move_storage(mock_handle, test_download, test_tdef, test_tdef_no_metain
     assert len(result) == 1
 
 
-@pytest.mark.asyncio
 async def test_save_checkpoint(test_download, test_tdef):
     await test_download.checkpoint()
     basename = hexlify(test_tdef.get_infohash()) + '.conf'
@@ -146,7 +143,6 @@ def test_get_share_mode(test_download):
     assert test_download.get_share_mode()
 
 
-@pytest.mark.asyncio
 async def test_set_share_mode(mock_handle, test_download):
     """
     Test whether we set the right share mode in Download
@@ -188,7 +184,6 @@ def test_get_num_connected_seeds_peers(mock_handle, test_download):
     assert num_peers == mock_leechers, "Expected peers differ"
 
 
-@pytest.mark.asyncio
 async def test_set_priority(mock_handle, test_download):
     """
     Test whether setting the priority calls the right methods in Download
@@ -249,7 +244,6 @@ def test_tracker_warning_alert(test_download):
     assert test_download.tracker_status[url][1] == 'Warning: test'
 
 
-@pytest.mark.asyncio
 async def test_on_metadata_received_alert(mock_handle, test_download):
     """
     Testing whether the right operations happen when we receive metadata
@@ -362,7 +356,6 @@ def test_get_pieces_bitmask(mock_handle, test_download):
     assert test_download.get_pieces_base64() == b"gA=="
 
 
-@pytest.mark.asyncio
 async def test_resume_data_failed(test_download):
     """
     Testing whether the correct operations happen when an error is raised during resume data saving
@@ -394,7 +387,6 @@ def test_on_state_changed(mock_handle, test_download):
     test_download.apply_ip_filter.assert_called_with(False)
 
 
-@pytest.mark.asyncio
 async def test_checkpoint_timeout(test_download):
     """
     Testing whether making a checkpoint times out when we receive no alert from libtorrent

--- a/src/tribler/core/components/libtorrent/tests/test_download_api.py
+++ b/src/tribler/core/components/libtorrent/tests/test_download_api.py
@@ -8,7 +8,6 @@ from tribler.core.utilities.rest_utils import path_to_url
 from tribler.core.utilities.simpledefs import DLSTATUS_DOWNLOADING
 
 
-@pytest.mark.asyncio
 async def test_download_torrent_from_url(tmp_path, file_server, download_manager):
     # Setup file server to serve torrent file
     shutil.copyfile(TORRENT_UBUNTU_FILE, tmp_path / "ubuntu.torrent")
@@ -17,14 +16,12 @@ async def test_download_torrent_from_url(tmp_path, file_server, download_manager
     await download.wait_for_status(DLSTATUS_DOWNLOADING)
 
 
-@pytest.mark.asyncio
 async def test_download_torrent_from_file(download_manager):
     uri = path_to_url(TORRENT_UBUNTU_FILE)
     d = await download_manager.start_download_from_uri(uri, config=DownloadConfig())
     await d.wait_for_status(DLSTATUS_DOWNLOADING)
 
 
-@pytest.mark.asyncio
 async def test_download_torrent_from_file_with_escaped_characters(download_manager, tmp_path):
     destination = tmp_path / 'ubuntu%20%21 15.04.torrent'
     shutil.copyfile(TORRENT_UBUNTU_FILE, destination)

--- a/src/tribler/core/components/libtorrent/tests/test_download_manager.py
+++ b/src/tribler/core/components/libtorrent/tests/test_download_manager.py
@@ -52,7 +52,6 @@ async def fake_dlmgr(tmp_path_factory):
     await dlmgr.shutdown(timeout=0)
 
 
-@pytest.mark.asyncio
 async def test_get_metainfo_valid_metadata(fake_dlmgr):
     """
     Testing the get_metainfo method when the handle has valid metadata immediately
@@ -74,7 +73,6 @@ async def test_get_metainfo_valid_metadata(fake_dlmgr):
     fake_dlmgr.remove_download.assert_called_once()
 
 
-@pytest.mark.asyncio
 async def test_get_metainfo_add_fail(fake_dlmgr):
     """
     Test whether we try to add a torrent again if the atp is rejected
@@ -97,7 +95,6 @@ async def test_get_metainfo_add_fail(fake_dlmgr):
     fake_dlmgr.remove.assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_get_metainfo_duplicate_request(fake_dlmgr):
     """
     Test whether the same request is returned when invoking get_metainfo twice with the same infohash
@@ -121,7 +118,6 @@ async def test_get_metainfo_duplicate_request(fake_dlmgr):
     fake_dlmgr.remove_download.assert_called_once()
 
 
-@pytest.mark.asyncio
 async def test_get_metainfo_cache(fake_dlmgr):
     """
     Testing whether cached metainfo is returned, if available
@@ -132,7 +128,6 @@ async def test_get_metainfo_cache(fake_dlmgr):
     assert await fake_dlmgr.get_metainfo(b"a" * 20) == "test"
 
 
-@pytest.mark.asyncio
 async def test_get_metainfo_with_already_added_torrent(fake_dlmgr):
     """
     Testing metainfo fetching for a torrent which is already in session.
@@ -152,7 +147,6 @@ async def test_get_metainfo_with_already_added_torrent(fake_dlmgr):
     assert await fake_dlmgr.get_metainfo(torrent_def.infohash)
 
 
-@pytest.mark.asyncio
 async def test_start_download_while_getting_metainfo(fake_dlmgr):
     """
     Testing adding a torrent while a metainfo request is running.
@@ -179,7 +173,6 @@ async def test_start_download_while_getting_metainfo(fake_dlmgr):
     fake_dlmgr.remove_download.assert_called_once_with(metainfo_dl, remove_content=True, remove_checkpoint=False)
 
 
-@pytest.mark.asyncio
 async def test_start_download(fake_dlmgr):
     """
     Testing the addition of a torrent to the libtorrent manager
@@ -239,7 +232,6 @@ async def test_start_download(fake_dlmgr):
     fake_dlmgr.downloads.clear()
 
 
-@pytest.mark.asyncio
 async def test_start_download_existing_handle(fake_dlmgr):
     """
     Testing the addition of a torrent to the libtorrent manager, if there is a pre-existing handle.
@@ -262,7 +254,6 @@ async def test_start_download_existing_handle(fake_dlmgr):
     await download.shutdown()
 
 
-@pytest.mark.asyncio
 async def test_start_download_existing_download(fake_dlmgr):
     """
     Testing the addition of a torrent to the libtorrent manager, if there is a pre-existing download.
@@ -343,7 +334,6 @@ def test_payout_on_disconnect(fake_dlmgr):
     fake_dlmgr.payout_manager.do_payout.is_called_with(b'a' * 20)
 
 
-@pytest.mark.asyncio
 async def test_post_session_stats(fake_dlmgr):
     """
     Test whether post_session_stats actually updates the state of libtorrent readiness for clean shutdown.
@@ -395,7 +385,6 @@ def test_load_empty_checkpoint(fake_dlmgr, tmpdir):
     fake_dlmgr.start_download.assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_load_checkpoints(fake_dlmgr, tmpdir):
     """
     Test whether we are resuming downloads after loading checkpoints
@@ -415,7 +404,6 @@ async def test_load_checkpoints(fake_dlmgr, tmpdir):
     assert mocked_load_checkpoint.called
 
 
-@pytest.mark.asyncio
 async def test_readd_download_safe_seeding(fake_dlmgr):
     """
     Test whether a download is re-added when doing safe seeding
@@ -444,7 +432,6 @@ def test_get_downloads_by_name(fake_dlmgr):
     assert fake_dlmgr.get_downloads_by_name("ubuntu-15.04-desktop-amd64.iso", channels_only=True)
 
 
-@pytest.mark.asyncio
 async def test_check_for_dht_ready(fake_dlmgr):
     fake_dlmgr.get_session = MagicMock()
     fake_dlmgr.get_session().status().dht_nodes = 1000

--- a/src/tribler/core/components/libtorrent/tests/test_libtorrent_component.py
+++ b/src/tribler/core/components/libtorrent/tests/test_libtorrent_component.py
@@ -7,7 +7,6 @@ from tribler.core.components.socks_servers.socks_servers_component import SocksS
 
 
 # pylint: disable=protected-access
-@pytest.mark.asyncio
 async def test_libtorrent_component(tribler_config):
     components = [KeyComponent(), SocksServersComponent(), LibtorrentComponent()]
     async with Session(tribler_config, components).start():

--- a/src/tribler/core/components/libtorrent/tests/test_libtorrent_settings.py
+++ b/src/tribler/core/components/libtorrent/tests/test_libtorrent_settings.py
@@ -4,7 +4,6 @@ from tribler.core.components.libtorrent.settings import DownloadDefaultsSettings
 from tribler.core.utilities.network_utils import NetworkUtils
 
 
-@pytest.mark.asyncio
 async def test_port_validation():
     assert LibtorrentSettings(port=-1)
     assert LibtorrentSettings(port=None)
@@ -16,7 +15,6 @@ async def test_port_validation():
         LibtorrentSettings(port=NetworkUtils.MAX_PORT + 1)
 
 
-@pytest.mark.asyncio
 async def test_proxy_type_validation():
     assert LibtorrentSettings(proxy_type=1)
 
@@ -27,7 +25,6 @@ async def test_proxy_type_validation():
         LibtorrentSettings(proxy_type=6)
 
 
-@pytest.mark.asyncio
 async def test_number_hops_validation():
     assert DownloadDefaultsSettings(number_hops=1)
 
@@ -38,7 +35,6 @@ async def test_number_hops_validation():
         DownloadDefaultsSettings(number_hops=4)
 
 
-@pytest.mark.asyncio
 async def test_seeding_mode():
     assert DownloadDefaultsSettings(seeding_mode=SeedingMode.forever)
 

--- a/src/tribler/core/components/libtorrent/tests/test_seeding.py
+++ b/src/tribler/core/components/libtorrent/tests/test_seeding.py
@@ -10,7 +10,6 @@ from tribler.core.tests.tools.common import TESTS_DATA_DIR
 from tribler.core.utilities.simpledefs import DLSTATUS_SEEDING
 
 
-@pytest.mark.asyncio
 async def test_seeding(download_manager, video_seeder, video_tdef, tmp_path):
     """
     Test whether a torrent is correctly seeded

--- a/src/tribler/core/components/libtorrent/tests/test_torrent_def.py
+++ b/src/tribler/core/components/libtorrent/tests/test_torrent_def.py
@@ -105,7 +105,6 @@ def test_is_private():
     assert not t2.is_private()
 
 
-@pytest.mark.asyncio
 async def test_load_from_url(file_server, tmpdir):
     shutil.copyfile(TORRENT_UBUNTU_FILE, tmpdir / 'ubuntu.torrent')
 
@@ -115,7 +114,6 @@ async def test_load_from_url(file_server, tmpdir):
     assert torrent_def.infohash == TorrentDef.load(TORRENT_UBUNTU_FILE).infohash
 
 
-@pytest.mark.asyncio
 async def test_load_from_url_404(file_server, tmpdir):
     torrent_url = 'http://localhost:%d/ubuntu.torrent' % file_server
     try:

--- a/src/tribler/core/components/metadata_store/db/tests/test_store.py
+++ b/src/tribler/core/components/metadata_store/db/tests/test_store.py
@@ -457,7 +457,6 @@ class ThreadedTestException(Exception):
     pass
 
 
-@pytest.mark.asyncio
 async def test_run_threaded(metadata_store):
     thread_id = threading.get_ident()
 

--- a/src/tribler/core/components/metadata_store/tests/test_channel_download.py
+++ b/src/tribler/core/components/metadata_store/tests/test_channel_download.py
@@ -1,5 +1,6 @@
+from unittest.mock import MagicMock
+
 import pytest
-from asynctest import MagicMock
 from ipv8.util import succeed
 from pony.orm import db_session
 
@@ -55,7 +56,6 @@ async def gigachannel_manager(metadata_store, download_manager):
     await gigachannel_manager.shutdown()
 
 
-@pytest.mark.asyncio
 async def test_channel_update_and_download(
     channel_tdef, channel_seeder, metadata_store, download_manager, gigachannel_manager
 ):

--- a/src/tribler/core/components/metadata_store/tests/test_metadata_store_component.py
+++ b/src/tribler/core/components/metadata_store/tests/test_metadata_store_component.py
@@ -9,7 +9,6 @@ from tribler.core.components.tag.tag_component import TagComponent
 # pylint: disable=protected-access
 
 
-@pytest.mark.asyncio
 async def test_metadata_store_component(tribler_config):
     components = [TagComponent(), Ipv8Component(), KeyComponent(), MetadataStoreComponent()]
     async with Session(tribler_config, components).start():

--- a/src/tribler/core/components/payout/tests/test_payout_component.py
+++ b/src/tribler/core/components/payout/tests/test_payout_component.py
@@ -8,7 +8,6 @@ from tribler.core.components.key.key_component import KeyComponent
 from tribler.core.components.payout.payout_component import PayoutComponent
 
 
-@pytest.mark.asyncio
 @pytest.mark.no_parallel
 async def test_payout_component(tribler_config):
     components = [BandwidthAccountingComponent(), KeyComponent(), Ipv8Component(), PayoutComponent()]

--- a/src/tribler/core/components/payout/tests/test_payout_manager.py
+++ b/src/tribler/core/components/payout/tests/test_payout_manager.py
@@ -22,7 +22,6 @@ async def payout_manager():
     await payout_manager.shutdown()
 
 
-@pytest.mark.asyncio
 async def test_do_payout(payout_manager):
     """
     Test doing a payout
@@ -40,7 +39,6 @@ async def test_do_payout(payout_manager):
     assert res
 
 
-@pytest.mark.asyncio
 async def test_do_payout_dht_error(payout_manager):
     """
     Test whether we are not doing a payout when the DHT lookup fails
@@ -54,7 +52,6 @@ async def test_do_payout_dht_error(payout_manager):
     assert not res
 
 
-@pytest.mark.asyncio
 async def test_do_payout_no_dht_peers(payout_manager):
     """
     Test whether we are not doing a payout when there are no peers returned by the DHT
@@ -68,7 +65,6 @@ async def test_do_payout_no_dht_peers(payout_manager):
     assert not res
 
 
-@pytest.mark.asyncio
 async def test_do_payout_error(payout_manager):
     """
     Test whether we are not doing a payout when the payout fails

--- a/src/tribler/core/components/popularity/community/tests/test_popularity_community.py
+++ b/src/tribler/core/components/popularity/community/tests/test_popularity_community.py
@@ -181,7 +181,6 @@ class TestPopularityCommunity(TestBase):
         self.nodes[1].overlay.send_remote_select.assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_select_torrents_to_gossip_small_list():
     torrents = [
         # infohash, seeders, leechers, last_check
@@ -196,7 +195,6 @@ async def test_select_torrents_to_gossip_small_list():
     assert not rand
 
 
-@pytest.mark.asyncio
 async def test_select_torrents_to_gossip_big_list():
     # torrent structure is (infohash, seeders, leechers, last_check)
     dead_torrents = {(random_infohash(), 0, randint(1, 10), None)
@@ -218,7 +216,6 @@ async def test_select_torrents_to_gossip_big_list():
     assert rand <= alive_torrents
 
 
-@pytest.mark.asyncio
 async def test_no_alive_torrents():
     torrents = {(random_infohash(), 0, randint(1, 10), None)
                 for _ in range(10)}
@@ -229,7 +226,6 @@ async def test_no_alive_torrents():
 
 
 # pylint: disable=super-init-not-called
-@pytest.mark.asyncio
 async def test_gossip_torrents_health_returns():
     class MockPopularityCommunity(PopularityCommunity):
         def __init__(self):

--- a/src/tribler/core/components/popularity/tests/test_popularity_component.py
+++ b/src/tribler/core/components/popularity/tests/test_popularity_component.py
@@ -13,7 +13,6 @@ from tribler.core.components.torrent_checker.torrent_checker_component import To
 # pylint: disable=protected-access
 
 
-@pytest.mark.asyncio
 async def test_popularity_component(tribler_config):
     components = [SocksServersComponent(), LibtorrentComponent(), TorrentCheckerComponent(), TagComponent(),
                   MetadataStoreComponent(), KeyComponent(), Ipv8Component(), PopularityComponent()]

--- a/src/tribler/core/components/reporter/tests/test_reporter_component.py
+++ b/src/tribler/core/components/reporter/tests/test_reporter_component.py
@@ -4,7 +4,6 @@ from tribler.core.components.base import Session
 from tribler.core.components.key.key_component import KeyComponent
 from tribler.core.components.reporter.reporter_component import ReporterComponent
 
-pytestmark = pytest.mark.asyncio
 
 
 # pylint: disable=protected-access

--- a/src/tribler/core/components/resource_monitor/implementation/tests/test_rm_settings.py
+++ b/src/tribler/core/components/resource_monitor/implementation/tests/test_rm_settings.py
@@ -3,7 +3,6 @@ import pytest
 from tribler.core.components.resource_monitor.settings import ResourceMonitorSettings
 
 
-@pytest.mark.asyncio
 async def test_cpu_priority():
     assert ResourceMonitorSettings(cpu_priority=3)
 
@@ -14,7 +13,6 @@ async def test_cpu_priority():
         ResourceMonitorSettings(cpu_priority=6)
 
 
-@pytest.mark.asyncio
 async def test_poll_interval():
     assert ResourceMonitorSettings(poll_interval=1)
     assert ResourceMonitorSettings(poll_interval=2)

--- a/src/tribler/core/components/resource_monitor/tests/test_resource_monitor_component.py
+++ b/src/tribler/core/components/resource_monitor/tests/test_resource_monitor_component.py
@@ -6,7 +6,6 @@ from tribler.core.components.resource_monitor.resource_monitor_component import 
 
 
 # pylint: disable=protected-access
-@pytest.mark.asyncio
 async def test_resource_monitor_component(tribler_config):
     components = [KeyComponent(), ResourceMonitorComponent()]
     async with Session(tribler_config, components).start():

--- a/src/tribler/core/components/restapi/rest/tests/test_events_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/tests/test_events_endpoint.py
@@ -76,7 +76,6 @@ async def open_events_socket(rest_manager_, connected_event, events_up):
                     break
 
 
-@pytest.mark.asyncio
 async def test_events(rest_manager, notifier: Notifier):
     """
     Testing whether various events are coming through the events endpoints
@@ -111,7 +110,6 @@ async def test_events(rest_manager, notifier: Notifier):
         await event_socket_task
 
 
-@pytest.mark.asyncio
 @patch.object(EventsEndpoint, 'write_data')
 @patch.object(EventsEndpoint, 'has_connection_to_gui', new=MagicMock(return_value=True))
 async def test_on_tribler_exception_has_connection_to_gui(mocked_write_data, endpoint, reported_error):
@@ -123,7 +121,6 @@ async def test_on_tribler_exception_has_connection_to_gui(mocked_write_data, end
     assert not endpoint.undelivered_error
 
 
-@pytest.mark.asyncio
 @patch.object(EventsEndpoint, 'write_data')
 @patch.object(EventsEndpoint, 'has_connection_to_gui', new=MagicMock(return_value=False))
 async def test_on_tribler_exception_no_connection_to_gui(mocked_write_data, endpoint, reported_error):
@@ -135,7 +132,6 @@ async def test_on_tribler_exception_no_connection_to_gui(mocked_write_data, endp
     assert endpoint.undelivered_error == endpoint.error_message(reported_error)
 
 
-@pytest.mark.asyncio
 @patch.object(EventsEndpoint, 'write_data', new=MagicMock())
 @patch.object(EventsEndpoint, 'has_connection_to_gui', new=MagicMock(return_value=False))
 async def test_on_tribler_exception_stores_only_first_error(endpoint, reported_error):
@@ -150,7 +146,6 @@ async def test_on_tribler_exception_stores_only_first_error(endpoint, reported_e
     assert endpoint.undelivered_error == endpoint.error_message(first_reported_error)
 
 
-@pytest.mark.asyncio
 @patch.object(EventsEndpoint, 'register_anonymous_task', new=AsyncMock(side_effect=CancelledError))
 @patch.object(RESTStreamResponse, 'prepare', new=AsyncMock())
 @patch.object(RESTStreamResponse, 'write', new_callable=AsyncMock)

--- a/src/tribler/core/components/restapi/rest/tests/test_rest_manager.py
+++ b/src/tribler/core/components/restapi/rest/tests/test_rest_manager.py
@@ -47,13 +47,11 @@ async def rest_manager(request, tribler_config, api_port, tmp_path):
 
 
 @pytest.mark.enable_https
-@pytest.mark.asyncio
 async def test_https(tribler_config, rest_manager, api_port):
     await do_real_request(api_port, f'https://localhost:{api_port}/settings')
 
 
 @pytest.mark.api_key('')
-@pytest.mark.asyncio
 async def test_api_key_disabled(rest_manager, api_port):
     await do_real_request(api_port, 'settings')
     await do_real_request(api_port, 'settings?apikey=111')
@@ -61,7 +59,6 @@ async def test_api_key_disabled(rest_manager, api_port):
 
 
 @pytest.mark.api_key('0' * 32)
-@pytest.mark.asyncio
 async def test_api_key_success(rest_manager, api_port):
     api_key = rest_manager.config.key
     await do_real_request(api_port, 'settings?apikey=' + api_key)
@@ -69,7 +66,6 @@ async def test_api_key_success(rest_manager, api_port):
 
 
 @pytest.mark.api_key('0' * 32)
-@pytest.mark.asyncio
 async def test_api_key_fail(rest_manager, api_port):
     await do_real_request(api_port, 'settings', expected_code=HTTP_UNAUTHORIZED,
                           expected_json={'error': 'Unauthorized access'})
@@ -79,7 +75,6 @@ async def test_api_key_fail(rest_manager, api_port):
                           expected_code=HTTP_UNAUTHORIZED, expected_json={'error': 'Unauthorized access'})
 
 
-@pytest.mark.asyncio
 async def test_unhandled_exception(rest_manager, api_port):
     """
     Testing whether the API returns a formatted 500 error and

--- a/src/tribler/core/components/restapi/tests/test_restapi_component.py
+++ b/src/tribler/core/components/restapi/tests/test_restapi_component.py
@@ -18,7 +18,6 @@ from tribler.core.components.tag.tag_component import TagComponent
 
 
 # pylint: disable=protected-access, not-callable, redefined-outer-name
-@pytest.mark.asyncio
 async def test_rest_component(tribler_config):
     components = [KeyComponent(), RESTComponent(), Ipv8Component(), LibtorrentComponent(), ResourceMonitorComponent(),
                   BandwidthAccountingComponent(), GigaChannelComponent(), TagComponent(), SocksServersComponent(),
@@ -55,7 +54,6 @@ def rest_component():
     return component
 
 
-@pytest.mark.asyncio
 async def test_maybe_add_check_args(rest_component, endpoint_cls):
     # test that in case `*args` in `maybe_add` function contains `NoneComponent` instance
     # no root_endpoint methods are called
@@ -66,7 +64,6 @@ async def test_maybe_add_check_args(rest_component, endpoint_cls):
     rest_component.root_endpoint.assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_maybe_add_check_kwargs(rest_component, endpoint_cls):
     # test that in case `**kwargs` in `maybe_add` function contains `NoneComponent` instance
     # no root_endpoint methods are called
@@ -77,7 +74,6 @@ async def test_maybe_add_check_kwargs(rest_component, endpoint_cls):
     rest_component.root_endpoint.assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_maybe_add(rest_component, endpoint_cls):
     # test that in case there are no `NoneComponent` instances in `**kwargs` or `*args`
     # root_endpoint methods are called

--- a/src/tribler/core/components/socks_servers/socks5/tests/test_connection.py
+++ b/src/tribler/core/components/socks_servers/socks5/tests/test_connection.py
@@ -53,7 +53,6 @@ def test_invalid_version(connection):
     assert not connection.transport.connected
 
 
-@pytest.mark.asyncio
 def test_method_request(connection):
     """
     Test sending a method request to the socks5 server
@@ -63,7 +62,6 @@ def test_method_request(connection):
     assert connection.state == ConnectionState.CONNECTED
 
 
-@pytest.mark.asyncio
 async def test_udp_associate(connection):
     """
     Test sending a udp associate request to the socks5 server
@@ -83,7 +81,6 @@ def test_bind(connection):
     assert len(connection.transport.written_data) == 2
 
 
-@pytest.mark.asyncio
 async def test_connect(connection):
     """
     Test sending a connect command and proxying data

--- a/src/tribler/core/components/socks_servers/socks5/tests/test_server.py
+++ b/src/tribler/core/components/socks_servers/socks5/tests/test_server.py
@@ -18,7 +18,6 @@ async def fixture_socks5_server(free_port):
     await socks5_server.stop()
 
 
-@pytest.mark.asyncio
 async def test_start_server(socks5_server):
     """
     Test writing an invalid version to the socks5 server
@@ -26,7 +25,6 @@ async def test_start_server(socks5_server):
     await socks5_server.start()
 
 
-@pytest.mark.asyncio
 async def test_socks5_udp_associate(socks5_server):
     """
     Test if sending a UDP associate request to the server succeeds.
@@ -39,7 +37,6 @@ async def test_socks5_udp_associate(socks5_server):
     assert client.connection.transport is not None
 
 
-@pytest.mark.asyncio
 async def test_socks5_sendto_fail(socks5_server):
     """
     Test if sending a UDP packet without a successful association fails.
@@ -50,7 +47,6 @@ async def test_socks5_sendto_fail(socks5_server):
         client.sendto(b'\x00', ('127.0.0.1', 123))
 
 
-@pytest.mark.asyncio
 async def test_socks5_sendto_success(socks5_server):
     """
     Test if sending/receiving a UDP packet works correctly.
@@ -76,7 +72,6 @@ async def test_socks5_sendto_success(socks5_server):
     client.callback.assert_called_once_with(data, target)
 
 
-@pytest.mark.asyncio
 async def test_socks5_tcp_connect(socks5_server):
     """
     Test if sending a TCP connect request to the server succeeds.
@@ -88,7 +83,6 @@ async def test_socks5_tcp_connect(socks5_server):
     assert client.connection is None
 
 
-@pytest.mark.asyncio
 async def test_socks5_write(socks5_server):
     """
     Test if sending a TCP data to the server succeeds.
@@ -102,7 +96,6 @@ async def test_socks5_write(socks5_server):
                                                                            ('127.0.0.1', 123), b' ')
 
 
-@pytest.mark.asyncio
 async def test_socks5_aiohttp_connector(socks5_server):
     """
     Test if making a HTTP request through Socks5Server using the Socks5Connector works as expected.

--- a/src/tribler/core/components/socks_servers/tests/test_socks_servers_component.py
+++ b/src/tribler/core/components/socks_servers/tests/test_socks_servers_component.py
@@ -5,7 +5,6 @@ from tribler.core.components.socks_servers.socks_servers_component import SocksS
 
 
 # pylint: disable=protected-access
-@pytest.mark.asyncio
 async def test_socks_servers_component(tribler_config):
     components = [SocksServersComponent()]
     async with Session(tribler_config, components).start():

--- a/src/tribler/core/components/tag/community/tests/test_tag_requests.py
+++ b/src/tribler/core/components/tag/community/tests/test_tag_requests.py
@@ -10,7 +10,6 @@ def tag_requests():
     return TagRequests()
 
 
-pytestmark = pytest.mark.asyncio
 
 
 async def test_add_peer(tag_requests):

--- a/src/tribler/core/components/tag/community/tests/test_tag_validator.py
+++ b/src/tribler/core/components/tag/community/tests/test_tag_validator.py
@@ -3,7 +3,6 @@ import pytest
 from tribler.core.components.tag.community.tag_payload import TagOperationEnum
 from tribler.core.components.tag.community.tag_validator import is_valid_tag, validate_operation, validate_tag
 
-pytestmark = pytest.mark.asyncio
 
 
 async def test_correct_tag_size():

--- a/src/tribler/core/components/tag/tests/test_tag_component.py
+++ b/src/tribler/core/components/tag/tests/test_tag_component.py
@@ -9,7 +9,6 @@ from tribler.core.components.tag.tag_component import TagComponent
 # pylint: disable=protected-access
 
 
-@pytest.mark.asyncio
 async def test_tag_component(tribler_config):
     components = [MetadataStoreComponent(), KeyComponent(), Ipv8Component(), TagComponent()]
     async with Session(tribler_config, components).start():

--- a/src/tribler/core/components/tests/test_base_component.py
+++ b/src/tribler/core/components/tests/test_base_component.py
@@ -2,7 +2,6 @@ import pytest
 
 from tribler.core.components.base import Component, MissedDependency, NoneComponent, Session, SessionError
 
-pytestmark = pytest.mark.asyncio
 
 
 class ComponentTestException(Exception):

--- a/src/tribler/core/components/torrent_checker/tests/test_torrent_checker_component.py
+++ b/src/tribler/core/components/torrent_checker/tests/test_torrent_checker_component.py
@@ -11,7 +11,6 @@ from tribler.core.components.torrent_checker.torrent_checker_component import To
 
 
 # pylint: disable=protected-access
-@pytest.mark.asyncio
 async def test_torrent_checker_component(tribler_config):
     components = [SocksServersComponent(), LibtorrentComponent(), KeyComponent(),
                   Ipv8Component(), TagComponent(), MetadataStoreComponent(), TorrentCheckerComponent()]

--- a/src/tribler/core/components/torrent_checker/torrent_checker/tests/test_torrentchecker.py
+++ b/src/tribler/core/components/torrent_checker/torrent_checker/tests/test_torrentchecker.py
@@ -2,14 +2,11 @@ import os
 import random
 import secrets
 import time
-
-from asynctest import MagicMock
-
-from ipv8.util import succeed
-
-from pony.orm import db_session
+from unittest.mock import MagicMock
 
 import pytest
+from ipv8.util import succeed
+from pony.orm import db_session
 
 import tribler.core.components.torrent_checker.torrent_checker.torrent_checker as torrent_checker_module
 from tribler.core.components.torrent_checker.torrent_checker.torrent_checker import TorrentChecker
@@ -38,7 +35,6 @@ async def fixture_torrent_checker(tribler_config, tracker_manager, metadata_stor
     await torrent_checker.shutdown()
 
 
-@pytest.mark.asyncio
 async def test_initialize(torrent_checker):  # pylint: disable=unused-argument
     """
     Test the initialization of the torrent checker
@@ -48,7 +44,6 @@ async def test_initialize(torrent_checker):  # pylint: disable=unused-argument
     assert torrent_checker.is_pending_task_active("torrent_check")
 
 
-@pytest.mark.asyncio
 async def test_create_socket_fail(torrent_checker):
     """
     Test creation of the UDP socket of the torrent checker when it fails
@@ -64,7 +59,6 @@ async def test_create_socket_fail(torrent_checker):
     assert torrent_checker.is_pending_task_active("listen_udp_port")
 
 
-@pytest.mark.asyncio
 async def test_health_check_blacklisted_trackers(torrent_checker):
     """
     Test whether only cached results of a torrent are returned with only blacklisted trackers
@@ -81,7 +75,6 @@ async def test_health_check_blacklisted_trackers(torrent_checker):
     assert result['db']['leechers'] == 10
 
 
-@pytest.mark.asyncio
 async def test_health_check_cached(torrent_checker):
     """
     Test whether cached results of a torrent are returned when fetching the health of a torrent
@@ -97,7 +90,6 @@ async def test_health_check_cached(torrent_checker):
     assert result['db']['leechers'] == 10
 
 
-@pytest.mark.asyncio
 async def test_load_torrents_check_from_db(torrent_checker):  # pylint: disable=unused-argument
     """
     Test if the torrents_checked set is properly initialized based on the last_check
@@ -146,7 +138,6 @@ async def test_load_torrents_check_from_db(torrent_checker):  # pylint: disable=
     assert len(torrent_checker.torrents_checked) == return_size
 
 
-@pytest.mark.asyncio
 async def test_task_select_no_tracker(torrent_checker):
     """
     Test whether we are not checking a random tracker if there are no trackers in the database.
@@ -155,7 +146,6 @@ async def test_task_select_no_tracker(torrent_checker):
     assert not result
 
 
-@pytest.mark.asyncio
 async def test_check_random_tracker_shutdown(torrent_checker):
     """
     Test whether we are not performing a tracker check if we are shutting down.
@@ -165,7 +155,6 @@ async def test_check_random_tracker_shutdown(torrent_checker):
     assert not result
 
 
-@pytest.mark.asyncio
 async def test_check_random_tracker_not_alive(torrent_checker):
     """
     Test whether we correctly update the tracker state when the number of failures is too large.
@@ -181,7 +170,6 @@ async def test_check_random_tracker_not_alive(torrent_checker):
         assert not tracker.alive
 
 
-@pytest.mark.asyncio
 async def test_task_select_tracker(torrent_checker):
     with db_session:
         tracker = torrent_checker.mds.TrackerState(url="http://localhost/tracker")
@@ -197,7 +185,6 @@ async def test_task_select_tracker(torrent_checker):
     assert len(controlled_session.infohash_list) == 1
 
 
-@pytest.mark.asyncio
 async def test_tracker_test_error_resolve(torrent_checker):
     """
     Test whether we capture the error when a tracker check fails
@@ -213,7 +200,6 @@ async def test_tracker_test_error_resolve(torrent_checker):
     assert len(torrent_checker._session_list) == 1
 
 
-@pytest.mark.asyncio
 async def test_tracker_no_infohashes(torrent_checker):
     """
     Test the check of a tracker without associated torrents

--- a/src/tribler/core/components/torrent_checker/torrent_checker/tests/test_torrentchecker_session.py
+++ b/src/tribler/core/components/torrent_checker/torrent_checker/tests/test_torrentchecker_session.py
@@ -51,7 +51,6 @@ async def fake_dht_session(mock_dlmgr):
     await fake_dht_session.shutdown_task_manager()
 
 
-@pytest.mark.asyncio
 async def test_httpsession_scrape_no_body():
     session = HttpTrackerSession("localhost", ("localhost", 8475), "/announce", 5, None)
     session._infohash_list = []
@@ -61,7 +60,6 @@ async def test_httpsession_scrape_no_body():
     await session.cleanup()
 
 
-@pytest.mark.asyncio
 async def test_httpsession_bdecode_fails():
     session = HttpTrackerSession("localhost", ("localhost", 8475), "/announce", 5, None)
     session._infohash_list = []
@@ -71,7 +69,6 @@ async def test_httpsession_bdecode_fails():
     await session.cleanup()
 
 
-@pytest.mark.asyncio
 async def test_httpsession_code_not_200():
     session = HttpTrackerSession("localhost", ("localhost", 8475), "/announce", 5, None)
 
@@ -84,7 +81,6 @@ async def test_httpsession_code_not_200():
     await session.cleanup()
 
 
-@pytest.mark.asyncio
 async def test_httpsession_failure_reason_in_dict():
     session = HttpTrackerSession("localhost", ("localhost", 8475), "/announce", 5, None)
     session._infohash_list = []
@@ -94,7 +90,6 @@ async def test_httpsession_failure_reason_in_dict():
     await session.cleanup()
 
 
-@pytest.mark.asyncio
 async def test_httpsession_unicode_err():
     session = HttpTrackerSession("retracker.local", ("retracker.local", 80),
                                  "/announce?comment=%26%23%3B%28%2C%29%5B%5D%E3%5B%D4%E8%EB%FC%EC%EE%E2", 5, None)
@@ -104,7 +99,6 @@ async def test_httpsession_unicode_err():
     await session.cleanup()
 
 
-@pytest.mark.asyncio
 async def test_httpsession_timeout():
     sleep_task = Future()
 
@@ -122,7 +116,6 @@ async def test_httpsession_timeout():
     server.close()
 
 
-@pytest.mark.asyncio
 async def test_udpsession_timeout(fake_udp_socket_manager):
     sleep_future = Future()
     fake_udp_socket_manager.send_request = lambda *_: sleep_future
@@ -136,7 +129,6 @@ async def test_udpsession_timeout(fake_udp_socket_manager):
     transport.close()
 
 
-@pytest.mark.asyncio
 async def test_pop_finished_transaction():
     """
     Test that receiving a datagram for an already finished tracker session does not result in InvalidStateError
@@ -155,7 +147,6 @@ async def test_pop_finished_transaction():
     assert task.done()
 
 
-@pytest.mark.asyncio
 async def test_proxy_transport():
     """
     Test that the UdpSocketManager uses a proxy if specified
@@ -176,7 +167,6 @@ async def test_proxy_transport():
     mgr.tracker_sessions[123].cancel()
 
 
-@pytest.mark.asyncio
 async def test_httpsession_cancel_operation():
     session = HttpTrackerSession("127.0.0.1", ("localhost", 8475), "/announce", 5, None)
     task = ensure_future(session.connect_to_tracker())
@@ -186,7 +176,6 @@ async def test_httpsession_cancel_operation():
     await session.cleanup()
 
 
-@pytest.mark.asyncio
 async def test_udpsession_cancel_operation(fake_udp_socket_manager):
     session = UdpTrackerSession("127.0.0.1", ("localhost", 8475), "/announce", 0, None, fake_udp_socket_manager)
     task = ensure_future(session.connect_to_tracker())
@@ -196,7 +185,6 @@ async def test_udpsession_cancel_operation(fake_udp_socket_manager):
     await session.cleanup()
 
 
-@pytest.mark.asyncio
 async def test_udpsession_handle_response_wrong_len(fake_udp_socket_manager):
     session = UdpTrackerSession("localhost", ("localhost", 4782), "/announce", 0, None, fake_udp_socket_manager)
     assert not session.is_failed
@@ -213,7 +201,6 @@ async def test_udpsession_handle_response_wrong_len(fake_udp_socket_manager):
     assert session.is_failed
 
 
-@pytest.mark.asyncio
 async def test_udpsession_no_port(fake_udp_socket_manager):
     session = UdpTrackerSession("localhost", ("localhost", 4782), "/announce", 0, None, fake_udp_socket_manager)
     assert not session.is_failed
@@ -223,7 +210,6 @@ async def test_udpsession_no_port(fake_udp_socket_manager):
     assert session.is_failed
 
 
-@pytest.mark.asyncio
 async def test_udpsession_handle_connection_wrong_action_transaction(fake_udp_socket_manager):
     session = UdpTrackerSession("localhost", ("localhost", 4782), "/announce", 0, None, fake_udp_socket_manager)
     assert not session.is_failed
@@ -233,7 +219,6 @@ async def test_udpsession_handle_connection_wrong_action_transaction(fake_udp_so
     assert session.is_failed
 
 
-@pytest.mark.asyncio
 async def test_udpsession_handle_packet(fake_udp_socket_manager):
     session = UdpTrackerSession("localhost", ("localhost", 4782), "/announce", 0, None, fake_udp_socket_manager)
     session.action = 123
@@ -244,7 +229,6 @@ async def test_udpsession_handle_packet(fake_udp_socket_manager):
     assert not session.is_failed
 
 
-@pytest.mark.asyncio
 async def test_udpsession_handle_wrong_action_transaction(fake_udp_socket_manager):
     session = UdpTrackerSession("localhost", ("localhost", 4782), "/announce", 0, None, fake_udp_socket_manager)
     assert not session.is_failed
@@ -254,7 +238,6 @@ async def test_udpsession_handle_wrong_action_transaction(fake_udp_socket_manage
     assert session.is_failed
 
 
-@pytest.mark.asyncio
 async def test_udpsession_mismatch(fake_udp_socket_manager):
     session = UdpTrackerSession("localhost", ("localhost", 4782), "/announce", 0, None, fake_udp_socket_manager)
     session.action = 123
@@ -267,7 +250,6 @@ async def test_udpsession_mismatch(fake_udp_socket_manager):
     assert session.is_failed
 
 
-@pytest.mark.asyncio
 async def test_udpsession_response_too_short(fake_udp_socket_manager):
     session = UdpTrackerSession("localhost", ("localhost", 4782), "/announce", 0, None, fake_udp_socket_manager)
     assert not session.is_failed
@@ -277,7 +259,6 @@ async def test_udpsession_response_too_short(fake_udp_socket_manager):
     assert session.is_failed
 
 
-@pytest.mark.asyncio
 async def test_udpsession_response_wrong_transaction_id(fake_udp_socket_manager):
     session = UdpTrackerSession("localhost", ("localhost", 4782), "/announce", 0, None, fake_udp_socket_manager)
     assert not session.is_failed
@@ -287,7 +268,6 @@ async def test_udpsession_response_wrong_transaction_id(fake_udp_socket_manager)
     assert session.is_failed
 
 
-@pytest.mark.asyncio
 async def test_udpsession_response_list_len_mismatch(fake_udp_socket_manager):
     session = UdpTrackerSession("localhost", ("localhost", 4782), "/announce", 0, None, fake_udp_socket_manager)
     session.action = 123
@@ -301,7 +281,6 @@ async def test_udpsession_response_list_len_mismatch(fake_udp_socket_manager):
     await session.cleanup()
 
 
-@pytest.mark.asyncio
 async def test_udpsession_correct_handle(fake_udp_socket_manager):
     session = UdpTrackerSession("localhost", ("localhost", 4782), "/announce", 5, None, fake_udp_socket_manager)
     session.ip_address = "127.0.0.1"
@@ -314,7 +293,6 @@ async def test_udpsession_correct_handle(fake_udp_socket_manager):
     await session.cleanup()
 
 
-@pytest.mark.asyncio
 async def test_big_correct_run(fake_udp_socket_manager):
     session = UdpTrackerSession("localhost", ("192.168.1.1", 1234), "/announce", 0, None, fake_udp_socket_manager)
     assert not session.is_failed
@@ -327,7 +305,6 @@ async def test_big_correct_run(fake_udp_socket_manager):
     await session.cleanup()
 
 
-@pytest.mark.asyncio
 async def test_http_unprocessed_infohashes():
     session = HttpTrackerSession("localhost", ("localhost", 8475), "/announce", 5, None)
     session.infohash_list.append(b"test")
@@ -337,7 +314,6 @@ async def test_http_unprocessed_infohashes():
     await session.cleanup()
 
 
-@pytest.mark.asyncio
 async def test_failed_unicode():
     session = HttpTrackerSession("localhost", ("localhost", 8475), "/announce", 5, None)
     with pytest.raises(ValueError):
@@ -351,7 +327,6 @@ def test_failed_unicode_udp(fake_udp_socket_manager):
         session.failed('\xd0')
 
 
-@pytest.mark.asyncio
 async def test_cleanup(bep33_session):
     """
     Test the cleanup of a DHT session
@@ -359,7 +334,6 @@ async def test_cleanup(bep33_session):
     await bep33_session.cleanup()
 
 
-@pytest.mark.asyncio
 async def test_connect_to_tracker(mock_dlmgr, fake_dht_session):
     """
     Test the metainfo lookup of the DHT session
@@ -374,7 +348,6 @@ async def test_connect_to_tracker(mock_dlmgr, fake_dht_session):
     assert metainfo['DHT'][0]['seeders'] == 42
 
 
-@pytest.mark.asyncio
 async def test_connect_to_tracker_fail(mock_dlmgr, fake_dht_session):
     """
     Test the metainfo lookup of the DHT session when it fails
@@ -384,7 +357,6 @@ async def test_connect_to_tracker_fail(mock_dlmgr, fake_dht_session):
         await fake_dht_session.connect_to_tracker()
 
 
-@pytest.mark.asyncio
 async def test_connect_to_tracker_bep33(bep33_session, mock_dlmgr):
     """
     Test the metainfo lookup of the BEP33 DHT session

--- a/src/tribler/core/components/tunnel/tests/test_dispatcher.py
+++ b/src/tribler/core/components/tunnel/tests/test_dispatcher.py
@@ -79,7 +79,6 @@ def test_on_socks_in_udp(dispatcher, mock_circuit):
     assert dispatcher.on_socks5_udp_data(mock_udp_connection, mock_request)
 
 
-@pytest.mark.asyncio
 async def test_on_socks_in_tcp(dispatcher):
     """
     Test whether TCP connect request are correctly dispatched to the TunnelCommunity

--- a/src/tribler/core/components/tunnel/tests/test_full_session/test_tunnel_community.py
+++ b/src/tribler/core/components/tunnel/tests/test_full_session/test_tunnel_community.py
@@ -6,10 +6,10 @@ from asyncio import all_tasks, get_event_loop, sleep
 from collections import defaultdict
 from itertools import permutations
 from typing import List, Optional, Tuple
+from unittest.mock import MagicMock
 
 import pytest
 from _pytest.tmpdir import TempPathFactory
-from asynctest import MagicMock
 from ipv8.messaging.anonymization.tunnel import PEER_FLAG_EXIT_BT
 from ipv8.peer import Peer
 from ipv8.test.messaging.anonymization import test_community
@@ -224,7 +224,6 @@ async def tunnel_community(tmp_path_factory: TempPathFactory):
 
 
 @pytest.mark.tunneltest
-@pytest.mark.asyncio
 async def test_anon_download(proxy_factory: ProxyFactory, video_seeder: DownloadManager, video_tdef: TorrentDef,
                              tunnel_community: TriblerTunnelCommunity, crash_on_error):
     """
@@ -248,7 +247,6 @@ async def test_anon_download(proxy_factory: ProxyFactory, video_seeder: Download
 
 
 @pytest.mark.tunneltest
-@pytest.mark.asyncio
 async def test_hidden_services(proxy_factory: ProxyFactory, hidden_seeder_comm: TriblerTunnelCommunity,
                                video_tdef: TorrentDef, crash_on_error):
     """

--- a/src/tribler/core/components/tunnel/tests/test_tunnel_component.py
+++ b/src/tribler/core/components/tunnel/tests/test_tunnel_component.py
@@ -8,7 +8,6 @@ from tribler.core.components.tunnel.tunnel_component import TunnelsComponent
 
 # pylint: disable=protected-access
 
-@pytest.mark.asyncio
 async def test_tunnels_component(tribler_config):
     components = [Ipv8Component(), KeyComponent(), TunnelsComponent()]
     async with Session(tribler_config, components).start():

--- a/src/tribler/core/components/tunnel/tests/test_tunnel_settings.py
+++ b/src/tribler/core/components/tunnel/tests/test_tunnel_settings.py
@@ -4,7 +4,6 @@ from tribler.core.components.ipv8.settings import Ipv8Settings
 from tribler.core.utilities.network_utils import NetworkUtils
 
 
-@pytest.mark.asyncio
 async def test_port_validation():
     assert Ipv8Settings(port=0)
 

--- a/src/tribler/core/components/version_check/tests/test_version_check_component.py
+++ b/src/tribler/core/components/version_check/tests/test_version_check_component.py
@@ -3,7 +3,6 @@ import pytest
 from tribler.core.components.base import Session
 from tribler.core.components.version_check.version_check_component import VersionCheckComponent
 
-pytestmark = pytest.mark.asyncio
 
 
 # pylint: disable=protected-access

--- a/src/tribler/core/components/version_check/tests/test_versioncheck.py
+++ b/src/tribler/core/components/version_check/tests/test_versioncheck.py
@@ -78,7 +78,6 @@ async def fixture_version_server(free_port):
     await site.stop()
 
 
-@pytest.mark.asyncio
 async def test_start(version_check_manager, version_server):
     """
     Test whether the periodic version lookup works as expected
@@ -99,7 +98,6 @@ async def test_start(version_check_manager, version_server):
     vcm.version_id = old_id
 
 
-@pytest.mark.asyncio
 async def test_user_agent(version_check_manager, version_server):
     global response, last_request_user_agent  # pylint: disable=global-statement
     response = json.dumps({'name': 'v1.0'})
@@ -108,7 +106,6 @@ async def test_user_agent(version_check_manager, version_server):
     assert last_request_user_agent == TEST_USER_AGENT
 
 
-@pytest.mark.asyncio
 async def test_old_version(version_check_manager, version_server):
     global response  # pylint: disable=global-statement
     response = json.dumps({'name': 'v1.0'})
@@ -116,7 +113,6 @@ async def test_old_version(version_check_manager, version_server):
     assert not has_new_version
 
 
-@pytest.mark.asyncio
 async def test_new_version(version_check_manager, version_server):
     global response  # pylint: disable=global-statement
     response = json.dumps({'name': NEW_VERSION_ID})
@@ -124,7 +120,6 @@ async def test_new_version(version_check_manager, version_server):
     assert has_new_version
 
 
-@pytest.mark.asyncio
 async def test_bad_request(version_check_manager, version_server):
     global response, response_code  # pylint: disable=global-statement
     response = json.dumps({'name': 'v1.0'})
@@ -133,7 +128,6 @@ async def test_bad_request(version_check_manager, version_server):
     assert not has_new_version
 
 
-@pytest.mark.asyncio
 async def test_connection_error(version_check_manager):
     global response  # pylint: disable=global-statement
     response = json.dumps({'name': 'v1.0'})
@@ -142,7 +136,6 @@ async def test_connection_error(version_check_manager):
     assert not has_new_version
 
 
-@pytest.mark.asyncio
 async def test_version_check_api_timeout(free_port, version_check_manager, version_server):
     global response, response_lag  # pylint: disable=global-statement
     response = json.dumps({'name': NEW_VERSION_ID})
@@ -161,7 +154,6 @@ async def test_version_check_api_timeout(free_port, version_check_manager, versi
     vcm.VERSION_CHECK_TIMEOUT = old_timeout
 
 
-@pytest.mark.asyncio
 async def test_fallback_on_multiple_urls(free_port, version_check_manager, version_server):
     """
     Scenario: Two release API URLs. First one is a non-existing URL so is expected to fail.

--- a/src/tribler/core/components/watch_folder/tests/test_watch_folder.py
+++ b/src/tribler/core/components/watch_folder/tests/test_watch_folder.py
@@ -1,8 +1,8 @@
 import os
 import shutil
+from unittest.mock import MagicMock
 
 import pytest
-from asynctest import MagicMock
 
 from tribler.core.components.watch_folder.settings import WatchFolderSettings
 from tribler.core.components.watch_folder.watch_folder import WatchFolder

--- a/src/tribler/core/components/watch_folder/tests/test_watch_folder_component.py
+++ b/src/tribler/core/components/watch_folder/tests/test_watch_folder_component.py
@@ -8,7 +8,6 @@ from tribler.core.components.watch_folder.watch_folder_component import WatchFol
 
 
 # pylint: disable=protected-access
-@pytest.mark.asyncio
 async def test_watch_folder_component(tribler_config):
     components = [KeyComponent(), SocksServersComponent(), LibtorrentComponent(), WatchFolderComponent()]
     async with Session(tribler_config, components).start():

--- a/src/tribler/core/config/tests/test_tribler_config.py
+++ b/src/tribler/core/config/tests/test_tribler_config.py
@@ -10,14 +10,12 @@ from tribler.core.utilities.path_util import Path
 CONFIG_PATH = TESTS_DATA_DIR / "config_files"
 
 
-@pytest.mark.asyncio
 async def test_create(tmpdir):
     config = TriblerConfig(state_dir=tmpdir)
     assert config
     assert config.state_dir == Path(tmpdir)
 
 
-@pytest.mark.asyncio
 async def test_base_getters_and_setters(tmpdir):
     config = TriblerConfig(state_dir=tmpdir)
     assert config.state_dir == Path(tmpdir)
@@ -26,7 +24,6 @@ async def test_base_getters_and_setters(tmpdir):
     assert config.state_dir == Path('.')
 
 
-@pytest.mark.asyncio
 async def test_load_write(tmpdir):
     config = TriblerConfig(state_dir=tmpdir)
     filename = 'test_read_write.ini'
@@ -48,7 +45,6 @@ async def test_load_write(tmpdir):
     assert config.file == tmpdir / filename
 
 
-@pytest.mark.asyncio
 async def test_load_write_nonascii(tmpdir):
     config = TriblerConfig(state_dir=tmpdir)
     filename = 'test_read_write.ini'
@@ -65,7 +61,6 @@ async def test_load_write_nonascii(tmpdir):
     assert config.file == tmpdir / filename
 
 
-@pytest.mark.asyncio
 async def test_copy(tmpdir):
     config = TriblerConfig(state_dir=tmpdir, file=tmpdir / '1.txt')
     config.api.http_port = 42
@@ -76,7 +71,6 @@ async def test_copy(tmpdir):
     assert cloned.file == tmpdir / '1.txt'
 
 
-@pytest.mark.asyncio
 async def test_get_path_relative(tmpdir):
     config = TriblerConfig(state_dir=tmpdir)
     config.general.log_dir = None
@@ -89,7 +83,6 @@ async def test_get_path_relative(tmpdir):
     assert config.general.get_path_as_absolute('log_dir', tmpdir) == Path(tmpdir) / '1'
 
 
-@pytest.mark.asyncio
 async def test_get_path_absolute(tmpdir):
     config = TriblerConfig(state_dir=tmpdir)
     config.general.log_dir = str(Path(tmpdir).parent)
@@ -104,7 +97,6 @@ def test_get_path_absolute_none(tmpdir):
     assert config.general.get_path_as_absolute(property_name='log_dir', state_dir=state_dir) is None
 
 
-@pytest.mark.asyncio
 async def test_invalid_config_recovers(tmpdir):
     default_config_file = tmpdir / 'triblerd.conf'
     shutil.copy2(CONFIG_PATH / 'corrupt-triblerd.conf', default_config_file)

--- a/src/tribler/core/config/tests/test_tribler_config_section.py
+++ b/src/tribler/core/config/tests/test_tribler_config_section.py
@@ -10,7 +10,6 @@ class TriblerTestConfigSection(TriblerConfigSection):
     path: Optional[str]
 
 
-@pytest.mark.asyncio
 async def test_put_path_relative(tmpdir):
     section = TriblerTestConfigSection()
 
@@ -21,7 +20,6 @@ async def test_put_path_relative(tmpdir):
     assert section.path == '1'
 
 
-@pytest.mark.asyncio
 async def test_put_path_absolute(tmpdir):
     section = TriblerTestConfigSection()
 
@@ -35,7 +33,6 @@ async def test_put_path_absolute(tmpdir):
     assert section.path == str(Path('/Tribler'))
 
 
-@pytest.mark.asyncio
 async def test_null_replacement():
     section = TriblerTestConfigSection(path='None')
     assert section.path is None

--- a/src/tribler/core/tests/test_check_os.py
+++ b/src/tribler/core/tests/test_check_os.py
@@ -11,7 +11,6 @@ from tribler.core.utilities.patch_import import patch_import
 # pylint: disable=import-outside-toplevel
 # fmt: off
 
-pytestmark = pytest.mark.asyncio
 
 
 @patch('sys.exit')

--- a/src/tribler/core/tests/test_start_core.py
+++ b/src/tribler/core/tests/test_start_core.py
@@ -3,9 +3,6 @@ from unittest.mock import MagicMock, patch
 from tribler.core.start_core import run_tribler_core_session
 from tribler.core.utilities.path_util import Path
 
-# pylint: disable=
-# fmt: off
-
 
 @patch('tribler.core.logger.logger.load_logger_config', new=MagicMock())
 @patch('tribler.core.start_core.set_process_priority', new=MagicMock())
@@ -13,7 +10,7 @@ from tribler.core.utilities.path_util import Path
 @patch('asyncio.get_event_loop', new=MagicMock())
 @patch('tribler.core.start_core.TriblerConfig.load', new=MagicMock())
 @patch('tribler.core.start_core.core_session')
-def test_start_tribler_core_no_exceptions(mocked_core_session):
+async def test_start_tribler_core_no_exceptions(mocked_core_session):
     # test that base logic of tribler core runs without exceptions
     run_tribler_core_session(1, 'key', Path('.'), False)
     mocked_core_session.assert_called_once()

--- a/src/tribler/core/upgrade/tests/test_upgrader.py
+++ b/src/tribler/core/upgrade/tests/test_upgrader.py
@@ -131,7 +131,6 @@ def test_upgrade_pony_8to10(upgrader, channels_dir, mds_path, trustchain_keypair
     mds.shutdown()
 
 
-@pytest.mark.asyncio
 async def test_upgrade_pony_10to11(upgrader, channels_dir, mds_path, trustchain_keypair):
     _copy('pony_v10.db', mds_path)
 
@@ -231,7 +230,6 @@ def test_calc_progress():
     assert calc_progress(1000, 100) == pytest.approx(99.158472, abs=EPSILON)
 
 
-@pytest.mark.asyncio
 async def test_upgrade_bw_accounting_db_8to9(upgrader, state_dir, trustchain_keypair):
     bandwidth_path = state_dir / 'sqlite/bandwidth.db'
     _copy('bandwidth_v8.db', bandwidth_path)

--- a/src/tribler/core/utilities/tests/test_dependencies.py
+++ b/src/tribler/core/utilities/tests/test_dependencies.py
@@ -10,7 +10,6 @@ from tribler.core.utilities.dependencies import (
 import tribler.core
 from tribler.core.utilities.path_util import Path
 
-pytestmark = pytest.mark.asyncio
 
 
 # pylint: disable=protected-access

--- a/src/tribler/core/utilities/tests/test_patch_import.py
+++ b/src/tribler/core/utilities/tests/test_patch_import.py
@@ -4,7 +4,6 @@ import pytest
 
 from tribler.core.utilities.patch_import import patch_import
 
-pytestmark = pytest.mark.asyncio
 
 
 # pylint: disable=import-outside-toplevel, import-error, unused-import

--- a/src/tribler/core/utilities/tests/test_path_utils.py
+++ b/src/tribler/core/utilities/tests/test_path_utils.py
@@ -3,7 +3,6 @@ import pytest
 from tribler.core.utilities.path_util import Path
 
 
-@pytest.mark.asyncio
 async def test_put_path_relative(tmpdir):
     assert Path(tmpdir).normalize_to(None) == Path(tmpdir)
     assert Path(tmpdir).normalize_to('') == Path(tmpdir)
@@ -12,7 +11,6 @@ async def test_put_path_relative(tmpdir):
     assert Path(tmpdir / '1').normalize_to(tmpdir) == Path('1')
 
 
-@pytest.mark.asyncio
 async def test_normalize_to(tmpdir):
     assert Path(tmpdir).normalize_to(None) == Path(tmpdir)
     assert Path(tmpdir).normalize_to('') == Path(tmpdir)

--- a/src/tribler/core/utilities/tests/test_torrent_utils.py
+++ b/src/tribler/core/utilities/tests/test_torrent_utils.py
@@ -63,7 +63,6 @@ def test_get_info_from_handle():
     assert not get_info_from_handle(mock_handle)
 
 
-@pytest.mark.asyncio
 def test_commonprefix(tmpdir):
     assert common_prefix([Path(tmpdir) / '1.txt']) == Path(tmpdir)
 

--- a/src/tribler/core/utilities/tests/test_utilities.py
+++ b/src/tribler/core/utilities/tests/test_utilities.py
@@ -58,7 +58,6 @@ def test_valid_url():
     assert is_valid_url(test_url4)
 
 
-@pytest.mark.asyncio
 async def test_http_get_with_redirect(magnet_redirect_server):
     """
     Test if http_get is working properly if url redirects to a magnet link.

--- a/src/tribler/gui/tests/test_error_handler.py
+++ b/src/tribler/gui/tests/test_error_handler.py
@@ -7,7 +7,6 @@ from tribler.core.sentry_reporter.sentry_reporter import SentryReporter, SentryS
 from tribler.gui.error_handler import ErrorHandler
 from tribler.gui.exceptions import CoreConnectTimeoutError, CoreCrashedError
 
-pytestmark = pytest.mark.asyncio
 
 
 # pylint: disable=redefined-outer-name, protected-access, function-redefined, unused-argument


### PR DESCRIPTION
Fixes #6865

In this PR:
1. `asyncio_mode` has been set to auto https://pypi.org/project/pytest-asyncio/
2. All unnecessary markers have been removed
3. Requirements for tests have been updated

The `test_start_core` has been fixed by adding `async` to the function definition (which could led to a correct setting of an event loop):

```python
@patch('tribler.core.logger.logger.load_logger_config', new=MagicMock())
@patch('tribler.core.start_core.set_process_priority', new=MagicMock())
@patch('tribler.core.start_core.check_and_enable_code_tracing', new=MagicMock())
@patch('asyncio.get_event_loop', new=MagicMock())
@patch('tribler.core.start_core.TriblerConfig.load', new=MagicMock())
@patch('tribler.core.start_core.core_session')
async def test_start_tribler_core_no_exceptions(mocked_core_session):
    # test that base logic of tribler core runs without exceptions
    run_tribler_core_session(1, 'key', Path('.'), False)
    mocked_core_session.assert_called_once()
```