### PR TITLE
Add the action for screenshots publishing

### DIFF
--- a/.github/workflows/guitest.yml
+++ b/.github/workflows/guitest.yml
@@ -32,3 +32,10 @@ jobs:
       - name: Run GUI tests
         run: |
           xvfb-run  pytest ./src/tribler/gui --guitests -v --randomly-seed=1
+
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: screenshots
+          path: ./src/tribler/gui/screenshots/
+          retention-days: 1


### PR DESCRIPTION
This PR closes #7082 by adding the action for screenshots publishing. 

<img width="883" alt="image" src="https://user-images.githubusercontent.com/13798583/196717319-1815d1a7-ee04-4b8f-8094-b346084b2378.png">


Refs:
* https://github.com/actions/upload-artifact
* https://stackoverflow.com/questions/58858429/how-to-run-a-github-actions-step-even-if-the-previous-step-fails-while-still-f
* https://github.com/orgs/community/discussions/26438