### PR TITLE
Fixes #6929

### DIFF
--- a/src/tribler/gui/core_manager.py
+++ b/src/tribler/gui/core_manager.py
@@ -87,6 +87,10 @@ class CoreManager(QObject):
         core_args = self.core_args
         if not core_args:
             core_args = sys.argv + ['--core']
+            if getattr(sys, 'frozen', False):
+                # remove duplicate tribler.exe from core_args when running complied binary
+                # https://pyinstaller.org/en/v3.3.1/runtime-information.html#using-sys-executable-and-sys-argv-0
+                core_args = core_args[1:]
 
         self.core_process = QProcess()
         self.core_process.setProcessEnvironment(core_env)
@@ -95,6 +99,7 @@ class CoreManager(QObject):
         connect(self.core_process.readyReadStandardOutput, self.on_core_stdout_read_ready)
         connect(self.core_process.readyReadStandardError, self.on_core_stderr_read_ready)
         connect(self.core_process.finished, self.on_core_finished)
+        self._logger.info(f'Start Tribler core process {sys.executable} with arguments: {core_args}')
         self.core_process.start(sys.executable, core_args)
 
     def on_core_started(self):


### PR DESCRIPTION
This PR fixes https://github.com/Tribler/tribler/issues/6929

@kozlovsky:

I debugged the problem and found the reason for the error. It is in [this line](https://github.com/Tribler/tribler/blob/410fb735d3758ccf8ac4745e0f2cd3c89a31f2e9/src/tribler/gui/core_manager.py#L98) of CoreManager:

```python
self.core_process.start(sys.executable, core_args)
```

There is a difference in arguments between a python script and a compiled executable. For script, arguments can look like
```python
["myscript.py", "arg1", "arg2"]
```

and sys.executable is something like C:/Python39/python.exe.

For the same code in the compiled executable, arguments will be

```python
["myscript.exe", "arg1", "arg2"]
```

and sys.executable is myscript.exe.

That means that when Tribler executes self.core_process.start(sys.executable, core_args) from the compiled binary, it runs tribler.exe with arguments ["tribler.exe", "some.torrent", "--core"], because tribler.exe comes both from sys.executable and from sys.argv[0]. The proper fix, in my opinion, is to remove duplicate "tribler.exe" from the argument list when running a code from compiled binary.

So, the reason for the error is that when compiled, GUI runs Core with arguments:

```python
tribler.exe tribler.exe some.torrent --core
```