### PR TITLE
Fix pyenv GitHub Action

### DIFF
--- a/.github/actions/pyenv/action.yml
+++ b/.github/actions/pyenv/action.yml
@@ -17,7 +17,7 @@ inputs:
     required: false
 
   invalidate-cache:
-    default: 'true' # temporary set to true. see: https://github.com/Tribler/tribler/issues/7091
+    default: 'false'
     description: 'Force create a virtualenv'
     required: false
 
@@ -38,6 +38,7 @@ runs:
       id: cache-virtualenv
       with:
         requirement_files: ${{inputs.requirements-key}}
+        custom_cache_key_element: ${{github.ref_name}}
 
     - name: Invalidate cache
       if: inputs.invalidate-cache == 'true'


### PR DESCRIPTION
This PR fixes #7091 by adding `ref_name` of a GitHub event as a `custom_cache_key_element` for the `restore-virtualenv` action.

This should help to isolate caches between branches.
