### PR TITLE
Fix random frozen ProcessChecker tests

### DIFF
--- a/src/tribler/core/utilities/tests/test_process_checker.py
+++ b/src/tribler/core/utilities/tests/test_process_checker.py
@@ -34,7 +34,7 @@ def checker(tmp_path):
 
 
 def idle():
-    sleep(100)
+    sleep(1)
 
 
 @pytest.fixture
@@ -42,7 +42,7 @@ def process():
     process = Process(target=idle)
     process.start()
     yield psutil.Process(process.pid)
-    process.terminate()
+    process.kill()
 
 
 def test_get_pid_lock_file(checker: ProcessChecker):


### PR DESCRIPTION
Sometimes ProcessChecker tests become frozen for an unknown reason.
This PR makes an attempt to fix it.

See:
* https://github.com/Tribler/tribler/runs/7088824564?check_suite_focus=true
* https://github.com/Tribler/tribler/runs/7089778224?check_suite_focus=true