### PR TITLE
Add an ability to send Sentry reports for developers

### DIFF
--- a/src/tribler/core/sentry_reporter/sentry_reporter.py
+++ b/src/tribler/core/sentry_reporter/sentry_reporter.py
@@ -7,12 +7,12 @@ from enum import Enum, auto
 from hashlib import md5
 from typing import Dict, List, Optional
 
-from faker import Faker
-
 import sentry_sdk
+from faker import Faker
 from sentry_sdk.integrations.logging import LoggingIntegration, ignore_logger
 from sentry_sdk.integrations.threading import ThreadingIntegration
 
+from tribler.core import version
 from tribler.core.sentry_reporter.sentry_tools import (
     delete_item,
     extract_dict,
@@ -328,7 +328,11 @@ class SentryReporter:
         return strategy if strategy else self.global_strategy
 
     @staticmethod
-    def get_test_sentry_url():
+    def get_sentry_url() -> Optional[str]:
+        return version.sentry_url or os.environ.get('TRIBLER_SENTRY_URL', None)
+
+    @staticmethod
+    def get_test_sentry_url() -> Optional[str]:
         return os.environ.get('TRIBLER_TEST_SENTRY_URL', None)
 
     @staticmethod

--- a/src/tribler/core/sentry_reporter/sentry_tools.py
+++ b/src/tribler/core/sentry_reporter/sentry_tools.py
@@ -2,6 +2,7 @@
 simplify work with several data structures.
 """
 import re
+from typing import Optional
 
 LONG_TEXT_DELIMITER = '--LONG TEXT--'
 CONTEXT_DELIMITER = '--CONTEXT--'
@@ -138,7 +139,7 @@ def distinct_by(list_of_dict, key):
     return result
 
 
-def format_version(version):
+def format_version(version: Optional[str]) -> Optional[str]:
     if not version:
         return version
 
@@ -146,7 +147,7 @@ def format_version(version):
     # to keep the meaning of the `latest` keyword:
     # See Also:https://docs.sentry.io/product/sentry-basics/search/
     if 'GIT' in version:
-        return None
+        return 'dev'
 
     parts = version.split('-', maxsplit=2)
     if len(parts) < 2:

--- a/src/tribler/core/sentry_reporter/tests/test_sentry_reporter.py
+++ b/src/tribler/core/sentry_reporter/tests/test_sentry_reporter.py
@@ -2,7 +2,6 @@ from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
-from tribler.core.utilities.patch_import import patch_import
 from tribler.core.sentry_reporter.sentry_reporter import (
     EXCEPTION,
     OS_ENVIRON,
@@ -13,6 +12,8 @@ from tribler.core.sentry_reporter.sentry_reporter import (
     this_sentry_strategy,
 )
 from tribler.core.sentry_reporter.sentry_scrubber import SentryScrubber
+from tribler.core.utilities.patch_import import patch_import
+
 
 # fmt: off
 # pylint: disable=redefined-outer-name, protected-access
@@ -119,6 +120,20 @@ def test_get_actual_strategy(sentry_reporter):
 
     sentry_reporter.thread_strategy.set(None)
     assert sentry_reporter.get_actual_strategy() == SentryStrategy.SEND_ALLOWED_WITH_CONFIRMATION
+
+
+def test_get_sentry_url_not_specified():
+    assert not SentryReporter.get_sentry_url()
+
+
+@patch('tribler.core.version.sentry_url', 'sentry_url')
+def test_get_sentry_url_from_version_file():
+    assert SentryReporter.get_sentry_url() == 'sentry_url'
+
+
+@patch('os.environ', {'TRIBLER_SENTRY_URL': 'env_url'})
+def test_get_sentry_url_from_env():
+    assert SentryReporter.get_sentry_url() == 'env_url'
 
 
 @patch('os.environ', {})
@@ -311,7 +326,7 @@ def test_before_send(sentry_reporter):
 
     # check release
     assert sentry_reporter._before_send({'release': '7.6.0'}, None) == {'release': '7.6.0'}
-    assert sentry_reporter._before_send({'release': '7.6.0-GIT'}, None) == {'release': None}
+    assert sentry_reporter._before_send({'release': '7.6.0-GIT'}, None) == {'release': 'dev'}
 
     # check confirmation
     sentry_reporter.global_strategy = SentryStrategy.SEND_ALLOWED_WITH_CONFIRMATION

--- a/src/tribler/core/sentry_reporter/tests/test_sentry_tools.py
+++ b/src/tribler/core/sentry_reporter/tests/test_sentry_tools.py
@@ -1,3 +1,5 @@
+import pytest
+
 from tribler.core.sentry_reporter.sentry_tools import (
     delete_item,
     distinct_by,
@@ -117,21 +119,21 @@ def test_distinct():
     assert distinct_by([{'a': {}}], 'b') == [{'a': {}}]
 
 
-def test_skip_dev_version():
-    assert format_version(None) is None
-    assert format_version('') == ''
-    assert format_version('7.6.0') == '7.6.0'
-    assert format_version('7.6.0-GIT') is None
+FORMATTED_VERSIONS = [
+    (None, None),
+    ('', ''),
+    ('7.6.0', '7.6.0'),
+    ('7.6.0-GIT', 'dev'),  # version from developers machines
+    ('7.7.1-17-gcb73f7baa', '7.7.1'),  # version from deployment tester
+    ('7.7.1-RC1-10-abcd', '7.7.1-RC1'),  # release candidate
+    ('7.7.1-exp1-1-abcd ', '7.7.1-exp1'),  # experimental versions
+    ('7.7.1-someresearchtopic-7-abcd ', '7.7.1-someresearchtopic'),
+]
 
-    # version from deployment tester
-    assert format_version('7.7.1-17-gcb73f7baa') == '7.7.1'
 
-    # release candidate
-    assert format_version('7.7.1-RC1-10-abcd') == '7.7.1-RC1'
-
-    # experimental versions
-    assert format_version('7.7.1-exp1-1-abcd ') == '7.7.1-exp1'
-    assert format_version('7.7.1-someresearchtopic-7-abcd ') == '7.7.1-someresearchtopic'
+@pytest.mark.parametrize('git_version, sentry_version', FORMATTED_VERSIONS)
+def test_format_version(git_version, sentry_version):
+    assert format_version(git_version) == sentry_version
 
 
 def test_extract_dict():


### PR DESCRIPTION
If you want to use Sentry as a developer, you have to specify the following env:

```bash
export TRIBLER_SENTRY_URL=<sentry_url>
```
I do recommend using [this](https://sentry.tribler.org/organizations/tribler/projects/tmp) project for dev's error reports.
After doing that all reported errors will be sent to this URL and be placed into `dev` [release](https://sentry.tribler.org/organizations/tribler/releases/dev/?project=3).

These are two examples of errors:
* https://sentry.tribler.org/organizations/tribler/issues/1220
* https://sentry.tribler.org/organizations/tribler/issues/1221