### PR TITLE
Refactor the WatchFolder

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -36,6 +36,7 @@ jobs:
         uses: ./.github/actions/windows_dependencies
 
       - name: Run Pytest
+        timeout-minutes: 10
         run: |
           pytest ./src/tribler/core ${{matrix.pytest-arguments}}
 

--- a/.pylintrc
+++ b/.pylintrc
@@ -65,7 +65,10 @@ confidence=
 # --disable=W"
 #disable=import-star-module-level,old-octal-literal,oct-method,print-statement,unpacking-in-except,parameter-unpacking,backtick,old-raise-syntax,old-ne-operator,long-suffix,dict-view-method,dict-iter-method,metaclass-assignment,next-method-called,raising-string,indexing-exception,raw_input-builtin,long-builtin,file-builtin,execfile-builtin,coerce-builtin,cmp-builtin,buffer-builtin,basestring-builtin,apply-builtin,filter-builtin-not-iterating,using-cmp-argument,useless-suppression,range-builtin-not-iterating,suppressed-message,no-absolute-import,old-division,cmp-method,reload-builtin,zip-builtin-not-iterating,intern-builtin,unichr-builtin,reduce-builtin,standarderror-builtin,unicode-builtin,xrange-builtin,coerce-method,delslice-method,getslice-method,setslice-method,input-builtin,round-builtin,hex-method,nonzero-method,map-builtin-not-iterating
 disable=C0321,W0142,invalid-name,missing-docstring,no-member,no-name-in-module,
-    no-self-use,too-few-public-methods,C0330,W1203,too-many-ancestors,too-many-arguments,too-many-public-methods,too-many-statements,too-many-instance-attributes,too-many-locals,too-many-branches,too-many-return-statements
+    no-self-use,too-few-public-methods,C0330,W1203,too-many-ancestors,
+    too-many-arguments,too-many-public-methods,too-many-statements,
+    too-many-instance-attributes,too-many-locals,too-many-branches,
+    too-many-return-statements, E5110
 
 #missing-type-doc
 

--- a/src/tribler/core/components/libtorrent/download_manager/download.py
+++ b/src/tribler/core/components/libtorrent/download_manager/download.py
@@ -293,8 +293,12 @@ class Download(TaskManager):
         basename = hexlify(resume_data[b'info-hash']) + '.conf'
         filename = self.dlmgr.get_checkpoint_dir() / basename
         self.config.config['download_defaults']['name'] = self.tdef.get_name_as_unicode()  # store name (for debugging)
-        self.config.write(str(filename))
-        self._logger.debug('Saving download config to file %s', filename)
+        try:
+            self.config.write(str(filename))
+        except OSError as e:
+            self._logger.warning(f'{e.__class__.__name__}: {e}')
+        else:
+            self._logger.debug(f'Resume data has been saved to: {filename}')
 
     def on_tracker_reply_alert(self, alert: lt.tracker_reply_alert):
         self._logger.info(f'On tracker reply alert: {alert}')

--- a/src/tribler/core/components/libtorrent/download_manager/download_config.py
+++ b/src/tribler/core/components/libtorrent/download_manager/download_config.py
@@ -56,8 +56,8 @@ class DownloadConfig:
                                         configspec=str(CONFIG_SPEC_PATH), default_encoding='utf-8'))
 
     @staticmethod
-    def convert(settings: DownloadDefaultsSettings):
-        config = DownloadConfig()
+    def from_defaults(settings: DownloadDefaultsSettings, state_dir=None):
+        config = DownloadConfig(state_dir=state_dir)
 
         config.set_hops(settings.number_hops)
         config.set_safe_seeding(settings.safeseeding_enabled)

--- a/src/tribler/core/components/libtorrent/download_manager/download_manager.py
+++ b/src/tribler/core/components/libtorrent/download_manager/download_manager.py
@@ -539,7 +539,7 @@ class DownloadManager(TaskManager):
                        hidden=False) -> Download:
         self._logger.debug(f'Starting download: filename: {torrent_file}, torrent def: {tdef}')
         if config is None:
-            config = DownloadConfig.convert(self.download_defaults)
+            config = DownloadConfig.from_defaults(self.download_defaults)
             self._logger.debug('Use a default config.')
 
         # the priority of the parameters is: (1) tdef, (2) torrent_file.

--- a/src/tribler/core/components/reporter/exception_handler.py
+++ b/src/tribler/core/components/reporter/exception_handler.py
@@ -30,6 +30,10 @@ IGNORED_ERRORS_BY_REGEX = {
 }
 
 
+class NoCrashException(Exception):
+    """Raising exceptions of this type doesn't lead to forced Tribler stop"""
+
+
 class CoreExceptionHandler:
     """
     This class handles Python errors arising in the Core by catching them, adding necessary context,
@@ -83,6 +87,9 @@ class CoreExceptionHandler:
             text = str(exception)
             if isinstance(exception, ComponentStartupException):
                 should_stop = exception.component.tribler_should_stop_on_component_error
+                exception = exception.__cause__
+            if isinstance(exception, NoCrashException):
+                should_stop = False
                 exception = exception.__cause__
 
             if self._is_ignored(exception):

--- a/src/tribler/core/components/watch_folder/watch_folder.py
+++ b/src/tribler/core/components/watch_folder/watch_folder.py
@@ -1,86 +1,100 @@
+import asyncio
 import logging
 import os
-from pathlib import Path
 
-from ipv8.taskmanager import TaskManager
-
-from tribler.core import notifications
+from tribler.core.components.libtorrent.download_manager.download_config import DownloadConfig
 from tribler.core.components.libtorrent.download_manager.download_manager import DownloadManager
 from tribler.core.components.libtorrent.torrentdef import TorrentDef
+from tribler.core.components.reporter.exception_handler import NoCrashException
 from tribler.core.components.watch_folder.settings import WatchFolderSettings
-from tribler.core.utilities import path_util
+from tribler.core.utilities.async_group import AsyncGroup
 from tribler.core.utilities.notifier import Notifier
+from tribler.core.utilities.path_util import Path
 
 WATCH_FOLDER_CHECK_INTERVAL = 10
 
 
-class WatchFolder(TaskManager):
+class WatchFolder:
     def __init__(self, state_dir: Path, settings: WatchFolderSettings, download_manager: DownloadManager,
-                 notifier: Notifier):
+                 notifier: Notifier, check_interval: float = WATCH_FOLDER_CHECK_INTERVAL):
         super().__init__()
         self.state_dir = state_dir
         self.settings = settings
         self.download_manager = download_manager
         self.notifier = notifier
-
+        self.check_interval = check_interval
+        self.group = AsyncGroup()
         self._logger = logging.getLogger(self.__class__.__name__)
         self._logger.info(f'Initialised with {settings}')
 
     def start(self):
-        self.register_task("check watch folder", self.check_watch_folder, interval=WATCH_FOLDER_CHECK_INTERVAL)
+        self.group.add(self._run())
 
     async def stop(self):
-        await self.shutdown_task_manager()
+        await self.group.cancel()
 
-    def cleanup_torrent_file(self, root, name):
-        fullpath = root / name
-        if not fullpath.exists():
-            self._logger.warning("File with path %s does not exist (anymore)", root / name)
-            return
-        path = Path(str(fullpath) + ".corrupt")
+    async def _run(self):
+        while True:
+            await asyncio.sleep(self.check_interval)
+            self.group.add(self._check_watch_folder_handle_exceptions())
+
+    async def _check_watch_folder_handle_exceptions(self):
         try:
-            path.unlink(missing_ok=True)
-            fullpath.rename(path)
-        except (PermissionError, FileExistsError) as e:
-            self._logger.warning(f'Cant rename the file to {path}. Exception: {e}')
+            self._check_watch_folder()
+        except Exception as e:
+            self._logger.exception(f'Failed download attempt: {e}')
+            raise NoCrashException from e
 
-        self._logger.warning("Watch folder - corrupt torrent file %s", name)
-        self.notifier[notifications.watch_folder_corrupt_file](name)
-
-    def check_watch_folder(self):
+    def _check_watch_folder(self):
         self._logger.debug('Checking watch folder...')
-
         if not self.settings.enabled or not self.state_dir:
             self._logger.debug(f'Cancelled. Enabled: {self.settings.enabled}. State dir: {self.state_dir}.')
             return
 
         directory = self.settings.get_path_as_absolute('directory', self.state_dir)
+        self._logger.debug(f'Watch dir: {directory}')
         if not directory.is_dir():
             self._logger.debug(f'Cancelled. Is not directory: {directory}.')
             return
 
-        # Make sure that we pass a str to os.walk
-        watch_dir = str(directory)
-        self._logger.debug(f'Watch dir: {watch_dir}')
-
-        for root, _, files in os.walk(watch_dir):
-            root = path_util.Path(root)
+        for root, _, files in os.walk(str(directory)):
             for name in files:
-                if not name.endswith(".torrent"):
-                    continue
+                path = Path(root) / name
+                self._process_torrent_file(path)
 
-                try:
-                    tdef = TorrentDef.load(root / name)
-                    if not tdef.get_metainfo():
-                        self.cleanup_torrent_file(root, name)
-                        continue
-                except:  # torrent appears to be corrupt
-                    self.cleanup_torrent_file(root, name)
-                    continue
-
-                infohash = tdef.get_infohash()
-
-                if not self.download_manager.download_exists(infohash):
-                    self._logger.info("Starting download from torrent file %s", name)
-                    self.download_manager.start_download(torrent_file=root / name)
         self._logger.debug('Checking watch folder completed.')
+
+    def _process_torrent_file(self, path: Path):
+        if not path.name.endswith(".torrent"):
+            return
+
+        self._logger.info(f'Torrent file found: {path}')
+        exception = None
+        try:
+            self._start_download(path)
+        except Exception as e:  # pylint: disable=broad-except
+            self._logger.error(f'{e.__class__.__name__}: {e}')
+            exception = e
+
+        if exception:
+            self._logger.info(f'Corrupted: {path}')
+            try:
+                path.replace(f'{path}.corrupt')
+            except OSError as e:
+                self._logger.warning(f'{e.__class__.__name__}: {e}')
+
+    def _start_download(self, path: Path):
+        tdef = TorrentDef.load(path)
+        if not tdef.get_metainfo():
+            self._logger.warning(f'Missed metainfo: {path}')
+            return
+
+        infohash = tdef.get_infohash()
+
+        if not self.download_manager.download_exists(infohash):
+            self._logger.info("Starting download from torrent file %s", path.name)
+
+            download_config = DownloadConfig.from_defaults(self.download_manager.download_defaults,
+                                                           state_dir=self.state_dir)
+
+            self.download_manager.start_download(torrent_file=path, config=download_config)

--- a/src/tribler/gui/error_handler.py
+++ b/src/tribler/gui/error_handler.py
@@ -70,6 +70,7 @@ class ErrorHandler:
     def core_error(self, reported_error: ReportedError):
         if self._tribler_stopped or reported_error.type in self._handled_exceptions:
             return
+        self._handled_exceptions.add(reported_error.type)
 
         error_text = f'{reported_error.text}\n{reported_error.long_text}'
         self._logger.error(error_text)


### PR DESCRIPTION
This PR contains refactoring of the Watch Folder.

Changes:
1. TaskManager has been swapped to AsyncGroup. 
2. All Watch Folders errors now have the type of `NoCrashException` meaning that these errors will not stop Tribler.
3. Logic of the Watch Folder has been simplified.
4. Core now has the same error handling logic that GUI has (only the first exception of a given type will be shown).

This PR prepared Watch Folder Component for future fixing of #5833.