### PR TITLE
Handle exceptions in UpgradeManager

### DIFF
--- a/src/tribler/gui/dialogs/feedbackdialog.py
+++ b/src/tribler/gui/dialogs/feedbackdialog.py
@@ -194,5 +194,5 @@ class FeedbackDialog(AddBreadcrumbOnShowMixin, QDialog):
     def closeEvent(self, close_event):
         if self.stop_application_on_close:
             self.core_manager.stop()
-            if self.core_manager.shutting_down and not self.core_manager.core_finished:
+            if self.core_manager.shutting_down and self.core_manager.core_running:
                 close_event.ignore()

--- a/src/tribler/gui/exceptions.py
+++ b/src/tribler/gui/exceptions.py
@@ -16,3 +16,7 @@ class CoreCrashedError(CoreError):
 
 class TriblerGuiTestException(Exception):
     """Can be intentionally generated in GUI by pressing Ctrl+Alt+Shift+G"""
+
+
+class UpgradeError(CoreError):
+    """The error raises by UpgradeManager in GUI process and should stop Tribler"""

--- a/src/tribler/gui/upgrade_manager.py
+++ b/src/tribler/gui/upgrade_manager.py
@@ -5,12 +5,13 @@ from PyQt5.QtCore import QObject, QThread, pyqtSignal
 from PyQt5.QtWidgets import QMessageBox
 
 from tribler.core.upgrade.version_manager import TriblerVersion, VersionHistory
+from tribler.gui.exceptions import UpgradeError
 from tribler.gui.utilities import connect, format_size, tr
 from tribler.run_tribler_upgrader import upgrade_state_dir
 
 
 class StateDirUpgradeWorker(QObject):
-    finished = pyqtSignal()
+    finished = pyqtSignal(object)
     status_update = pyqtSignal(str)
     stop_upgrade = pyqtSignal()
 
@@ -31,12 +32,16 @@ class StateDirUpgradeWorker(QObject):
         self.status_update.emit(text)
 
     def run(self):
-        self._upgrade_state_dir(
-            self.root_state_dir,
-            update_status_callback=self._update_status_callback,
-            interrupt_upgrade_event=self.upgrade_interrupted,
-        )
-        self.finished.emit()
+        try:
+            self._upgrade_state_dir(
+                self.root_state_dir,
+                update_status_callback=self._update_status_callback,
+                interrupt_upgrade_event=self.upgrade_interrupted,
+            )
+        except Exception as exc:  # pylint: disable=broad-except
+            self.finished.emit(exc)
+        else:
+            self.finished.emit(None)
 
 
 class UpgradeManager(QObject):
@@ -120,12 +125,18 @@ class UpgradeManager(QObject):
         # ACHTUNG!!! the following signals cannot be properly handled by our "connect" method.
         # These must be connected directly to prevent problems with disconnecting and thread handling.
         self._upgrade_worker.status_update.connect(self.upgrader_tick.emit)
-        self._upgrade_thread.finished.connect(self._upgrade_thread.deleteLater)
-        self._upgrade_worker.finished.connect(self._upgrade_thread.quit)
-        self._upgrade_worker.finished.connect(self.upgrader_finished.emit)
-        self._upgrade_worker.finished.connect(self._upgrade_worker.deleteLater)
+        self._upgrade_worker.finished.connect(self.on_worker_finished)
 
         self._upgrade_thread.start()
+
+    def on_worker_finished(self, exc):
+        self._upgrade_thread.deleteLater()
+        self._upgrade_thread.quit()
+        self._upgrade_worker.deleteLater()
+        if exc is None:
+            self.upgrader_finished.emit()
+        else:
+            raise UpgradeError(f'{exc.__class__.__name__}: {exc}') from exc
 
     def stop_upgrade(self):
         self._upgrade_worker.stop_upgrade.emit()


### PR DESCRIPTION
This PR fixes #7003.

After I added exception handling for the error in the `UpgradeManager`, I discovered that Tribler GUI does not handle it properly. First, it considered the error as a GUI error by default, and the current Tribler policy is not to close on GUI errors. To fix this, I added an `UpgradeError` exception inherited from Core exception. This way GUI knows that the exception is serious enough to finish Tribler execution.

Second, the close button of the FeedbackDialog does not close it. The reason is the following: GUI thinks that Core is shutting down but not finished yet, so trying to wait until it is finished. Actually, Core was not even started, as the exception happened before the `start_tribler_core` method was called. Because of this, the logic of the `FeedbackDialog` close button should be corrected a bit.