### PR TITLE
Fixes Tribler does not send crash reports to Sentry

### DIFF
--- a/src/run_tribler.py
+++ b/src/run_tribler.py
@@ -8,8 +8,7 @@ import logging.config
 import os
 import sys
 
-from tribler.core.components.reporter.exception_handler import default_core_exception_handler
-from tribler.core.sentry_reporter.sentry_reporter import SentryStrategy
+from tribler.core.sentry_reporter.sentry_reporter import default_sentry_reporter, SentryStrategy
 from tribler.core.sentry_reporter.sentry_scrubber import SentryScrubber
 
 logger = logging.getLogger(__name__)
@@ -46,7 +45,7 @@ def init_sentry_reporter():
     as a URL for sending sentry's reports while a Tribler client running in
     test mode
     """
-    sentry_reporter = default_core_exception_handler.sentry_reporter
+    sentry_reporter = default_sentry_reporter
     from tribler.core.version import sentry_url, version_id
     test_sentry_url = sentry_reporter.get_test_sentry_url()
 

--- a/src/tribler/core/components/reporter/exception_handler.py
+++ b/src/tribler/core/components/reporter/exception_handler.py
@@ -9,7 +9,7 @@ from typing import Callable, Optional
 
 from tribler.core.components.base import ComponentStartupException
 from tribler.core.components.reporter.reported_error import ReportedError
-from tribler.core.sentry_reporter.sentry_reporter import SentryReporter
+from tribler.core.sentry_reporter.sentry_reporter import default_sentry_reporter
 
 # There are some errors that we are ignoring.
 IGNORED_ERRORS_BY_CODE = {
@@ -40,7 +40,7 @@ class CoreExceptionHandler:
         self.logger = logging.getLogger("CoreExceptionHandler")
         self.report_callback: Optional[Callable[[ReportedError], None]] = None
         self.unreported_error: Optional[ReportedError] = None
-        self.sentry_reporter = SentryReporter()
+        self.sentry_reporter = default_sentry_reporter
 
     @staticmethod
     def _get_long_text_from(exception: Exception):

--- a/src/tribler/core/components/reporter/tests/test_exception_handler.py
+++ b/src/tribler/core/components/reporter/tests/test_exception_handler.py
@@ -56,8 +56,7 @@ def test_get_long_text_from(exception_handler):
     assert 'raise_error' in actual_string
 
 
-@patch(f'{sentry_reporter.__name__}.{SentryReporter.__name__}.{SentryReporter.event_from_exception.__name__}',
-       new=MagicMock(return_value={'sentry': 'event'}))
+@patch.object(SentryReporter, 'event_from_exception', new=MagicMock(return_value={'sentry': 'event'}))
 def test_unhandled_error_observer_exception(exception_handler):
     # test that unhandled exception, represented by Exception, reported to the GUI
     context = {'exception': raise_error(AttributeError('Any')), 'Any key': 'Any value'}

--- a/src/tribler/core/sentry_reporter/sentry_reporter.py
+++ b/src/tribler/core/sentry_reporter/sentry_reporter.py
@@ -382,3 +382,6 @@ class SentryReporter:
             event = self.scrubber.scrub_event(event)
 
         return event
+
+
+default_sentry_reporter = SentryReporter()

--- a/src/tribler/core/start_core.py
+++ b/src/tribler/core/start_core.py
@@ -34,7 +34,7 @@ from tribler.core.components.version_check.version_check_component import Versio
 from tribler.core.components.watch_folder.watch_folder_component import WatchFolderComponent
 from tribler.core.config.tribler_config import TriblerConfig
 from tribler.core.logger.logger import load_logger_config
-from tribler.core.sentry_reporter.sentry_reporter import SentryReporter, SentryStrategy
+from tribler.core.sentry_reporter.sentry_reporter import default_sentry_reporter, SentryStrategy
 from tribler.core.upgrade.version_manager import VersionHistory
 from tribler.core.utilities.process_checker import ProcessChecker
 
@@ -124,7 +124,7 @@ def run_tribler_core_session(api_port, api_key, state_dir, gui_test_mode=False):
         reset_config_on_error=True)
     config.gui_test_mode = gui_test_mode
 
-    if SentryReporter.is_in_test_mode():
+    if default_sentry_reporter.is_in_test_mode():
         default_core_exception_handler.sentry_reporter.global_strategy = SentryStrategy.SEND_ALLOWED
 
     config.api.http_port = int(api_port)

--- a/src/tribler/gui/__init__.py
+++ b/src/tribler/gui/__init__.py
@@ -1,6 +1,3 @@
 """
 This package contains the code for the GUI, written in pyQt.
 """
-from tribler.core.sentry_reporter.sentry_reporter import SentryReporter
-
-gui_sentry_reporter = SentryReporter()

--- a/src/tribler/gui/dialogs/feedbackdialog.py
+++ b/src/tribler/gui/dialogs/feedbackdialog.py
@@ -11,7 +11,7 @@ from PyQt5 import uic
 from PyQt5.QtWidgets import QAction, QDialog, QMessageBox, QTreeWidgetItem
 
 from tribler.core.components.reporter.reported_error import ReportedError
-from tribler.core.sentry_reporter.sentry_reporter import SentryReporter
+from tribler.core.sentry_reporter.sentry_reporter import default_sentry_reporter
 from tribler.core.sentry_reporter.sentry_scrubber import SentryScrubber
 from tribler.core.sentry_reporter.sentry_tools import CONTEXT_DELIMITER, LONG_TEXT_DELIMITER
 from tribler.gui.core_manager import CoreManager
@@ -26,7 +26,6 @@ class FeedbackDialog(AddBreadcrumbOnShowMixin, QDialog):
     def __init__(  # pylint: disable=too-many-arguments, too-many-locals
         self,
         parent,
-        sentry_reporter: SentryReporter,
         reported_error: ReportedError,
         tribler_version,
         start_time,
@@ -43,7 +42,7 @@ class FeedbackDialog(AddBreadcrumbOnShowMixin, QDialog):
         self.tribler_version = tribler_version
         self.reported_error = reported_error
         self.scrubber = SentryScrubber()
-        self.sentry_reporter = sentry_reporter
+        self.sentry_reporter = default_sentry_reporter
         self.stop_application_on_close = stop_application_on_close
         self.additional_tags = additional_tags
         self.retrieve_error_message_from_stacktrace = retrieve_error_message_from_stacktrace
@@ -116,7 +115,7 @@ class FeedbackDialog(AddBreadcrumbOnShowMixin, QDialog):
         # Users can remove specific lines in the report
         connect(self.env_variables_list.customContextMenuRequested, self.on_right_click_item)
 
-        self.send_automatically = SentryReporter.is_in_test_mode()
+        self.send_automatically = self.sentry_reporter.is_in_test_mode()
         if self.send_automatically:
             self.stop_application_on_close = True
             self.on_send_clicked(True)

--- a/src/tribler/gui/error_handler.py
+++ b/src/tribler/gui/error_handler.py
@@ -4,8 +4,7 @@ import logging
 import traceback
 
 from tribler.core.components.reporter.reported_error import ReportedError
-from tribler.core.sentry_reporter.sentry_reporter import SentryStrategy
-from tribler.gui import gui_sentry_reporter
+from tribler.core.sentry_reporter.sentry_reporter import SentryStrategy, default_sentry_reporter
 from tribler.gui.app_manager import AppManager
 from tribler.gui.dialogs.feedbackdialog import FeedbackDialog
 from tribler.gui.exceptions import CoreError
@@ -17,7 +16,7 @@ class ErrorHandler:
     def __init__(self, tribler_window):
         logger_name = self.__class__.__name__
         self._logger = logging.getLogger(logger_name)
-        gui_sentry_reporter.ignore_logger(logger_name)
+        default_sentry_reporter.ignore_logger(logger_name)
 
         self.tribler_window = tribler_window
         self.app_manager: AppManager = tribler_window.app_manager
@@ -34,7 +33,7 @@ class ErrorHandler:
         if self._tribler_stopped:
             return
 
-        if gui_sentry_reporter.global_strategy == SentryStrategy.SEND_SUPPRESSED:
+        if default_sentry_reporter.global_strategy == SentryStrategy.SEND_SUPPRESSED:
             self._logger.info(f'GUI error was suppressed and not sent to Sentry: {info_type.__name__}: {info_error}')
             return
 
@@ -50,7 +49,7 @@ class ErrorHandler:
         reported_error = ReportedError(
             type=type(info_type).__name__,
             text=text,
-            event=gui_sentry_reporter.event_from_exception(info_error),
+            event=default_sentry_reporter.event_from_exception(info_error),
         )
 
         if self.app_manager.quitting_app:
@@ -58,7 +57,6 @@ class ErrorHandler:
 
         FeedbackDialog(
             parent=self.tribler_window,
-            sentry_reporter=gui_sentry_reporter,
             reported_error=reported_error,
             tribler_version=self.tribler_window.tribler_version,
             start_time=self.tribler_window.start_time,
@@ -79,7 +77,6 @@ class ErrorHandler:
 
         FeedbackDialog(
             parent=self.tribler_window,
-            sentry_reporter=gui_sentry_reporter,
             reported_error=reported_error,
             tribler_version=self.tribler_window.tribler_version,
             start_time=self.tribler_window.start_time,

--- a/src/tribler/gui/event_request_manager.py
+++ b/src/tribler/gui/event_request_manager.py
@@ -7,10 +7,11 @@ from PyQt5.QtNetwork import QNetworkAccessManager, QNetworkReply, QNetworkReques
 
 from tribler.core import notifications
 from tribler.core.components.reporter.reported_error import ReportedError
+from tribler.core.sentry_reporter.sentry_reporter import default_sentry_reporter
 from tribler.core.utilities.notifier import Notifier
-from tribler.gui import gui_sentry_reporter
 from tribler.gui.exceptions import CoreConnectTimeoutError, CoreConnectionError
 from tribler.gui.utilities import connect
+
 
 received_events = []
 
@@ -65,7 +66,7 @@ class EventRequestManager(QNetworkAccessManager):
     def on_events_start(self, public_key: str, version: str):
         # if public key format is changed, don't forget to change it at the core side as well
         if public_key:
-            gui_sentry_reporter.set_user(public_key.encode('utf-8'))
+            default_sentry_reporter.set_user(public_key.encode('utf-8'))
         self.core_connected.emit(version)
 
     def on_tribler_exception(self, error: dict):

--- a/src/tribler/gui/sentry_mixin.py
+++ b/src/tribler/gui/sentry_mixin.py
@@ -1,4 +1,4 @@
-from tribler.gui import gui_sentry_reporter
+from tribler.core.sentry_reporter.sentry_reporter import default_sentry_reporter
 
 
 class AddBreadcrumbOnShowMixin:
@@ -9,4 +9,4 @@ class AddBreadcrumbOnShowMixin:
     def showEvent(self, *args):
         super().showEvent(*args)
 
-        gui_sentry_reporter.add_breadcrumb(message=f'{self.__class__.__name__}.Show', category='UI', level='info')
+        default_sentry_reporter.add_breadcrumb(message=f'{self.__class__.__name__}.Show', category='UI', level='info')

--- a/src/tribler/gui/start_gui.py
+++ b/src/tribler/gui/start_gui.py
@@ -13,13 +13,13 @@ from tribler.core.check_os import (
 )
 from tribler.core.exceptions import TriblerException
 from tribler.core.logger.logger import load_logger_config
-from tribler.core.sentry_reporter.sentry_reporter import SentryStrategy
+from tribler.core.sentry_reporter.sentry_reporter import SentryStrategy, default_sentry_reporter
 from tribler.core.utilities.rest_utils import path_to_url
-from tribler.gui import gui_sentry_reporter
 from tribler.gui.app_manager import AppManager
 from tribler.gui.tribler_app import TriblerApplication
 from tribler.gui.tribler_window import TriblerWindow
 from tribler.gui.utilities import get_translator
+
 
 logger = logging.getLogger(__name__)
 
@@ -93,5 +93,5 @@ def run_gui(api_port, api_key, root_state_dir, parsed_args):
         for handler in logging.getLogger().handlers:
             handler.flush()
 
-        gui_sentry_reporter.global_strategy = SentryStrategy.SEND_SUPPRESSED
+        default_sentry_reporter.global_strategy = SentryStrategy.SEND_SUPPRESSED
         raise

--- a/src/tribler/gui/tests/test_error_handler.py
+++ b/src/tribler/gui/tests/test_error_handler.py
@@ -1,9 +1,9 @@
-from unittest.mock import MagicMock, PropertyMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from tribler.core.components.reporter.reported_error import ReportedError
-from tribler.core.sentry_reporter.sentry_reporter import SentryReporter, SentryStrategy
+from tribler.core.sentry_reporter.sentry_reporter import default_sentry_reporter, SentryStrategy
 from tribler.gui.error_handler import ErrorHandler
 from tribler.gui.exceptions import CoreConnectTimeoutError, CoreCrashedError
 
@@ -34,8 +34,7 @@ async def test_gui_error_tribler_stopped(mocked_feedback_dialog: MagicMock, erro
 
 
 @patch('tribler.gui.error_handler.FeedbackDialog')
-@patch.object(SentryReporter, 'global_strategy', create=True,
-              new=PropertyMock(return_value=SentryStrategy.SEND_SUPPRESSED))
+@patch.object(default_sentry_reporter, 'global_strategy', new=SentryStrategy.SEND_SUPPRESSED)
 async def test_gui_error_suppressed(mocked_feedback_dialog: MagicMock, error_handler: ErrorHandler):
     logger_info_mock = MagicMock()
     error_handler._logger = MagicMock(info=logger_info_mock)

--- a/src/tribler/gui/tests/test_gui.py
+++ b/src/tribler/gui/tests/test_gui.py
@@ -12,7 +12,6 @@ from PyQt5.QtWidgets import QListWidget, QTableView, QTextEdit, QTreeWidget, QTr
 import tribler.gui
 from tribler.core.components.reporter.reported_error import ReportedError
 from tribler.core.components.tag.tag_constants import MIN_TAG_LENGTH
-from tribler.core.sentry_reporter.sentry_reporter import SentryReporter
 from tribler.core.tests.tools.common import TESTS_DATA_DIR
 from tribler.core.utilities.rest_utils import path_to_url
 from tribler.core.utilities.unicode import hexlify
@@ -430,8 +429,7 @@ def test_feedback_dialog(window):
         dialog.close()
 
     reported_error = ReportedError('type', 'text', {})
-    sentry_reporter = SentryReporter()
-    dialog = FeedbackDialog(window, sentry_reporter, reported_error, "1.2.3", 23)
+    dialog = FeedbackDialog(window, reported_error, "1.2.3", 23)
     dialog.closeEvent = lambda _: None  # Otherwise, the application will stop
     QTimer.singleShot(1000, screenshot_dialog)
     dialog.exec_()
@@ -448,8 +446,7 @@ def test_feedback_dialog_report_sent(window):
 
     on_report_sent.did_send_report = False
     reported_error = ReportedError('', 'Tribler GUI Test to test sending crash report works', {})
-    sentry_reporter = SentryReporter()
-    dialog = FeedbackDialog(window, sentry_reporter, reported_error, "1.2.3", 23)
+    dialog = FeedbackDialog(window, reported_error, "1.2.3", 23)
     dialog.closeEvent = lambda _: None  # Otherwise, the application will stop
     dialog.on_report_sent = on_report_sent
     QTest.mouseClick(dialog.send_report_button, Qt.LeftButton)

--- a/src/tribler/gui/widgets/tabbuttonpanel.py
+++ b/src/tribler/gui/widgets/tabbuttonpanel.py
@@ -1,7 +1,7 @@
 from PyQt5.QtCore import pyqtSignal
 from PyQt5.QtWidgets import QWidget
 
-from tribler.gui import gui_sentry_reporter
+from tribler.core.sentry_reporter.sentry_reporter import default_sentry_reporter
 from tribler.gui.utilities import connect
 
 
@@ -22,7 +22,8 @@ class TabButtonPanel(QWidget):
             connect(button.clicked_tab_button, self.on_tab_button_click)
 
     def on_tab_button_click(self, clicked_button):
-        gui_sentry_reporter.add_breadcrumb(message=f'{clicked_button.objectName()}.Click', category='UI', level='info')
+        sentry_reporter = default_sentry_reporter
+        sentry_reporter.add_breadcrumb(message=f'{clicked_button.objectName()}.Click', category='UI', level='info')
 
         self.deselect_all_buttons(except_select=clicked_button)
         self.clicked_tab_button.emit(clicked_button.objectName())


### PR DESCRIPTION
This PR fixes #6974

As it turns out, in #6694, SentryReporter stops being a singleton. Several instances of it are created in different places in the code, one in [`tribler_gui.__init__`](https://github.com/Tribler/tribler/blob/0901e0e2bd24d41e173d9ce95333971985ea60bb/src/tribler-gui/tribler_gui/__init__.py#L6), another in [`CoreExceptionHandler`](https://github.com/Tribler/tribler/blob/0901e0e2bd24d41e173d9ce95333971985ea60bb/src/tribler-core/tribler_core/components/reporter/exception_handler.py#L43) that is imported by [`run_tribler`](https://github.com/Tribler/tribler/blob/0901e0e2bd24d41e173d9ce95333971985ea60bb/src/run_tribler.py#L17) and so presents in GUI process as well. The reporter that's `init` method is called in [`init_sentry_reporter`](https://github.com/Tribler/tribler/blob/0901e0e2bd24d41e173d9ce95333971985ea60bb/src/run_tribler.py#L33) is not the same as [`gui_sentry_reporter`](https://github.com/Tribler/tribler/blob/0901e0e2bd24d41e173d9ce95333971985ea60bb/src/tribler-gui/tribler_gui/__init__.py#L6).

This PR switches to use the single instance of SentryReporter, `default_sentry_reporter`. It fixes the problem, and crash reports can be delivered to Sentry again.

