### PR TITLE
Unconditionally include RESTComponent when starting Tribler Core

### DIFF
--- a/src/tribler/core/start_core.py
+++ b/src/tribler/core/start_core.py
@@ -51,8 +51,7 @@ def components_gen(config: TriblerConfig):
     """
     yield ReporterComponent()
     yield GuiProcessWatcherComponent()
-    if config.api.http_enabled or config.api.https_enabled:
-        yield RESTComponent()
+    yield RESTComponent()
     if config.chant.enabled or config.torrent_checking.enabled:
         yield MetadataStoreComponent()
     if config.ipv8.enabled:


### PR DESCRIPTION
Currently, it is theoretically possible to run Tribler Core without `RESTComponent`. This PR unconditionally includes `RESTComponent` in the component list, as this component is necessary for GUI-Core communication.