### PR TITLE
Add the `requirements-key` parameter to the pyenv GitHub Action

### DIFF
--- a/.github/actions/pyenv/action.yml
+++ b/.github/actions/pyenv/action.yml
@@ -11,6 +11,11 @@ inputs:
     description: 'The path to requirements.txt file'
     required: false
 
+  requirements-key:
+    default: '**/requirements*.txt'
+    description: 'Requirements-files to use for building the cache key'
+    required: false
+
   invalidate-cache:
     default: 'false'
     description: 'Force create a virtualenv'
@@ -32,7 +37,7 @@ runs:
       uses: drew2a/restore-virtualenv@v1.2.1
       id: cache-virtualenv
       with:
-        requirement_files: ${{inputs.requirements}}
+        requirement_files: ${{inputs.requirements-key}}
 
     - name: Invalidate cache
       if: inputs.invalidate-cache == 'true'


### PR DESCRIPTION
This PR fixes #7026 by adding the dedicated `requirements-key` parameter.

This parameter will be used in the `restore-virtualenv@v1.2.1` action as a value on which the cache key be generated.

```yml
    - name: Restore virtual env
      uses: drew2a/restore-virtualenv@v1.2.1
      id: cache-virtualenv
      with:
        requirement_files: ${{inputs.requirements-key}}
```

The old parameter `requirements` is still be used for passing it into:
```yml
    - name: Install pip dependencies
      if: steps.cache-virtualenv.outputs.cache-hit != 'true' || inputs.invalidate-cache == 'true'
      shell: bash
      run: |
        python -m pip install --upgrade pip
        pip install -r ${{inputs.requirements}}
```

Therefore by default for the cache key generation, we use the pattern `**/requirements*.txt` which can be translated into:

```
requirements-build.txt
requirements-core.txt
requirements-test.txt
requirements.txt
```

Therefore `**/requirements*.txt` value suits all our actions although it is a bit redundant (by default).