### PR TITLE
Re-send shutdown request from GUI to Core if the previous shutdown request was canceled

### DIFF
--- a/src/tribler/core/components/base.py
+++ b/src/tribler/core/components/base.py
@@ -172,6 +172,7 @@ class Session:
             self._startup_exception = exc
 
     async def shutdown(self):
+        self.logger.info('Session shutdown process started')
         await gather(*[create_task(component.stop()) for component in self.components.values()])
 
     def __enter__(self):

--- a/src/tribler/core/components/restapi/rest/shutdown_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/shutdown_endpoint.py
@@ -36,5 +36,6 @@ class ShutdownEndpoint(RESTEndpoint):
         }
     )
     async def shutdown(self, request):
+        self._logger.info('Received a shutdown request from GUI')
         self.shutdown_callback()
         return RESTResponse({"shutdown": True})

--- a/src/tribler/core/start_core.py
+++ b/src/tribler/core/start_core.py
@@ -101,6 +101,7 @@ async def core_session(config: TriblerConfig, components: List[Component]):
 
         # SHUTDOWN
         await session.shutdown_event.wait()
+        logger.info('Shutdown event fired')
 
         if not config.gui_test_mode:
             session.notifier[notifications.tribler_shutdown_state]("Saving configuration...")

--- a/src/tribler/gui/tribler_request_manager.py
+++ b/src/tribler/gui/tribler_request_manager.py
@@ -245,6 +245,7 @@ class TriblerNetworkRequest(QObject):
         """
         Cancel the request by aborting the reply handle and calling on_cancel if available.
         """
+        logging.warning(f'Request from GUI to Core was canceled: {self.url}')
         if self.reply:
             self.reply.abort()
         self.on_cancel()


### PR DESCRIPTION
This PR fixes #6968