### PR TITLE
Fix #7080

### DIFF
--- a/scripts/bandwidth_crawler/run_bandwidth_crawler.py
+++ b/scripts/bandwidth_crawler/run_bandwidth_crawler.py
@@ -40,7 +40,7 @@ if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
 
     state_dir = Path(args.statedir).absolute()
-    config = TriblerConfig.load(file=state_dir / 'triblerd.conf', state_dir=state_dir)
+    config = TriblerConfig.load(state_dir=state_dir)
 
     config.tunnel_community.enabled = False
     config.libtorrent.enabled = False

--- a/scripts/exit_node/run_exit_node.py
+++ b/scripts/exit_node/run_exit_node.py
@@ -51,7 +51,7 @@ def make_config(options) -> TriblerConfig:
             raise ValueError('ipv8_port option is not set, and HELPER_BASE/HELPER_INDEX env vars are not defined')
 
     statedir = Path(os.path.join(get_root_state_directory(), "tunnel-%d") % ipv8_port)
-    config = TriblerConfig.load(file=statedir / 'triblerd.conf', state_dir=statedir)
+    config = TriblerConfig.load(state_dir=statedir)
     config.tunnel_community.random_slots = options.random_slots
     config.tunnel_community.competing_slots = options.competing_slots
     config.torrent_checking.enabled = False

--- a/src/run_tribler_headless.py
+++ b/src/run_tribler_headless.py
@@ -69,7 +69,7 @@ class TriblerService:
         signal.signal(signal.SIGTERM, lambda sig, _: ensure_future(signal_handler(sig)))
 
         statedir = Path(options.statedir or Path(get_appstate_dir(), '.Tribler'))
-        config = TriblerConfig.load(file=statedir / 'triblerd.conf', state_dir=statedir)
+        config = TriblerConfig.load(state_dir=statedir)
 
         # Check if we are already running a Tribler instance
         root_state_dir = get_root_state_directory()

--- a/src/tribler/core/config/tribler_config.py
+++ b/src/tribler/core/config/tribler_config.py
@@ -30,6 +30,8 @@ from tribler.core.settings import GeneralSettings
 
 logger = logging.getLogger('Tribler Config')
 
+DEFAULT_CONFIG_NAME = 'triblerd.conf'
+
 
 class TriblerConfig(BaseSettings):
     """ Tribler config class that contains common logic for manipulating with a config."""
@@ -74,25 +76,27 @@ class TriblerConfig(BaseSettings):
             **kwargs: Arguments that will be passed to the `BaseSettings` constructor.
         """
         super().__init__(*args, **kwargs)
-        logger.info(f'Init. State dir: {state_dir}. File: {file}')
+        if not file and state_dir:
+            file = state_dir / DEFAULT_CONFIG_NAME  # assign default file name
 
         self.set_state_dir(state_dir)
         self.set_file(file)
 
         self._error = error
+        logger.info(f'Init. State dir: {state_dir}. File: {file}')
 
     @staticmethod
-    def load(file: Path, state_dir: Path, reset_config_on_error: bool = False) -> TriblerConfig:
+    def load(state_dir: Path, file: Path = None, reset_config_on_error: bool = False) -> TriblerConfig:
         """ Load a config from a file
 
         Args:
-            file: A path to the config file.
             state_dir: A Tribler's state dir.
-            reset_config_on_error: Ф flag that shows whether it is necessary to
+            file: A path to the config file.
+            reset_config_on_error: a flag that shows whether it is necessary to
                 create a new config in case of an error.
-
         Returns: `TriblerConfig` instance.
         """
+        file = file or state_dir / DEFAULT_CONFIG_NAME
         logger.info(f'Load: {file}. State dir: {state_dir}. Reset config on error: {reset_config_on_error}')
         error = None
         config = None

--- a/src/tribler/core/start_core.py
+++ b/src/tribler/core/start_core.py
@@ -131,10 +131,7 @@ def run_tribler_core_session(api_port: str, api_key: str, state_dir: Path, gui_t
                 f'API key: "{api_key}". State dir: "{state_dir}". '
                 f'Core test mode: "{gui_test_mode}"')
 
-    config = TriblerConfig.load(
-        file=state_dir / CONFIG_FILE_NAME,
-        state_dir=state_dir,
-        reset_config_on_error=True)
+    config = TriblerConfig.load(state_dir=state_dir, reset_config_on_error=True)
     config.gui_test_mode = gui_test_mode
 
     if SentryReporter.is_in_test_mode():

--- a/src/tribler/core/upgrade/tests/test_config_upgrade_to_76.py
+++ b/src/tribler/core/upgrade/tests/test_config_upgrade_to_76.py
@@ -14,7 +14,7 @@ def test_convert_tribler_conf_76(tmpdir):
     shutil.copy2(CONFIG_PATH / 'triblerd75.conf', tmpdir / 'triblerd.conf')
     convert_config_to_tribler76(tmpdir)
 
-    config = TriblerConfig.load(file=tmpdir / 'triblerd.conf', state_dir=tmpdir)
+    config = TriblerConfig.load(state_dir=tmpdir)
     assert config.api.key == '7671750ba34423c97dc3c6763041e4cb'
     assert config.api.http_port == 8085
     assert config.api.http_enabled

--- a/src/tribler/core/upgrade/tests/test_version_manager.py
+++ b/src/tribler/core/upgrade/tests/test_version_manager.py
@@ -37,7 +37,7 @@ def test_read_write_version_history(tmpdir):
     history = VersionHistory(root_path, code_version_id='100.100.100')
 
     assert history.root_state_dir == root_path
-    assert history.file_path == root_path / "version_history.json"
+    assert history.file_path == root_path / VERSION_HISTORY_FILENAME
     assert history.file_data == {"last_version": None, "history": {}}
 
     # If there is no version history file, no information about last version is available
@@ -223,7 +223,7 @@ def test_copy_state_directory(tmpdir):
     # Make sure only the neccessary stuff is copied, and junk is omitted
     backup_list = {STATEDIR_DB_DIR, STATEDIR_CHECKPOINT_DIR, STATEDIR_CHANNELS_DIR,
                    'ec_multichain.pem', 'ecpub_multichain.pem', 'ec_trustchain_testnet.pem',
-                   'ecpub_trustchain_testnet.pem', 'triblerd.conf'}
+                   'triblerd.conf'}
     tgt_list = set(os.listdir(tgt_dir))
     assert backup_list & tgt_list == backup_list
 
@@ -380,7 +380,7 @@ def test_coverage(tmpdir):
     with pytest.raises(VersionError, match="Invalid history file structure"):
         VersionHistory(root_state_dir)
 
-    (root_state_dir / "version_history.json").write_text(
+    (root_state_dir / VERSION_HISTORY_FILENAME).write_text(
         '{"last_version": "7.7", "history": {"1": "7.3.1a", "2": "7.7", "3": "7.5.1a", "4": "7.6.1b", "5": "7.8.1"}}')
 
     (root_state_dir / "sqlite").mkdir()

--- a/src/tribler/run_tribler_upgrader.py
+++ b/src/tribler/run_tribler_upgrader.py
@@ -27,7 +27,7 @@ def upgrade_state_dir(root_state_dir: Path,
         logger.info('State dir does not exist. Exit upgrade procedure.')
         return
 
-    config = TriblerConfig.load(file=state_dir / CONFIG_FILE_NAME, state_dir=state_dir, reset_config_on_error=True)
+    config = TriblerConfig.load(state_dir=state_dir, reset_config_on_error=True)
     channels_dir = config.chant.get_path_as_absolute('channels_dir', config.state_dir)
 
     primary_private_key_path = config.state_dir / KeyComponent.get_private_key_filename(config)


### PR DESCRIPTION
This PR fixes #7080 by creating the list of copied files dynamically (based on config) instead of using static `STATE_FILES_TO_COPY`.

Please note. The file: `ecpub_trustchain_testnet.pem` was removed from the Upgrader because it is not used by any Tribler code anymore.