### PR TITLE
Pass secrets to callable workflows.

### DIFF
--- a/.github/workflows/!main.yml
+++ b/.github/workflows/!main.yml
@@ -8,16 +8,30 @@ on:
 jobs:
   docker:
     uses: ./.github/workflows/docker-image.yml
+    secrets:
+      DOCKER_USER: ${{ secrets.DOCKER_USER }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 
   codacy:
     uses: ./.github/workflows/codacy.yml
+    secrets:
+      CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
 
   coverage:
     uses: ./.github/workflows/coverage.yml
     with:
       python-version: 3.8
+    secrets:
+      CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
 
   pytest:
     uses: ./.github/workflows/pytest.yml
     with:
       python-version: 3.8
+
+  ubuntu:
+    uses: ./.github/workflows/build_ubuntu.yml
+    with:
+      python-version: 3.8
+    secrets:
+      SENTRY_URL: ${{ secrets.SENTRY_URL }}

--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -17,6 +17,9 @@ on:
         default: false
         type: boolean
         required: false
+    secrets:
+      SENTRY_URL:
+        required: false
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -2,7 +2,9 @@ name: Codacy Security Scan
 
 on:
   workflow_call:
-
+    secrets:
+      CODACY_PROJECT_TOKEN:
+        required: true
 jobs:
   analyse:
     runs-on: ubuntu-latest

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,6 +7,9 @@ on:
         default: 3.8
         type: string
         required: false
+    secrets:
+      CODACY_PROJECT_TOKEN:
+        required: false
 
 jobs:
   generate_and_upload:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,23 +2,32 @@ name: Docker Image CI
 
 on:
   workflow_call:
-
+    secrets:
+        DOCKER_USER:
+          required: true
+        DOCKER_PASSWORD:
+          required: true
 jobs:
-
   build:
-
     runs-on: ubuntu-latest
 
     steps:
     - name: Checkout repository and submodules
       uses: actions/checkout@v2
+
     - name: Docker login
       env:
         DOCKER_USER: ${{secrets.DOCKER_USER}}
         DOCKER_PASSWORD: ${{secrets.DOCKER_PASSWORD}}
       run: |
         docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
+
     - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag triblercore/triblercore:latest
+      run: |
+        docker build . --file Dockerfile --tag triblercore/triblercore:latest
+
     - name: Push to Docker Hub
-      run: docker push ${{secrets.DOCKER_USER}}/triblercore:latest
+      env:
+        DOCKER_USER: ${{secrets.DOCKER_USER}}
+      run: |
+        docker push $DOCKER_USER/triblercore:latest


### PR DESCRIPTION
This PR fixes #6952, #6951 by passing secrets to callable workflows explicitly.

Also, this PR adds missed ubuntu build step for the "push to main" event and fixes a security issue with the docker image build.

Ref:
* https://github.community/t/reusable-workflows-secrets-and-environments/203695/40