### PR TITLE
Build Tribler binaries for win

### DIFF
--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Save Git info
         run: |
-          git describe | python -c 'import sys; print(next(sys.stdin).lstrip("v"))' > .TriblerVersion
+          git describe | python -c "import sys; print(next(sys.stdin).lstrip('v'))" > .TriblerVersion
           git rev-parse HEAD > .TriblerCommit
           echo "TRIBLER_VERSION=$(head -n 1 .TriblerVersion)" >> $GITHUB_ENV
 

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -1,0 +1,120 @@
+name: Windows
+
+on:
+  workflow_call:
+    inputs:
+      upload:
+        default: false
+        type: boolean
+        required: false
+
+      os:
+        default: windows-latest
+        type: string
+        required: false
+
+      python-version:
+        default: 3.8
+        type: string
+        required: false
+
+  workflow_dispatch:
+    inputs:
+      upload:
+        description: Upload
+        default: true
+        type: boolean
+        required: true
+
+      os:
+        description: Environment
+        default: windows-latest
+        type: string
+        required: true
+
+      python-version:
+        description: Python version
+        default: '3.8'
+        type: string
+        required: true
+jobs:
+  build:
+    runs-on: ${{ github.event.inputs.os || inputs.os }}
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{github.event.pull_request.head.sha}}
+
+      - name: Modify PATH
+        run: |
+          echo "C:\msys64\usr\bin" >> $env:GITHUB_PATH
+
+      - uses: actions/setup-python@v3
+        with:
+          python-version: ${{ github.event.inputs.python-version || inputs.python-version }}
+
+      - name: Save Git info
+        run: |
+          git describe | python -c "import sys; print(next(sys.stdin).lstrip('v'))" > .TriblerVersion
+          git rev-parse HEAD > .TriblerCommit
+
+      - name: Install windows dependencies
+        uses: ./.github/actions/windows_dependencies
+
+      - name: Prepare files
+        env:
+          SENTRY_URL: ${{secrets.SENTRY_URL}}
+        shell: cmd
+        run: |
+          python ./build/update_version.py -r .
+          python ./build/win/replace_nsi.py -r . --architecture x64
+
+      - name: Collect required binaries
+        shell: cmd
+        run: |
+          mkdir C:\build\
+          wget -q https://download.microsoft.com/download/9/3/F/93FCF1E7-E6A4-478B-96E7-D4B285925B00/vc_redist.x64.exe
+          move vc_redist.x64.exe C:\build\vc_redist_140.exe
+          copy C:\Windows\system32\libsodium.dll C:\build\
+
+      - name: Install NSIS plugins
+        env:
+          NSIS_PLUGINS: C:\Program Files (x86)\NSIS\Plugins
+          NSIS_INCLUDE: C:\Program Files (x86)\NSIS\Include
+        shell: cmd
+        run: |
+          wget -q https://nsis.sourceforge.io/mediawiki/images/1/18/NsProcess.zip
+          7z x NsProcess.zip -oNsProcess
+          move .\NsProcess\Plugin\nsProcessW.dll "%NSIS_PLUGINS%\x86-unicode\nsProcess.dll"
+          move .\NsProcess\Plugin\nsProcess.dll "%NSIS_PLUGINS%\x86-ansi\nsProcess.dll"
+          move .\NsProcess\Include\* "%NSIS_INCLUDE%"
+          echo AccessControl
+          wget -q https://nsis.sourceforge.io/mediawiki/images/4/4a/AccessControl.zip
+          7z x AccessControl.zip -oAccessControl
+          move .\AccessControl\Plugins\i386-unicode\* "%NSIS_PLUGINS%\x86-unicode"
+          move .\AccessControl\Plugins\i386-ansi\* "%NSIS_PLUGINS%\x86-ansi"
+          echo NSIS_Simple_Firewall_Plugin
+          wget -q https://nsis.sourceforge.io/mediawiki/images/e/e0/NSIS_Simple_Firewall_Plugin_Unicode_1.21.zip
+          7z x NSIS_Simple_Firewall_Plugin_Unicode_1.21.zip -oSFP
+          move .\SFP\SimpleFC.dll "%NSIS_PLUGINS%\x86-unicode"
+
+      - name: Run build script
+        timeout-minutes: 10
+        env:
+          QT_QPA_PLATFORM: offscreen
+          QT_ACCESSIBILITY: 1
+          QT_IM_MODULE: ibus
+          SKIP_SIGNING_TRIBLER_BINARIES: 'yes please'
+        shell: cmd
+        run: |
+          ./build/win/makedist_win.bat
+
+      - name: Upload Artifact
+        if: github.event.inputs.upload || inputs.upload
+        uses: actions/upload-artifact@v3
+        with:
+          name: tribler
+          path: dist/
+          retention-days: 1

--- a/build/win/makedist_win.bat
+++ b/build/win/makedist_win.bat
@@ -46,7 +46,7 @@ REM packs them in the installer .EXE
 ECHO Install pip dependencies for correct py-installer's work
 python3 -m pip install --upgrade -r build\win\requirements.txt
 
-%PYTHONHOME%\Scripts\pyinstaller.exe tribler.spec --log-level=DEBUG
+%PYTHONHOME%\Scripts\pyinstaller.exe tribler.spec --log-level=DEBUG || exit /b
 
 copy build\win\resources\tribler*.nsi dist\tribler
 
@@ -69,9 +69,6 @@ copy C:\build\libsodium.dll dist\tribler
 REM Sandip, 2019-10-24: No need to copy openssl dlls separately
 REM copy C:\build\openssl\*.dll dist\tribler
 
-REM Copy missing dll files
-copy C:\build\missing_dlls\*.dll dist\tribler
-
 
 @echo Running NSIS
 cd dist\tribler
@@ -81,13 +78,14 @@ set /p PASSWORD="Enter the PFX password:"
 
 REM Arno: Sign Tribler.exe so MS "Block / Unblock" dialog has publisher info.
 REM --- Doing this in ugly way for now
-
-signtool.exe sign /f C:\build\certs\certificate.pfx /p "%PASSWORD%" /d "Tribler" /t "http://timestamp.digicert.com" tribler.exe
-
+if not defined SKIP_SIGNING_TRIBLER_BINARIES (
+    signtool.exe sign /f C:\build\certs\certificate.pfx /p "%PASSWORD%" /d "Tribler" /t "http://timestamp.digicert.com" tribler.exe
+)
 :makeinstaller
-%NSIS% tribler.nsi
+%NSIS% tribler.nsi || exit /b
 move Tribler_*.exe ..
 cd ..
 REM Arno: Sign installer
-signtool.exe sign /f c:\build\certs\certificate.pfx /p "%PASSWORD%" /d "Tribler" /t "http://timestamp.digicert.com" Tribler_*.exe
-cd ..
+if not defined SKIP_SIGNING_TRIBLER_BINARIES (
+    signtool.exe sign /f c:\build\certs\certificate.pfx /p "%PASSWORD%" /d "Tribler" /t "http://timestamp.digicert.com" Tribler_*.exe
+)

--- a/build/win/replace_nsi.py
+++ b/build/win/replace_nsi.py
@@ -1,0 +1,31 @@
+import logging
+from argparse import ArgumentParser
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+
+def parse_arguments():
+    parser = ArgumentParser(description='Update Tribler NSI')
+    parser.add_argument('-r', '--repo', type=str, help='path to a repository folder', default='.')
+    parser.add_argument('-a', '--architecture', type=str, help='architecture (x86 or x64)', default='x86')
+    return parser.parse_args()
+
+
+if __name__ == '__main__':
+    arguments = parse_arguments()
+
+    version = Path('.TriblerVersion').read_text().lstrip('v').rstrip('\n')
+    tribler_nsi = Path(arguments.repo) / 'build/win/resources/tribler.nsi'
+    content = tribler_nsi.read_text()
+
+    content = content.replace('__GIT__', version)
+    if arguments.architecture == 'x64':
+        content = content.replace('x86', 'x64')
+        content = content.replace('"32"', '"64"')
+        content = content.replace('$PROGRAMFILES', '$PROGRAMFILES64')
+
+    tribler_nsi.write_text(content)
+
+    logger.info(f'Content of tribler.nsi: {content}')


### PR DESCRIPTION
This PR adds the `build_windows.yml` workflow that can be run manually.

GitHub windows build skips signing part:
```
signtool.exe sign /f C:\build\certs\certificate.pfx /p "%PASSWORD%" /d "Tribler" /t "http://timestamp.digicert.com" tribler.exe
```

The reason for skipping is that signing by itself is a highly discussible topic (particularly how we should sign Tribler binaries in GitHub). But the build itself will be very helpful for investigating virus alerts that we see in our Jenkins.

---

Also, this PR performs the second step of `update_version_from_git.py` refactoring: extracting `replace_nsi.py`.

When I add a build workflow for macOS, `update_version_from_git.py` could be deleted.

This change is backward-compatible with Jenkins one-click-release, but we must add the following lines to Jenkins before the call `makedist_win.bat`:

```
          git describe | python -c "import sys; print(next(sys.stdin).lstrip('v'))" > .TriblerVersion
          git rev-parse HEAD > .TriblerCommit

          python ./build/update_version.py -r .
          python ./build/win/replace_nsi.py -r . --architecture x64
```

Ref:
* https://nsis.sourceforge.io/How_can_I_install_a_plugin
* https://nsis.sourceforge.io/NsProcess_plugin
* https://github.com/actions/virtual-environments/blob/main/images/win/Windows2022-Readme.md
* https://stackoverflow.com/questions/36589736/nsis-check-if-process-exists-nsprocess-not-working