### PR TITLE
Fix Tribler shutdown after closing of FeedbackDialog

### DIFF
--- a/src/tribler/core/components/restapi/rest/debug_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/debug_endpoint.py
@@ -388,7 +388,7 @@ class DebugEndpoint(RESTEndpoint):
             try:
                 raise TriblerCoreTestException('Tribler Core Test Exception')
             except TriblerCoreTestException as e:
-                context = dict(should_stop=False, message='Test message', exception=e)
+                context = dict(should_stop=True, message='Test message', exception=e)
                 self.core_exception_handler.unhandled_error_observer(None, context)
         else:
             self._logger.info('Exception handler is not set in DebugEndpoint')

--- a/src/tribler/gui/core_manager.py
+++ b/src/tribler/gui/core_manager.py
@@ -143,10 +143,15 @@ class CoreManager(QObject):
 
         self.shutting_down = True
         self._logger.info("Stopping Core manager")
-        if self.core_process or self.core_connected:
+
+        need_to_shutdown_core = (self.core_process or self.core_connected) and not self.core_finished
+        if need_to_shutdown_core:
             self._logger.info("Sending shutdown request to Tribler Core")
             self.events_manager.shutting_down = True
             TriblerNetworkRequest("shutdown", lambda _: None, method="PUT", priority=QNetworkRequest.HighPriority)
+        elif self.should_quit_app_on_core_finished:
+            self._logger.info('Core finished, quitting GUI application')
+            self.app_manager.quit_application()
 
     def on_core_finished(self, exit_code, exit_status):
         self.core_running = False

--- a/src/tribler/gui/dialogs/feedbackdialog.py
+++ b/src/tribler/gui/dialogs/feedbackdialog.py
@@ -14,7 +14,7 @@ from tribler.core.components.reporter.reported_error import ReportedError
 from tribler.core.sentry_reporter.sentry_reporter import SentryReporter
 from tribler.core.sentry_reporter.sentry_scrubber import SentryScrubber
 from tribler.core.sentry_reporter.sentry_tools import CONTEXT_DELIMITER, LONG_TEXT_DELIMITER
-from tribler.gui.app_manager import AppManager
+from tribler.gui.core_manager import CoreManager
 from tribler.gui.event_request_manager import received_events
 from tribler.gui.sentry_mixin import AddBreadcrumbOnShowMixin
 from tribler.gui.tribler_action_menu import TriblerActionMenu
@@ -35,7 +35,7 @@ class FeedbackDialog(AddBreadcrumbOnShowMixin, QDialog):
         retrieve_error_message_from_stacktrace=False,
     ):
         QDialog.__init__(self, parent)
-        self.app_manager: AppManager = parent.app_manager
+        self.core_manager: CoreManager = parent.core_manager
 
         uic.loadUi(get_ui_file_path('feedback_dialog.ui'), self)
 
@@ -196,5 +196,6 @@ class FeedbackDialog(AddBreadcrumbOnShowMixin, QDialog):
 
     def closeEvent(self, close_event):
         if self.stop_application_on_close:
-            self.app_manager.quit_application()
-            close_event.ignore()
+            self.core_manager.stop()
+            if self.core_manager.shutting_down and not self.core_manager.core_finished:
+                close_event.ignore()


### PR DESCRIPTION
Currently, in case of exception, if SentryReporter is in test mode, after reporting an exception it calls [`AppManager.quit_application()`](https://github.com/Tribler/tribler/blob/da025dc5b5e651064bd4e54cfe2a2d29f367bf20/src/tribler/gui/dialogs/feedbackdialog.py#L199), which in turn calls `QApplication.quit()`.

This logic is incorrect, as the Tribler core process, managed by a `QProcess` instance, terminated immediately without any possibility to do cleanup work, like removing the `triblerd.lock` file or saving the libtorrent state.

The correct behavior is to stop the Core process the usual way and then shut down GUI. This PR fixes the shutdown logic, allowing the Core to shut down properly.