### PR TITLE
Fix PR event

### DIFF
--- a/.github/workflows/!PR.yml
+++ b/.github/workflows/!PR.yml
@@ -3,6 +3,7 @@ name: PR
 on:
   pull_request:
     types:
+      - opened
       - synchronize
       - ready_for_review
 
@@ -34,3 +35,5 @@ jobs:
     with:
       upload: false
       os: ubuntu-20.04
+      python-version: 3.8
+

--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -7,10 +7,16 @@ on:
         default: false
         type: boolean
         required: true
+
       os:
         default: ubuntu-latest
         type: string
         required: true
+
+      python-version:
+        default: 3.8
+        type: string
+        required: false
 
 jobs:
   build:
@@ -23,7 +29,7 @@ jobs:
 
       - uses: actions/setup-python@v3
         with:
-          python-version: 3.8
+          python-version: ${{inputs.python-version}}
 
       - name: Save Git info
         run: |


### PR DESCRIPTION
This PR fixes the PR event type (which has been introduced here: https://github.com/Tribler/tribler/pull/6913) by adding the type "opened". This makes it possible to run all the checks immediately after a PR is created.

Also, it adds `python-version` as a parameter to Ubuntu build.


Ref:
* https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request)