### PR TITLE
Handle exceptions in UpgradeManager

### DIFF
--- a/src/tribler/gui/dialogs/feedbackdialog.py
+++ b/src/tribler/gui/dialogs/feedbackdialog.py
@@ -194,5 +194,5 @@ class FeedbackDialog(AddBreadcrumbOnShowMixin, QDialog):
     def closeEvent(self, close_event):
         if self.stop_application_on_close:
             self.core_manager.stop()
-            if self.core_manager.shutting_down and not self.core_manager.core_finished:
+            if self.core_manager.shutting_down and self.core_manager.core_running:
                 close_event.ignore()

--- a/src/tribler/gui/exceptions.py
+++ b/src/tribler/gui/exceptions.py
@@ -16,3 +16,7 @@ class CoreCrashedError(CoreError):
 
 class TriblerGuiTestException(Exception):
     """Can be intentionally generated in GUI by pressing Ctrl+Alt+Shift+G"""
+
+
+class UpgradeError(CoreError):
+    """The error raises by UpgradeManager in GUI process and should stop Tribler"""


### PR DESCRIPTION
This PR fixes #7003.

After I added exception handling for the error in the `UpgradeManager`, I discovered that Tribler GUI does not handle it properly. First, it considered the error as a GUI error by default, and the current Tribler policy is not to close on GUI errors. Second, the close button of the FeedbackDialog does not close it. The reason is the following: GUI thinks that Core is shutting down but not finished yet, so trying to wait until it is finished. Actually, Core was not even started, as the exception happened before the `start_tribler_core` method was called. Because of this, the logic of the `FeedbackDialog` close button should be corrected a bit.