### PR TITLE
Refactoring for the New Version Dialog

### DIFF
--- a/src/tribler/gui/i18n/pt_BR.ts
+++ b/src/tribler/gui/i18n/pt_BR.ts
@@ -644,7 +644,7 @@ If unsure, press &apos;No&apos;. You will be able to remove those directories fr
     </message>
     <message>
         <location filename="../tribler_window.py" line="595"/>
-        <source>Version %s of Tribler is available.Do you want to visit the website to download the newest version?</source>
+        <source>Version %s of Tribler is available. Do you want to visit the website to download the newest version?</source>
         <translation>Versão %s disponível. Quer visitar o site para baixar a versão mais recente?</translation>
     </message>
     <message>

--- a/src/tribler/gui/i18n/ru_RU.ts
+++ b/src/tribler/gui/i18n/ru_RU.ts
@@ -632,7 +632,7 @@ If unsure, press &apos;No&apos;. You will be able to remove those directories fr
     </message>
     <message>
         <location filename="../tribler_window.py" line="649"/>
-        <source>Version %s of Tribler is available.Do you want to visit the website to download the newest version?</source>
+        <source>Version %s of Tribler is available. Do you want to visit the website to download the newest version?</source>
         <translation>Доступна новая версия Tribler: %s. Перейти к веб-сайту разработчиков чтобы загрузить её?</translation>
     </message>
     <message>

--- a/src/tribler/gui/i18n/zh_CN.ts
+++ b/src/tribler/gui/i18n/zh_CN.ts
@@ -638,7 +638,7 @@ If unsure, press &apos;No&apos;. You will be able to remove those directories fr
     </message>
     <message>
         <location filename="../tribler_window.py" line="595"/>
-        <source>Version %s of Tribler is available.Do you want to visit the website to download the newest version?</source>
+        <source>Version %s of Tribler is available. Do you want to visit the website to download the newest version?</source>
         <translation>Tribler 版本 %s 可用。你想要访问网站下载最新版本吗？</translation>
     </message>
     <message>

--- a/src/tribler/gui/tribler_window.py
+++ b/src/tribler/gui/tribler_window.py
@@ -206,7 +206,6 @@ class TriblerWindow(QMainWindow):
         self.dialog = None
         self.create_dialog = None
         self.chosen_dir = None
-        self.new_version_dialog = None
         self.new_version_dialog_postponed = False
         self.start_download_dialog_active = False
         self.selected_torrent_files = []
@@ -731,39 +730,7 @@ class TriblerWindow(QMainWindow):
         self.window().add_to_channel_dialog.show_dialog(on_add_button_pressed, confirm_button_text="Add torrent")
 
     def on_new_version_available(self, version):
-        if version == str(self.gui_settings.value('last_reported_version')):
-            return
-        if self.new_version_dialog_postponed:
-            return
-
-        # To prevent multiple dialogs on top of each other,
-        # close any existing dialog first.
-        if self.new_version_dialog:
-            self.new_version_dialog.close_dialog()
-            self.new_version_dialog = None
-
-        self.new_version_dialog = ConfirmationDialog(
-            self,
-            tr("New version available"),
-            tr("Version %s of Tribler is available.Do you want to visit the " "website to download the newest version?")
-            % version,
-            [(tr("IGNORE"), BUTTON_TYPE_NORMAL), (tr("LATER"), BUTTON_TYPE_NORMAL), (tr("OK"), BUTTON_TYPE_NORMAL)],
-        )
-        connect(self.new_version_dialog.button_clicked, lambda action: self.on_new_version_dialog_done(version, action))
-        self.new_version_dialog.show()
-
-    def on_new_version_dialog_done(self, version, action):
-        if action == 0:  # ignore
-            self.gui_settings.setValue("last_reported_version", version)
-        elif action == 1: # postpone
-            self.new_version_dialog_postponed = True
-        elif action == 2:  # ok
-            import webbrowser
-
-            webbrowser.open("https://tribler.org")
-        if self.new_version_dialog:
-            self.new_version_dialog.close_dialog()
-            self.new_version_dialog = None
+        self.upgrade_manager.on_new_version_available(tribler_window=self, new_version=version)
 
     def on_search_text_change(self, text):
         # We do not want to bother the database on petty 1-character queries


### PR DESCRIPTION
This PR adds a refactoring for #7077

<img width="519" alt="image" src="https://user-images.githubusercontent.com/13798583/197203304-b48a5a82-60a3-40c7-8294-71906ae90398.png">

The actions for the buttons are the following:
1. Ignore: ignore this version at all. During the next Tribler run, all notifications about this version will be silently ignored.
2. Later: ignore the version check for the current Tribler run.
3. Ok: go to the Tribler website. The next version check will be performed 6 hours later.