### PR TITLE
Add Windows and macOS GUI tests to GitHub Actions

### DIFF
--- a/.github/workflows/!PR.yml
+++ b/.github/workflows/!PR.yml
@@ -41,3 +41,10 @@ jobs:
       upload: false
       os: ubuntu-20.04
       python-version: 3.8
+
+  guitest_nix:
+    if: github.event.pull_request.draft == false
+    uses: ./.github/workflows/guitest.yml
+    with:
+      python-version: 3.8
+      matrix: '{"os":["macos-latest","ubuntu-latest"]}'

--- a/.github/workflows/guitest.yml
+++ b/.github/workflows/guitest.yml
@@ -8,13 +8,17 @@ on:
         type: string
         required: false
 
+      matrix:
+        default: '{"os":["windows-latest"]}'
+        type: string
+        required: false
+
 jobs:
   run:
     runs-on: ${{ matrix.os }}
     strategy:
-      matrix:
-        python-version: [ '3.8' ]
-        os: [ ubuntu-latest ]
+      matrix: ${{fromJson(inputs.matrix)}}
+
     steps:
       - uses: actions/checkout@v3
 
@@ -24,18 +28,27 @@ jobs:
           python-version: ${{inputs.python-version}}
           requirements: requirements-test.txt
 
-      - name: Install xvfb dependencies
+      - name: Install dependencies (Win)
+        if: runner.os == 'Windows'
+        uses: ./.github/actions/windows_dependencies
+
+      - name: Install dependencies (Linux)
+        if: runner.os == 'Linux'
         run: |
-          sudo apt install xvfb libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 xdotool pyqt5-dev-tools
-        # For more information see: https://pytest-qt.readthedocs.io/en/latest/troubleshooting.html#github-actions
+          sudo apt install pyqt5-dev-tools
+
+      - name: Setup headless display
+        if: runner.os == 'Linux'
+        uses: pyvista/setup-headless-display-action@v1
 
       - name: Run GUI tests
+        timeout-minutes: 5
         run: |
-          xvfb-run  pytest ./src/tribler/gui --guitests -v --randomly-seed=1
+          pytest ./src/tribler/gui --guitests -v --randomly-seed=1 --timeout=300
 
       - uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: screenshots
+          name: ${{runner.os}}_screenshots
           path: ./src/tribler/gui/screenshots/
           retention-days: 1


### PR DESCRIPTION
This PR closes #7086, closes #7087

To my great surprise, it worked out of the box.

The only one issue was "how to call a workflow with the custom matrix?".
The solution is to use `fromJson` for passing the matrix as a JSON object:

```yml
name: PR

on:
  pull_request:
    types:
      - opened
      - synchronize
      - ready_for_review

jobs:
  magic:
    uses: ./.github/workflows/magic.yml
    with:
      matrix: '{"os":["macos-latest","ubuntu-latest"]}'}
```

```yml
name: Magic

on:
  workflow_call:
      matrix:
        default: '{"os":["windows-latest"]}'
        type: string
        required: false

jobs:
  run:
    runs-on: ${{ matrix.os }}
    strategy:
      matrix: ${{fromJson(inputs.matrix)}}
```

<img width="701" alt="image" src="https://user-images.githubusercontent.com/13798583/198583849-51d0e28d-4a51-481d-9442-cf51e5f02803.png">



Refs:
* https://stackoverflow.com/questions/57946173/github-actions-run-step-on-specific-os
* https://github.com/pyvista/setup-headless-display-action
* https://docs.github.com/en/enterprise-cloud@latest/actions/learn-github-actions/expressions#example-returning-a-json-object
* https://stackoverflow.com/questions/59977364/github-actions-how-use-strategy-matrix-with-script