### PR TITLE
Add `format_error_message` function

### DIFF
--- a/src/tribler/gui/tests/test_core_manager.py
+++ b/src/tribler/gui/tests/test_core_manager.py
@@ -1,3 +1,4 @@
+import errno
 import sys
 from unittest.mock import MagicMock, patch
 
@@ -61,3 +62,16 @@ def test_on_core_read_ready_os_error_suppressed(core_manager):
     core_manager.on_core_stdout_read_ready()
     core_manager.on_core_stderr_read_ready()
     assert print.call_count == 2
+
+
+def test_format_error_message():
+    actual = CoreManager.format_error_message(exit_code=errno.ENOENT, exit_status=1, last_core_output='last\noutput')
+    expected = '''The Tribler core has unexpectedly finished with exit code 2 and status: 1.
+
+Error message: No such file or directory
+
+Last core output:
+> last
+> output'''
+
+    assert actual == expected


### PR DESCRIPTION
This PR addresses #6810

This PR changes the error formatting style in "`on_core_finished` with an error".

Two changes:
1. Added translation from `err_code` to `strerror`
2. Added quoting for the last core output

An example of an error message:

```
The Tribler core has unexpectedly finished with exit code 2 and status: 2.

Error message: No such file or directory

Last core output:
> ERROR <loggingstuff:8> root.print_error(): Something went wrong!
> Traceback (most recent call last):,
>   File "ipv8  askmanager.py", line 131, in done_cb,
>   File "ipv8\messagingnonymization\hidden_services.py", line 366, in on_create_e2e,
>   File "ipv8\messagingnonymization\hidden_services.py", line 378, in create_created_e2e,
> KeyError: 1030643827
```

Ref:
* https://docs.python.org/3/library/errno.html
* https://docs.python.org/3/library/os.html#os.strerror