### PR TITLE
Specify the `requirements-key` parameter for `documentation.yml`

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           python-version: ${{inputs.python-version}}
           requirements: ./doc/requirements.txt
+          requirements-key: ./doc/requirements*.txt
 
       - name: Build documentation
         run: |


### PR DESCRIPTION
This PR fixes `documentation.yml` by specifying the `requirements-key` parameter.

Otherwise, the virtual environment will not be restored properly.

Error: https://github.com/Tribler/tribler/runs/8135472947?check_suite_focus=true
Related: https://github.com/Tribler/tribler/pull/7028