### PR TITLE
Add `windows_dependencies` action

### DIFF
--- a/.github/actions/windows_dependencies/action.yml
+++ b/.github/actions/windows_dependencies/action.yml
@@ -1,0 +1,36 @@
+name: windows_dependencies
+description: Setup windows dependencies for Tribler
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Cache Binaries
+      id: cache-binaries
+      uses: actions/cache@v3
+      with:
+        path: cached-bin
+        key: ${{ runner.os }}-cached-bin
+
+    - name: Create bin folder
+      shell: cmd
+      run: |
+        if not exist "cached-bin" mkdir "cached-bin"
+
+    - name: Check Libsodium existence
+      id: check_libsodium
+      uses: andstor/file-existence-action@v1
+      with:
+        files: "cached-bin/libsodium.dll"
+
+    - name: Download Libsodium
+      if: steps.check_libsodium.outputs.files_exists == 'false'
+      shell: cmd
+      run: |
+        C:\msys64\usr\bin\wget.exe -q https://download.libsodium.org/libsodium/releases/libsodium-1.0.17-msvc.zip
+        7z x libsodium-1.0.17-msvc.zip
+        copy .\x64\Release\v141\dynamic\libsodium.dll .\cached-bin\
+
+    - name: Install Libsodium
+      shell: cmd
+      run: |
+        copy .\cached-bin\libsodium.dll C:\Windows\system32\

--- a/.github/actions/windows_dependencies/action.yml
+++ b/.github/actions/windows_dependencies/action.yml
@@ -1,5 +1,10 @@
 name: windows_dependencies
 description: Setup windows dependencies for Tribler
+inputs:
+  libsodium-version:
+    default: '1.0.17'
+    description: 'Libsodium version'
+    required: false
 
 runs:
   using: 'composite'
@@ -20,17 +25,18 @@ runs:
       id: check_libsodium
       uses: andstor/file-existence-action@v1
       with:
-        files: "cached-bin/libsodium.dll"
+        files: "cached-bin/libsodium-${{inputs.libsodium-version}}/libsodium.dll"
 
     - name: Download Libsodium
       if: steps.check_libsodium.outputs.files_exists == 'false'
       shell: cmd
       run: |
-        C:\msys64\usr\bin\wget.exe -q https://download.libsodium.org/libsodium/releases/libsodium-1.0.17-msvc.zip
-        7z x libsodium-1.0.17-msvc.zip
-        copy .\x64\Release\v141\dynamic\libsodium.dll .\cached-bin\
+        C:\msys64\usr\bin\wget.exe -q https://download.libsodium.org/libsodium/releases/libsodium-${{inputs.libsodium-version}}-msvc.zip
+        7z x libsodium-${{inputs.libsodium-version}}-msvc.zip
+        if not exist "cached-bin\libsodium-${{inputs.libsodium-version}}" mkdir "cached-bin\libsodium-${{inputs.libsodium-version}}"
+        copy .\x64\Release\v141\dynamic\libsodium.dll .\cached-bin\libsodium-${{inputs.libsodium-version}}\libsodium.dll
 
     - name: Install Libsodium
       shell: cmd
       run: |
-        copy .\cached-bin\libsodium.dll C:\Windows\system32\
+        copy .\cached-bin\libsodium-${{inputs.libsodium-version}}\libsodium.dll C:\Windows\system32\

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -31,12 +31,9 @@ jobs:
           python-version: ${{inputs.python-version}}
           requirements: requirements-test.txt
 
-      - name: Install Libsodium (win)
-        if: matrix.os == 'windows-latest'
-        run: |
-          C:\msys64\usr\bin\wget.exe -q https://download.libsodium.org/libsodium/releases/libsodium-1.0.17-msvc.zip
-          7z x libsodium-1.0.17-msvc.zip
-          copy ./x64/Release/v141/dynamic/libsodium.dll C:\Windows\system32\
+      - name: Install windows dependencies
+        if: runner.os == 'Windows'
+        uses: ./.github/actions/windows_dependencies
 
       - name: Run Pytest
         run: |


### PR DESCRIPTION
This PR adds the `windows_dependencies` action to our GitHub Workflows. This functionality has been extracted from https://github.com/Tribler/tribler/pull/6920.

(it saves ~ 10s for each win run and generalises logic of win jobs)

Ref:
* https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy