### PR TITLE
Restore name "triblerd.lock" for lock file

### DIFF
--- a/src/tribler/core/utilities/process_checker.py
+++ b/src/tribler/core/utilities/process_checker.py
@@ -12,6 +12,9 @@ import psutil
 from tribler.core.utilities.path_util import Path
 
 
+LOCK_FILE_NAME = 'triblerd.lock'
+
+
 @contextmanager
 def single_tribler_instance(directory: Path):
     checker = ProcessChecker(directory)
@@ -28,9 +31,9 @@ class ProcessChecker:
     This class contains code to check whether a Tribler process is already running.
     """
 
-    def __init__(self, directory: Path, lock_file_name: str = 'tribler.lock'):
+    def __init__(self, directory: Path, lock_file_name: Optional[str] = None):
         self.logger = logging.getLogger(self.__class__.__name__)
-        self.lock_file = directory / lock_file_name
+        self.lock_file = directory / (lock_file_name or LOCK_FILE_NAME)
         self.re_tribler = re.compile(r'tribler\b(?![/\\])')
         self.logger.info(f'Lock file: {self.lock_file}')
 

--- a/src/tribler/core/utilities/process_checker.py
+++ b/src/tribler/core/utilities/process_checker.py
@@ -32,10 +32,11 @@ class ProcessChecker:
     """
 
     def __init__(self, directory: Path, lock_file_name: Optional[str] = None):
+        lock_file_name = lock_file_name or LOCK_FILE_NAME
+        self.lock_file = directory / lock_file_name
         self.logger = logging.getLogger(self.__class__.__name__)
-        self.lock_file = directory / (lock_file_name or LOCK_FILE_NAME)
-        self.re_tribler = re.compile(r'tribler\b(?![/\\])')
         self.logger.info(f'Lock file: {self.lock_file}')
+        self.re_tribler = re.compile(r'tribler\b(?![/\\])')
 
     def check_and_restart_if_necessary(self) -> bool:
         self.logger.info('Check')


### PR DESCRIPTION
[Recently](https://github.com/Tribler/tribler/commit/258fe001d9b1023f74a55dc2690b61ab6aebb5b8), the lock file name was changed in the main branch from `triblerd.lock` to `tribler.lock`. We need to have the same name of the lock file as in previous Tribler releases to ensure that lock works across releases.

Also, sometimes it may be convenient to have a constant with a file name on a module level (as we had before) and not just as a default value for a constructor argument.

With these changes, we can cherry-pick #6941 from the main branch to the release branch