### PR TITLE
Fix/stop core on components startup exception

### DIFF
--- a/src/tribler/core/components/base.py
+++ b/src/tribler/core/components/base.py
@@ -162,6 +162,10 @@ class Session:
 
     def _reraise_startup_exception_in_separate_task(self):
         async def exception_reraiser():
+            e = self._startup_exception
+            if isinstance(e, ComponentStartupException) and e.component.tribler_should_stop_on_component_error:
+                self.shutdown_event.set()
+
             # the exception should be intercepted by event loop exception handler
             raise self._startup_exception
 

--- a/src/tribler/core/components/base.py
+++ b/src/tribler/core/components/base.py
@@ -86,6 +86,7 @@ class Session:
                  shutdown_event: Event = None, notifier: Notifier = None, failfast: bool = True):
         # deepcode ignore unguarded~next~call: not necessary to catch StopIteration on infinite iterator
         self.id = next(Session._next_session_id)
+        self.exit_code = 0
         self.failfast = failfast
         self.logger = logging.getLogger(self.__class__.__name__)
         self.config: TriblerConfig = config or TriblerConfig()
@@ -164,6 +165,7 @@ class Session:
         async def exception_reraiser():
             e = self._startup_exception
             if isinstance(e, ComponentStartupException) and e.component.tribler_should_stop_on_component_error:
+                self.exit_code = 1
                 self.shutdown_event.set()
 
             # the exception should be intercepted by event loop exception handler

--- a/src/tribler/core/sentry_reporter/sentry_reporter.py
+++ b/src/tribler/core/sentry_reporter/sentry_reporter.py
@@ -280,7 +280,7 @@ class SentryReporter:
         Returns:
             the event that has been saved in `_before_send` method
         """
-        self._logger.info(f"Event from exception: {exception}")
+        self._logger.debug(f"Event from exception: {exception}")
 
         if not exception:
             return {}

--- a/src/tribler/core/start_core.py
+++ b/src/tribler/core/start_core.py
@@ -4,6 +4,7 @@ import logging.config
 import os
 import signal
 import sys
+from pathlib import Path
 from typing import List
 
 from tribler.core import notifications
@@ -92,7 +93,12 @@ def components_gen(config: TriblerConfig):
         yield GigachannelManagerComponent()
 
 
-async def core_session(config: TriblerConfig, components: List[Component]):
+async def core_session(config: TriblerConfig, components: List[Component]) -> int:
+    """
+    Async task for running a new Tribler session.
+
+    Returns an exit code, which is non-zero if the Tribler session finished with an error.
+    """
     session = Session(config, components, failfast=False)
     signal.signal(signal.SIGTERM, lambda signum, stack: session.shutdown_event.set)
     async with session.start() as session:
@@ -108,12 +114,16 @@ async def core_session(config: TriblerConfig, components: List[Component]):
             session.notifier[notifications.tribler_shutdown_state]("Saving configuration...")
             config.write()
 
+    return session.exit_code
 
-def run_tribler_core_session(api_port, api_key, state_dir, gui_test_mode=False):
+
+def run_tribler_core_session(api_port: str, api_key: str, state_dir: Path, gui_test_mode: bool = False) -> int:
     """
     This method will start a new Tribler session.
     Note that there is no direct communication between the GUI process and the core: all communication is performed
     through the HTTP API.
+
+    Returns an exit code value, which is non-zero if the Tribler session finished with an error.
     """
     logger.info(f'Start tribler core. API port: "{api_port}". '
                 f'API key: "{api_key}". State dir: "{state_dir}". '
@@ -154,7 +164,7 @@ def run_tribler_core_session(api_port, api_key, state_dir, gui_test_mode=False):
     loop.set_exception_handler(exception_handler.unhandled_error_observer)
 
     try:
-        loop.run_until_complete(core_session(config, components=list(components_gen(config))))
+        exit_code = loop.run_until_complete(core_session(config, components=list(components_gen(config))))
     finally:
         if trace_logger:
             trace_logger.close()
@@ -162,6 +172,8 @@ def run_tribler_core_session(api_port, api_key, state_dir, gui_test_mode=False):
         # Flush the logs to the file before exiting
         for handler in logging.getLogger().handlers:
             handler.flush()
+
+    return exit_code
 
 
 def run_core(api_port, api_key, root_state_dir, parsed_args):
@@ -171,4 +183,7 @@ def run_core(api_port, api_key, root_state_dir, parsed_args):
     with single_tribler_instance(root_state_dir):
         version_history = VersionHistory(root_state_dir)
         state_dir = version_history.code_version.directory
-        run_tribler_core_session(api_port, api_key, state_dir, gui_test_mode=parsed_args.gui_test_mode)
+        exit_code = run_tribler_core_session(api_port, api_key, state_dir, gui_test_mode=parsed_args.gui_test_mode)
+
+    if exit_code:
+        sys.exit(exit_code)

--- a/src/tribler/gui/core_manager.py
+++ b/src/tribler/gui/core_manager.py
@@ -211,11 +211,14 @@ class CoreManager(QObject):
     @staticmethod
     def format_error_message(exit_code: int, exit_status: int) -> str:
         message = f"The Tribler core has unexpectedly finished with exit code {exit_code} and status: {exit_status}."
-        try:
-            string_error = os.strerror(exit_code)
-        except ValueError:
-            # On platforms where strerror() returns NULL when given an unknown error number, ValueError is raised.
-            string_error = 'unknown error number'
+        if exit_code == 1:
+            string_error = "Application error"
+        else:
+            try:
+                string_error = os.strerror(exit_code)
+            except ValueError:
+                # On platforms where strerror() returns NULL when given an unknown error number, ValueError is raised.
+                string_error = 'unknown error number'
         message += f'\n\nError message: {string_error}'
         return message
 

--- a/src/tribler/gui/error_handler.py
+++ b/src/tribler/gui/error_handler.py
@@ -44,7 +44,7 @@ class ErrorHandler:
 
         is_core_exception = issubclass(info_type, CoreError)
         if is_core_exception:
-            text = text + self.tribler_window.core_manager.last_core_stderr_output
+            text = f'{text}\n\nLast Core output:\n{self.tribler_window.core_manager.get_last_core_output()}'
             self._stop_tribler(text)
 
         reported_error = ReportedError(


### PR DESCRIPTION
Fixes #7013. Stops Tribler Core on Session component's startup exception. Returns non-zero exit code from the Core process.