### PR TITLE
Add core stdout breadcrumb

### DIFF
--- a/src/tribler/core/sentry_reporter/sentry_scrubber.py
+++ b/src/tribler/core/sentry_reporter/sentry_scrubber.py
@@ -47,6 +47,10 @@ class SentryScrubber:
 
         self._compile_re()
 
+    @staticmethod
+    def remove_breadcrumbs(event: Dict) -> Dict:
+        return delete_item(event, BREADCRUMBS)
+
     def _compile_re(self):
         """Compile all regular expressions."""
         for folder in self.home_folders:

--- a/src/tribler/core/sentry_reporter/tests/test_sentry_scrubber.py
+++ b/src/tribler/core/sentry_reporter/tests/test_sentry_scrubber.py
@@ -318,3 +318,19 @@ def test_scrub_list(scrubber):
 
     assert scrubber.scrub_entity_recursively(['/home/username/some/']) == ['/home/<highlight>/some/']
     assert 'username' in scrubber.sensitive_occurrences
+
+
+def test_remove_breadcrumbs():
+    """ Test that the function `SentryScrubber.remove_breadcrumbs` removes breadcrumbs from a dictionary """
+    event = {
+        BREADCRUMBS: {
+            'values': [
+                {'type': 'log', 'message': 'Traceback File: /Users/username/Tribler/', 'timestamp': '1'},
+                {'type': 'log', 'message': 'Traceback File: /Users/username/Tribler/', 'timestamp': '1'},
+                {'type': 'log', 'message': 'IP: 192.168.1.1', 'timestamp': '2'},
+            ]
+        },
+        'key': 'value'
+    }
+
+    assert SentryScrubber.remove_breadcrumbs(event) == {'key': 'value'}

--- a/src/tribler/gui/core_manager.py
+++ b/src/tribler/gui/core_manager.py
@@ -8,6 +8,7 @@ from typing import Optional
 from PyQt5.QtCore import QObject, QProcess, QProcessEnvironment
 from PyQt5.QtNetwork import QNetworkRequest
 
+from tribler.gui import gui_sentry_reporter
 from tribler.gui.app_manager import AppManager
 from tribler.gui.event_request_manager import EventRequestManager
 from tribler.gui.exceptions import CoreCrashedError
@@ -112,6 +113,11 @@ class CoreManager(QObject):
 
         raw_output = bytes(self.core_process.readAllStandardOutput())
         self.last_core_stdout_output = self.decode_raw_core_output(raw_output).strip()
+        gui_sentry_reporter.add_breadcrumb(
+            message=self.last_core_stdout_output,
+            category='CORE_STDOUT',
+            level='info'
+        )
 
         try:
             print(self.last_core_stdout_output)  # print core output # noqa: T001

--- a/src/tribler/gui/core_manager.py
+++ b/src/tribler/gui/core_manager.py
@@ -132,6 +132,11 @@ class CoreManager(QObject):
 
         raw_output = bytes(self.core_process.readAllStandardError())
         self.last_core_stderr_output = self.decode_raw_core_output(raw_output).strip()
+        gui_sentry_reporter.add_breadcrumb(
+            message=self.last_core_stderr_output,
+            category='CORE_STDOUT',
+            level='error'
+        )
 
         try:
             print(self.last_core_stderr_output, file=sys.stderr)  # print core output # noqa: T001

--- a/src/tribler/gui/error_handler.py
+++ b/src/tribler/gui/error_handler.py
@@ -5,10 +5,12 @@ import traceback
 
 from tribler.core.components.reporter.reported_error import ReportedError
 from tribler.core.sentry_reporter.sentry_reporter import SentryStrategy
+from tribler.core.sentry_reporter.sentry_scrubber import SentryScrubber
 from tribler.gui import gui_sentry_reporter
 from tribler.gui.app_manager import AppManager
 from tribler.gui.dialogs.feedbackdialog import FeedbackDialog
 from tribler.gui.exceptions import CoreError
+
 
 # fmt: off
 
@@ -77,6 +79,8 @@ class ErrorHandler:
 
         if reported_error.should_stop:
             self._stop_tribler(error_text)
+
+        SentryScrubber.remove_breadcrumbs(reported_error.event)
 
         FeedbackDialog(
             parent=self.tribler_window,


### PR DESCRIPTION
This PR changes the process of collecting CORE core breadcrumbs.

Instead of collecting them on the core side, they are added to the GUI Sentry Reported as they appear.

"Normal" error: https://sentry.tribler.org/organizations/tribler/issues/1599
CoreCrashError: https://sentry.tribler.org/organizations/tribler/issues/1546

The purpose of this improvement is to investigate `CoreConnectionError` issues like https://github.com/Tribler/tribler/issues/6989