### PR TITLE
Fix failing GUI test on Linux Github action

### DIFF
--- a/.github/workflows/guitest.yml
+++ b/.github/workflows/guitest.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install xvfb dependencies
         run: |
-          sudo apt install xvfb libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 xdotool
+          sudo apt install xvfb libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 xdotool pyqt5-dev-tools
         # For more information see: https://pytest-qt.readthedocs.io/en/latest/troubleshooting.html#github-actions
 
       - name: Run GUI tests


### PR DESCRIPTION
PR job was missing some dependencies which is fulfilled by pyqt5-dev-tools.
This dependency might be because of the update of the base docker image
running on Github Action which is unclear.

Fixes https://github.com/Tribler/tribler/issues/6970