### PR TITLE
Remove the `time_delta` parameter from the `get_operations_for_gossip` function

### DIFF
--- a/.github/actions/pyenv/action.yml
+++ b/.github/actions/pyenv/action.yml
@@ -17,7 +17,7 @@ inputs:
     required: false
 
   invalidate-cache:
-    default: 'false'
+    default: 'true' # temporary set to true. see: https://github.com/Tribler/tribler/issues/7091
     description: 'Force create a virtualenv'
     required: false
 

--- a/src/tribler/core/components/knowledge/community/knowledge_community.py
+++ b/src/tribler/core/components/knowledge/community/knowledge_community.py
@@ -24,7 +24,6 @@ REQUESTED_OPERATIONS_COUNT = 10
 
 REQUEST_INTERVAL = 5  # 5 sec
 CLEAR_ALL_REQUESTS_INTERVAL = 10 * 60  # 10 minutes
-TIME_DELTA_READY_TO_GOSSIP = {'minutes': 1}
 
 
 class KnowledgeCommunity(TriblerCommunity):
@@ -90,10 +89,7 @@ class KnowledgeCommunity(TriblerCommunity):
         self.logger.info(f'<- peer {peer.mid.hex()} requested {operations_count} operations')
 
         with db_session:
-            random_operations = self.db.get_operations_for_gossip(
-                count=operations_count,
-                time_delta=TIME_DELTA_READY_TO_GOSSIP
-            )
+            random_operations = self.db.get_operations_for_gossip(count=operations_count)
 
             self.logger.debug(f'Response {len(random_operations)} operations')
             sent_operations = []

--- a/src/tribler/core/components/knowledge/db/knowledge_db.py
+++ b/src/tribler/core/components/knowledge/db/knowledge_db.py
@@ -352,16 +352,14 @@ class KnowledgeDatabase:
         op = self.instance.StatementOp.get(statement=statement, peer=peer)
         return op.clock if op else CLOCK_START_VALUE
 
-    def get_operations_for_gossip(self, time_delta, count: int = 10) -> Iterable[Entity]:
+    def get_operations_for_gossip(self, count: int = 10) -> Set[Entity]:
         """ Get random operations from the DB that older than time_delta.
 
         Args:
-            time_delta: a dictionary for `datetime.timedelta`
             count: a limit for a resulting query
         """
-        updated_at = datetime.datetime.utcnow() - datetime.timedelta(**time_delta)
         return self._get_random_operations_by_condition(
-            condition=lambda so: so.updated_at <= updated_at and not so.auto_generated,
+            condition=lambda so: not so.auto_generated,
             count=count
         )
 


### PR DESCRIPTION
Remove the `time_delta` parameter from the `get_operations_for_gossip` function.

(Based on the morning dev meeting)

Related to https://github.com/Tribler/tribler/issues/6214