### PR TITLE
Skipped randomness (Shapiro) test

### DIFF
--- a/src/tribler/core/utilities/tests/test_utilities.py
+++ b/src/tribler/core/utilities/tests/test_utilities.py
@@ -260,6 +260,7 @@ def test_load_logger(tmpdir):
     assert len(logging.root.manager.loggerDict) >= logger_count
 
 
+@pytest.mark.skip(reason="Skipping the randomness check as it can sometimes fail.")
 def test_get_normally_distributed_number():
     """
     To test if the random number is from normal distribution, we do Shapiro test and check that


### PR DESCRIPTION
The following test depends on randomness which has been found to fail sometimes as reported here: https://github.com/Tribler/tribler/issues/7081 
This PR marks the test to skip.