### PR TITLE
Simplify base64 conversion in `get_pieces_base64`

### DIFF
--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -23,5 +23,6 @@ yappi==1.3.3
 yarl==1.7.2 # keep this dependency higher than 1.6.3. See: https://github.com/aio-libs/yarl/issues/517
 Faker==9.8.2
 sentry-sdk==1.5.0
+bitarray==2.5.1
 pyipv8==2.8.0
 libtorrent==1.2.15

--- a/src/tribler/core/components/libtorrent/download_manager/download.py
+++ b/src/tribler/core/components/libtorrent/download_manager/download.py
@@ -9,8 +9,9 @@ from asyncio import CancelledError, Future, iscoroutine, sleep, wait_for
 from collections import defaultdict
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
 
+from bitarray import bitarray
 from ipv8.taskmanager import TaskManager, task
-from ipv8.util import int2byte, succeed
+from ipv8.util import succeed
 
 from tribler.core import notifications
 from tribler.core.components.libtorrent.download_manager.download_config import DownloadConfig
@@ -225,14 +226,9 @@ class Download(TaskManager):
         """
         Returns a base64 encoded bitmask of the pieces that we have.
         """
-        bitstr = b""
-        for bit in self.handle.status().pieces:
-            bitstr += b'1' if bit else b'0'
-
-        encoded_str = b""
-        for i in range(0, len(bitstr), 8):
-            encoded_str += int2byte(int(bitstr[i:i + 8].ljust(8, b'0'), 2))
-        return base64.b64encode(encoded_str)
+        binary_gen = (int(boolean) for boolean in self.handle.status().pieces)
+        bits = bitarray(binary_gen)
+        return base64.b64encode(bits.tobytes())
 
     def post_alert(self, alert_type: str, alert_dict: Optional[Dict] = None):
         alert_dict = alert_dict or {}

--- a/src/tribler/core/components/libtorrent/tests/test_download.py
+++ b/src/tribler/core/components/libtorrent/tests/test_download.py
@@ -2,18 +2,16 @@ from asyncio import Future, sleep
 from pathlib import Path
 from unittest.mock import Mock
 
-from ipv8.util import succeed
-
 import libtorrent as lt
+import pytest
+from ipv8.util import succeed
 from libtorrent import bencode
 
-import pytest
-
-from tribler.core.exceptions import SaveResumeDataError
 from tribler.core.components.libtorrent.download_manager.download_config import DownloadConfig
+from tribler.core.components.libtorrent.utils.torrent_utils import get_info_from_handle
+from tribler.core.exceptions import SaveResumeDataError
 from tribler.core.tests.tools.base_test import MockObject
 from tribler.core.tests.tools.common import TESTS_DATA_DIR
-from tribler.core.components.libtorrent.utils.torrent_utils import get_info_from_handle
 from tribler.core.utilities.unicode import hexlify
 from tribler.core.utilities.utilities import bdecode_compat
 
@@ -86,6 +84,7 @@ def test_selected_files(mock_handle, test_download):
     """
     Test whether the selected files are set correctly
     """
+
     def mocked_set_file_prios(_):
         mocked_set_file_prios.called = True
 
@@ -113,6 +112,7 @@ def test_selected_files_no_files(mock_handle, test_download):
     """
     Test that no files are selected if torrent info is not available.
     """
+
     def mocked_set_file_prios(_):
         mocked_set_file_prios.called = True
 
@@ -147,6 +147,7 @@ async def test_set_share_mode(mock_handle, test_download):
     """
     Test whether we set the right share mode in Download
     """
+
     def mocked_set_share_mode(val):
         assert val
         mocked_set_share_mode.called = True
@@ -161,11 +162,12 @@ def test_get_num_connected_seeds_peers(mock_handle, test_download):
     """
     Test whether connected peers and seeds are correctly returned
     """
+
     def get_peer_info(seeders, leechers):
         peer_info = []
         for _ in range(seeders):
             seeder = MockObject()
-            seeder.flags = 140347   # some value where seed flag(1024) is true
+            seeder.flags = 140347  # some value where seed flag(1024) is true
             seeder.seed = 1024
             peer_info.append(seeder)
         for _ in range(leechers):
@@ -188,6 +190,7 @@ async def test_set_priority(mock_handle, test_download):
     """
     Test whether setting the priority calls the right methods in Download
     """
+
     def mocked_set_priority(prio):
         assert prio == 1234
         mocked_set_priority.called = True
@@ -202,6 +205,7 @@ def test_add_trackers(mock_handle, test_download):
     """
     Testing whether trackers are added to the libtorrent handler in Download
     """
+
     def mocked_add_trackers(tracker_info):
         assert isinstance(tracker_info, dict)
         assert tracker_info['url'] == 'http://google.com'
@@ -278,6 +282,7 @@ def test_metadata_received_invalid_info(mock_handle, test_download):
     """
     Testing whether the right operations happen when we receive metadata but the torrent info is invalid
     """
+
     def mocked_checkpoint():
         raise RuntimeError("This code should not be reached!")
 
@@ -291,6 +296,7 @@ def test_metadata_received_invalid_torrent_with_value_error(mock_handle, test_do
     Testing whether the right operations happen when we receive metadata but the torrent info is invalid and throws
     Value Error
     """
+
     def mocked_checkpoint():
         raise RuntimeError("This code should not be reached!")
 
@@ -312,6 +318,7 @@ def test_torrent_checked_alert(mock_handle, test_download):
     """
     Testing whether the right operations happen after a torrent checked alert is received
     """
+
     def mocked_pause_checkpoint():
         mocked_pause_checkpoint.called = True
         return succeed(None)
@@ -352,8 +359,8 @@ def test_get_pieces_bitmask(mock_handle, test_download):
     test_download.handle.status().pieces = [True, False, True, False, False]
     assert test_download.get_pieces_base64() == b"oA=="
 
-    test_download.handle.status().pieces = [True * 16]
-    assert test_download.get_pieces_base64() == b"gA=="
+    test_download.handle.status().pieces = [True] * 16
+    assert test_download.get_pieces_base64() == b"//8="
 
 
 async def test_resume_data_failed(test_download):


### PR DESCRIPTION
Fixes #6875

This PR fixes two independent problems. 

First is an incorrect test `test_get_pieces_bitmask`.
This test used `[True * 16]` as an array initialization which is lead to the following array
```python
    assert [True * 16] == [16]
```

Another problem is `get_pieces_base64` itself, which could be rewritten as:

```python
    def get_pieces_base64(self) -> bytes:
        binary_gen = (int(boolean) for boolean in self.handle.status().pieces)
        bits = bitarray(binary_gen)
        return base64.b64encode(bits.tobytes())
```

Refs:
* https://www.libtorrent.org/reference-Torrent_Status.html#torrent_status
* https://github.com/ilanschnell/bitarray