### PR TITLE
[mac] Fix Tribler.app is damaged 

### DIFF
--- a/build/mac/makedist_macos.sh
+++ b/build/mac/makedist_macos.sh
@@ -22,6 +22,7 @@ export RESOURCES=build/mac/resources
 python3 -m venv build-env
 . ./build-env/bin/activate
 python3 -m pip install --upgrade pip
+python3 -m pip install PyInstaller==4.2 --no-use-pep517
 python3 -m pip install --upgrade -r requirements-build.txt
 
 # ----- Build

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,6 +1,7 @@
 -r requirements.txt
 
-PyInstaller==5.1
+PyInstaller==5.1; sys_platform != 'darwin'
+setuptools==60.0.2; sys_platform == 'darwin'
 defusedxml==0.7.1; sys_platform == 'linux2' or sys_platform == 'linux'
 markupsafe==2.0.1; sys_platform == 'linux2' or sys_platform == 'linux'
 requests==2.25.1


### PR DESCRIPTION
The alert window for the first Tribler's run has been changed to the old one:

<img width="203" alt="image" src="https://user-images.githubusercontent.com/13798583/173888942-db08a013-c6ff-4226-93f7-7b2edf865169.png">
<img width="234" alt="image" src="https://user-images.githubusercontent.com/13798583/173894578-8ef0eab7-f401-4222-9fb0-74fdbb0fe2df.png">


I got a version of `PyInstaller==4.2` from the builder machine, tried to build binaries, and hopefully, it solved the problem that we encountered in https://github.com/Tribler/tribler/pull/6928

All modern version of `pyinstaler` leads to the following error: "Tribler.app is damaged and can’t be opened. you should move it to the bin".
