### PR TITLE
Add a posiibility to manually trigger GUI and Core exceptions in Tribler for debugging purposes

### DIFF
--- a/src/tribler/core/components/restapi/rest/debug_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/debug_endpoint.py
@@ -15,8 +15,10 @@ from marshmallow.fields import Boolean, Float, Integer, String
 
 import psutil
 
+from tribler.core.components.reporter.exception_handler import CoreExceptionHandler
 from tribler.core.components.resource_monitor.implementation.base import ResourceMonitor
 from tribler.core.components.restapi.rest.rest_endpoint import RESTEndpoint, RESTResponse
+from tribler.core.exceptions import TriblerCoreTestException
 from tribler.core.utilities.instrumentation import WatchDog
 from tribler.core.utilities.osutils import get_root_state_directory
 from tribler.core.utilities.path_util import Path
@@ -47,12 +49,14 @@ class DebugEndpoint(RESTEndpoint):
                  state_dir: Path,
                  log_dir: Path,
                  tunnel_community: TunnelCommunity = None,
-                 resource_monitor: ResourceMonitor = None):
+                 resource_monitor: ResourceMonitor = None,
+                 core_exception_handler: CoreExceptionHandler = None):
         super().__init__()
         self.state_dir = state_dir
         self.log_dir = log_dir
         self.tunnel_community = tunnel_community
         self.resource_monitor = resource_monitor
+        self.core_exception_handler = core_exception_handler
 
     def setup_routes(self):
         self.app.add_routes([web.get('/circuits/slots', self.get_circuit_slots),
@@ -64,7 +68,9 @@ class DebugEndpoint(RESTEndpoint):
                              web.get('/log', self.get_log),
                              web.get('/profiler', self.get_profiler_state),
                              web.put('/profiler', self.start_profiler),
-                             web.delete('/profiler', self.stop_profiler)])
+                             web.delete('/profiler', self.stop_profiler),
+                             web.post('/core_test_exception', self.core_test_exception),
+                             ])
         if HAS_MELIAE:
             self.app.add_routes([web.get('/memory/dump', self.get_memory_dump)])
 
@@ -364,3 +370,27 @@ class DebugEndpoint(RESTEndpoint):
     async def stop_profiler(self, _):
         file_path = self.resource_monitor.profiler.stop()
         return RESTResponse({"success": True, "profiler_file": str(file_path)})
+
+    @docs(
+        tags=['Debug'],
+        summary="Generates a test exception in the Core process.",
+        responses={
+            200: {
+                'schema': schema(CoreTestException={
+                    'success': Boolean
+                })
+            }
+        }
+    )
+    async def core_test_exception(self, _):
+        self._logger.info('Test Tribler Core exception was triggered')
+        if self.core_exception_handler:
+            try:
+                raise TriblerCoreTestException('Tribler Core Test Exception')
+            except TriblerCoreTestException as e:
+                context = dict(should_stop=False, message='Test message', exception=e)
+                self.core_exception_handler.unhandled_error_observer(None, context)
+        else:
+            self._logger.info('Exception handler is not set in DebugEndpoint')
+
+        return RESTResponse({"success": True})

--- a/src/tribler/core/components/restapi/restapi_component.py
+++ b/src/tribler/core/components/restapi/restapi_component.py
@@ -91,8 +91,10 @@ class RESTComponent(Component):
         self.root_endpoint.add_endpoint('/events', self._events_endpoint)
         self.maybe_add('/settings', SettingsEndpoint, config, download_manager=libtorrent_component.download_manager)
         self.maybe_add('/shutdown', ShutdownEndpoint, shutdown_event.set)
-        self.maybe_add('/debug', DebugEndpoint, config.state_dir, log_dir, tunnel_community=tunnel_community,
-                       resource_monitor=resource_monitor_component.resource_monitor)
+        self.maybe_add('/debug', DebugEndpoint, config.state_dir, log_dir,
+                       tunnel_community=tunnel_community,
+                       resource_monitor=resource_monitor_component.resource_monitor,
+                       core_exception_handler=self._core_exception_handler)
         self.maybe_add('/bandwidth', BandwidthEndpoint, bandwidth_accounting_component.community)
         self.maybe_add('/trustview', TrustViewEndpoint, bandwidth_accounting_component.database)
         self.maybe_add('/downloads', DownloadsEndpoint, libtorrent_component.download_manager,

--- a/src/tribler/core/exceptions.py
+++ b/src/tribler/core/exceptions.py
@@ -34,3 +34,7 @@ class InvalidConfigException(TriblerException):
 
 class TrustGraphException(TriblerException):
     """Exception specific to Trust graph."""
+
+
+class TriblerCoreTestException(TriblerException):
+    """Can be intentionally generated in Core by pressing Ctrl+Alt+Shift+C"""

--- a/src/tribler/gui/exceptions.py
+++ b/src/tribler/gui/exceptions.py
@@ -12,3 +12,7 @@ class CoreConnectTimeoutError(CoreError):
 
 class CoreCrashedError(CoreError):
     """This error raises in case of tribler core finished with error"""
+
+
+class TriblerGuiTestException(Exception):
+    """Can be intentionally generated in GUI by pressing Ctrl+Alt+Shift+G"""

--- a/src/tribler/gui/tribler_window.py
+++ b/src/tribler/gui/tribler_window.py
@@ -251,6 +251,9 @@ class TriblerWindow(QMainWindow):
         self.tribler_gui_test_exception_shortcut = QShortcut(QKeySequence("Ctrl+Alt+Shift+G"), self)
         connect(self.tribler_gui_test_exception_shortcut.activated, self.on_test_tribler_gui_exception)
 
+        self.tribler_core_test_exception_shortcut = QShortcut(QKeySequence("Ctrl+Alt+Shift+C"), self)
+        connect(self.tribler_core_test_exception_shortcut.activated, self.on_test_tribler_core_exception)
+
         connect(self.top_search_bar.clicked, self.clicked_search_bar)
         connect(self.top_search_bar.returnPressed, self.on_top_search_bar_return_pressed)
 
@@ -405,6 +408,12 @@ class TriblerWindow(QMainWindow):
 
     def on_test_tribler_gui_exception(self, *args):
         raise TriblerGuiTestException("Tribler GUI Test Exception")
+
+    def on_test_tribler_core_exception(self, *args):
+        def dummy_callback(_):
+            pass
+
+        TriblerNetworkRequest("/debug/core_test_exception", dummy_callback, method='POST')
 
     def create_new_channel(self, checked):
         # TODO: DRY this with tablecontentmodel, possibly using QActions

--- a/src/tribler/gui/tribler_window.py
+++ b/src/tribler/gui/tribler_window.py
@@ -85,6 +85,7 @@ from tribler.gui.dialogs.createtorrentdialog import CreateTorrentDialog
 from tribler.gui.dialogs.new_channel_dialog import NewChannelDialog
 from tribler.gui.dialogs.startdownloaddialog import StartDownloadDialog
 from tribler.gui.error_handler import ErrorHandler
+from tribler.gui.exceptions import TriblerGuiTestException
 from tribler.gui.event_request_manager import EventRequestManager
 from tribler.gui.tribler_action_menu import TriblerActionMenu
 from tribler.gui.tribler_request_manager import (
@@ -240,10 +241,15 @@ class TriblerWindow(QMainWindow):
 
         self.debug_pane_shortcut = QShortcut(QKeySequence("Ctrl+d"), self)
         connect(self.debug_pane_shortcut.activated, self.clicked_debug_panel_button)
+
         self.import_torrent_shortcut = QShortcut(QKeySequence("Ctrl+o"), self)
         connect(self.import_torrent_shortcut.activated, self.on_add_torrent_browse_file)
+
         self.add_torrent_url_shortcut = QShortcut(QKeySequence("Ctrl+i"), self)
         connect(self.add_torrent_url_shortcut.activated, self.on_add_torrent_from_url)
+
+        self.tribler_gui_test_exception_shortcut = QShortcut(QKeySequence("Ctrl+Alt+Shift+G"), self)
+        connect(self.tribler_gui_test_exception_shortcut.activated, self.on_test_tribler_gui_exception)
 
         connect(self.top_search_bar.clicked, self.clicked_search_bar)
         connect(self.top_search_bar.returnPressed, self.on_top_search_bar_return_pressed)
@@ -396,6 +402,9 @@ class TriblerWindow(QMainWindow):
             run_core=run_core,
             upgrade_manager=self.upgrade_manager,
         )
+
+    def on_test_tribler_gui_exception(self, *args):
+        raise TriblerGuiTestException("Tribler GUI Test Exception")
 
     def create_new_channel(self, checked):
         # TODO: DRY this with tablecontentmodel, possibly using QActions


### PR DESCRIPTION
Sometimes it is very convenient to manually trigger an exception in Tribler to see how the exception is handled with the current configuration settings.

This PR adds a possibility to trigger a test exception in the "frontend" GUI process by pressing `Ctrl+Alt+Shift+Home`, as well as trigger another exception in the "backend" Core process by pressing `Ctrl+Alt+Shift+End`. The triggered exceptions are processed the same way "natural" exceptions are processed.

This functionality allows manually discovering and fixing bugs in error handling code with specific error reporting configuration settings.