### PR TITLE
Obfuscate machine name for Sentry events

### DIFF
--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -5,7 +5,7 @@ chardet==4.0.0
 configobj==5.0.6
 cryptography==35.0.0
 decorator==5.1.0
-Faker==9.8.2
+Faker==14.1.0
 libnacl==1.8.0
 lz4==3.1.3
 marshmallow==3.14.1

--- a/src/tribler/core/sentry_reporter/sentry_scrubber.py
+++ b/src/tribler/core/sentry_reporter/sentry_scrubber.py
@@ -1,5 +1,5 @@
 import re
-from typing import Dict
+from typing import Any, Dict, List, Union
 
 from tribler.core.sentry_reporter.sentry_reporter import (
     BREADCRUMBS,
@@ -144,7 +144,7 @@ class SentryScrubber:
 
         return text
 
-    def scrub_entity_recursively(self, entity: Dict, depth=10):
+    def scrub_entity_recursively(self, entity: Union[str, Dict, List, Any], depth=10):
         """Recursively traverses entity and remove all sensitive information.
 
         Can work with:

--- a/src/tribler/core/sentry_reporter/sentry_scrubber.py
+++ b/src/tribler/core/sentry_reporter/sentry_scrubber.py
@@ -37,6 +37,8 @@ class SentryScrubber:
 
         # placeholders
         self.create_placeholder = lambda text: f'<{text}>'
+        self.hash_placeholder = self.create_placeholder('hash')
+        self.ip_placeholder = self.create_placeholder('IP')
 
         # compiled regular expressions
         self.re_folders = []
@@ -122,13 +124,12 @@ class SentryScrubber:
 
         # cut an IP
         def scrub_ip(m):
-            return self.create_placeholder('IP') if m.group(0) not in self.exclusions else m.group(0)
+            return self.ip_placeholder if m.group(0) not in self.exclusions else m.group(0)
 
         text = self.re_ip.sub(scrub_ip, text)
 
         # cut hash
-        hash_placeholder = self.create_placeholder('hash')
-        text = self.re_hash.sub(hash_placeholder, text)
+        text = self.re_hash.sub(self.hash_placeholder, text)
 
         # replace all sensitive occurrences in the whole string
         if self.sensitive_occurrences:

--- a/src/tribler/core/sentry_reporter/sentry_scrubber.py
+++ b/src/tribler/core/sentry_reporter/sentry_scrubber.py
@@ -1,4 +1,5 @@
 import re
+from typing import Dict
 
 from tribler.core.sentry_reporter.sentry_reporter import (
     BREADCRUMBS,
@@ -26,8 +27,7 @@ class SentryScrubber:
             'Documents and Settings',
             'Users',
         ]
-
-        self.dict_keys_for_scrub = ['USERNAME', 'USERDOMAIN']
+        self.dict_keys_for_scrub = ['USERNAME', 'USERDOMAIN', 'server_name']
         self.event_fields_to_cut = []
         self.exclusions = ['local', '127.0.0.1']
 
@@ -145,7 +145,7 @@ class SentryScrubber:
 
         return text
 
-    def scrub_entity_recursively(self, entity, depth=10):
+    def scrub_entity_recursively(self, entity: Dict, depth=10):
         """Recursively traverses entity and remove all sensitive information.
 
         Can work with:

--- a/src/tribler/core/sentry_reporter/sentry_tools.py
+++ b/src/tribler/core/sentry_reporter/sentry_tools.py
@@ -2,7 +2,10 @@
 simplify work with several data structures.
 """
 import re
+from hashlib import md5
 from typing import Optional
+
+from faker import Faker
 
 LONG_TEXT_DELIMITER = '--LONG TEXT--'
 CONTEXT_DELIMITER = '--CONTEXT--'
@@ -159,3 +162,12 @@ def format_version(version: Optional[str]) -> Optional[str]:
 
     # for all other cases keep <version>-<first_part>
     return f"{parts[0]}-{parts[1]}"
+
+
+def obfuscate_string(s: str, part_of_speech: str = 'noun') -> str:
+    if not s:
+        return s
+
+    faker = Faker(locale='en_US')
+    faker.seed_instance(s)
+    return faker.word(part_of_speech=part_of_speech)

--- a/src/tribler/core/sentry_reporter/sentry_tools.py
+++ b/src/tribler/core/sentry_reporter/sentry_tools.py
@@ -2,7 +2,6 @@
 simplify work with several data structures.
 """
 import re
-from hashlib import md5
 from typing import Optional
 
 from faker import Faker
@@ -165,6 +164,10 @@ def format_version(version: Optional[str]) -> Optional[str]:
 
 
 def obfuscate_string(s: str, part_of_speech: str = 'noun') -> str:
+    """Obfuscate string by replacing it with random word.
+
+    The same random words will be generated for the same given strings.
+    """
     if not s:
         return s
 

--- a/src/tribler/core/sentry_reporter/tests/test_sentry_reporter.py
+++ b/src/tribler/core/sentry_reporter/tests/test_sentry_reporter.py
@@ -321,7 +321,7 @@ def test_before_send(sentry_reporter):
 
     # check information has been scrubbed
     assert sentry_reporter._before_send({'contexts': {'reporter': {'_stacktrace': ['/Users/username/']}}}, None) == {
-        'contexts': {'reporter': {'_stacktrace': [f'/Users/<highlight>/']}}
+        'contexts': {'reporter': {'_stacktrace': ['/Users/<highlight>/']}}
     }
 
     # check release

--- a/src/tribler/core/sentry_reporter/tests/test_sentry_reporter.py
+++ b/src/tribler/core/sentry_reporter/tests/test_sentry_reporter.py
@@ -15,7 +15,6 @@ from tribler.core.sentry_reporter.sentry_scrubber import SentryScrubber
 from tribler.core.utilities.patch_import import patch_import
 
 
-# fmt: off
 # pylint: disable=redefined-outer-name, protected-access
 
 
@@ -122,6 +121,7 @@ def test_get_actual_strategy(sentry_reporter):
     assert sentry_reporter.get_actual_strategy() == SentryStrategy.SEND_ALLOWED_WITH_CONFIRMATION
 
 
+@patch('os.environ', {})
 def test_get_sentry_url_not_specified():
     assert not SentryReporter.get_sentry_url()
 
@@ -321,7 +321,7 @@ def test_before_send(sentry_reporter):
 
     # check information has been scrubbed
     assert sentry_reporter._before_send({'contexts': {'reporter': {'_stacktrace': ['/Users/username/']}}}, None) == {
-        'contexts': {'reporter': {'_stacktrace': [f'/Users/{scrubber.placeholder_user}/']}}
+        'contexts': {'reporter': {'_stacktrace': [f'/Users/<highlight>/']}}
     }
 
     # check release

--- a/src/tribler/core/sentry_reporter/tests/test_sentry_scrubber.py
+++ b/src/tribler/core/sentry_reporter/tests/test_sentry_scrubber.py
@@ -117,10 +117,10 @@ def test_scrub_path_negative_match(scrubber: SentryScrubber):
 
 def test_scrub_path_positive_match(scrubber: SentryScrubber):
     """ Test that the scrubber scrubs paths """
-    assert scrubber.scrub_text('/users/user/apps') == f'/users/<boot>/apps'
+    assert scrubber.scrub_text('/users/user/apps') == '/users/<boot>/apps'
     assert 'user' in scrubber.sensitive_occurrences
 
-    assert scrubber.scrub_text('/users/username/some/long_path') == f'/users/<highlight>/some/long_path'
+    assert scrubber.scrub_text('/users/username/some/long_path') == '/users/<highlight>/some/long_path'
     assert 'username' in scrubber.sensitive_occurrences
 
 
@@ -149,7 +149,7 @@ def test_scrub_text_hash_negative_match(scrubber: SentryScrubber):
 def test_scrub_text_hash_positive_match(scrubber: SentryScrubber):
     """ Test that the scrubber scrubs hashes """
     assert scrubber.scrub_text('3' * 40) == '<hash>'
-    assert scrubber.scrub_text('hash:' + '4' * 40) == f'hash:<hash>'
+    assert scrubber.scrub_text('hash:' + '4' * 40) == 'hash:<hash>'
 
     assert not scrubber.sensitive_occurrences
 
@@ -220,36 +220,36 @@ def test_scrub_event(scrubber):
                 OS_ENVIRON: {
                     'USERNAME': '<father>',
                     'USERDOMAIN_ROAMINGPROFILE': '<protection>',
-                    'PATH': f'/users/<highlight>/apps',
-                    'TMP_WIN': f'C:\\Users\\<restaurant>\\AppData\\Local\\Temp',
+                    'PATH': '/users/<highlight>/apps',
+                    'TMP_WIN': 'C:\\Users\\<restaurant>\\AppData\\Local\\Temp',
                     'USERDOMAIN': '<answer>',
                 },
                 STACKTRACE: [
                     'Traceback (most recent call last):',
-                    f'File "/Users/<highlight>/Tribler/tribler/src/tribler-gui/tribler_gui/"',
+                    'File "/Users/<highlight>/Tribler/tribler/src/tribler-gui/tribler_gui/"',
                 ],
                 SYSINFO: {
                     'sys.path': [
-                        f'/Users/<highlight>/Tribler/',
-                        f'/Users/<highlight>/',
+                        '/Users/<highlight>/Tribler/',
+                        '/Users/<highlight>/',
                         '.',
                     ]
                 },
             },
         },
         LOGENTRY: {
-            'message': f'Exception with <highlight>',
-            'params': [f'Traceback File: /Users/<highlight>/Tribler/'],
+            'message': 'Exception with <highlight>',
+            'params': ['Traceback File: /Users/<highlight>/Tribler/'],
         },
-        EXTRA: {SYS_ARGV: [f'/Users/<highlight>/Tribler']},
+        EXTRA: {SYS_ARGV: ['/Users/<highlight>/Tribler']},
         BREADCRUMBS: {
             'values': [
                 {
                     'type': 'log',
-                    'message': f'Traceback File: /Users/<highlight>/Tribler/',
+                    'message': 'Traceback File: /Users/<highlight>/Tribler/',
                     'timestamp': '1',
                 },
-                {'type': 'log', 'message': f'IP: <IP>', 'timestamp': '2'},
+                {'type': 'log', 'message': 'IP: <IP>', 'timestamp': '2'},
             ]
         },
     }
@@ -275,7 +275,7 @@ def test_entities_recursively(scrubber):
         }
     }
     assert scrubber.scrub_entity_recursively(event) == {
-        'some': {'value': [{'path': f'/Users/<highlight>/Tribler'}]}
+        'some': {'value': [{'path': '/Users/<highlight>/Tribler'}]}
     }
     # stop on depth
     assert scrubber.scrub_entity_recursively(event) != event
@@ -316,5 +316,5 @@ def test_scrub_list(scrubber):
     assert scrubber.scrub_entity_recursively(None) is None
     assert scrubber.scrub_entity_recursively([]) == []
 
-    assert scrubber.scrub_entity_recursively(['/home/username/some/']) == [f'/home/<highlight>/some/']
+    assert scrubber.scrub_entity_recursively(['/home/username/some/']) == ['/home/<highlight>/some/']
     assert 'username' in scrubber.sensitive_occurrences

--- a/src/tribler/core/sentry_reporter/tests/test_sentry_scrubber.py
+++ b/src/tribler/core/sentry_reporter/tests/test_sentry_scrubber.py
@@ -97,7 +97,8 @@ def test_scrub_text_ip(scrubber):
 def test_scrub_text_hash(scrubber):
     # negative
     assert (
-        scrubber.scrub_text('0a303030303030303030303030303030303030300') == '0a303030303030303030303030303030303030300'
+            scrubber.scrub_text(
+                '0a303030303030303030303030303030303030300') == '0a303030303030303030303030303030303030300'
     )
     assert scrubber.scrub_text('0a3030303030303030303303030303030303030') == '0a3030303030303030303303030303030303030'
 
@@ -119,10 +120,10 @@ def test_scrub_text_complex_string(scrubber):
     actual = scrubber.scrub_text(source)
 
     assert (
-        actual == f'this is a string that have been sent from '
-        f'{scrubber.placeholder_ip}({scrubber.placeholder_hash}) '
-        f'located at usr/{scrubber.placeholder_user}/path at '
-        f'{scrubber.placeholder_user} machine(someuserany)'
+            actual == f'this is a string that have been sent from '
+                      f'{scrubber.placeholder_ip}({scrubber.placeholder_hash}) '
+                      f'located at usr/{scrubber.placeholder_user}/path at '
+                      f'{scrubber.placeholder_user} machine(someuserany)'
     )
 
     assert 'someuser' in scrubber.sensitive_occurrences
@@ -138,10 +139,12 @@ def test_scrub_simple_event(scrubber):
 def test_scrub_event(scrubber):
     event = {
         'the very first item': 'username',
+        'server_name': 'userhost',
         CONTEXTS: {
             REPORTER: {
                 OS_ENVIRON: {
                     'USERNAME': 'User Name',
+                    'USERDOMAIN_ROAMINGPROFILE': 'userhost',
                     'PATH': '/users/username/apps',
                     'TMP_WIN': r'C:\Users\USERNAM~1\AppData\Local\Temp',
                     'USERDOMAIN': 'a',
@@ -166,10 +169,12 @@ def test_scrub_event(scrubber):
 
     assert scrubber.scrub_event(event) == {
         'the very first item': scrubber.placeholder_user,
+        'server_name': '<server_name>',
         CONTEXTS: {
             REPORTER: {
                 OS_ENVIRON: {
                     'USERNAME': '<USERNAME>',
+                    'USERDOMAIN_ROAMINGPROFILE': '<server_name>',
                     'PATH': f'/users/{scrubber.placeholder_user}/apps',
                     'TMP_WIN': f'C:\\Users\\{scrubber.placeholder_user}\\AppData\\Local\\Temp',
                     'USERDOMAIN': '<USERDOMAIN>',
@@ -249,11 +254,11 @@ def test_scrub_dict(scrubber):
     assert scrubber.scrub_entity_recursively(
         {'PATH': '/home/username/some/', 'USERDOMAIN': 'UD', 'USERNAME': 'U', 'REPEATED': 'user username UD U'}
     ) == {
-        'PATH': f'/home/{scrubber.placeholder_user}/some/',
-        'USERDOMAIN': '<USERDOMAIN>',
-        'USERNAME': '<USERNAME>',
-        'REPEATED': f'user {scrubber.placeholder_user} <USERDOMAIN> <USERNAME>',
-    }
+               'PATH': f'/home/{scrubber.placeholder_user}/some/',
+               'USERDOMAIN': '<USERDOMAIN>',
+               'USERNAME': '<USERNAME>',
+               'REPEATED': f'user {scrubber.placeholder_user} <USERDOMAIN> <USERNAME>',
+           }
 
     assert 'username' in scrubber.sensitive_occurrences.keys()
     assert 'UD' in scrubber.sensitive_occurrences.keys()

--- a/src/tribler/core/sentry_reporter/tests/test_sentry_tools.py
+++ b/src/tribler/core/sentry_reporter/tests/test_sentry_tools.py
@@ -9,7 +9,7 @@ from tribler.core.sentry_reporter.sentry_tools import (
     get_last_item,
     get_value,
     modify_value,
-    parse_os_environ,
+    obfuscate_string, parse_os_environ,
     parse_stacktrace,
 )
 
@@ -141,3 +141,16 @@ def test_extract_dict():
 
     assert extract_dict({}, '') == {}
     assert extract_dict({'k': 'v', 'k1': 'v1'}, r'\w$') == {'k': 'v'}
+
+
+OBFUSCATED_STRINGS = [
+    (None, None),
+    ('', ''),
+    ('any', 'challenge'),
+    ('string', 'quality'),
+]
+
+
+@pytest.mark.parametrize('given, expected', OBFUSCATED_STRINGS)
+def test_obfuscate_string(given, expected):
+    assert obfuscate_string(given) == expected


### PR DESCRIPTION
This PR implements the change for a sentry event processing requested by @kozlovsky 

There are three changes in this PR:

1.  `server_name` now is a part of the `self.dict_keys_for_scrub` which leads to scrubbing the server name from the corresponding field of the sentry event.
2. For all scrubbed values the `obfuscate_string` function has been applied instead of a static placeholder.
3. The `test_sentry_scrubber` file has been refactored.


Example: https://sentry.tribler.org/organizations/tribler/issues/1592


<img width="464" alt="image" src="https://user-images.githubusercontent.com/13798583/187691169-440291dd-7900-4b7d-844b-d91eb3c83632.png">
<img width="455" alt="image" src="https://user-images.githubusercontent.com/13798583/187691343-62a4c6da-e46c-4087-84dc-c3f95f55e568.png">
