### PR TITLE
Add `workflow_dispatch` for ubuntu build

### DIFF
--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -18,9 +18,29 @@ on:
         type: string
         required: false
 
+  workflow_dispatch:
+    inputs:
+      upload:
+        description: Upload
+        default: true
+        type: boolean
+        required: true
+
+      os:
+        description: Environment
+        default: ubuntu-latest
+        type: string
+        required: true
+
+      python-version:
+        description: Python version
+        default: '3.8'
+        type: string
+        required: true
+
 jobs:
   build:
-    runs-on: ${{inputs.os}}
+    runs-on: ${{ github.event.inputs.os || inputs.os }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -31,7 +51,7 @@ jobs:
         id: pyenv
         uses: ./.github/actions/pyenv
         with:
-          python-version: ${{inputs.python-version}}
+          python-version: ${{ github.event.inputs.python-version || inputs.python-version }}
           requirements: requirements-build.txt
 
       - name: Save Git info
@@ -59,7 +79,7 @@ jobs:
           ./build/debian/makedist_debian.sh
 
       - name: Upload Artifact
-        if: inputs.upload
+        if: github.event.inputs.upload || inputs.upload
         uses: actions/upload-artifact@v3
         with:
           name: tribler.deb


### PR DESCRIPTION
This PR makes it possible to invoke ubuntu build manually from this page: https://github.com/Tribler/tribler/actions/workflows/build_ubuntu.yml

The following screens will be available after merge:
<img width="657" alt="image" src="https://user-images.githubusercontent.com/13798583/172412077-e3b560b6-e3b8-4675-b549-e8d9ae795ac0.png">
<img width="489" alt="image" src="https://user-images.githubusercontent.com/13798583/172412298-cb532650-bb4b-4b72-b9f3-968ea23d3d94.png">


Ref:
* https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch
* https://github.community/t/inconsistent-inputs-context-for-workflow-dispatch-and-workflow-call/207835/7