### PR TITLE
Add macOS and windows builds as PR checks

### DIFF
--- a/.github/workflows/!PR.yml
+++ b/.github/workflows/!PR.yml
@@ -14,7 +14,7 @@ jobs:
     uses: ./.github/workflows/pytest.yml
     with:
       python-version: 3.8
-      matrix: '{"os": ["ubuntu-latest"]}'
+      matrix: '{"os": ["windows-latest"]}'
 
   guitest:
     uses: ./.github/workflows/guitest.yml
@@ -33,30 +33,46 @@ jobs:
       python-version: 3.8
 
   # PR is Ready only
-  pytest_ready:
-    if: github.event.pull_request.draft == false
+  pytest_nix:
+    if: ${{!github.event.pull_request.draft}}
     uses: ./.github/workflows/pytest.yml
     with:
       python-version: 3.8
-      matrix: '{"os": ["windows-latest", "macos-latest"]}'
+      matrix: '{"os": ["macos-latest", "ubuntu-latest"]}'
 
-  guitest_ready:
-    if: github.event.pull_request.draft == false
+  guitest_nix:
+    if: ${{!github.event.pull_request.draft}}
     uses: ./.github/workflows/guitest.yml
     with:
       python-version: 3.8
       matrix: '{"os": ["macos-latest", "ubuntu-latest"]}'
 
-  ubuntu_ready:
-    if: github.event.pull_request.draft == false
+  ubuntu:
+    if: ${{!github.event.pull_request.draft}}
     uses: ./.github/workflows/build_ubuntu.yml
     with:
       upload: false
       os: ubuntu-20.04
       python-version: 3.8
 
-  documentation_ready:
-    if: github.event.pull_request.draft == false
+  windows:
+    if: ${{!github.event.pull_request.draft}}
+    uses: ./.github/workflows/build_windows.yml
+    with:
+      upload: false
+      os: windows-latest
+      python-version: 3.8
+
+  mac:
+    if: ${{!github.event.pull_request.draft}}
+    uses: ./.github/workflows/build_mac.yml
+    with:
+      upload: false
+      os: macos-10.15
+      python-version: 3.8
+
+  documentation:
+    if: ${{!github.event.pull_request.draft}}
     uses: ./.github/workflows/documentation.yml
     with:
       python-version: 3.8

--- a/.github/workflows/build_mac.yml
+++ b/.github/workflows/build_mac.yml
@@ -28,7 +28,7 @@ on:
 
       python-version:
         description: Python version
-        default: '3.8'
+        default: 3.8
         type: string
         required: true
 

--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -31,7 +31,7 @@ on:
 
       python-version:
         description: Python version
-        default: '3.8'
+        default: 3.8
         type: string
         required: true
 

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -28,7 +28,7 @@ on:
 
       python-version:
         description: Python version
-        default: '3.8'
+        default: 3.8
         type: string
         required: true
 
@@ -40,7 +40,6 @@ on:
 
 jobs:
   build:
-    environment: build
     runs-on: ${{ github.event.inputs.os || inputs.os }}
 
     steps:

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,7 +1,11 @@
 -r requirements.txt
 
 PyInstaller==5.1; sys_platform != 'darwin'
+
 setuptools==60.0.2; sys_platform == 'darwin'
+text-unidecode==1.3; sys_platform == 'darwin'
+
 defusedxml==0.7.1; sys_platform == 'linux2' or sys_platform == 'linux'
 markupsafe==2.0.1; sys_platform == 'linux2' or sys_platform == 'linux'
+
 requests==2.25.1


### PR DESCRIPTION
This PR follows https://github.com/Tribler/tribler/pull/7123 and adds Windows and macOS builds as PR checks.

As a side effect, it fixes the `macOS` build.

Also, this PR contains some cosmetic changes for https://github.com/Tribler/tribler/pull/7130.