### PR TITLE
Divide `pytest` into two categories: for a draft PR and for a ready PR

### DIFF
--- a/.github/workflows/!PR.yml
+++ b/.github/workflows/!PR.yml
@@ -8,33 +8,46 @@ on:
       - ready_for_review
 
 jobs:
-  coverage:
-    uses: ./.github/workflows/coverage.yml
-    with:
-      python-version: 3.8
 
+  # PR is Draft and PR is Ready
   pytest:
     uses: ./.github/workflows/pytest.yml
     with:
       python-version: 3.8
+      matrix: '{"os": ["ubuntu-latest"]}'
+
+  guitest:
+    uses: ./.github/workflows/guitest.yml
+    with:
+      python-version: 3.8
+      matrix: '{"os": ["windows-latest"]}'
 
   scripttest:
     uses: ./.github/workflows/scripttest.yml
     with:
       python-version: 3.8
 
-  guitest:
+  coverage:
+    uses: ./.github/workflows/coverage.yml
+    with:
+      python-version: 3.8
+
+  # PR is Ready only
+  pytest_ready:
+    if: github.event.pull_request.draft == false
+    uses: ./.github/workflows/pytest.yml
+    with:
+      python-version: 3.8
+      matrix: '{"os": ["windows-latest", "macos-latest"]}'
+
+  guitest_ready:
+    if: github.event.pull_request.draft == false
     uses: ./.github/workflows/guitest.yml
     with:
       python-version: 3.8
+      matrix: '{"os": ["macos-latest", "ubuntu-latest"]}'
 
-  documentation:
-    if: github.event.pull_request.draft == false
-    uses: ./.github/workflows/documentation.yml
-    with:
-      python-version: 3.8
-
-  ubuntu:
+  ubuntu_ready:
     if: github.event.pull_request.draft == false
     uses: ./.github/workflows/build_ubuntu.yml
     with:
@@ -42,9 +55,8 @@ jobs:
       os: ubuntu-20.04
       python-version: 3.8
 
-  guitest_nix:
+  documentation_ready:
     if: github.event.pull_request.draft == false
-    uses: ./.github/workflows/guitest.yml
+    uses: ./.github/workflows/documentation.yml
     with:
       python-version: 3.8
-      matrix: '{"os":["macos-latest","ubuntu-latest"]}'

--- a/.github/workflows/guitest.yml
+++ b/.github/workflows/guitest.yml
@@ -17,6 +17,7 @@ jobs:
   run:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix: ${{fromJson(inputs.matrix)}}
 
     steps:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -8,19 +8,16 @@ on:
         type: string
         required: false
 
+      matrix:
+        default: '{"os":["ubuntu-latest"]}'
+        type: string
+        required: false
+
 jobs:
   run:
     runs-on: ${{ matrix.os }}
     strategy:
-      matrix:
-        os: [ macos-latest, windows-latest, ubuntu-latest ]
-        include:
-          - os: macos-latest
-            pytest-arguments: --timeout=300 --looptime
-          - os: windows-latest
-            pytest-arguments: --timeout=300
-          - os: ubuntu-latest
-            pytest-arguments: --timeout=60 --looptime
+      matrix: ${{fromJson(inputs.matrix)}}
 
     steps:
       - uses: actions/checkout@v3
@@ -35,11 +32,18 @@ jobs:
         if: runner.os == 'Windows'
         uses: ./.github/actions/windows_dependencies
 
-      - name: Run Pytest
+      - name: Run Pytest (nix)
+        if: runner.os != 'Windows'
         timeout-minutes: 5
         run: |
-          pytest ./src/tribler/core --exitfirst --disable-warnings ${{matrix.pytest-arguments}} 
+          pytest ./src/tribler/core --exitfirst --disable-warnings --looptime
 
+      - name: Run Pytest (win)
+        if: runner.os == 'Windows'
+        timeout-minutes: 5
+        run: |
+          pytest ./src/tribler/core --exitfirst --disable-warnings
+          
       - name: Run Tunnels Tests
         run: |
-          pytest ./src/tribler/core/components/tunnel/tests/test_full_session --tunneltests --exitfirst --disable-warnings ${{matrix.pytest-arguments}}
+          pytest ./src/tribler/core/components/tunnel/tests/test_full_session --tunneltests --exitfirst --disable-warnings

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -17,6 +17,7 @@ jobs:
   run:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix: ${{fromJson(inputs.matrix)}}
 
     steps:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-timeout = 60
+timeout = 300
 ;https://pypi.org/project/pytest-asyncio/
 asyncio_mode = auto
 log_level = INFO


### PR DESCRIPTION
This PR continues work started in  https://github.com/Tribler/tribler/pull/7115 and divides pytest into two categories:
1. Ubuntu — for a draft PR
2. Ubuntu+Win+macOS — for a ready PR