### PR TITLE
Copy libtorrent session state when upgrading Tribler to a new version

### DIFF
--- a/src/tribler/core/upgrade/version_manager.py
+++ b/src/tribler/core/upgrade/version_manager.py
@@ -24,6 +24,7 @@ STATE_FILES_TO_COPY = (
     'ec_trustchain_testnet.pem',
     'ecpub_trustchain_testnet.pem',
     'triblerd.conf',
+    'lt.state',
 )
 
 STATE_DIRS_TO_COPY = (STATEDIR_DB_DIR, STATEDIR_CHECKPOINT_DIR, STATEDIR_CHANNELS_DIR)


### PR DESCRIPTION
Fixes #6977