### PR TITLE
Add pip cache for GitHub Actions

### DIFF
--- a/.github/actions/pyenv/action.yml
+++ b/.github/actions/pyenv/action.yml
@@ -1,0 +1,37 @@
+name: pyenv
+description: Setup python and install required dependencies to venv with cache
+inputs:
+  python-version:
+    default: '3.8'
+    description: 'Python version'
+    required: false
+
+  requirements:
+    default: 'requirements.txt'
+    description: 'The path to requirements.txt file'
+    required: false
+
+outputs:
+  virtualenv-directory:
+    description: 'The path to the restored or created virtualenv'
+    value: ${{steps.cache-virtualenv.outputs.virtualenv-directory}}
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/setup-python@v3
+      with:
+        python-version: ${{inputs.python-version}}
+
+    - name: Restore virtual env
+      uses: syphar/restore-virtualenv@v1
+      id: cache-virtualenv
+      with:
+        requirement_files: ${{inputs.requirements}}
+
+    - name: Install pip dependencies
+      if: steps.cache-virtualenv.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r ${{inputs.requirements}}

--- a/.github/workflows/!PR.yml
+++ b/.github/workflows/!PR.yml
@@ -36,4 +36,3 @@ jobs:
       upload: false
       os: ubuntu-20.04
       python-version: 3.8
-

--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -27,9 +27,12 @@ jobs:
           fetch-depth: 0
           ref: ${{github.event.pull_request.head.sha}}
 
-      - uses: actions/setup-python@v3
+      - name: Create python environment
+        id: pyenv
+        uses: ./.github/actions/pyenv
         with:
           python-version: ${{inputs.python-version}}
+          requirements: requirements-build.txt
 
       - name: Save Git info
         run: |
@@ -51,6 +54,7 @@ jobs:
           QT_QPA_PLATFORM: offscreen
           QT_ACCESSIBILITY: 1
           QT_IM_MODULE: ibus
+          VENV: ${{steps.pyenv.outputs.virtualenv-directory}}
         run: |
           ./build/debian/makedist_debian.sh
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,14 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+
+      - name: Create python environment
+        uses: ./.github/actions/pyenv
         with:
           python-version: ${{inputs.python-version}}
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r ./requirements-test.txt
+          requirements: requirements-test.txt
 
       - name: Run Pytest with Coverage
         run: |

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -14,14 +14,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v3
+      - name: Create python environment
+        uses: ./.github/actions/pyenv
         with:
           python-version: ${{inputs.python-version}}
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r ./doc/requirements.txt
+          requirements: ./doc/requirements.txt
 
       - name: Build documentation
         run: |

--- a/.github/workflows/guitest.yml
+++ b/.github/workflows/guitest.yml
@@ -18,14 +18,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v3
+      - name: Create python environment
+        uses: ./.github/actions/pyenv
         with:
           python-version: ${{inputs.python-version}}
-
-      - name: Install pip dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r ./requirements-test.txt
+          requirements: requirements-test.txt
 
       - name: Install xvfb dependencies
         run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -25,9 +25,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v3
+      - name: Create python environment
+        uses: ./.github/actions/pyenv
         with:
           python-version: ${{inputs.python-version}}
+          requirements: requirements-test.txt
 
       - name: Install Libsodium (win)
         if: matrix.os == 'windows-latest'
@@ -35,11 +37,6 @@ jobs:
           C:\msys64\usr\bin\wget.exe -q https://download.libsodium.org/libsodium/releases/libsodium-1.0.17-msvc.zip
           7z x libsodium-1.0.17-msvc.zip
           copy ./x64/Release/v141/dynamic/libsodium.dll C:\Windows\system32\
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r ./requirements-test.txt
 
       - name: Run Pytest
         run: |


### PR DESCRIPTION
This PR adds cache for pip python dependencies. It should decrease the time of job runs.

(this improvement saves ~1m for each run)


Ref:
* https://github.com/actions/setup-python/issues/330
* https://docs.github.com/en/actions/creating-actions/about-custom-actions#composite-actions
* https://github.com/syphar/restore-virtualenv