### PR TITLE
Cherry-pick adding `format_error_message` function to CoreManager

### DIFF
--- a/src/tribler/gui/core_manager.py
+++ b/src/tribler/gui/core_manager.py
@@ -1,10 +1,11 @@
 import logging
 import os
+import re
 import sys
 from pathlib import Path
 from typing import Optional
 
-from PyQt5.QtCore import QObject, QProcess, QProcessEnvironment, pyqtSignal
+from PyQt5.QtCore import QObject, QProcess, QProcessEnvironment
 from PyQt5.QtNetwork import QNetworkRequest
 
 from tribler.core.utilities.process_checker import ProcessChecker
@@ -195,6 +196,20 @@ class CoreManager(QObject):
         process_checker = ProcessChecker(self.root_state_dir)
         process_checker.remove_lock()
 
+    @staticmethod
+    def format_error_message(exit_code: int, exit_status: int, last_core_output: str) -> str:
+        message = f"The Tribler core has unexpectedly finished with exit code {exit_code} and status: {exit_status}."
+        try:
+            string_error = os.strerror(exit_code)
+        except ValueError:
+            # On platforms where strerror() returns NULL when given an unknown error number, ValueError is raised.
+            string_error = 'unknown error number'
+        message += f'\n\nError message: {string_error}'
+
+        quoted_output = re.sub(r'^', '> ', last_core_output, flags=re.MULTILINE)
+        message += f"\n\nLast core output:\n{quoted_output}"
+        return message
+
     def on_core_finished(self, exit_code, exit_status):
         self._logger.info("Core process finished")
         self.core_running = False
@@ -203,10 +218,8 @@ class CoreManager(QObject):
             if self.should_quit_app_on_core_finished:
                 self.app_manager.quit_application()
         else:
-            error_message = (
-                f"The Tribler core has unexpectedly finished with exit code {exit_code} and status: {exit_status}!\n"
-                f"Last core output: \n {self.last_core_stderr_output or self.last_core_stdout_output}"
-            )
+            output = self.last_core_stderr_output or self.last_core_stdout_output
+            error_message = self.format_error_message(exit_code, exit_status, output)
             self._logger.warning(error_message)
 
             if not self.app_manager.quitting_app:

--- a/src/tribler/gui/tests/test_core_manager.py
+++ b/src/tribler/gui/tests/test_core_manager.py
@@ -1,3 +1,4 @@
+import errno
 import sys
 from unittest.mock import MagicMock, patch
 
@@ -67,3 +68,16 @@ def test_decode_raw_core_output(core_manager):
     assert core_manager.decode_raw_core_output(b'test') == 'test'
     assert core_manager.decode_raw_core_output('test привет'.encode('utf-8')) == 'test привет'
     assert core_manager.decode_raw_core_output('test привет'.encode('cp1251')) == r'test \xef\xf0\xe8\xe2\xe5\xf2'
+
+
+def test_format_error_message():
+    actual = CoreManager.format_error_message(exit_code=errno.ENOENT, exit_status=1, last_core_output='last\noutput')
+    expected = '''The Tribler core has unexpectedly finished with exit code 2 and status: 1.
+
+Error message: No such file or directory
+
+Last core output:
+> last
+> output'''
+
+    assert actual == expected


### PR DESCRIPTION
This PR cherry-picks #6881 from main to the release branch. I need it to fix #7013 without merge conflicts between `main` and `release` branches