### PR TITLE
Improved ranking for search results and updated search UI without the artifical delay at the loading screen

### DIFF
--- a/src/tribler/core/components/gigachannel/community/sync_strategy.py
+++ b/src/tribler/core/components/gigachannel/community/sync_strategy.py
@@ -3,6 +3,9 @@ from random import choice
 from ipv8.peerdiscovery.discovery import DiscoveryStrategy
 
 
+TARGET_PEERS_NUMBER = 20
+
+
 class RemovePeers(DiscoveryStrategy):
     """
     Synchronization strategy for remote query community.
@@ -10,8 +13,12 @@ class RemovePeers(DiscoveryStrategy):
     Remove a random peer, if we have enough peers to walk to.
     """
 
+    def __init__(self, overlay, target_peers_number=TARGET_PEERS_NUMBER):
+        super().__init__(overlay)
+        self.target_peers_number = target_peers_number
+
     def take_step(self):
         with self.walk_lock:
             peers = self.overlay.get_peers()
-            if peers and len(peers) > 20:
+            if peers and len(peers) > self.target_peers_number:
                 self.overlay.network.remove_peer(choice(peers))

--- a/src/tribler/core/components/metadata_store/db/store.py
+++ b/src/tribler/core/components/metadata_store/db/store.py
@@ -10,6 +10,7 @@ from lz4.frame import LZ4FrameDecompressor
 
 from pony import orm
 from pony.orm import db_session, desc, left_join, raw_sql, select
+from pony.orm.dbproviders.sqlite import keep_exception
 
 from tribler.core import notifications
 from tribler.core.components.metadata_store.db.orm_bindings import (
@@ -50,8 +51,10 @@ from tribler.core.exceptions import InvalidSignatureException
 from tribler.core.utilities.notifier import Notifier
 from tribler.core.utilities.path_util import Path
 from tribler.core.utilities.pony_utils import get_max, get_or_create
+from tribler.core.utilities.search_utils import torrent_rank
 from tribler.core.utilities.unicode import hexlify
 from tribler.core.utilities.utilities import MEMORY_DB
+
 
 BETA_DB_VERSIONS = [0, 1, 2, 3, 4, 5]
 CURRENT_DB_VERSION = 14
@@ -167,7 +170,7 @@ class MetadataStore:
         # with the static analysis.
         # pylint: disable=unused-variable
         @self._db.on_connect(provider='sqlite')
-        def sqlite_disable_sync(_, connection):
+        def on_connect(_, connection):
             cursor = connection.cursor()
             cursor.execute("PRAGMA journal_mode = WAL")
             cursor.execute("PRAGMA synchronous = NORMAL")
@@ -180,6 +183,10 @@ class MetadataStore:
                 # losing power during a write will corrupt the database.
                 cursor.execute("PRAGMA journal_mode = 0")
                 cursor.execute("PRAGMA synchronous = 0")
+
+            sqlite_rank = keep_exception(torrent_rank)
+            connection.create_function('search_rank', 4, sqlite_rank)
+
             # pylint: enable=unused-variable
 
         self.MiscData = misc.define_binding(self._db)
@@ -591,7 +598,7 @@ class MetadataStore:
         )
 
     # pylint: disable=unused-argument
-    def search_keyword(self, query, lim=100):
+    def search_keyword(self, query):
         # Requires FTS5 table "FtsIndex" to be generated and populated.
         # FTS table is maintained automatically by SQL triggers.
         # BM25 ranking is embedded in FTS5.
@@ -600,10 +607,11 @@ class MetadataStore:
         if not query or query == "*":
             return []
 
-        fts_ids = raw_sql(
-            """SELECT rowid FROM ChannelNode WHERE rowid IN (SELECT rowid FROM FtsIndex WHERE FtsIndex MATCH $query
-            ORDER BY bm25(FtsIndex) LIMIT $lim) GROUP BY coalesce(infohash, rowid)"""
-        )
+        fts_ids = raw_sql("""
+            SELECT rowid FROM ChannelNode
+            WHERE rowid IN (SELECT rowid FROM FtsIndex WHERE FtsIndex MATCH $query)
+            GROUP BY coalesce(infohash, rowid)
+        """)
         return left_join(g for g in self.MetadataNode if g.rowid in fts_ids)  # pylint: disable=E1135
 
     @db_session
@@ -639,7 +647,7 @@ class MetadataStore:
 
         if cls is None:
             cls = self.ChannelNode
-        pony_query = self.search_keyword(txt_filter, lim=1000) if txt_filter else left_join(g for g in cls)
+        pony_query = self.search_keyword(txt_filter) if txt_filter else left_join(g for g in cls)
         infohash_set = infohash_set or ({infohash} if infohash else None)
         if popular:
             if metadata_type != REGULAR_TORRENT:
@@ -731,7 +739,11 @@ class MetadataStore:
                 pony_query = pony_query.sort_by(
                     f"""
                     (1 if g.metadata_type == {CHANNEL_TORRENT} else 2 if g.metadata_type == {COLLECTION_NODE} else 3),
-                    desc(g.health.seeders), desc(g.health.leechers)
+                    raw_sql('''search_rank(
+                        $txt_filter, g.title, torrentstate.seeders + 0.1 * torrentstate.leechers,
+                        $int(time()) - strftime('%s', g.torrent_date)
+                    ) DESC'''),
+                    desc(g.health.last_check)  # just to trigger the TorrentState table inclusion into the left join
                 """
                 )
             elif popular:

--- a/src/tribler/core/components/metadata_store/remote_query_community/settings.py
+++ b/src/tribler/core/components/metadata_store/remote_query_community/settings.py
@@ -5,7 +5,16 @@ class RemoteQueryCommunitySettings(TriblerConfigSection):
     minimal_blob_size: int = 200
     maximum_payload_size: int = 1300
     max_entries: int = maximum_payload_size // minimal_blob_size
+
+    # The next option is currently used by GigaChannelCommunity only. We probably should move it to the
+    # GigaChannelCommunity settings or to a dedicated search-related section. The value of the option is corresponding
+    # with the TARGET_PEERS_NUMBER of src/tribler/core/components/gigachannel/community/sync_strategy.py, that is, to
+    # the number of peers that GigaChannelCommunity will have after a long run (initially, the number of peers in
+    # GigaChannelCommunity can rise up to several hundred due to DiscoveryBooster). The number of parallel remote
+    # requests should be not too small (to have various results from remote peers) and not too big (to avoid flooding
+    # the network with exceedingly high number of queries). TARGET_PEERS_NUMBER looks like a good middle ground here.
     max_query_peers: int = 20
+
     max_response_size: int = 100  # Max number of entries returned by SQL query
     max_channel_query_back: int = 4  # Max number of entries to query back on receiving an unknown channel
     push_updates_back_enabled = True

--- a/src/tribler/core/components/metadata_store/remote_query_community/settings.py
+++ b/src/tribler/core/components/metadata_store/remote_query_community/settings.py
@@ -5,7 +5,7 @@ class RemoteQueryCommunitySettings(TriblerConfigSection):
     minimal_blob_size: int = 200
     maximum_payload_size: int = 1300
     max_entries: int = maximum_payload_size // minimal_blob_size
-    max_query_peers: int = 5
+    max_query_peers: int = 20
     max_response_size: int = 100  # Max number of entries returned by SQL query
     max_channel_query_back: int = 4  # Max number of entries to query back on receiving an unknown channel
     push_updates_back_enabled = True

--- a/src/tribler/core/components/metadata_store/remote_query_community/tests/test_remote_search_by_tags.py
+++ b/src/tribler/core/components/metadata_store/remote_query_community/tests/test_remote_search_by_tags.py
@@ -72,9 +72,7 @@ class TestRemoteSearchByTags(TestBase):
     async def test_process_rpc_query_no_tags(self, mocked_get_entries_threaded: AsyncMock):
         # test that in case of missed tags, the remote search works like normal remote search
         parameters = {'first': 0, 'infohash_set': None, 'last': 100}
-        json = dumps(parameters).encode('utf-8')
-
-        await self.rqc.process_rpc_query(json)
+        await self.rqc.process_rpc_query(parameters)
 
         expected_parameters = {'infohash_set': None}
         expected_parameters.update(parameters)
@@ -117,10 +115,8 @@ class TestRemoteSearchByTags(TestBase):
 
         # Then we try to query search for three tags: 'tag1', 'tag2', 'tag3'
         parameters = {'first': 0, 'infohash_set': None, 'last': 100, 'tags': ['tag1']}
-        json = dumps(parameters).encode('utf-8')
-
         with db_session:
-            query_results = [r.to_dict() for r in await self.rqc.process_rpc_query(json)]
+            query_results = [r.to_dict() for r in await self.rqc.process_rpc_query(parameters)]
 
         # Expected results: only one infohash (b'infohash1') should be returned.
         result_infohash_list = [r['infohash'] for r in query_results]

--- a/src/tribler/core/components/metadata_store/restapi/search_endpoint.py
+++ b/src/tribler/core/components/metadata_store/restapi/search_endpoint.py
@@ -1,3 +1,4 @@
+import time
 from collections import defaultdict
 from typing import Dict, List
 
@@ -119,13 +120,27 @@ class SearchEndpoint(MetadataEndpointBase):
 
         def search_db():
             with db_session:
+                t1 = time.time()
                 pony_query = mds.get_entries(**sanitized)
+                t2 = time.time()
                 search_results = [r.to_simple_dict() for r in pony_query]
+                t3 = time.time()
                 if include_total:
                     total = mds.get_total_count(**sanitized)
+                    t4 = time.time()
                     max_rowid = mds.get_max_rowid()
+                    t5 = time.time()
+                    self._logger.info(f'Search performance for {sanitized}:\n'
+                                      f'Main query executed in {t2 - t1:.6} seconds;\n'
+                                      f'Result constructed in {t3 - t2:.6} seconds;\n'
+                                      f'Total rows count calculated in {t4 - t3:.6} seconds;\n'
+                                      f'Max rowid determined in {t5 - t4:.6} seconds.')
                 else:
                     total = max_rowid = None
+                    self._logger.info(f'Search performance for {sanitized}:\n'
+                                      f'Main query executed in {t2 - t1:.6} seconds;\n'
+                                      f'Result constructed in {t3 - t2:.6} seconds.')
+
             return search_results, total, max_rowid
 
         try:

--- a/src/tribler/core/tests/test_search_utils.py
+++ b/src/tribler/core/tests/test_search_utils.py
@@ -2,8 +2,8 @@ from collections import deque
 
 import pytest
 
-from tribler.core.utilities.search_utils import filter_keywords, find_word, freshness_rank, item_rank, seeders_rank, \
-    split_into_keywords, torrent_rank, title_rank
+from tribler.core.utilities.search_utils import filter_keywords, find_word_and_rotate_title, freshness_rank, item_rank,\
+    seeders_rank, split_into_keywords, torrent_rank, title_rank
 
 
 DAY = 60 * 60 * 24
@@ -153,51 +153,51 @@ def test_item_rank():
 
 
 def test_find_word():
-    # To use the find_word function, you can call it one time for each word from the query and see:
+    # To use the find_word_and_rotate_title function, you can call it one time for each word from the query and see:
     # - how many query words are missed in the title;
     # - how many excess or out-of-place title words are found before each query word;
     # - and how many title words are not mentioned in the query.
 
     # Example 1, query "A B C", title "A B C"
     title = deque(["A", "B", "C"])
-    assert find_word("A", title) == (True, 0) and title == deque(["B", "C"])
-    assert find_word("B", title) == (True, 0) and title == deque(["C"])
-    assert find_word("C", title) == (True, 0) and title == deque([])
+    assert find_word_and_rotate_title("A", title) == (True, 0) and title == deque(["B", "C"])
+    assert find_word_and_rotate_title("B", title) == (True, 0) and title == deque(["C"])
+    assert find_word_and_rotate_title("C", title) == (True, 0) and title == deque([])
     # Conclusion: exact match.
 
     # Example 2, query "A B C", title "A B C D"
     title = deque(["A", "B", "C", "D"])
-    assert find_word("A", title) == (True, 0) and title == deque(["B", "C", "D"])
-    assert find_word("B", title) == (True, 0) and title == deque(["C", "D"])
-    assert find_word("C", title) == (True, 0) and title == deque(["D"])
+    assert find_word_and_rotate_title("A", title) == (True, 0) and title == deque(["B", "C", "D"])
+    assert find_word_and_rotate_title("B", title) == (True, 0) and title == deque(["C", "D"])
+    assert find_word_and_rotate_title("C", title) == (True, 0) and title == deque(["D"])
     # Conclusion: minor penalty for one excess word in the title that is not in the query.
 
     # Example 3, query "A B C", title "X Y A B C"
     title = deque(["X", "Y", "A", "B", "C"])
-    assert find_word("A", title) == (True, 2) and title == deque(["B", "C", "X", "Y"])
-    assert find_word("B", title) == (True, 0) and title == deque(["C", "X", "Y"])
-    assert find_word("C", title) == (True, 0) and title == deque(["X", "Y"])
+    assert find_word_and_rotate_title("A", title) == (True, 2) and title == deque(["B", "C", "X", "Y"])
+    assert find_word_and_rotate_title("B", title) == (True, 0) and title == deque(["C", "X", "Y"])
+    assert find_word_and_rotate_title("C", title) == (True, 0) and title == deque(["X", "Y"])
     # Conclusion: major penalty for skipping two words at the beginning of the title plus a minor penalty for two
     # excess words in the title that are not in the query.
 
     # Example 4, query "A B C", title "A B X Y C"
     title = deque(["A", "B", "X", "Y", "C"])
-    assert find_word("A", title) == (True, 0) and title == deque(["B", "X", "Y", "C"])
-    assert find_word("B", title) == (True, 0) and title == deque(["X", "Y", "C"])
-    assert find_word("C", title) == (True, 2) and title == deque(["X", "Y"])
+    assert find_word_and_rotate_title("A", title) == (True, 0) and title == deque(["B", "X", "Y", "C"])
+    assert find_word_and_rotate_title("B", title) == (True, 0) and title == deque(["X", "Y", "C"])
+    assert find_word_and_rotate_title("C", title) == (True, 2) and title == deque(["X", "Y"])
     # Conclusion: average penalty for skipping two words in the middle of the title plus a minor penalty for two
     # excess words in the title that are not in the query.
 
     # Example 5, query "A B C", title "A C B"
     title = deque(["A", "C", "B"])
-    assert find_word("A", title) == (True, 0) and title == deque(["C", "B"])
-    assert find_word("B", title) == (True, 1) and title == deque(["C"])
-    assert find_word("C", title) == (True, 0) and title == deque([])
+    assert find_word_and_rotate_title("A", title) == (True, 0) and title == deque(["C", "B"])
+    assert find_word_and_rotate_title("B", title) == (True, 1) and title == deque(["C"])
+    assert find_word_and_rotate_title("C", title) == (True, 0) and title == deque([])
     # Conclusion: average penalty for skipping one word in the middle of the title.
 
     # Example 6, query "A B C", title "A C X"
     title = deque(["A", "C", "X"])
-    assert find_word("A", title) == (True, 0) and title == deque(["C", "X"])
-    assert find_word("B", title) == (False, 0) and title == deque(["C", "X"])
-    assert find_word("C", title) == (True, 0) and title == deque(["X"])
+    assert find_word_and_rotate_title("A", title) == (True, 0) and title == deque(["C", "X"])
+    assert find_word_and_rotate_title("B", title) == (False, 0) and title == deque(["C", "X"])
+    assert find_word_and_rotate_title("C", title) == (True, 0) and title == deque(["X"])
     # Conclusion: huge penalty for missing one query word plus a minor penalty for one excess title word.

--- a/src/tribler/core/tests/test_search_utils.py
+++ b/src/tribler/core/tests/test_search_utils.py
@@ -1,7 +1,9 @@
+from collections import deque
+
 import pytest
 
-from tribler.core.utilities.search_utils import filter_keywords, item_rank, split_into_keywords, torrent_rank, \
-    title_rank
+from tribler.core.utilities.search_utils import filter_keywords, find_word, item_rank, split_into_keywords,\
+    torrent_rank, title_rank
 
 
 DAY = 60 * 60 * 24
@@ -120,3 +122,54 @@ def test_title_rank():
 def test_item_rank():
     item = dict(name="abc", num_seeders=10, num_leechers=20)
     assert item_rank("abc", item) == pytest.approx(0.81978445)
+
+
+def test_find_word():
+    # To use the find_word function, you can call it one time for each word from the query and see:
+    # - how many query words are missed in the title;
+    # - how many excess or out-of-place title words are found before each query word;
+    # - and how many title words are not mentioned in the query.
+
+    # Example 1, query "A B C", title "A B C"
+    title = deque(["A", "B", "C"])
+    assert find_word("A", title) == (True, 0) and title == deque(["B", "C"])
+    assert find_word("B", title) == (True, 0) and title == deque(["C"])
+    assert find_word("C", title) == (True, 0) and title == deque([])
+    # Conclusion: exact match.
+
+    # Example 2, query "A B C", title "A B C D"
+    title = deque(["A", "B", "C", "D"])
+    assert find_word("A", title) == (True, 0) and title == deque(["B", "C", "D"])
+    assert find_word("B", title) == (True, 0) and title == deque(["C", "D"])
+    assert find_word("C", title) == (True, 0) and title == deque(["D"])
+    # Conclusion: minor penalty for one excess word in the title that is not in the query.
+
+    # Example 3, query "A B C", title "X Y A B C"
+    title = deque(["X", "Y", "A", "B", "C"])
+    assert find_word("A", title) == (True, 2) and title == deque(["B", "C", "X", "Y"])
+    assert find_word("B", title) == (True, 0) and title == deque(["C", "X", "Y"])
+    assert find_word("C", title) == (True, 0) and title == deque(["X", "Y"])
+    # Conclusion: major penalty for skipping two words at the beginning of the title plus a minor penalty for two
+    # excess words in the title that are not in the query.
+
+    # Example 4, query "A B C", title "A B X Y C"
+    title = deque(["A", "B", "X", "Y", "C"])
+    assert find_word("A", title) == (True, 0) and title == deque(["B", "X", "Y", "C"])
+    assert find_word("B", title) == (True, 0) and title == deque(["X", "Y", "C"])
+    assert find_word("C", title) == (True, 2) and title == deque(["X", "Y"])
+    # Conclusion: average penalty for skipping two words in the middle of the title plus a minor penalty for two
+    # excess words in the title that are not in the query.
+
+    # Example 5, query "A B C", title "A C B"
+    title = deque(["A", "C", "B"])
+    assert find_word("A", title) == (True, 0) and title == deque(["C", "B"])
+    assert find_word("B", title) == (True, 1) and title == deque(["C"])
+    assert find_word("C", title) == (True, 0) and title == deque([])
+    # Conclusion: average penalty for skipping one word in the middle of the title.
+
+    # Example 6, query "A B C", title "A C X"
+    title = deque(["A", "C", "X"])
+    assert find_word("A", title) == (True, 0) and title == deque(["C", "X"])
+    assert find_word("B", title) == (False, 0) and title == deque(["C", "X"])
+    assert find_word("C", title) == (True, 0) and title == deque(["X"])
+    # Conclusion: huge penalty for missing one query word plus a minor penalty for one excess title word.

--- a/src/tribler/core/tests/test_search_utils.py
+++ b/src/tribler/core/tests/test_search_utils.py
@@ -1,6 +1,7 @@
 import pytest
 
-from tribler.core.utilities.search_utils import filter_keywords, split_into_keywords, torrent_rank
+from tribler.core.utilities.search_utils import filter_keywords, item_rank, split_into_keywords, torrent_rank, \
+    title_rank
 
 
 DAY = 60 * 60 * 24
@@ -89,3 +90,14 @@ def test_torrent_rank():
     assert torrent_rank("Internet's Own Boy", "Internet's Own Boy") == pytest.approx(0.81)
     assert torrent_rank("Internet's Own Boy", "Internet's very Own Boy") == pytest.approx(0.75099337)
     assert torrent_rank("Internet's Own Boy", "Internet's very special Boy person") == pytest.approx(0.4353166986)
+
+
+def test_title_rank():
+    # tests for better covarage of corner cases
+    assert title_rank("", "title") == pytest.approx(1.0)
+    assert title_rank("query", "") == pytest.approx(0.0)
+
+
+def test_item_rank():
+    item = dict(name="abc", num_seeders=10, num_leechers=20)
+    assert item_rank("abc", item) == pytest.approx(0.81978445)

--- a/src/tribler/core/tests/test_search_utils.py
+++ b/src/tribler/core/tests/test_search_utils.py
@@ -2,8 +2,8 @@ from collections import deque
 
 import pytest
 
-from tribler.core.utilities.search_utils import filter_keywords, find_word, item_rank, split_into_keywords,\
-    torrent_rank, title_rank
+from tribler.core.utilities.search_utils import filter_keywords, find_word, freshness_rank, item_rank, seeders_rank, \
+    split_into_keywords, torrent_rank, title_rank
 
 
 DAY = 60 * 60 * 24
@@ -23,6 +23,34 @@ def test_filter_keywords():
     result = filter_keywords(["to", "be", "or", "not", "to", "be"])
     assert isinstance(result, list)
     assert len(result) == 4
+
+
+def test_title_rank_range():
+    assert title_rank('Big Buck Bunny', 'Big Buck Bunny') == 1
+
+    long_query = ' '.join(['foo'] * 1000)
+    long_title = ' '.join(['bar'] * 1000)
+    assert title_rank(long_query, long_title) == pytest.approx(0.03554968)
+
+
+def test_freshness_rank_range():
+    assert freshness_rank(-1) == 0
+    assert freshness_rank(0) == 0
+    assert freshness_rank(0.001) == pytest.approx(1.0)
+    assert freshness_rank(1000000000) == pytest.approx(0.0025852989)
+
+
+def test_seeders_rank_range():
+    assert seeders_rank(0) == 0
+    assert seeders_rank(1000000) == pytest.approx(0.9999)
+
+
+def test_torrent_rank_range():
+    assert torrent_rank('Big Buck Bunny', 'Big Buck Bunny', seeders=1000000, freshness=0.01) == pytest.approx(0.99999)
+
+    long_query = ' '.join(['foo'] * 1000)
+    long_title = ' '.join(['bar'] * 1000)
+    assert torrent_rank(long_query, long_title, freshness=1000000 * 365 * DAY) == pytest.approx(+0.02879524)
 
 
 def test_torrent_rank():

--- a/src/tribler/core/tests/test_search_utils.py
+++ b/src/tribler/core/tests/test_search_utils.py
@@ -25,117 +25,90 @@ def test_filter_keywords():
 
 def test_torrent_rank():
     query = 'Big Buck Bunny'
-
     # The exact match ranked as pretty high
-
-    r1 = torrent_rank(query, 'Big Buck Bunny')  # 0.81
-    assert r1 > 0.8
+    title_match = torrent_rank(query, 'Big Buck Bunny')  # 0.81
+    assert title_match > 0.8
 
     # Seeders are good for the rank
-
-    r2 = torrent_rank(query, 'Big Buck Bunny', seeders=100, freshness=100 * DAY)  # 0.876923
-
     # The more seeders the better
-
-    r3 = torrent_rank(query, 'Big Buck Bunny', seeders=1000, freshness=100 * DAY)  # 0.9146853
-
     # The fewer days have passed since the creation of the torrent, the higher its rank
-
-    r4 = torrent_rank(query, 'Big Buck Bunny', seeders=1000, freshness=1 * DAY)  # 0.9877126
-
-    assert r1 < r2 < r3 < r4
+    assert torrent_rank(query, 'Big Buck Bunny', seeders=1000, freshness=1 * DAY) > \
+           torrent_rank(query, 'Big Buck Bunny', seeders=1000, freshness=100 * DAY) > \
+           torrent_rank(query, 'Big Buck Bunny', seeders=100, freshness=100 * DAY) > \
+           title_match
 
     # If a title contains non-matching words missed in the query string it is not as good as the exact match
-
-    r5 = torrent_rank(query, 'Big Buck Bunny II')  # 0.80381679
-
     # The closer to the start of the string non-matching words are placed in the title, the worse is rank
-
-    r6 = torrent_rank(query, 'Big Buck Brown Bunny')  # 0.75061099
-    r7 = torrent_rank(query, 'Big Bad Buck Bunny')  # 0.74242068
-    r8 = torrent_rank(query, 'Boring Big Buck Bunny')  # 0.73125
-
-    assert r8 < r7 < r6 < r5 < r1
+    assert title_match > \
+           torrent_rank(query, 'Big Buck Bunny II') > \
+           torrent_rank(query, 'Big Buck Brown Bunny') > \
+           torrent_rank(query, 'Big Bad Buck Bunny') > \
+           torrent_rank(query, 'Boring Big Buck Bunny')
 
     # The more non-matching words are in the title, the worse is rank
-
-    r9 = torrent_rank(query, 'Big Buck A Bunny')  # 0.75061099
-    r10 = torrent_rank(query, 'Big Buck A B Bunny')  # 0.699335863
-    r11 = torrent_rank(query, 'Big Buck A B C Bunny')  # 0.6546181
-
-    assert r11 < r10 < r9 < r1
+    assert title_match > \
+           torrent_rank(query, 'Big Buck A Bunny') > \
+           torrent_rank(query, 'Big Buck A B Bunny') > \
+           torrent_rank(query, 'Big Buck A B C Bunny')
 
     # Non-matching words close to the beginning of the title give a bigger penalty
+    assert title_match > \
+           torrent_rank(query, 'Big A Buck Bunny') > \
+           torrent_rank(query, 'Big A B Buck Bunny') > \
+           torrent_rank(query, 'Big A B C Buck Bunny')
 
-    r12 = torrent_rank(query, 'Big A Buck Bunny')  # 0.742420681
-    r13 = torrent_rank(query, 'Big A B Buck Bunny')  # 0.6852494577
-    r14 = torrent_rank(query, 'Big A B C Buck Bunny')  # 0.636253776
+    assert title_match > \
+           torrent_rank(query, 'A Big Buck Bunny') > \
+           torrent_rank(query, 'A B Big Buck Bunny') > \
+           torrent_rank(query, 'A B C Big Buck Bunny')
 
-    assert r14 < r13 < r12 < r1
+    assert torrent_rank(query, 'Big A Buck Bunny') > \
+           torrent_rank(query, 'A Big Buck Bunny')
 
-    r15 = torrent_rank(query, 'A Big Buck Bunny')  # 0.73125
-    r16 = torrent_rank(query, 'A B Big Buck Bunny')  # 0.66645569
-    r17 = torrent_rank(query, 'A B C Big Buck Bunny')  # 0.6122093
+    assert torrent_rank(query, 'Big A B Buck Bunny') > \
+           torrent_rank(query, 'A B Big Buck Bunny')
 
-    assert r17 < r16 < r15 < r1
-    assert r15 < r12 and r16 < r13 and r17 < r14
+    assert torrent_rank(query, 'Big A B C Buck Bunny') > \
+           torrent_rank(query, 'A B C Big Buck Bunny')
 
     # Wrong order of words in the title imposes a penalty to the rank
-
-    r18 = torrent_rank(query, 'Big Bunny Buck')  # 0.7476923
-
-    assert r18 < r1
+    assert title_match > \
+           torrent_rank(query, 'Big Bunny Buck')
 
     # Missed query words imposes a really big penalty
-
-    r19 = torrent_rank(query, 'Big Buck')  # 0.4725
-
-    assert r19 < 0.5
+    assert torrent_rank(query, 'Big Buck') < 0.5
 
     # The close the missed words to the beginning of the query, the worse
-
-    r20 = torrent_rank(query, 'Big Bunny')  # 0.441818181
-    r21 = torrent_rank(query, 'Buck Bunny')  # 0.405
-
-    assert r21 < r20 < r19
+    assert torrent_rank(query, 'Big Buck') > \
+           torrent_rank(query, 'Big Bunny') > \
+           torrent_rank(query, 'Buck Bunny')
 
     # The more seeders is still better
-
-    r22 = torrent_rank(query, 'Buck Bunny', seeders=10, freshness=5 * DAY)  # 0.44805194
-    r23 = torrent_rank(query, 'Buck Bunny', seeders=100, freshness=5 * DAY)  # 0.46821428
-    r24 = torrent_rank(query, 'Buck Bunny', seeders=1000, freshness=5 * DAY)  # 0.4883766
-
-    assert r21 < r22 < r23 < r24
+    assert torrent_rank(query, 'Buck Bunny', seeders=1000, freshness=5 * DAY) > \
+           torrent_rank(query, 'Buck Bunny', seeders=100, freshness=5 * DAY) > \
+           torrent_rank(query, 'Buck Bunny', seeders=10, freshness=5 * DAY) > \
+           torrent_rank(query, 'Buck Bunny')
 
     # The more days from the check the less relevant the number of seeders is
-
-    r25 = torrent_rank(query, 'Buck Bunny', seeders=1000, freshness=10 * DAY)  # 0.48306818
-    r26 = torrent_rank(query, 'Buck Bunny', seeders=1000, freshness=20 * DAY)  # 0.47563636
-
-    assert r26 < r25 < r24
+    assert torrent_rank(query, 'Buck Bunny', freshness=5 * DAY) > \
+           torrent_rank(query, 'Buck Bunny', freshness=10 * DAY) > \
+           torrent_rank(query, 'Buck Bunny', freshness=20 * DAY)
 
     # The exact match has a good rank
-    r27 = torrent_rank('Sintel', 'Sintel')  # 0.81
-    assert r27 > 0.8
+    assert torrent_rank('Sintel', 'Sintel') > 0.8
 
     # Non-matching words at the end of the title give slightly worse results
-    r28 = torrent_rank('Sintel', 'Sintel Part II')  # 0.79553571
-
     # Non-matching words at the beginning of the title are much worse
-    r29 = torrent_rank('Sintel', 'Part of Sintel')  # 0.664925373
-
     # Too many non-matching words give a bigger penalty
-    r30 = torrent_rank('Sintel', 'the.script.from.the.movie.Sintel.pdf')  # 0.52105263
-
-    assert r30 < r29 < r28 < r27
+    assert torrent_rank('Sintel', 'Sintel') > \
+           torrent_rank('Sintel', 'Sintel Part II') > \
+           torrent_rank('Sintel', 'Part of Sintel') > \
+           torrent_rank('Sintel', 'the.script.from.the.movie.Sintel.pdf')
 
     # Some more examples
-
-    r31 = torrent_rank("Internet's Own Boy", "Internet's Own Boy")  # 0.81
-    r32 = torrent_rank("Internet's Own Boy", "Internet's very Own Boy")  # 0.75099337
-    r33 = torrent_rank("Internet's Own Boy", "Internet's very special Boy person")  # 0.4353166986
-
-    assert r33 < r32 < r31
+    assert torrent_rank("Internet's Own Boy", "Internet's Own Boy") > \
+           torrent_rank("Internet's Own Boy", "Internet's very Own Boy") > \
+           torrent_rank("Internet's Own Boy", "Internet's very special Boy person")
 
 
 def test_title_rank():

--- a/src/tribler/core/tests/test_search_utils.py
+++ b/src/tribler/core/tests/test_search_utils.py
@@ -27,69 +27,115 @@ def test_torrent_rank():
     query = 'Big Buck Bunny'
 
     # The exact match ranked as pretty high
-    assert torrent_rank(query, 'Big Buck Bunny') == pytest.approx(0.81)
+
+    r1 = torrent_rank(query, 'Big Buck Bunny')  # 0.81
+    assert r1 > 0.8
 
     # Seeders are good for the rank
-    assert torrent_rank(query, 'Big Buck Bunny', seeders=100, freshness=100 * DAY) == pytest.approx(0.876923)
+
+    r2 = torrent_rank(query, 'Big Buck Bunny', seeders=100, freshness=100 * DAY)  # 0.876923
 
     # The more seeders the better
-    assert torrent_rank(query, 'Big Buck Bunny', seeders=1000, freshness=100 * DAY) == pytest.approx(0.9146853)
+
+    r3 = torrent_rank(query, 'Big Buck Bunny', seeders=1000, freshness=100 * DAY)  # 0.9146853
 
     # The fewer days have passed since the creation of the torrent, the higher its rank
-    assert torrent_rank(query, 'Big Buck Bunny', seeders=1000, freshness=1 * DAY) == pytest.approx(0.9877126)
+
+    r4 = torrent_rank(query, 'Big Buck Bunny', seeders=1000, freshness=1 * DAY)  # 0.9877126
+
+    assert r1 < r2 < r3 < r4
 
     # If a title contains non-matching words missed in the query string it is not as good as the exact match
-    assert torrent_rank(query, 'Big Buck Bunny II') == pytest.approx(0.80381679)
+
+    r5 = torrent_rank(query, 'Big Buck Bunny II')  # 0.80381679
 
     # The closer to the start of the string non-matching words are placed in the title, the worse is rank
-    assert torrent_rank(query, 'Big Buck Brown Bunny') == pytest.approx(0.75061099)
-    assert torrent_rank(query, 'Big Bad Buck Bunny') == pytest.approx(0.74242068)
-    assert torrent_rank(query, 'Boring Big Buck Bunny') == pytest.approx(0.73125)
+
+    r6 = torrent_rank(query, 'Big Buck Brown Bunny')  # 0.75061099
+    r7 = torrent_rank(query, 'Big Bad Buck Bunny')  # 0.74242068
+    r8 = torrent_rank(query, 'Boring Big Buck Bunny')  # 0.73125
+
+    assert r8 < r7 < r6 < r5 < r1
 
     # The more non-matching words are in the title, the worse is rank
-    assert torrent_rank(query, 'Big Buck A Bunny') == pytest.approx(0.75061099)
-    assert torrent_rank(query, 'Big Buck A B Bunny') == pytest.approx(0.699335863)
-    assert torrent_rank(query, 'Big Buck A B C Bunny') == pytest.approx(0.6546181)
+
+    r9 = torrent_rank(query, 'Big Buck A Bunny')  # 0.75061099
+    r10 = torrent_rank(query, 'Big Buck A B Bunny')  # 0.699335863
+    r11 = torrent_rank(query, 'Big Buck A B C Bunny')  # 0.6546181
+
+    assert r11 < r10 < r9 < r1
 
     # Non-matching words close to the beginning of the title give a bigger penalty
-    assert torrent_rank(query, 'Big A Buck Bunny') == pytest.approx(0.742420681)
-    assert torrent_rank(query, 'Big A B Buck Bunny') == pytest.approx(0.6852494577)
-    assert torrent_rank(query, 'Big A B C Buck Bunny') == pytest.approx(0.636253776)
 
-    assert torrent_rank(query, 'A Big Buck Bunny') == pytest.approx(0.73125)
-    assert torrent_rank(query, 'A B Big Buck Bunny') == pytest.approx(0.66645569)
-    assert torrent_rank(query, 'A B C Big Buck Bunny') == pytest.approx(0.6122093)
+    r12 = torrent_rank(query, 'Big A Buck Bunny')  # 0.742420681
+    r13 = torrent_rank(query, 'Big A B Buck Bunny')  # 0.6852494577
+    r14 = torrent_rank(query, 'Big A B C Buck Bunny')  # 0.636253776
+
+    assert r14 < r13 < r12 < r1
+
+    r15 = torrent_rank(query, 'A Big Buck Bunny')  # 0.73125
+    r16 = torrent_rank(query, 'A B Big Buck Bunny')  # 0.66645569
+    r17 = torrent_rank(query, 'A B C Big Buck Bunny')  # 0.6122093
+
+    assert r17 < r16 < r15 < r1
+    assert r15 < r12 and r16 < r13 and r17 < r14
 
     # Wrong order of words in the title imposes a penalty to the rank
-    assert torrent_rank(query, 'Big Bunny Buck') == pytest.approx(0.7476923)
+
+    r18 = torrent_rank(query, 'Big Bunny Buck')  # 0.7476923
+
+    assert r18 < r1
 
     # Missed query words imposes a really big penalty
-    assert torrent_rank(query, 'Big Buck') == pytest.approx(0.4725)
+
+    r19 = torrent_rank(query, 'Big Buck')  # 0.4725
+
+    assert r19 < 0.5
 
     # The close the missed words to the beginning of the query, the worse
-    assert torrent_rank(query, 'Big Bunny') == pytest.approx(0.441818181)
-    assert torrent_rank(query, 'Buck Bunny') == pytest.approx(0.405)
 
-    # The more seeders is still better, the more days from the check the less relevant the number of seeders is
-    assert torrent_rank(query, 'Buck Bunny', seeders=10, freshness=5 * DAY) == pytest.approx(0.44805194)
-    assert torrent_rank(query, 'Buck Bunny', seeders=100, freshness=5 * DAY) == pytest.approx(0.46821428)
-    assert torrent_rank(query, 'Buck Bunny', seeders=1000, freshness=5 * DAY) == pytest.approx(0.4883766)
-    assert torrent_rank(query, 'Buck Bunny', seeders=1000, freshness=10 * DAY) == pytest.approx(0.48306818)
-    assert torrent_rank(query, 'Buck Bunny', seeders=1000, freshness=20 * DAY) == pytest.approx(0.47563636)
+    r20 = torrent_rank(query, 'Big Bunny')  # 0.441818181
+    r21 = torrent_rank(query, 'Buck Bunny')  # 0.405
 
-    # The exact match
-    assert torrent_rank('Sintel', 'Sintel') == pytest.approx(0.81)
+    assert r21 < r20 < r19
+
+    # The more seeders is still better
+
+    r22 = torrent_rank(query, 'Buck Bunny', seeders=10, freshness=5 * DAY)  # 0.44805194
+    r23 = torrent_rank(query, 'Buck Bunny', seeders=100, freshness=5 * DAY)  # 0.46821428
+    r24 = torrent_rank(query, 'Buck Bunny', seeders=1000, freshness=5 * DAY)  # 0.4883766
+
+    assert r21 < r22 < r23 < r24
+
+    # The more days from the check the less relevant the number of seeders is
+
+    r25 = torrent_rank(query, 'Buck Bunny', seeders=1000, freshness=10 * DAY)  # 0.48306818
+    r26 = torrent_rank(query, 'Buck Bunny', seeders=1000, freshness=20 * DAY)  # 0.47563636
+
+    assert r26 < r25 < r24
+
+    # The exact match has a good rank
+    r27 = torrent_rank('Sintel', 'Sintel')  # 0.81
+    assert r27 > 0.8
+
     # Non-matching words at the end of the title give slightly worse results
-    assert torrent_rank('Sintel', 'Sintel Part II') == pytest.approx(0.79553571)
+    r28 = torrent_rank('Sintel', 'Sintel Part II')  # 0.79553571
+
     # Non-matching words at the beginning of the title are much worse
-    assert torrent_rank('Sintel', 'Part of Sintel') == pytest.approx(0.664925373)
+    r29 = torrent_rank('Sintel', 'Part of Sintel')  # 0.664925373
+
     # Too many non-matching words give a bigger penalty
-    assert torrent_rank('Sintel', 'the.script.from.the.movie.Sintel.pdf') == pytest.approx(0.52105263)
+    r30 = torrent_rank('Sintel', 'the.script.from.the.movie.Sintel.pdf')  # 0.52105263
+
+    assert r30 < r29 < r28 < r27
 
     # Some more examples
-    assert torrent_rank("Internet's Own Boy", "Internet's Own Boy") == pytest.approx(0.81)
-    assert torrent_rank("Internet's Own Boy", "Internet's very Own Boy") == pytest.approx(0.75099337)
-    assert torrent_rank("Internet's Own Boy", "Internet's very special Boy person") == pytest.approx(0.4353166986)
+
+    r31 = torrent_rank("Internet's Own Boy", "Internet's Own Boy")  # 0.81
+    r32 = torrent_rank("Internet's Own Boy", "Internet's very Own Boy")  # 0.75099337
+    r33 = torrent_rank("Internet's Own Boy", "Internet's very special Boy person")  # 0.4353166986
+
+    assert r33 < r32 < r31
 
 
 def test_title_rank():

--- a/src/tribler/core/tests/test_search_utils.py
+++ b/src/tribler/core/tests/test_search_utils.py
@@ -1,4 +1,9 @@
-from tribler.core.utilities.search_utils import filter_keywords, split_into_keywords
+import pytest
+
+from tribler.core.utilities.search_utils import filter_keywords, split_into_keywords, torrent_rank
+
+
+DAY = 60 * 60 * 24
 
 
 def test_split_into_keywords():
@@ -15,3 +20,72 @@ def test_filter_keywords():
     result = filter_keywords(["to", "be", "or", "not", "to", "be"])
     assert isinstance(result, list)
     assert len(result) == 4
+
+
+def test_torrent_rank():
+    query = 'Big Buck Bunny'
+
+    # The exact match ranked as pretty high
+    assert torrent_rank(query, 'Big Buck Bunny') == pytest.approx(0.81)
+
+    # Seeders are good for the rank
+    assert torrent_rank(query, 'Big Buck Bunny', seeders=100, freshness=100 * DAY) == pytest.approx(0.876923)
+
+    # The more seeders the better
+    assert torrent_rank(query, 'Big Buck Bunny', seeders=1000, freshness=100 * DAY) == pytest.approx(0.9146853)
+
+    # The fewer days have passed since the creation of the torrent, the higher its rank
+    assert torrent_rank(query, 'Big Buck Bunny', seeders=1000, freshness=1 * DAY) == pytest.approx(0.9877126)
+
+    # If a title contains non-matching words missed in the query string it is not as good as the exact match
+    assert torrent_rank(query, 'Big Buck Bunny II') == pytest.approx(0.80381679)
+
+    # The closer to the start of the string non-matching words are placed in the title, the worse is rank
+    assert torrent_rank(query, 'Big Buck Brown Bunny') == pytest.approx(0.75061099)
+    assert torrent_rank(query, 'Big Bad Buck Bunny') == pytest.approx(0.74242068)
+    assert torrent_rank(query, 'Boring Big Buck Bunny') == pytest.approx(0.73125)
+
+    # The more non-matching words are in the title, the worse is rank
+    assert torrent_rank(query, 'Big Buck A Bunny') == pytest.approx(0.75061099)
+    assert torrent_rank(query, 'Big Buck A B Bunny') == pytest.approx(0.699335863)
+    assert torrent_rank(query, 'Big Buck A B C Bunny') == pytest.approx(0.6546181)
+
+    # Non-matching words close to the beginning of the title give a bigger penalty
+    assert torrent_rank(query, 'Big A Buck Bunny') == pytest.approx(0.742420681)
+    assert torrent_rank(query, 'Big A B Buck Bunny') == pytest.approx(0.6852494577)
+    assert torrent_rank(query, 'Big A B C Buck Bunny') == pytest.approx(0.636253776)
+
+    assert torrent_rank(query, 'A Big Buck Bunny') == pytest.approx(0.73125)
+    assert torrent_rank(query, 'A B Big Buck Bunny') == pytest.approx(0.66645569)
+    assert torrent_rank(query, 'A B C Big Buck Bunny') == pytest.approx(0.6122093)
+
+    # Wrong order of words in the title imposes a penalty to the rank
+    assert torrent_rank(query, 'Big Bunny Buck') == pytest.approx(0.7476923)
+
+    # Missed query words imposes a really big penalty
+    assert torrent_rank(query, 'Big Buck') == pytest.approx(0.4725)
+
+    # The close the missed words to the beginning of the query, the worse
+    assert torrent_rank(query, 'Big Bunny') == pytest.approx(0.441818181)
+    assert torrent_rank(query, 'Buck Bunny') == pytest.approx(0.405)
+
+    # The more seeders is still better, the more days from the check the less relevant the number of seeders is
+    assert torrent_rank(query, 'Buck Bunny', seeders=10, freshness=5 * DAY) == pytest.approx(0.44805194)
+    assert torrent_rank(query, 'Buck Bunny', seeders=100, freshness=5 * DAY) == pytest.approx(0.46821428)
+    assert torrent_rank(query, 'Buck Bunny', seeders=1000, freshness=5 * DAY) == pytest.approx(0.4883766)
+    assert torrent_rank(query, 'Buck Bunny', seeders=1000, freshness=10 * DAY) == pytest.approx(0.48306818)
+    assert torrent_rank(query, 'Buck Bunny', seeders=1000, freshness=20 * DAY) == pytest.approx(0.47563636)
+
+    # The exact match
+    assert torrent_rank('Sintel', 'Sintel') == pytest.approx(0.81)
+    # Non-matching words at the end of the title give slightly worse results
+    assert torrent_rank('Sintel', 'Sintel Part II') == pytest.approx(0.79553571)
+    # Non-matching words at the beginning of the title are much worse
+    assert torrent_rank('Sintel', 'Part of Sintel') == pytest.approx(0.664925373)
+    # Too many non-matching words give a bigger penalty
+    assert torrent_rank('Sintel', 'the.script.from.the.movie.Sintel.pdf') == pytest.approx(0.52105263)
+
+    # Some more examples
+    assert torrent_rank("Internet's Own Boy", "Internet's Own Boy") == pytest.approx(0.81)
+    assert torrent_rank("Internet's Own Boy", "Internet's very Own Boy") == pytest.approx(0.75099337)
+    assert torrent_rank("Internet's Own Boy", "Internet's very special Boy person") == pytest.approx(0.4353166986)

--- a/src/tribler/core/utilities/search_utils.py
+++ b/src/tribler/core/utilities/search_utils.py
@@ -4,6 +4,7 @@ Search utilities.
 Author(s): Jelle Roozenburg, Arno Bakker, Alexander Kozlovsky
 """
 import re
+import time
 from collections import deque
 from typing import Deque, List, Optional, Tuple
 
@@ -31,6 +32,14 @@ def split_into_keywords(string, to_filter_stopwords=False):
 
 def filter_keywords(keywords):
     return [kw for kw in keywords if len(kw) > 0 and kw not in DIALOG_STOPWORDS]
+
+
+def item_rank(query: str, item: dict):
+    title = item['name']
+    seeders = item.get('num_seeders', 0)
+    leechers = item.get('num_leechers', 0)
+    freshness = time.time() - item.get('updated', 0)
+    return torrent_rank(query, title, seeders + leechers * 0.1, freshness)
 
 
 def torrent_rank(query: str, title: str, seeders: int = 0, freshness: Optional[float] = 0) -> float:

--- a/src/tribler/core/utilities/search_utils.py
+++ b/src/tribler/core/utilities/search_utils.py
@@ -125,8 +125,14 @@ def freshness_rank(freshness: Optional[float] = 0) -> float:
     """
     freshness = max(0, freshness or 0)
     if not freshness:
-        return 0
+        return 0  # for freshness <= 0 the rank value is 0 because of an incorrect freshness value
 
+    # The function declines from 1.0 to 0.0 on range (0..Infinity], with the following properties:
+    #   *  for just created torrents the rank value is close to 1.0
+    #   *  for 30-days old torrents the rank value is 0.5
+    #   *  for very old torrens the rank value is going to zero
+    # It was possible to use another formulas with the same properties (for example, exponent-based),
+    # the exact curve shape is not really important.
     days = (freshness or 0) / SECONDS_IN_DAY
     return 1 / (1 + days / 30)
 

--- a/src/tribler/core/utilities/search_utils.py
+++ b/src/tribler/core/utilities/search_utils.py
@@ -196,73 +196,24 @@ def find_word(word: str, title: Deque[str]) -> Tuple[bool, int]:
     """
     Finds the query word in the title. Returns whether it was found or not and the number of skipped words in the title.
 
-    :param word: a word from the query
-    :param title: a list of words in the title
+    :param word: a word from the user-defined query string
+    :param title: a deque of words in the title
     :return: a two-elements tuple, whether the word was found in the title and the number of skipped words
 
     This is a helper function to efficiently answer a question of how close a query string and a title string are,
     taking into account the ordering of words in both strings.
 
-    The `word` parameter is a word from a search string.
-
-    The `title` parameter is a deque of words from the torrent title. It also can be a deque of stemmed words
-    if the `torrent_rank` function supports stemming.
-
-    The `find_word` function returns the boolean value of whether the word was found in the title deque or not and
-    the number of the skipped leading words in the `title` deque. Also, it modifies the `title` deque in place by
-    removing the first entrance of the found word and rotating all leading non-matching words to the end of the deque.
+    For efficiency reasons, the function modifies the `title` deque in place by removing the first entrance
+    of the found word and rotating all leading non-matching words to the end of the deque. It allows to efficiently
+    perform multiple calls of the `find_word` function for subsequent words from the same query string.
 
     An example: find_word('A', deque(['X', 'Y', 'A', 'B', 'C'])) returns `(True, 2)`, where True means that
     the word 'A' was found in the `title` deque, and 2 is the number of skipped words ('X', 'Y'). Also, it modifies
     the `title` deque, so it starts looking like deque(['B', 'C', 'X', 'Y']). The found word 'A' was removed, and
-    the leading non-matching words ('X', 'Y') was moved to the end of the deque.
-
-    Now some examples of how the function can be used. To use the function, you can call it one time for each word
-    from the query and see:
-    - how many query words are missed in the title;
-    - how many excess or out-of-place title words are found before each query word;
-    - and how many title words are not mentioned in the query.
-
-    Example 1, query "A B C", title "A B C":
-    find_word("A", deque(["A", "B", "C"])) -> (found=True, skipped=0, rest=deque(["B", "C"]))
-    find_word("B", deque(["B", "C"])) -> (found=True, skipped=0, rest=deque(["C"]))
-    find_word("C", deque(["C"])) -> (found=True, skipped=0, rest=deque([]))
-    Conclusion: exact match.
-
-    Example 2, query "A B C", title "A B C D":
-    find_word("A", deque(["A", "B", "C", "D"])) -> (found=True, skipped=0, rest=deque(["B", "C", "D"]))
-    find_word("B", deque(["B", "C", "D"])) -> (found=True, skipped=0, rest=deque(["C", "D"]))
-    find_word("C", deque(["C", "D"])) -> (found=True, skipped=0, rest=deque(["D"]))
-    Conclusion: minor penalty for one excess word in the title that is not in the query.
-
-    Example 3, query "A B C", title "X Y A B C":
-    find_word("A", deque(["X", "Y", "A", "B", "C"])) -> (found=True, skipped=2, rest=deque(["B", "C", "X", "Y"]))
-    find_word("B", deque(["B", "C", "X", "Y"])) -> (found=True, skipped=0, rest=deque(["C", "X", "Y"]))
-    find_word("C", deque(["C", "X", "Y"])) -> (found=True, skipped=0, rest=deque(["X", "Y"]))
-    Conclusion: major penalty for skipping two words at the beginning of the title plus a minor penalty for two
-    excess words in the title that are not in the query.
-
-    Example 4, query "A B C", title "A B X Y C":
-    find_word("A", deque(["A", "B", "X", "Y", "C"])) -> (found=True, skipped=0, rest=deque(["B", "X", "Y", "C"]))
-    find_word("B", deque(["B", "X", "Y", "C"])) -> (found=True, skipped=0, rest=deque(["X", "Y", "C"]))
-    find_word("C", deque(["X", "Y", "C"])) -> (found=True, skipped=2, rest=deque(["X", "Y"]))
-    Conclusion: average penalty for skipping two words in the middle of the title plus a minor penalty for two
-    excess words in the title that are not in the query.
-
-    Example 5, query "A B C", title "A C B":
-    find_word("A", deque(["A", "C", "B"])) -> (found=True, skipped=0, rest=deque(["C", "B"]))
-    find_word("B", deque(["C", "B"])) -> (found=True, skipped=1, rest=deque(["C"]))
-    find_word("C", deque(["C"])) -> (found=True, skipped=0, rest=deque(["C"]))
-    Conclusion: average penalty for skipping one word in the middle of the title.
-
-    Example 6, query "A B C", title "A C X":
-    find_word("A", deque(["A", "C", "X"])) -> (found=True, skipped=0, rest=deque(["C", "X"]))
-    find_word("B", deque(["C", "X"])) -> (found=False, skipped=0, rest=deque(["C", "X"]))
-    find_word("C", deque(["C", "X"])) -> (found=True, skipped=0, rest=deque(["X"]))
-    Conclusion: huge penalty for missing one query word plus a minor penalty for one excess title word.
+    the leading non-matching words ('X', 'Y') were moved to the end of the deque.
     """
     try:
-        skipped = title.index(word)
+        skipped = title.index(word)  # find the query word placement in the title and the number of preceding words
     except ValueError:
         return False, 0
 

--- a/src/tribler/core/utilities/search_utils.py
+++ b/src/tribler/core/utilities/search_utils.py
@@ -191,11 +191,12 @@ def calculate_rank(query: List[str], title: List[str]) -> float:
         # The first word is more important than the second word, and so on
         word_weight = POSITION_COEFF / (POSITION_COEFF + i)
 
-        # Read the description of the `find_word` function to understand what is going on. Basically, we are trying
-        # to find each query word in the title words, calculate the penalty if the query word is not found or if there
-        # are some title words before it, and then rotate the skipped title words to the end of the title. This way,
-        # the least penalty got a title that has query words in the proper order at the beginning of the title.
-        found, skipped = find_word(word, title)
+        # Read the description of the `find_word_and_rotate_title` function to understand what is going on.
+        # Basically, we are trying to find each query word in the title words, calculate the penalty if the query word
+        # is not found or if there are some title words before it, and then rotate the skipped title words to the end
+        # of the title. This way, the least penalty got a title that has query words in the proper order at the
+        # beginning of the title.
+        found, skipped = find_word_and_rotate_title(word, title)
         if found:
             # if the query word is found in the title, add penalty for skipped words in title before it
             total_error += skipped * word_weight
@@ -212,7 +213,7 @@ def calculate_rank(query: List[str], title: List[str]) -> float:
     return RANK_NORMALIZATION_COEFF / (RANK_NORMALIZATION_COEFF + total_error)
 
 
-def find_word(word: str, title: Deque[str]) -> Tuple[bool, int]:
+def find_word_and_rotate_title(word: str, title: Deque[str]) -> Tuple[bool, int]:
     """
     Finds the query word in the title. Returns whether it was found or not and the number of skipped words in the title.
 
@@ -225,10 +226,10 @@ def find_word(word: str, title: Deque[str]) -> Tuple[bool, int]:
 
     For efficiency reasons, the function modifies the `title` deque in place by removing the first entrance
     of the found word and rotating all leading non-matching words to the end of the deque. It allows to efficiently
-    perform multiple calls of the `find_word` function for subsequent words from the same query string.
+    perform multiple calls of the `find_word_and_rotate_title` function for subsequent words from the same query string.
 
-    An example: find_word('A', deque(['X', 'Y', 'A', 'B', 'C'])) returns `(True, 2)`, where True means that
-    the word 'A' was found in the `title` deque, and 2 is the number of skipped words ('X', 'Y'). Also, it modifies
+    An example: find_word_and_rotate_title('A', deque(['X', 'Y', 'A', 'B', 'C'])) returns `(True, 2)`, where True means
+    that the word 'A' was found in the `title` deque, and 2 is the number of skipped words ('X', 'Y'). Also, it modifies
     the `title` deque, so it starts looking like deque(['B', 'C', 'X', 'Y']). The found word 'A' was removed, and
     the leading non-matching words ('X', 'Y') were moved to the end of the deque.
     """

--- a/src/tribler/core/utilities/search_utils.py
+++ b/src/tribler/core/utilities/search_utils.py
@@ -1,12 +1,16 @@
 """
 Search utilities.
 
-Author(s): Jelle Roozenburg, Arno Bakker
+Author(s): Jelle Roozenburg, Arno Bakker, Alexander Kozlovsky
 """
 import re
+from collections import deque
+from typing import Deque, List, Optional, Tuple
 
 RE_KEYWORD_SPLIT = re.compile(r"[\W_]", re.UNICODE)
 DIALOG_STOPWORDS = {'an', 'and', 'by', 'for', 'from', 'of', 'the', 'to', 'with'}
+
+SECONDS_IN_DAY = 60 * 60 * 24
 
 
 def split_into_keywords(string, to_filter_stopwords=False):
@@ -27,3 +31,100 @@ def split_into_keywords(string, to_filter_stopwords=False):
 
 def filter_keywords(keywords):
     return [kw for kw in keywords if len(kw) > 0 and kw not in DIALOG_STOPWORDS]
+
+
+def torrent_rank(query: str, title: str, seeders: int = 0, freshness: Optional[float] = 0) -> float:
+    """
+    Calculates search rank for a torrent.
+    Takes into account:
+      - similarity of the title to the query string;
+      - the reported number of seeders;
+      - how long ago the torrent file was created.
+    """
+    freshness = max(0, freshness or 0)
+    tr = title_rank(query or '', title or '')
+    sr = (seeders_rank(seeders or 0) + 9) / 10  # range [0.9, 1]
+    fr = (freshness_rank(freshness) + 9) / 10  # range [0.9, 1]
+    result = tr * sr * fr
+    # uncomment the next line to debug the function inside an SQL query:
+    # print(f'*** {result} : {seeders}/{freshness} ({freshness / SECONDS_IN_DAY} days)/{title} | {query}')
+    return result
+
+
+def seeders_rank(seeders: float) -> float:
+    """
+    Calculates rank based on the number of seeders. The result is normalized to the range [0, 1]
+    """
+    return seeders / (100 + seeders)  # inf seeders -> 1; 100 seeders -> 0.5; 10 seeders -> approx 0.1
+
+
+def freshness_rank(freshness: Optional[float] = 0):
+    """
+    Calculates rank based on the torrent freshness. The result is normalized to the range [0, 1]
+    """
+    if not freshness:
+        return 0
+
+    days = (freshness or 0) / SECONDS_IN_DAY
+
+    return 1 / (1 + days / 30)  # 2x drop per 30 days
+
+
+word_re = re.compile(r'\w+', re.UNICODE)
+
+
+def title_rank(query: str, title: str) -> float:
+    """
+    Calculate the similarity of the title string to a query string, with or without stemming.
+    """
+    query = word_re.findall(query.lower())
+    title = word_re.findall(title.lower())
+    return calculate_rank(query, title)
+
+
+def calculate_rank(query: List[str], title: List[str]) -> float:
+    """
+    Calculate the similarity of the title to the query as a float value in range [0, 1].
+    """
+    if not query:
+        return 1.0
+
+    if not title:
+        return 0.0
+
+    title = deque(title)
+    total_error = 0
+    for i, term in enumerate(query):
+        # The first word is more important than the second word, and so on
+        term_weight = 5 / (5 + i)
+
+        found, skipped = find_term(term, title)
+        if found:
+            # if the query word is found in the title, add penalty for skipped words in title before it
+            total_error += skipped * term_weight
+        else:
+            # if the query word is not found in the title, add a big penalty for it
+            total_error += 10 * term_weight
+
+    # a small penalty for excess words in the title that was not mentioned in the search phrase
+    remainder_weight = 1 / (10 + len(query))
+    remained_words_error = len(title) * remainder_weight
+    total_error += remained_words_error
+
+    # a search rank should be between 1 and 0
+    return 10 / (10 + total_error)
+
+
+def find_term(term: str, title: Deque[str]) -> Tuple[bool, int]:
+    """
+    Finds the query word in the title.
+    Returns whether it was found or not and the number of skipped words in the title.
+    """
+    try:
+        skipped = title.index(term)
+    except ValueError:
+        return False, 0
+
+    title.rotate(-skipped)  # rotate skipped words to the end
+    title.popleft()  # remove found word
+    return True, skipped

--- a/src/tribler/core/utilities/search_utils.py
+++ b/src/tribler/core/utilities/search_utils.py
@@ -121,21 +121,21 @@ def calculate_rank(query: List[str], title: List[str]) -> float:
 
     title = deque(title)
     total_error = 0
-    for i, term in enumerate(query):
+    for i, word in enumerate(query):
         # The first word is more important than the second word, and so on
-        term_weight = POSITION_COEFF / (POSITION_COEFF + i)
+        word_weight = POSITION_COEFF / (POSITION_COEFF + i)
 
-        # Read the description of the `find_term` function to understand what is going on. Basically, we are trying
+        # Read the description of the `find_word` function to understand what is going on. Basically, we are trying
         # to find each query word in the title words, calculate the penalty if the query word is not found or if there
         # are some title words before it, and then rotate the skipped title words to the end of the title. This way,
         # the least penalty got a title that has query words in the proper order at the beginning of the title.
-        found, skipped = find_term(term, title)
+        found, skipped = find_word(word, title)
         if found:
             # if the query word is found in the title, add penalty for skipped words in title before it
-            total_error += skipped * term_weight
+            total_error += skipped * word_weight
         else:
             # if the query word is not found in the title, add a big penalty for it
-            total_error += MISSED_WORD_PENALTY * term_weight
+            total_error += MISSED_WORD_PENALTY * word_weight
 
     # a small penalty for excess words in the title that was not mentioned in the search phrase
     remainder_weight = 1 / (REMAINDER_COEFF + len(query))
@@ -146,7 +146,7 @@ def calculate_rank(query: List[str], title: List[str]) -> float:
     return RANK_NORMALIZATION_COEFF / (RANK_NORMALIZATION_COEFF + total_error)
 
 
-def find_term(term: str, title: Deque[str]) -> Tuple[bool, int]:
+def find_word(word: str, title: Deque[str]) -> Tuple[bool, int]:
     """
     Finds the query word in the title.
     Returns whether it was found or not and the number of skipped words in the title.
@@ -154,22 +154,19 @@ def find_term(term: str, title: Deque[str]) -> Tuple[bool, int]:
     This is a helper function to efficiently answer a question of how close a query string and a title string are,
     taking into account the ordering of words in both strings.
 
-    The `term` parameter is a word from a search string. It is called `term` and not `word` because it can also be
-    a stemmed version of the word if the comparison algorithm implemented in the top-level `torrent_rank` function
-    works with stemmed words. The ability to work with stemmed words was added to `torrent_rank` and then removed,
-    as it currently does not give significant benefits, but it can be added again in the future.
+    The `word` parameter is a word from a search string.
 
     The `title` parameter is a deque of words from the torrent title. It also can be a deque of stemmed words
     if the `torrent_rank` function supports stemming.
 
-    The `find_term` function returns the boolean value of whether the term was found in the title deque or not and
-    the number of the skipped leading terms in the `title` deque. Also, it modifies the `title` deque in place by
-    removing the first entrance of the found term and rotating all leading non-matching terms to the end of the deque.
+    The `find_word` function returns the boolean value of whether the word was found in the title deque or not and
+    the number of the skipped leading words in the `title` deque. Also, it modifies the `title` deque in place by
+    removing the first entrance of the found word and rotating all leading non-matching words to the end of the deque.
 
-    An example: find_term('A', deque(['X', 'Y', 'A', 'B', 'C'])) returns `(True, 2)`, where True means that
-    the term 'A' was found in the `title` deque, and 2 is the number of skipped terms ('X', 'Y'). Also, it modifies
-    the `title` deque, so it starts looking like deque(['B', 'C', 'X', 'Y']). The found term 'A' was removed, and
-    the leading non-matching terms ('X', 'Y') was moved to the end of the deque.
+    An example: find_word('A', deque(['X', 'Y', 'A', 'B', 'C'])) returns `(True, 2)`, where True means that
+    the word 'A' was found in the `title` deque, and 2 is the number of skipped words ('X', 'Y'). Also, it modifies
+    the `title` deque, so it starts looking like deque(['B', 'C', 'X', 'Y']). The found word 'A' was removed, and
+    the leading non-matching words ('X', 'Y') was moved to the end of the deque.
 
     Now some examples of how the function can be used. To use the function, you can call it one time for each word
     from the query and see:
@@ -178,45 +175,45 @@ def find_term(term: str, title: Deque[str]) -> Tuple[bool, int]:
     - and how many title words are not mentioned in the query.
 
     Example 1, query "A B C", title "A B C":
-    find_term("A", deque(["A", "B", "C"])) -> (found=True, skipped=0, rest=deque(["B", "C"]))
-    find_term("B", deque(["B", "C"])) -> (found=True, skipped=0, rest=deque(["C"]))
-    find_term("C", deque(["C"])) -> (found=True, skipped=0, rest=deque([]))
+    find_word("A", deque(["A", "B", "C"])) -> (found=True, skipped=0, rest=deque(["B", "C"]))
+    find_word("B", deque(["B", "C"])) -> (found=True, skipped=0, rest=deque(["C"]))
+    find_word("C", deque(["C"])) -> (found=True, skipped=0, rest=deque([]))
     Conclusion: exact match.
 
     Example 2, query "A B C", title "A B C D":
-    find_term("A", deque(["A", "B", "C", "D"])) -> (found=True, skipped=0, rest=deque(["B", "C", "D"]))
-    find_term("B", deque(["B", "C", "D"])) -> (found=True, skipped=0, rest=deque(["C", "D"]))
-    find_term("C", deque(["C", "D"])) -> (found=True, skipped=0, rest=deque(["D"]))
+    find_word("A", deque(["A", "B", "C", "D"])) -> (found=True, skipped=0, rest=deque(["B", "C", "D"]))
+    find_word("B", deque(["B", "C", "D"])) -> (found=True, skipped=0, rest=deque(["C", "D"]))
+    find_word("C", deque(["C", "D"])) -> (found=True, skipped=0, rest=deque(["D"]))
     Conclusion: minor penalty for one excess word in the title that is not in the query.
 
     Example 3, query "A B C", title "X Y A B C":
-    find_term("A", deque(["X", "Y", "A", "B", "C"])) -> (found=True, skipped=2, rest=deque(["B", "C", "X", "Y"]))
-    find_term("B", deque(["B", "C", "X", "Y"])) -> (found=True, skipped=0, rest=deque(["C", "X", "Y"]))
-    find_term("C", deque(["C", "X", "Y"])) -> (found=True, skipped=0, rest=deque(["X", "Y"]))
+    find_word("A", deque(["X", "Y", "A", "B", "C"])) -> (found=True, skipped=2, rest=deque(["B", "C", "X", "Y"]))
+    find_word("B", deque(["B", "C", "X", "Y"])) -> (found=True, skipped=0, rest=deque(["C", "X", "Y"]))
+    find_word("C", deque(["C", "X", "Y"])) -> (found=True, skipped=0, rest=deque(["X", "Y"]))
     Conclusion: major penalty for skipping two words at the beginning of the title plus a minor penalty for two
     excess words in the title that are not in the query.
 
     Example 4, query "A B C", title "A B X Y C":
-    find_term("A", deque(["A", "B", "X", "Y", "C"])) -> (found=True, skipped=0, rest=deque(["B", "X", "Y", "C"]))
-    find_term("B", deque(["B", "X", "Y", "C"])) -> (found=True, skipped=0, rest=deque(["X", "Y", "C"]))
-    find_term("C", deque(["X", "Y", "C"])) -> (found=True, skipped=2, rest=deque(["X", "Y"]))
+    find_word("A", deque(["A", "B", "X", "Y", "C"])) -> (found=True, skipped=0, rest=deque(["B", "X", "Y", "C"]))
+    find_word("B", deque(["B", "X", "Y", "C"])) -> (found=True, skipped=0, rest=deque(["X", "Y", "C"]))
+    find_word("C", deque(["X", "Y", "C"])) -> (found=True, skipped=2, rest=deque(["X", "Y"]))
     Conclusion: average penalty for skipping two words in the middle of the title plus a minor penalty for two
     excess words in the title that are not in the query.
 
     Example 5, query "A B C", title "A C B":
-    find_term("A", deque(["A", "C", "B"])) -> (found=True, skipped=0, rest=deque(["C", "B"]))
-    find_term("B", deque(["C", "B"])) -> (found=True, skipped=1, rest=deque(["C"]))
-    find_term("C", deque(["C"])) -> (found=True, skipped=0, rest=deque(["C"]))
+    find_word("A", deque(["A", "C", "B"])) -> (found=True, skipped=0, rest=deque(["C", "B"]))
+    find_word("B", deque(["C", "B"])) -> (found=True, skipped=1, rest=deque(["C"]))
+    find_word("C", deque(["C"])) -> (found=True, skipped=0, rest=deque(["C"]))
     Conclusion: average penalty for skipping one word in the middle of the title.
 
     Example 6, query "A B C", title "A C X":
-    find_term("A", deque(["A", "C", "X"])) -> (found=True, skipped=0, rest=deque(["C", "X"]))
-    find_term("B", deque(["C", "X"])) -> (found=False, skipped=0, rest=deque(["C", "X"]))
-    find_term("C", deque(["C", "X"])) -> (found=True, skipped=0, rest=deque(["X"]))
+    find_word("A", deque(["A", "C", "X"])) -> (found=True, skipped=0, rest=deque(["C", "X"]))
+    find_word("B", deque(["C", "X"])) -> (found=False, skipped=0, rest=deque(["C", "X"]))
+    find_word("C", deque(["C", "X"])) -> (found=True, skipped=0, rest=deque(["X"]))
     Conclusion: huge penalty for missing one query word plus a minor penalty for one excess title word.
     """
     try:
-        skipped = title.index(term)
+        skipped = title.index(word)
     except ValueError:
         return False, 0
 

--- a/src/tribler/core/utilities/search_utils.py
+++ b/src/tribler/core/utilities/search_utils.py
@@ -91,7 +91,7 @@ def seeders_rank(seeders: int, leechers: int = 0) -> float:
     :return: the torrent rank based on seeders and leechers, normalized to the range [0, 1]
     """
     sl = seeders + leechers * LEECHERS_COEFF
-    return sl / (100 + sl)  # inf seeders -> 1; 100 seeders -> 0.5; 10 seeders -> approx 0.1
+    return sl / (100 + sl)  # infinity seeders -> rank 1.0; 100 seeders -> rank 0.5; 10 seeders -> approximately 0.1
 
 
 def freshness_rank(freshness: Optional[float] = 0) -> float:

--- a/src/tribler/core/utilities/search_utils.py
+++ b/src/tribler/core/utilities/search_utils.py
@@ -59,8 +59,9 @@ def torrent_rank(query: str, title: str, seeders: int = 0, leechers: int = 0, fr
     :param title: a torrent name
     :param seeders: the number of seeders
     :param leechers: the number of leechers
-    :param freshness: the number of seconds since the torrent creation.
-                      Zero or negative value means the torrent creation date is unknown.
+    :param freshness: the number of seconds since the torrent creation. Zero or negative value means the torrent
+                      creation date is unknown. It is more convenient to use comparing to a timestamp, as it avoids
+                      using the `time()` function call and simplifies testing.
     :return: the torrent rank value in range [0, 1]
 
     Takes into account:

--- a/src/tribler/core/utilities/search_utils.py
+++ b/src/tribler/core/utilities/search_utils.py
@@ -125,6 +125,10 @@ def calculate_rank(query: List[str], title: List[str]) -> float:
         # The first word is more important than the second word, and so on
         term_weight = POSITION_COEFF / (POSITION_COEFF + i)
 
+        # Read the description of the `find_term` function to understand what is going on. Basically, we are trying
+        # to find each query word in the title words, calculate the penalty if the query word is not found or if there
+        # are some title words before it, and then rotate the skipped title words to the end of the title. This way,
+        # the least penalty got a title that has query words in the proper order at the beginning of the title.
         found, skipped = find_term(term, title)
         if found:
             # if the query word is found in the title, add penalty for skipped words in title before it
@@ -146,6 +150,70 @@ def find_term(term: str, title: Deque[str]) -> Tuple[bool, int]:
     """
     Finds the query word in the title.
     Returns whether it was found or not and the number of skipped words in the title.
+
+    This is a helper function to efficiently answer a question of how close a query string and a title string are,
+    taking into account the ordering of words in both strings.
+
+    The `term` parameter is a word from a search string. It is called `term` and not `word` because it can also be
+    a stemmed version of the word if the comparison algorithm implemented in the top-level `torrent_rank` function
+    works with stemmed words. The ability to work with stemmed words was added to `torrent_rank` and then removed,
+    as it currently does not give significant benefits, but it can be added again in the future.
+
+    The `title` parameter is a deque of words from the torrent title. It also can be a deque of stemmed words
+    if the `torrent_rank` function supports stemming.
+
+    The `find_term` function returns the boolean value of whether the term was found in the title deque or not and
+    the number of the skipped leading terms in the `title` deque. Also, it modifies the `title` deque in place by
+    removing the first entrance of the found term and rotating all leading non-matching terms to the end of the deque.
+
+    An example: find_term('A', deque(['X', 'Y', 'A', 'B', 'C'])) returns `(True, 2)`, where True means that
+    the term 'A' was found in the `title` deque, and 2 is the number of skipped terms ('X', 'Y'). Also, it modifies
+    the `title` deque, so it starts looking like deque(['B', 'C', 'X', 'Y']). The found term 'A' was removed, and
+    the leading non-matching terms ('X', 'Y') was moved to the end of the deque.
+
+    Now some examples of how the function can be used. To use the function, you can call it one time for each word
+    from the query and see:
+    - how many query words are missed in the title;
+    - how many excess or out-of-place title words are found before each query word;
+    - and how many title words are not mentioned in the query.
+
+    Example 1, query "A B C", title "A B C":
+    find_term("A", deque(["A", "B", "C"])) -> (found=True, skipped=0, rest=deque(["B", "C"]))
+    find_term("B", deque(["B", "C"])) -> (found=True, skipped=0, rest=deque(["C"]))
+    find_term("C", deque(["C"])) -> (found=True, skipped=0, rest=deque([]))
+    Conclusion: exact match.
+
+    Example 2, query "A B C", title "A B C D":
+    find_term("A", deque(["A", "B", "C", "D"])) -> (found=True, skipped=0, rest=deque(["B", "C", "D"]))
+    find_term("B", deque(["B", "C", "D"])) -> (found=True, skipped=0, rest=deque(["C", "D"]))
+    find_term("C", deque(["C", "D"])) -> (found=True, skipped=0, rest=deque(["D"]))
+    Conclusion: minor penalty for one excess word in the title that is not in the query.
+
+    Example 3, query "A B C", title "X Y A B C":
+    find_term("A", deque(["X", "Y", "A", "B", "C"])) -> (found=True, skipped=2, rest=deque(["B", "C", "X", "Y"]))
+    find_term("B", deque(["B", "C", "X", "Y"])) -> (found=True, skipped=0, rest=deque(["C", "X", "Y"]))
+    find_term("C", deque(["C", "X", "Y"])) -> (found=True, skipped=0, rest=deque(["X", "Y"]))
+    Conclusion: major penalty for skipping two words at the beginning of the title plus a minor penalty for two
+    excess words in the title that are not in the query.
+
+    Example 4, query "A B C", title "A B X Y C":
+    find_term("A", deque(["A", "B", "X", "Y", "C"])) -> (found=True, skipped=0, rest=deque(["B", "X", "Y", "C"]))
+    find_term("B", deque(["B", "X", "Y", "C"])) -> (found=True, skipped=0, rest=deque(["X", "Y", "C"]))
+    find_term("C", deque(["X", "Y", "C"])) -> (found=True, skipped=2, rest=deque(["X", "Y"]))
+    Conclusion: average penalty for skipping two words in the middle of the title plus a minor penalty for two
+    excess words in the title that are not in the query.
+
+    Example 5, query "A B C", title "A C B":
+    find_term("A", deque(["A", "C", "B"])) -> (found=True, skipped=0, rest=deque(["C", "B"]))
+    find_term("B", deque(["C", "B"])) -> (found=True, skipped=1, rest=deque(["C"]))
+    find_term("C", deque(["C"])) -> (found=True, skipped=0, rest=deque(["C"]))
+    Conclusion: average penalty for skipping one word in the middle of the title.
+
+    Example 6, query "A B C", title "A C X":
+    find_term("A", deque(["A", "C", "X"])) -> (found=True, skipped=0, rest=deque(["C", "X"]))
+    find_term("B", deque(["C", "X"])) -> (found=False, skipped=0, rest=deque(["C", "X"]))
+    find_term("C", deque(["C", "X"])) -> (found=True, skipped=0, rest=deque(["X"]))
+    Conclusion: huge penalty for missing one query word plus a minor penalty for one excess title word.
     """
     try:
         skipped = title.index(term)

--- a/src/tribler/gui/qt_resources/search_results.ui
+++ b/src/tribler/gui/qt_resources/search_results.ui
@@ -110,7 +110,38 @@
     </item>
    </layout>
   </widget>
-  <widget class="ChannelContentsWidget" name="results_page_content"/>
+  <widget class="QWidget" name="results_page">
+   <layout class="QVBoxLayout" name="results_page_layout">
+    <item>
+     <widget class="SearchProgressBar" name="search_progress_bar">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>16777215</width>
+        <height>10</height>
+       </size>
+      </property>
+      <property name="value">
+       <number>0</number>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+      </property>
+      <property name="format">
+       <string notr="true"/>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="ChannelContentsWidget" name="results_page_content"/>
+    </item>
+   </layout>
+  </widget>
  </widget>
  <customwidgets>
   <customwidget>
@@ -127,6 +158,12 @@
    <class>TimeoutProgressBar</class>
    <extends>QProgressBar</extends>
    <header>tribler.gui.widgets.timeoutprogressbar.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>SearchProgressBar</class>
+   <extends>QProgressBar</extends>
+   <header>tribler.gui.widgets.search_progress_bar.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/tribler/gui/qt_resources/search_results.ui
+++ b/src/tribler/gui/qt_resources/search_results.ui
@@ -110,7 +110,7 @@
     </item>
    </layout>
   </widget>
-  <widget class="ChannelContentsWidget" name="results_page"/>
+  <widget class="ChannelContentsWidget" name="results_page_content"/>
  </widget>
  <customwidgets>
   <customwidget>

--- a/src/tribler/gui/tests/test_gui.py
+++ b/src/tribler/gui/tests/test_gui.py
@@ -384,9 +384,8 @@ def test_search_suggestions(window):
 def test_search(window):
     window.top_search_bar.setText("a")  # This is likely to trigger some search results
     QTest.keyClick(window.top_search_bar, Qt.Key_Enter)
-    wait_for_variable(window, "search_results_page.search_request")
+    QTest.qWait(100)
     screenshot(window, name="search_loading_page")
-    QTest.mouseClick(window.search_results_page.show_results_button, Qt.LeftButton)
     tst_channels_widget(
         window,
         window.search_results_page.results_page,

--- a/src/tribler/gui/tests/test_gui.py
+++ b/src/tribler/gui/tests/test_gui.py
@@ -388,13 +388,12 @@ def test_search(window):
     screenshot(window, name="search_loading_page")
     tst_channels_widget(
         window,
-        window.search_results_page.results_page,
+        window.search_results_page.results_page_content,
         "search_results",
         sort_column=2,
         test_filter=False,
         test_subscribe=False,
     )
-
 
 @pytest.mark.guitest
 def test_add_download_url(window):

--- a/src/tribler/gui/widgets/channelcontentswidget.py
+++ b/src/tribler/gui/widgets/channelcontentswidget.py
@@ -318,6 +318,16 @@ class ChannelContentsWidget(AddBreadcrumbOnShowMixin, widget_form, widget_class)
             # Reset the view if the user clicks on the last part of the breadcrumb
             self.reset_view()
 
+    def format_search_title(self):
+        self.channel_name_label.setTextFormat(Qt.RichText)
+        text = self.format_link(self.model.format_title())
+        self.channel_name_label.setText(text)
+        self.channel_name_label.setTextInteractionFlags(Qt.TextBrowserInteraction)
+        self.channel_name_label.setFocusPolicy(Qt.NoFocus)
+
+    def format_link(self, text):
+        return f'<a style="text-decoration:none;color:#eee;" href="/">{text}</a>'
+
     def _set_filter_controls_from_model(self):
         # This should typically be called under freeze_controls context manager
         content_category = ContentCategories.get(self.model.category_filter)

--- a/src/tribler/gui/widgets/channelcontentswidget.py
+++ b/src/tribler/gui/widgets/channelcontentswidget.py
@@ -1,7 +1,7 @@
 from base64 import b64encode
 
 from PyQt5 import uic
-from PyQt5.QtCore import QDir, QTimer, Qt
+from PyQt5.QtCore import QDir, QTimer, Qt, pyqtSignal
 from PyQt5.QtGui import QIcon
 from PyQt5.QtWidgets import QAction, QFileDialog
 
@@ -39,6 +39,9 @@ widget_form, widget_class = uic.loadUiType(get_ui_file_path('torrents_list.ui'))
 
 # pylint: disable=too-many-instance-attributes, too-many-public-methods
 class ChannelContentsWidget(AddBreadcrumbOnShowMixin, widget_form, widget_class):
+
+    model_query_completed = pyqtSignal()
+
     def __init__(self, parent=None):
         widget_class.__init__(self, parent=parent)
 
@@ -109,6 +112,10 @@ class ChannelContentsWidget(AddBreadcrumbOnShowMixin, widget_form, widget_class)
     @property
     def model(self):
         return self.channels_stack[-1] if self.channels_stack else None
+
+    @property
+    def root_model(self):
+        return self.channels_stack[0] if self.channels_stack else None
 
     def on_channel_committed(self, response):
         if not response or not response.get("success", False):
@@ -260,6 +267,9 @@ class ChannelContentsWidget(AddBreadcrumbOnShowMixin, widget_form, widget_class)
         self.model.channel_info["dirty"] = dirty
         self.update_labels()
 
+    def on_model_query_completed(self):
+        self.model_query_completed.emit()
+
     def initialize_root_model_from_channel_info(self, channel_info):
         if channel_info.get("state") == CHANNEL_STATE.PERSONAL.value:
             self.default_channel_model = self.personal_channel_model
@@ -293,10 +303,13 @@ class ChannelContentsWidget(AddBreadcrumbOnShowMixin, widget_form, widget_class)
     def disconnect_current_model(self):
         disconnect(self.window().core_manager.events_manager.node_info_updated, self.model.update_node_info)
         disconnect(self.model.info_changed, self.on_model_info_changed)
+        disconnect(self.model.query_complete, self.on_model_query_completed)
+
         self.controller.unset_model()  # Disconnect the selectionChanged signal
 
     def connect_current_model(self):
         connect(self.model.info_changed, self.on_model_info_changed)
+        connect(self.model.query_complete, self.on_model_query_completed)
         connect(self.window().core_manager.events_manager.node_info_updated, self.model.update_node_info)
 
     @property
@@ -319,14 +332,8 @@ class ChannelContentsWidget(AddBreadcrumbOnShowMixin, widget_form, widget_class)
             self.reset_view()
 
     def format_search_title(self):
-        self.channel_name_label.setTextFormat(Qt.RichText)
-        text = self.format_link(self.model.format_title())
+        text = self.model.format_title()
         self.channel_name_label.setText(text)
-        self.channel_name_label.setTextInteractionFlags(Qt.TextBrowserInteraction)
-        self.channel_name_label.setFocusPolicy(Qt.NoFocus)
-
-    def format_link(self, text):
-        return f'<a style="text-decoration:none;color:#eee;" href="/">{text}</a>'
 
     def _set_filter_controls_from_model(self):
         # This should typically be called under freeze_controls context manager

--- a/src/tribler/gui/widgets/channelsmenulistwidget.py
+++ b/src/tribler/gui/widgets/channelsmenulistwidget.py
@@ -133,7 +133,7 @@ class ChannelsMenuListWidget(QListWidget):
 
         self.items_set = frozenset(entry_to_tuple(channel_info) for channel_info in channels)
 
-    def load_channels(self, request=None):
+    def load_channels(self):
         TriblerNetworkRequest(self.base_url, self.on_query_results, url_params={"subscribed": True, "last": 1000})
 
     def reload_if_necessary(self, changed_entries):

--- a/src/tribler/gui/widgets/search_progress_bar.py
+++ b/src/tribler/gui/widgets/search_progress_bar.py
@@ -1,0 +1,104 @@
+import time
+
+from PyQt5.QtCore import QTimer, pyqtSignal
+from PyQt5.QtWidgets import QProgressBar
+
+from tribler.gui.utilities import connect
+
+MAX_VALUE = 10000
+UPDATE_DELAY = 0.5
+REMOTE_DELAY = 0.25
+
+
+class SearchProgressBar(QProgressBar):
+    ready_to_update_results = pyqtSignal()
+
+    def __init__(self, parent=None, timeout=20):
+        super().__init__(parent)
+        self.timeout_interval = timeout
+        self.timer = QTimer()
+        self.timer.setSingleShot(False)
+        self.timer.setInterval(100)  # update the progress bar tick
+
+        self.start_time = None
+        self.last_update_time = None
+        self.last_remote_result_time = None
+        self.has_new_remote_results = False
+        self.peers_total = 0
+        self.peers_responded = 0
+        self.new_remote_items_count = 0
+        self.total_remote_items_count = 0
+
+        self._value = 0
+        self.setValue(0)
+        self.setMaximum(MAX_VALUE)
+
+        connect(self.timer.timeout, self._update)
+
+    def start(self):
+        t = time.time()
+        self.start_time = t
+        self.peers_total = 0
+        self.peers_responded = 0
+        self.setToolTip('')
+        self.setValue(0)
+        self.timer.start()
+        self.show()
+
+    def _update(self):
+        if self.start_time is None:
+            return
+
+        t = time.time()
+
+        time_progress = (t - self.start_time) / self.timeout_interval
+        response_progress = (self.peers_responded / self.peers_total) if self.peers_total else 0
+        scale = 1 - ((1 - time_progress) * (1 - response_progress)) ** 2
+        value = int(scale * MAX_VALUE)
+        self.setValue(value)
+
+        timeout = time_progress >= 1
+        most_peers_responded = self.peers_total > 0 and self.peers_responded / self.peers_total >= 0.8
+        active_transfers_finished = self.last_remote_result_time and t - self.last_remote_result_time > REMOTE_DELAY
+
+        should_stop = timeout or (most_peers_responded and active_transfers_finished)
+
+        if self.last_update_time is not None and self.has_new_remote_results \
+                and (t - self.last_update_time > UPDATE_DELAY and active_transfers_finished or should_stop):
+            self.last_update_time = t
+            self.has_new_remote_results = False
+            self.new_remote_items_count = 0
+            self.ready_to_update_results.emit()
+
+        if should_stop:
+            self.stop()
+
+    def stop(self):
+        self.start_time = None
+        self.timer.stop()
+        self.hide()
+
+    def mousePressEvent(self, _):
+        self.stop()
+
+    def on_local_results(self):
+        self.last_update_time = time.time()
+        self.has_new_remote_results = False
+        self._update()
+
+    def set_remote_total(self, total: int):
+        self.peers_total = total
+        self.setToolTip(f'0/{total} remote responded')
+        self._update()
+
+    def on_remote_results(self, new_items_count, peers_responded):
+        self.last_remote_result_time = time.time()
+        tool_tip = f'{peers_responded}/{self.peers_total} peers responded'
+        if self.total_remote_items_count:
+            tool_tip += f', {self.total_remote_items_count} new results'
+        self.setToolTip(tool_tip)
+        self.has_new_remote_results = True
+        self.new_remote_items_count += new_items_count
+        self.total_remote_items_count += new_items_count
+        self.peers_responded = peers_responded
+        self._update()

--- a/src/tribler/gui/widgets/searchresultswidget.py
+++ b/src/tribler/gui/widgets/searchresultswidget.py
@@ -99,7 +99,8 @@ class SearchResultsWidget(AddBreadcrumbOnShowMixin, widget_form, widget_class):
             original_query=query.original_query,
             text_filter=to_fts_query(query.fts_text),
             tags=list(query.tags),
-            type_filter=[REGULAR_TORRENT, CHANNEL_TORRENT, COLLECTION_NODE],
+            type_filter=[REGULAR_TORRENT],
+            exclude_deleted=True,
         )
         self.results_page_content.initialize_root_model(model)
         self.setCurrentWidget(self.results_page)
@@ -115,7 +116,8 @@ class SearchResultsWidget(AddBreadcrumbOnShowMixin, widget_form, widget_class):
             self.search_request = SearchRequest(response["request_uuid"], query, peers)
             self.search_progress_bar.set_remote_total(len(peers))
 
-        params = {'txt_filter': fts_query, 'hide_xxx': self.hide_xxx, 'tags': list(query.tags)}
+        params = {'txt_filter': fts_query, 'hide_xxx': self.hide_xxx, 'tags': list(query.tags),
+                  'metadata_type': REGULAR_TORRENT, 'exclude_deleted': True}
         TriblerNetworkRequest('remote_query', register_request, method="PUT", url_params=params)
 
         return True

--- a/src/tribler/gui/widgets/searchresultswidget.py
+++ b/src/tribler/gui/widgets/searchresultswidget.py
@@ -62,8 +62,8 @@ class SearchResultsWidget(AddBreadcrumbOnShowMixin, widget_form, widget_class):
 
     def initialize(self, hide_xxx=False):
         self.hide_xxx = hide_xxx
-        self.results_page.initialize_content_page(hide_xxx=hide_xxx)
-        self.results_page.channel_torrents_filter_input.setHidden(True)
+        self.results_page_content.initialize_content_page(hide_xxx=hide_xxx)
+        self.results_page_content.channel_torrents_filter_input.setHidden(True)
 
     @property
     def has_results(self):
@@ -90,22 +90,22 @@ class SearchResultsWidget(AddBreadcrumbOnShowMixin, widget_form, widget_class):
         self.last_search_query = query.original_query
         self.last_search_time = time.time()
 
-        self.results_page.initialize_root_model(
+        self.results_page_content.initialize_root_model(
             SearchResultsModel(
                 endpoint_url="search",
-                hide_xxx=self.results_page.hide_xxx,
+                hide_xxx=self.results_page_content.hide_xxx,
                 original_query=query.original_query,
                 text_filter=to_fts_query(query.fts_text),
                 tags=list(query.tags),
                 type_filter=[REGULAR_TORRENT, CHANNEL_TORRENT, COLLECTION_NODE],
             )
         )
-        self.setCurrentWidget(self.results_page)
-        self.results_page.format_search_title()
+        self.setCurrentWidget(self.results_page_content)
+        self.results_page_content.format_search_title()
 
         # After transitioning to the page with search results, we refresh the viewport since some rows might have been
         # rendered already with an incorrect row height.
-        self.results_page.run_brain_dead_refresh()
+        self.results_page_content.run_brain_dead_refresh()
 
         def register_request(response):
             self.search_request = SearchRequest(response["request_uuid"], query, set(response["peers"]))
@@ -116,8 +116,8 @@ class SearchResultsWidget(AddBreadcrumbOnShowMixin, widget_form, widget_class):
         return True
 
     def reset(self):
-        if self.currentWidget() == self.results_page:
-            self.results_page.go_back_to_level(0)
+        if self.currentWidget() == self.results_page_content:
+            self.results_page_content.go_back_to_level(0)
 
     def update_loading_page(self, remote_results):
         if not self.search_request or self.search_request.uuid != remote_results.get("uuid"):
@@ -128,5 +128,5 @@ class SearchResultsWidget(AddBreadcrumbOnShowMixin, widget_form, widget_class):
         self.search_request.peers_complete.add(peer)
         self.search_request.remote_results.append(results)
 
-        self.results_page.model.on_remote_results(results)
-        self.results_page.format_search_title()
+        self.results_page_content.model.on_remote_results(results)
+        self.results_page_content.format_search_title()

--- a/src/tribler/gui/widgets/tablecontentdelegate.py
+++ b/src/tribler/gui/widgets/tablecontentdelegate.py
@@ -374,11 +374,20 @@ class TagsMixin:
 
     def draw_title_and_tags(self, painter: QPainter, option: QStyleOptionViewItem, index: QModelIndex,
                             data_item: Dict) -> None:
+        debug = False  # change to True to see the search rank of items and to highlight remote items
         item_name = data_item["name"]
+
         group = data_item.get("group")
         if group:
-            plural = len(group) > 1
-            item_name += f"    (and {len(group)} similar item{'s' if plural else ''})"
+            has_remote_items = any(group_item.get('remote') for group_item in group.values())
+            item_name += f"    (+ {len(group)} similar{' *' if debug and has_remote_items else ''})"
+
+        if debug:
+            rank = data_item.get("rank")
+            if rank is not None:
+                item_name += f'    rank: {rank:.6}'
+            if data_item.get('remote'):
+                item_name = '*  ' + item_name
         painter.setRenderHint(QPainter.Antialiasing, True)
         title_text_pos = option.rect.topLeft()
         title_text_height = 60 if data_item["type"] == SNIPPET else 28

--- a/src/tribler/gui/widgets/tablecontentdelegate.py
+++ b/src/tribler/gui/widgets/tablecontentdelegate.py
@@ -35,7 +35,7 @@ from tribler.gui.defs import (
 )
 from tribler.gui.utilities import format_votes, get_color, get_gui_setting, get_health, get_image_path, tr, \
     get_objects_with_predicate
-from tribler.gui.widgets.tablecontentmodel import Column
+from tribler.gui.widgets.tablecontentmodel import Column, RemoteTableModel
 from tribler.gui.widgets.tableiconbuttons import DownloadIconButton
 
 PROGRESS_BAR_BACKGROUND = QColor("#444444")
@@ -268,18 +268,20 @@ class TriblerButtonsDelegate(QStyledItemDelegate):
             yield QRect(x, y, w, h), button
 
     def paint(self, painter, option, index):
-        # Draw 'hover' state highlight for every cell of a row
-        if index.row() == self.hover_index.row():
+        model: RemoteTableModel = index.model()
+        data_item = model.data_items[index.row()]
+        if index.row() == self.hover_index.row() or model.should_highlight_item(data_item):
+            # Draw 'hover' state highlight for every cell of a row
             option.state |= QStyle.State_MouseOver
-        if not self.paint_exact(painter, option, index):
+        if not self.paint_exact(painter, option, index, data_item):
             # Draw the rest of the columns
             super().paint(painter, option, index)
 
-    def paint_exact(self, painter, option, index):
-        data_item = index.model().data_items[index.row()]
+    def paint_exact(self, painter, option, index, data_item):
         for column, drawing_action in self.column_drawing_actions:
             if column in index.model().column_position and index.column() == index.model().column_position[column]:
                 return drawing_action(painter, option, index, data_item)
+        return False
 
     def editorEvent(self, event, model, option, index):
         for control in self.controls:

--- a/src/tribler/gui/widgets/tablecontentdelegate.py
+++ b/src/tribler/gui/widgets/tablecontentdelegate.py
@@ -372,9 +372,13 @@ class TagsMixin:
     edit_tags_icon = QIcon(get_image_path("edit_white.png"))
     edit_tags_icon_hover = QIcon(get_image_path("edit_orange.png"))
 
-    def draw_title_and_tags(
-            self, painter: QPainter, option: QStyleOptionViewItem, index: QModelIndex, data_item: Dict
-    ) -> None:
+    def draw_title_and_tags(self, painter: QPainter, option: QStyleOptionViewItem, index: QModelIndex,
+                            data_item: Dict) -> None:
+        item_name = data_item["name"]
+        group = data_item.get("group")
+        if group:
+            plural = len(group) > 1
+            item_name += f"    (and {len(group)} similar item{'s' if plural else ''})"
         painter.setRenderHint(QPainter.Antialiasing, True)
         title_text_pos = option.rect.topLeft()
         title_text_height = 60 if data_item["type"] == SNIPPET else 28
@@ -391,7 +395,7 @@ class TagsMixin:
         painter.drawText(
             QRectF(title_text_x, title_text_y, option.rect.width() - 6, title_text_height),
             Qt.AlignVCenter,
-            data_item["name"],
+            item_name,
         )
 
         if data_item["type"] == SNIPPET:

--- a/src/tribler/gui/widgets/tablecontentmodel.py
+++ b/src/tribler/gui/widgets/tablecontentmodel.py
@@ -258,6 +258,9 @@ class RemoteTableModel(QAbstractTableModel):
 
         self.info_changed.emit(items)
 
+    def perform_initial_query(self):
+        self.perform_query()
+
     def perform_query(self, **kwargs):
         """
         Fetch results for a given query.
@@ -316,8 +319,8 @@ class RemoteTableModel(QAbstractTableModel):
             if update_labels:
                 self.info_changed.emit(response['results'])
 
-        self.query_complete.emit()
         self.loaded = True
+        self.query_complete.emit()
         return True
 
 
@@ -360,7 +363,7 @@ class ChannelContentModel(RemoteTableModel):
         self.endpoint_url_override = endpoint_url
 
         # Load the initial batch of entries
-        self.perform_query()
+        self.perform_initial_query()
 
     @property
     def edit_enabled(self):
@@ -548,8 +551,12 @@ class ChannelPreviewModel(ChannelContentModel):
 
 
 class SearchResultsModel(ChannelContentModel):
-    pass
+    def perform_initial_query(self):
+        return self.perform_query(first=1, last=200)
 
+    @property
+    def all_local_entries_loaded(self):
+        return self.loaded
 
 class PopularTorrentsModel(ChannelContentModel):
     columns_shown = (Column.CATEGORY, Column.NAME, Column.SIZE, Column.UPDATED)

--- a/src/tribler/gui/widgets/tablecontentmodel.py
+++ b/src/tribler/gui/widgets/tablecontentmodel.py
@@ -106,11 +106,14 @@ class RemoteTableModel(QAbstractTableModel):
         self.sort_desc = True
         self.saved_header_state = None
         self.saved_scroll_state = None
+        self.highlight_remote_results = True
         self.qt_object_destroyed = False
 
         self.group_by_name = False
         self.sort_by_rank = False
         self.text_filter = ''
+
+        self.highlight_remote_results = True
 
         connect(self.destroyed, self.on_destroy)
         # Every remote query must be attributed to its specific model to avoid updating wrong models
@@ -147,6 +150,9 @@ class RemoteTableModel(QAbstractTableModel):
         self.item_uid_map = {}
         self.endResetModel()
         self.perform_query()
+
+    def should_highlight_item(self, data_item):
+        return self.highlight_remote_results and data_item.get('remote')
 
     def sort(self, column_index, order):
         if not self.columns[column_index].sortable:

--- a/src/tribler/gui/widgets/tablecontentmodel.py
+++ b/src/tribler/gui/widgets/tablecontentmodel.py
@@ -188,7 +188,7 @@ class RemoteTableModel(QAbstractTableModel):
             if item_uid not in self.item_uid_map:
 
                 prev_item = name_mapping.get(item['name'])
-                if self.group_by_name and prev_item is not None and not on_top:
+                if self.group_by_name and prev_item is not None and not on_top and prev_item['type'] == REGULAR_TORRENT:
                     group = prev_item.setdefault('group', {})
                     if item_uid not in group:
                         group[item_uid] = item
@@ -208,8 +208,18 @@ class RemoteTableModel(QAbstractTableModel):
             return
 
         if remote and self.sort_by_rank:
-            new_data_items = self.data_items + unique_new_items
-            new_data_items.sort(key = lambda item: item['rank'], reverse=True)
+            torrents = [item for item in self.data_items if item['type'] == REGULAR_TORRENT]
+            non_torrents = [item for item in self.data_items if item['type'] != REGULAR_TORRENT]
+
+            new_torrents = [item for item in unique_new_items if item['type'] == REGULAR_TORRENT]
+            new_non_torrents = [item for item in unique_new_items if item['type'] != REGULAR_TORRENT]
+
+            torrents += new_torrents
+            non_torrents += new_non_torrents
+
+            torrents.sort(key = lambda item: item['rank'], reverse=True)
+            new_data_items = non_torrents + torrents
+
             new_item_uid_map = {}
             for item in new_data_items:
                 item_uid = get_item_uid(item)


### PR DESCRIPTION
This PR implements improved search with better item ranking implemented at the DB level, as described in https://github.com/Tribler/tribler/issues/2250#issuecomment-1157735819. Elements with relevant titles and many seeders are placed closer to the top of the search result list.

UI shows local search results immediately, ready without any artificial delay. Remote items show automatically with a slight delay to avoid result flickering and have highlighted background to prevent user confusion when remote results appear on the screen.

Search UI has a progress bar to show the progress for the remote searches. The tooltip of the progress bar displays the number of complete remote requests and the total number of remote requests. It is possible to click on the progress bar to stop processing remote results if they take a long time.

Remote requests have a timeout of 20 seconds to be incorporated into the search result in the UI, and the progress bar actual progress takes into account this hard timeout as well as the current progress on receiving remote results; the more results we have, the close the progress bar to a finish.