### PR TITLE
Remove unnecessary `async` statements 

### DIFF
--- a/src/tribler/core/components/gigachannel/community/tests/test_gigachannel_community.py
+++ b/src/tribler/core/components/gigachannel/community/tests/test_gigachannel_community.py
@@ -265,7 +265,7 @@ class TestGigaChannelUnits(TestBase):
         assert len(mapping._peers_channels) == 0
         assert len(mapping._channels_dict) == 0
 
-    async def test_get_known_subscribed_peers_for_node(self):
+    def test_get_known_subscribed_peers_for_node(self):
         key = default_eccrypto.generate_key("curve25519")
         with db_session:
             channel = self.overlay(0).mds.ChannelMetadata(origin_id=0, infohash=random_infohash(), sign_with=key)

--- a/src/tribler/core/components/gui_process_watcher/tests/test_gui_process_watcher.py
+++ b/src/tribler/core/components/gui_process_watcher/tests/test_gui_process_watcher.py
@@ -52,20 +52,20 @@ def test_get_gui_process():
                 GuiProcessWatcher.get_gui_process()
 
 
-async def test_check_gui_process_working(watcher):
+def test_check_gui_process_working(watcher):
     watcher.check_gui_process()
     assert not watcher.shutdown_callback.called
     assert not watcher.shutdown_callback_called
 
 
-async def test_check_gui_process_zombie(watcher):
+def test_check_gui_process_zombie(watcher):
     watcher.gui_process.status.return_value = psutil.STATUS_ZOMBIE
     watcher.check_gui_process()
     assert watcher.shutdown_callback.called
     assert watcher.shutdown_callback_called
 
 
-async def test_check_gui_process_not_running(watcher):
+def test_check_gui_process_not_running(watcher):
     watcher.gui_process.is_running.return_value = False
     watcher.check_gui_process()
     assert not watcher.gui_process.status.called

--- a/src/tribler/core/components/ipv8/eva/tests/test_scheduler.py
+++ b/src/tribler/core/components/ipv8/eva/tests/test_scheduler.py
@@ -31,7 +31,7 @@ class MockTransfer(MagicMock):
         self.container[self.peer] = self
 
 
-async def test_can_be_send_immediately(scheduler: Scheduler):
+def test_can_be_send_immediately(scheduler: Scheduler):
     scheduler.eva.incoming = {}
     scheduler.eva.outgoing = {}
     assert scheduler.can_be_send_immediately(MockTransfer(peer='peer', container=scheduler.eva.incoming))
@@ -54,7 +54,7 @@ async def test_can_be_send_immediately(scheduler: Scheduler):
     assert not scheduler.can_be_send_immediately(MockTransfer(peer='peer', container=scheduler.eva.outgoing))
 
 
-async def test_is_simultaneously_served_transfers_limit_not_exceeded(scheduler: Scheduler):
+def test_is_simultaneously_served_transfers_limit_not_exceeded(scheduler: Scheduler):
     # In this test we will try to exceed `max_simultaneous_transfers` limit.
     scheduler.eva.settings.max_simultaneous_transfers = 2
 
@@ -83,7 +83,7 @@ async def test_is_simultaneously_served_transfers_limit_not_exceeded(scheduler: 
     assert scheduler._is_simultaneously_served_transfers_limit_exceeded()
 
 
-async def test_is_simultaneously_served_transfers_limit_exceeded(scheduler: Scheduler):
+def test_is_simultaneously_served_transfers_limit_exceeded(scheduler: Scheduler):
     # In this test we will try to exceed `max_simultaneous_transfers` limit.
     scheduler.eva.settings.max_simultaneous_transfers = 2
 
@@ -100,7 +100,7 @@ async def test_is_simultaneously_served_transfers_limit_exceeded(scheduler: Sche
     assert scheduler._is_simultaneously_served_transfers_limit_exceeded()
 
 
-async def test_schedule(scheduler: Scheduler):
+def test_schedule(scheduler: Scheduler):
     scheduler.can_be_send_immediately = Mock(return_value=False)
 
     scheduler.schedule(transfer=MockTransfer())
@@ -109,7 +109,7 @@ async def test_schedule(scheduler: Scheduler):
     assert len(scheduler.scheduled) == 1
 
 
-async def test_start_transfer(scheduler: Scheduler):
+def test_start_transfer(scheduler: Scheduler):
     scheduler.can_be_send_immediately = Mock(return_value=True)
     transfer = MockTransfer()
     transfer.start = Mock(wraps=transfer.start)
@@ -143,7 +143,7 @@ def _transform_to_str(eva, transfers: Iterable[Transfer]) -> Iterable[str]:
         yield f'{transfer.peer}_{container}'
 
 
-async def test_transfers_that_can_be_send(scheduler: Scheduler):
+def test_transfers_that_can_be_send(scheduler: Scheduler):
     _fill_test_data(scheduler)
 
     # Regarding the test data, all scheduled transfer should be ready to send
@@ -154,7 +154,7 @@ async def test_transfers_that_can_be_send(scheduler: Scheduler):
     assert str_representation == ['peer1_out', 'peer2_in', 'peer3_in', 'peer3_out']
 
 
-async def test_send_scheduled(scheduler: Scheduler):
+def test_send_scheduled(scheduler: Scheduler):
     _fill_test_data(scheduler)
 
     # Regarding the test data, all scheduled transfer should be ready to send

--- a/src/tribler/core/components/ipv8/eva/transfer/tests/test_base.py
+++ b/src/tribler/core/components/ipv8/eva/transfer/tests/test_base.py
@@ -39,7 +39,7 @@ async def transfer():
 
 
 @pytest.mark.looptime(start=42)
-async def test_update(transfer: Transfer):
+def test_update(transfer: Transfer):
     # In this test we ensure that `transfer.update` method sets `time.time` value
     # to `transfer.updated` property.
     transfer.update()

--- a/src/tribler/core/components/ipv8/eva/transfer/tests/test_window.py
+++ b/src/tribler/core/components/ipv8/eva/transfer/tests/test_window.py
@@ -10,12 +10,12 @@ async def window() -> TransferWindow:
     return TransferWindow(start=0, size=10)
 
 
-async def test_constructor(window: TransferWindow):
+def test_constructor(window: TransferWindow):
     assert len(window.blocks) == 10
     assert all(not block for block in window.blocks)
 
 
-async def test_add(window: TransferWindow):
+def test_add(window: TransferWindow):
     window.add(0, b'first')
     window.add(0, b'first')
     window.add(9, b'last')
@@ -25,7 +25,7 @@ async def test_add(window: TransferWindow):
     assert not window.is_finished()
 
 
-async def test_finished(window: TransferWindow):
+def test_finished(window: TransferWindow):
     for i in range(10):
         window.add(i, b'block')
 
@@ -33,7 +33,7 @@ async def test_finished(window: TransferWindow):
     assert window.is_finished()
 
 
-async def test_consecutive_blocks(window: TransferWindow):
+def test_consecutive_blocks(window: TransferWindow):
     window.add(0, b'first')
     window.add(1, b'second')
     window.add(3, b'fourth')

--- a/src/tribler/core/components/knowledge/community/tests/test_knowledge_validator.py
+++ b/src/tribler/core/components/knowledge/community/tests/test_knowledge_validator.py
@@ -19,37 +19,37 @@ INVALID_TAGS = [
 
 
 @pytest.mark.parametrize('tag', VALID_TAGS)
-async def test_valid_tags(tag):
+def test_valid_tags(tag):
     validate_resource(tag)  # no exception
     assert is_valid_resource(tag)
 
 
 @pytest.mark.parametrize('tag', INVALID_TAGS)
-async def test_invalid(tag):
+def test_invalid(tag):
     assert not is_valid_resource(tag)
     with pytest.raises(ValueError):
         validate_resource(tag)
 
 
-async def test_correct_operation():
+def test_correct_operation():
     for operation in Operation:
         validate_operation(operation)  # no exception
         validate_operation(operation.value)  # no exception
 
 
-async def test_incorrect_operation():
+def test_incorrect_operation():
     max_operation = max(Operation)
     with pytest.raises(ValueError):
         validate_operation(max_operation.value + 1)
 
 
-async def test_correct_relation():
+def test_correct_relation():
     for relation in ResourceType:
         validate_resource_type(relation)  # no exception
         validate_resource_type(relation.value)  # no exception
 
 
-async def test_incorrect_relation():
+def test_incorrect_relation():
     max_relation = max(ResourceType)
     with pytest.raises(ValueError):
         validate_operation(max_relation.value + 1)

--- a/src/tribler/core/components/knowledge/community/tests/test_operations_requests.py
+++ b/src/tribler/core/components/knowledge/community/tests/test_operations_requests.py
@@ -10,12 +10,12 @@ def operations_requests():
     return OperationsRequests()
 
 
-async def test_add_peer(operations_requests):
+def test_add_peer(operations_requests):
     operations_requests.register_peer('peer', number_of_responses=10)
     assert operations_requests.requests['peer'] == 10
 
 
-async def test_clear_requests(operations_requests):
+def test_clear_requests(operations_requests):
     operations_requests.register_peer('peer', number_of_responses=10)
     assert len(operations_requests.requests) == 1
 
@@ -23,17 +23,17 @@ async def test_clear_requests(operations_requests):
     assert len(operations_requests.requests) == 0
 
 
-async def test_valid_peer(operations_requests):
+def test_valid_peer(operations_requests):
     operations_requests.register_peer('peer', number_of_responses=10)
     operations_requests.validate_peer('peer')
 
 
-async def test_missed_peer(operations_requests):
+def test_missed_peer(operations_requests):
     with pytest.raises(ValueError):
         operations_requests.validate_peer('peer')
 
 
-async def test_invalid_peer(operations_requests):
+def test_invalid_peer(operations_requests):
     operations_requests.register_peer('peer', number_of_responses=1)
     operations_requests.validate_peer('peer')
 

--- a/src/tribler/core/components/knowledge/db/tests/test_knowledge_db.py
+++ b/src/tribler/core/components/knowledge/db/tests/test_knowledge_db.py
@@ -23,7 +23,7 @@ class TestTagDB(TestTagDBBase):
         mocked_generate_mapping.assert_called_with(create_tables=False)
 
     @db_session
-    async def test_get_or_create(self):
+    def test_get_or_create(self):
         # Test that function get_or_create() works as expected:
         # it gets an entity if the entity is exist and create the entity otherwise
         assert self.db.instance.Peer.select().count() == 0
@@ -40,7 +40,7 @@ class TestTagDB(TestTagDBBase):
         assert self.db.instance.Peer.select().count() == 1
 
     @db_session
-    async def test_update_counter_add(self):
+    def test_update_counter_add(self):
         statement = self.create_statement()
 
         # let's update ADD counter
@@ -50,7 +50,7 @@ class TestTagDB(TestTagDBBase):
         assert not statement.local_operation
 
     @db_session
-    async def test_update_counter_remove(self):
+    def test_update_counter_remove(self):
         statement = self.create_statement()
 
         # let's update REMOVE counter
@@ -60,7 +60,7 @@ class TestTagDB(TestTagDBBase):
         assert not statement.local_operation
 
     @db_session
-    async def test_update_counter_local(self):
+    def test_update_counter_local(self):
         statement = self.create_statement()
 
         # let's update local operation
@@ -70,7 +70,7 @@ class TestTagDB(TestTagDBBase):
         assert statement.local_operation == Operation.REMOVE
 
     @db_session
-    async def test_remote_add_tag_operation(self):
+    def test_remote_add_tag_operation(self):
         def assert_all_tables_have_the_only_one_entity():
             assert self.db.instance.Peer.select().count() == 1
             assert self.db.instance.Resource.select().count() == 2
@@ -106,7 +106,7 @@ class TestTagDB(TestTagDBBase):
         assert self.db.instance.Statement.get().removed_count == 1
 
     @db_session
-    async def test_resource_type(self):
+    def test_resource_type(self):
         # Test that resources with different type are stored in separated db entities.
         def resources():
             """get all resources from self.db.instance.Resource and convert them to the tuples:
@@ -132,7 +132,7 @@ class TestTagDB(TestTagDBBase):
                                (ResourceType.TAG, 'infohash')]
 
     @db_session
-    async def test_remote_add_multiple_tag_operations(self):
+    def test_remote_add_multiple_tag_operations(self):
         self.add_operation(self.db, ResourceType.TORRENT, 'infohash', ResourceType.TAG, 'tag', b'peer1')
         self.add_operation(self.db, ResourceType.TORRENT, 'infohash', ResourceType.TAG, 'tag', b'peer2')
         self.add_operation(self.db, ResourceType.TORRENT, 'infohash', ResourceType.TAG, 'tag', b'peer3')
@@ -164,7 +164,7 @@ class TestTagDB(TestTagDBBase):
         assert self.db.instance.Statement.get(predicate=ResourceType.TAG).removed_count == 1
 
     @db_session
-    async def test_add_auto_generated_tag(self):
+    def test_add_auto_generated_tag(self):
         self.db.add_auto_generated(
             subject_type=ResourceType.TORRENT,
             subject='infohash',
@@ -177,7 +177,7 @@ class TestTagDB(TestTagDBBase):
         assert self.db.instance.Peer.get().public_key == PUBLIC_KEY_FOR_AUTO_GENERATED_OPERATIONS
 
     @db_session
-    async def test_multiple_tags(self):
+    def test_multiple_tags(self):
         self.add_operation_set(
             self.db,
             {
@@ -210,7 +210,7 @@ class TestTagDB(TestTagDBBase):
         assert statement.removed_count == 0
 
     @db_session
-    async def test_get_objects_added(self):
+    def test_get_objects_added(self):
         self.add_operation_set(
             self.db,
             {
@@ -228,7 +228,7 @@ class TestTagDB(TestTagDBBase):
         assert self.db.get_objects('infohash1', predicate=ResourceType.CONTRIBUTOR) == ['Contributor']
 
     @db_session
-    async def test_get_objects_removed(self):
+    def test_get_objects_removed(self):
         self.add_operation_set(
             self.db,
             {
@@ -245,7 +245,7 @@ class TestTagDB(TestTagDBBase):
         assert self.db.get_objects('infohash1', predicate=ResourceType.TAG) == ['tag1']
 
     @db_session
-    async def test_get_objects_case_insensitive(self):
+    def test_get_objects_case_insensitive(self):
         # Test that for case sensitive queries the result is the exact match.
         # Test that for case insensitive queries the result is the case insensitive match.
 
@@ -279,7 +279,7 @@ class TestTagDB(TestTagDBBase):
         assert self.db.get_subjects('Torrent', predicate=ResourceType.TORRENT, case_sensitive=True) == ['Ubuntu']
 
     @db_session
-    async def test_show_local_resources(self):
+    def test_show_local_resources(self):
         # Test that locally added tags have a priority to show.
         # That means no matter of other peers opinions, locally added tag should be visible.
         self.add_operation(self.db, ResourceType.TORRENT, 'infohash1', ResourceType.TAG, 'tag1', b'peer1',
@@ -299,7 +299,7 @@ class TestTagDB(TestTagDBBase):
         assert self.db.get_objects('infohash1', predicate=ResourceType.CONTRIBUTOR) == ['contributor']
 
     @db_session
-    async def test_hide_local_tags(self):
+    def test_hide_local_tags(self):
         # Test that locally removed tags should not be visible to local user.
         # No matter of other peers opinions, locally removed tag should be not visible.
         self.add_operation(self.db, ResourceType.TORRENT, 'infohash1', ResourceType.TAG, 'tag1', b'peer1')
@@ -313,7 +313,7 @@ class TestTagDB(TestTagDBBase):
         assert self.db.get_objects('infohash1', ResourceType.TAG) == []
 
     @db_session
-    async def test_suggestions(self):
+    def test_suggestions(self):
         # Test whether the database returns the right suggestions.
         # Suggestions are tags that have not gathered enough support for display yet.
         self.add_operation(self.db, subject='subject', predicate=ResourceType.TAG, obj='tag1', peer=b'1')
@@ -336,7 +336,7 @@ class TestTagDB(TestTagDBBase):
         assert not self.db.get_suggestions('infohash', predicate=ResourceType.TAG)  # below the threshold
 
     @db_session
-    async def test_get_clock_of_operation(self):
+    def test_get_clock_of_operation(self):
         operation = self.create_operation()
         assert self.db.get_clock(operation) == 0
 
@@ -346,7 +346,7 @@ class TestTagDB(TestTagDBBase):
         assert self.db.get_clock(operation) == 1
 
     @db_session
-    async def test_get_tags_operations_for_gossip(self):
+    def test_get_tags_operations_for_gossip(self):
         self.add_operation_set(
             self.db,
             {
@@ -365,7 +365,7 @@ class TestTagDB(TestTagDBBase):
         assert all(not o.auto_generated for o in operations)
 
     @db_session
-    async def test_get_subjects_intersection_threshold(self):
+    def test_get_subjects_intersection_threshold(self):
         # test that `get_subjects_intersection` function returns only infohashes with tags
         # above the threshold
         self.add_operation_set(
@@ -386,7 +386,7 @@ class TestTagDB(TestTagDBBase):
         assert self.db.get_subjects_intersection({'tag1'}, predicate=ResourceType.TAG) == {'infohash1', 'infohash3'}
 
     @db_session
-    async def test_get_subjects_intersection(self):
+    def test_get_subjects_intersection(self):
         # test that `get_infohashes` function returns an intersection of result
         # in case of more than one tag passed to the function
         self.add_operation_set(
@@ -430,13 +430,13 @@ class TestTagDB(TestTagDBBase):
                    'infohash1', 'infohash4'}
 
     @db_session
-    async def test_show_condition(self):
+    def test_show_condition(self):
         assert KnowledgeDatabase._show_condition(SimpleNamespace(local_operation=Operation.ADD))
         assert KnowledgeDatabase._show_condition(SimpleNamespace(local_operation=None, score=SHOW_THRESHOLD))
         assert not KnowledgeDatabase._show_condition(SimpleNamespace(local_operation=None, score=0))
 
     @db_session
-    async def test_get_random_operations_by_condition_less_than_count(self):
+    def test_get_random_operations_by_condition_less_than_count(self):
         # Check that `_get_random_tag_operations_by_condition` returns values even in the case that requested amount
         # of operations is unavailable
 
@@ -459,7 +459,7 @@ class TestTagDB(TestTagDBBase):
         assert len(random_operations) == 3
 
     @db_session
-    async def test_get_random_operations_by_condition_greater_than_count(self):
+    def test_get_random_operations_by_condition_greater_than_count(self):
         # Check that `_get_random_tag_operations_by_condition` returns requested amount of entities
         # even if there are more entities in DB than this requested amount.
         self.add_operation_set(
@@ -481,7 +481,7 @@ class TestTagDB(TestTagDBBase):
         assert len(random_operations) == 5
 
     @db_session
-    async def test_get_random_tag_operations_by_condition(self):
+    def test_get_random_tag_operations_by_condition(self):
         # Check that `_get_random_tag_operations_by_condition` uses a passed condition.
 
         self.add_operation_set(
@@ -508,7 +508,7 @@ class TestTagDB(TestTagDBBase):
         assert all(not o.auto_generated for o in random_operations)
 
     @db_session
-    async def test_get_random_tag_operations_by_condition_no_results(self):
+    def test_get_random_tag_operations_by_condition_no_results(self):
         # test the case when the database is not empty but no operations satisfy
         # the condition. The result should be empty.
 

--- a/src/tribler/core/components/libtorrent/tests/test_dht_health_manager.py
+++ b/src/tribler/core/components/libtorrent/tests/test_dht_health_manager.py
@@ -44,7 +44,7 @@ async def test_combine_bloom_filters(dht_health_manager):
     assert dht_health_manager.combine_bloomfilters(bf1, bf2) == bf2
 
 
-async def test_get_size_from_bloom_filter(dht_health_manager):
+def test_get_size_from_bloom_filter(dht_health_manager):
     """
     Test whether we can successfully estimate the size from a bloom filter
     """
@@ -64,7 +64,7 @@ async def test_get_size_from_bloom_filter(dht_health_manager):
     assert dht_health_manager.get_size_from_bloomfilter(bf) == 6000
 
 
-async def test_receive_bloomfilters(dht_health_manager):
+def test_receive_bloomfilters(dht_health_manager):
     """
     Test whether the right operations happen when receiving a bloom filter
     """

--- a/src/tribler/core/components/libtorrent/tests/test_download_manager.py
+++ b/src/tribler/core/components/libtorrent/tests/test_download_manager.py
@@ -255,7 +255,7 @@ async def test_start_download_existing_handle(fake_dlmgr):
     await download.shutdown()
 
 
-async def test_start_download_existing_download(fake_dlmgr):
+def test_start_download_existing_download(fake_dlmgr):
     """
     Testing the addition of a torrent to the libtorrent manager, if there is a pre-existing download.
     """
@@ -335,7 +335,7 @@ def test_payout_on_disconnect(fake_dlmgr):
     fake_dlmgr.payout_manager.do_payout.is_called_with(b'a' * 20)
 
 
-async def test_post_session_stats(fake_dlmgr):
+def test_post_session_stats(fake_dlmgr):
     """
     Test whether post_session_stats actually updates the state of libtorrent readiness for clean shutdown.
     """

--- a/src/tribler/core/components/libtorrent/tests/test_libtorrent_settings.py
+++ b/src/tribler/core/components/libtorrent/tests/test_libtorrent_settings.py
@@ -4,7 +4,7 @@ from tribler.core.components.libtorrent.settings import DownloadDefaultsSettings
 from tribler.core.utilities.network_utils import NetworkUtils
 
 
-async def test_port_validation():
+def test_port_validation():
     assert LibtorrentSettings(port=-1)
     assert LibtorrentSettings(port=None)
 
@@ -25,7 +25,7 @@ async def test_proxy_type_validation():
         LibtorrentSettings(proxy_type=6)
 
 
-async def test_number_hops_validation():
+def test_number_hops_validation():
     assert DownloadDefaultsSettings(number_hops=1)
 
     with pytest.raises(ValueError):
@@ -35,7 +35,7 @@ async def test_number_hops_validation():
         DownloadDefaultsSettings(number_hops=4)
 
 
-async def test_seeding_mode():
+def test_seeding_mode():
     assert DownloadDefaultsSettings(seeding_mode=SeedingMode.forever)
 
     with pytest.raises(ValueError):

--- a/src/tribler/core/components/metadata_store/remote_query_community/tests/test_remote_search_by_tags.py
+++ b/src/tribler/core/components/metadata_store/remote_query_community/tests/test_remote_search_by_tags.py
@@ -57,12 +57,12 @@ class TestRemoteSearchByTags(TestBase):
         return self.overlay(0)
 
     @patch.object(RemoteQueryCommunity, 'knowledge_db', new=PropertyMock(return_value=None), create=True)
-    async def test_search_for_tags_no_db(self):
+    def test_search_for_tags_no_db(self):
         # test that in case of missed `knowledge_db`, function `search_for_tags` returns None
         assert self.rqc.search_for_tags(tags=['tag']) is None
 
     @patch.object(KnowledgeDatabase, 'get_subjects_intersection')
-    async def test_search_for_tags_only_valid_tags(self, mocked_get_subjects_intersection: Mock):
+    def test_search_for_tags_only_valid_tags(self, mocked_get_subjects_intersection: Mock):
         # test that function `search_for_tags` uses only valid tags
         self.rqc.search_for_tags(tags=['invalid_tag' * 50, 'valid_tag'])
         mocked_get_subjects_intersection.assert_called_with({'valid_tag'}, predicate=ResourceType.TAG,

--- a/src/tribler/core/components/resource_monitor/implementation/tests/test_rm_settings.py
+++ b/src/tribler/core/components/resource_monitor/implementation/tests/test_rm_settings.py
@@ -3,7 +3,7 @@ import pytest
 from tribler.core.components.resource_monitor.settings import ResourceMonitorSettings
 
 
-async def test_cpu_priority():
+def test_cpu_priority():
     assert ResourceMonitorSettings(cpu_priority=3)
 
     with pytest.raises(ValueError):

--- a/src/tribler/core/components/restapi/tests/test_restapi_component.py
+++ b/src/tribler/core/components/restapi/tests/test_restapi_component.py
@@ -54,8 +54,7 @@ def rest_component():
     component.root_endpoint = MagicMock()
     return component
 
-
-async def test_maybe_add_check_args(rest_component, endpoint_cls):
+def test_maybe_add_check_args(rest_component, endpoint_cls):
     # test that in case `*args` in `maybe_add` function contains `NoneComponent` instance
     # no root_endpoint methods are called
     rest_component.maybe_add('path', endpoint_cls, NoneComponent())
@@ -65,7 +64,7 @@ async def test_maybe_add_check_args(rest_component, endpoint_cls):
     rest_component.root_endpoint.assert_not_called()
 
 
-async def test_maybe_add_check_kwargs(rest_component, endpoint_cls):
+def test_maybe_add_check_kwargs(rest_component, endpoint_cls):
     # test that in case `**kwargs` in `maybe_add` function contains `NoneComponent` instance
     # no root_endpoint methods are called
     rest_component.maybe_add('path', endpoint_cls, component=NoneComponent())
@@ -75,7 +74,7 @@ async def test_maybe_add_check_kwargs(rest_component, endpoint_cls):
     rest_component.root_endpoint.assert_not_called()
 
 
-async def test_maybe_add(rest_component, endpoint_cls):
+def test_maybe_add(rest_component, endpoint_cls):
     # test that in case there are no `NoneComponent` instances in `**kwargs` or `*args`
     # root_endpoint methods are called
     rest_component.maybe_add('path', endpoint_cls, 'arg')

--- a/src/tribler/core/components/torrent_checker/torrent_checker/tests/test_torrentchecker.py
+++ b/src/tribler/core/components/torrent_checker/torrent_checker/tests/test_torrentchecker.py
@@ -90,7 +90,7 @@ async def test_health_check_cached(torrent_checker):
     assert result['db']['leechers'] == 10
 
 
-async def test_load_torrents_check_from_db(torrent_checker):  # pylint: disable=unused-argument
+def test_load_torrents_check_from_db(torrent_checker):  # pylint: disable=unused-argument
     """
     Test if the torrents_checked set is properly initialized based on the last_check
     and self_checked values from the database.

--- a/src/tribler/core/components/tunnel/tests/test_tunnel_settings.py
+++ b/src/tribler/core/components/tunnel/tests/test_tunnel_settings.py
@@ -4,7 +4,7 @@ from tribler.core.components.ipv8.settings import Ipv8Settings
 from tribler.core.utilities.network_utils import NetworkUtils
 
 
-async def test_port_validation():
+def test_port_validation():
     assert Ipv8Settings(port=0)
 
     with pytest.raises(ValueError):

--- a/src/tribler/core/config/tests/test_tribler_config_section.py
+++ b/src/tribler/core/config/tests/test_tribler_config_section.py
@@ -10,7 +10,7 @@ class TriblerTestConfigSection(TriblerConfigSection):
     path: Optional[str]
 
 
-async def test_put_path_relative(tmpdir):
+def test_put_path_relative(tmpdir):
     section = TriblerTestConfigSection()
 
     section.put_path_as_relative(property_name='path', value=Path(tmpdir), state_dir=tmpdir)
@@ -20,7 +20,7 @@ async def test_put_path_relative(tmpdir):
     assert section.path == '1'
 
 
-async def test_put_path_absolute(tmpdir):
+def test_put_path_absolute(tmpdir):
     section = TriblerTestConfigSection()
 
     section.put_path_as_relative(property_name='path')
@@ -33,6 +33,6 @@ async def test_put_path_absolute(tmpdir):
     assert section.path == str(Path('/Tribler'))
 
 
-async def test_null_replacement():
+def test_null_replacement():
     section = TriblerTestConfigSection(path='None')
     assert section.path is None

--- a/src/tribler/core/tests/test_check_os.py
+++ b/src/tribler/core/tests/test_check_os.py
@@ -10,7 +10,7 @@ from tribler.core.utilities.patch_import import patch_import
 
 @patch('sys.exit')
 @patch('tribler.core.check_os.show_system_popup')
-async def test_error_and_exit(mocked_show_system_popup, mocked_sys_exit):
+def test_error_and_exit(mocked_show_system_popup, mocked_sys_exit):
     error_and_exit('title', 'text')
     mocked_show_system_popup.assert_called_once_with('title', 'text')
     mocked_sys_exit.assert_called_once_with(1)
@@ -18,7 +18,7 @@ async def test_error_and_exit(mocked_show_system_popup, mocked_sys_exit):
 
 @patch_import(['faulthandler'], strict=True, enable=MagicMock())
 @patch('tribler.core.check_os.open', new=MagicMock())
-async def test_enable_fault_handler():
+def test_enable_fault_handler():
     import faulthandler
     enable_fault_handler(log_dir=MagicMock())
     faulthandler.enable.assert_called_once()
@@ -27,14 +27,14 @@ async def test_enable_fault_handler():
 @patch_import(['faulthandler'], strict=True, always_raise_exception_on_import=True)
 @patch.object(Logger, 'error')
 @patch('tribler.core.check_os.open', new=MagicMock())
-async def test_enable_fault_handler_import_error(mocked_log_error: MagicMock):
+def test_enable_fault_handler_import_error(mocked_log_error: MagicMock):
     enable_fault_handler(log_dir=MagicMock())
     mocked_log_error.assert_called_once()
 
 
 @patch_import(['faulthandler'], strict=True, enable=MagicMock())
 @patch('tribler.core.check_os.open', new=MagicMock())
-async def test_enable_fault_handler_log_dir_not_exists():
+def test_enable_fault_handler_log_dir_not_exists():
     log_dir = MagicMock(exists=MagicMock(return_value=False),
                         mkdir=MagicMock())
 

--- a/src/tribler/core/tests/test_start_core.py
+++ b/src/tribler/core/tests/test_start_core.py
@@ -10,7 +10,7 @@ from tribler.core.utilities.path_util import Path
 @patch('asyncio.get_event_loop', new=MagicMock())
 @patch('tribler.core.start_core.TriblerConfig.load', new=MagicMock())
 @patch('tribler.core.start_core.core_session')
-async def test_start_tribler_core_no_exceptions(mocked_core_session):
+def test_start_tribler_core_no_exceptions(mocked_core_session):
     # test that base logic of tribler core runs without exceptions
     run_tribler_core_session(1, 'key', Path('.'), False)
     mocked_core_session.assert_called_once()

--- a/src/tribler/core/upgrade/tests/test_upgrader.py
+++ b/src/tribler/core/upgrade/tests/test_upgrader.py
@@ -130,7 +130,7 @@ def test_upgrade_pony_8to10(upgrader, channels_dir, mds_path, trustchain_keypair
     mds.shutdown()
 
 
-async def test_upgrade_pony_10to11(upgrader, channels_dir, mds_path, trustchain_keypair):
+def test_upgrade_pony_10to11(upgrader, channels_dir, mds_path, trustchain_keypair):
     _copy('pony_v10.db', mds_path)
 
     upgrader.upgrade_pony_db_10to11()
@@ -251,7 +251,7 @@ def test_calc_progress():
     assert calc_progress(1000, 100) == pytest.approx(99.158472, abs=EPSILON)
 
 
-async def test_upgrade_bw_accounting_db_8to9(upgrader, state_dir, trustchain_keypair):
+def test_upgrade_bw_accounting_db_8to9(upgrader, state_dir, trustchain_keypair):
     bandwidth_path = state_dir / 'sqlite/bandwidth.db'
     _copy('bandwidth_v8.db', bandwidth_path)
 

--- a/src/tribler/core/utilities/tests/test_dependencies.py
+++ b/src/tribler/core/utilities/tests/test_dependencies.py
@@ -1,22 +1,20 @@
 import pytest
 
+import tribler.core
 from tribler.core.utilities.dependencies import (
     Scope,
     _extract_libraries_from_requirements,
     _get_pip_dependencies,
     get_dependencies,
 )
-
-import tribler.core
 from tribler.core.utilities.path_util import Path
-
 
 
 # pylint: disable=protected-access
 
 # fmt: off
 
-async def test_extract_libraries_from_requirements():
+def test_extract_libraries_from_requirements():
     # check that libraries extracts from text correctly
     text = 'PyQt5>=5.14\n' \
            'psutil\n' \
@@ -26,19 +24,19 @@ async def test_extract_libraries_from_requirements():
     assert list(_extract_libraries_from_requirements(text)) == ['PyQt5', 'psutil', 'configobj']
 
 
-async def test_pip_dependencies_gen():
+def test_pip_dependencies_gen():
     # check that libraries extracts from file correctly
     path = Path(tribler.__file__).parent.parent.parent / 'requirements.txt'
     assert list(_get_pip_dependencies(path))
 
 
-async def test_get_dependencies():
+def test_get_dependencies():
     # assert that in each scope dependencies are exist
     assert list(get_dependencies(Scope.gui))
     assert list(get_dependencies(Scope.core))
 
 
-async def test_get_dependencies_wrong_scope():
+def test_get_dependencies_wrong_scope():
     # test that get_dependencies raises AttributeError in case of wrong scope
     with pytest.raises(AttributeError):
         get_dependencies(100)

--- a/src/tribler/core/utilities/tests/test_patch_import.py
+++ b/src/tribler/core/utilities/tests/test_patch_import.py
@@ -5,12 +5,10 @@ import pytest
 from tribler.core.utilities.patch_import import patch_import
 
 
-
 # pylint: disable=import-outside-toplevel, import-error, unused-import
-# fmt: off
 
 @patch_import(['library_that_does_not_exist'])
-async def test_mock_import_mocked_lib():
+def test_mock_import_mocked_lib():
     import library_that_does_not_exist
     assert library_that_does_not_exist
 
@@ -22,13 +20,13 @@ async def test_mock_import_mocked_lib():
 
 
 @patch_import('library_as_a_string')
-async def test_library_as_a_string():
+def test_library_as_a_string():
     import library_as_a_string
     assert library_as_a_string
 
 
 @patch_import([])
-async def test_mock_import_import_real_lib():
+def test_mock_import_import_real_lib():
     with pytest.raises(ImportError):
         import library_that_does_not_exist
         # `library_that_does_not_exist.inner_function()` call is unnecessary for the test itself, but it prevents
@@ -37,19 +35,19 @@ async def test_mock_import_import_real_lib():
 
 
 @patch_import(['time'])
-async def test_mock_import_not_strict():
+def test_mock_import_not_strict():
     import time
     assert not isinstance(time, MagicMock)
 
 
 @patch_import(['time'], strict=True)
-async def test_mock_import_strict():
+def test_mock_import_strict():
     import time
     assert isinstance(time, MagicMock)
 
 
 @patch_import(['time'], always_raise_exception_on_import=True)
-async def test_mock_import_always_raise_exception_on_import():
+def test_mock_import_always_raise_exception_on_import():
     with pytest.raises(ImportError):
         import time
         # `time.gmtime(0)` call is unnecessary for the test itself, but it prevents removing "unused"

--- a/src/tribler/core/utilities/tests/test_path_utils.py
+++ b/src/tribler/core/utilities/tests/test_path_utils.py
@@ -3,7 +3,7 @@ import pytest
 from tribler.core.utilities.path_util import Path
 
 
-async def test_put_path_relative(tmpdir):
+def test_put_path_relative(tmpdir):
     assert Path(tmpdir).normalize_to(None) == Path(tmpdir)
     assert Path(tmpdir).normalize_to('') == Path(tmpdir)
     assert Path(tmpdir).normalize_to('1/2') == Path(tmpdir)
@@ -11,7 +11,7 @@ async def test_put_path_relative(tmpdir):
     assert Path(tmpdir / '1').normalize_to(tmpdir) == Path('1')
 
 
-async def test_normalize_to(tmpdir):
+def test_normalize_to(tmpdir):
     assert Path(tmpdir).normalize_to(None) == Path(tmpdir)
     assert Path(tmpdir).normalize_to('') == Path(tmpdir)
     assert Path(tmpdir / '1' / '2').normalize_to(Path(tmpdir)) == Path('1') / '2'

--- a/src/tribler/gui/tests/test_error_handler.py
+++ b/src/tribler/gui/tests/test_error_handler.py
@@ -24,7 +24,7 @@ def reported_error():
 
 
 @patch('tribler.gui.error_handler.FeedbackDialog')
-async def test_gui_error_tribler_stopped(mocked_feedback_dialog: MagicMock, error_handler: ErrorHandler, caplog):
+def test_gui_error_tribler_stopped(mocked_feedback_dialog: MagicMock, error_handler: ErrorHandler, caplog):
     # test that while tribler_stopped is True FeedbackDialog is not called
     error_handler._tribler_stopped = True
     error_handler.gui_error(AssertionError, AssertionError("error text"), None)
@@ -37,7 +37,7 @@ async def test_gui_error_tribler_stopped(mocked_feedback_dialog: MagicMock, erro
 @patch('tribler.gui.error_handler.FeedbackDialog')
 @patch.object(SentryReporter, 'global_strategy', create=True,
               new=PropertyMock(return_value=SentryStrategy.SEND_SUPPRESSED))
-async def test_gui_error_suppressed(mocked_feedback_dialog: MagicMock, error_handler: ErrorHandler, caplog):
+def test_gui_error_suppressed(mocked_feedback_dialog: MagicMock, error_handler: ErrorHandler, caplog):
     error_handler.gui_error(AssertionError, AssertionError('error_text'), None)
     mocked_feedback_dialog.assert_not_called()
     assert not error_handler._handled_exceptions
@@ -51,8 +51,8 @@ async def test_gui_error_suppressed(mocked_feedback_dialog: MagicMock, error_han
 
 
 @patch('tribler.gui.error_handler.FeedbackDialog')
-async def test_gui_info_type_in_handled_exceptions(mocked_feedback_dialog: MagicMock, error_handler: ErrorHandler,
-                                                   caplog):
+def test_gui_info_type_in_handled_exceptions(mocked_feedback_dialog: MagicMock, error_handler: ErrorHandler,
+                                             caplog):
     # test that if exception type in _handled_exceptions then FeedbackDialog is not called
     error_handler._handled_exceptions = {AssertionError}
     error_handler.gui_error(AssertionError, AssertionError("error text"), None)
@@ -68,8 +68,8 @@ async def test_gui_info_type_in_handled_exceptions(mocked_feedback_dialog: Magic
 
 @patch('tribler.gui.error_handler.FeedbackDialog')
 @patch.object(ErrorHandler, '_stop_tribler')
-async def test_gui_core_connect_timeout_error(mocked_stop_tribler, mocked_feedback_dialog: MagicMock,
-                                              error_handler: ErrorHandler):
+def test_gui_core_connect_timeout_error(mocked_stop_tribler, mocked_feedback_dialog: MagicMock,
+                                        error_handler: ErrorHandler):
     # test that in case of CoreConnectTimeoutError Tribler should stop it's work
     error_handler.gui_error(CoreConnectTimeoutError, None, None)
 
@@ -79,8 +79,8 @@ async def test_gui_core_connect_timeout_error(mocked_stop_tribler, mocked_feedba
 
 @patch('tribler.gui.error_handler.FeedbackDialog')
 @patch.object(ErrorHandler, '_stop_tribler')
-async def test_gui_core_crashed_error(mocked_stop_tribler: MagicMock, mocked_feedback_dialog: MagicMock,
-                                      error_handler: ErrorHandler):
+def test_gui_core_crashed_error(mocked_stop_tribler: MagicMock, mocked_feedback_dialog: MagicMock,
+                                error_handler: ErrorHandler):
     # test that in case of CoreRuntimeError Tribler should stop it's work
     error_handler.gui_error(CoreCrashedError, None, None)
 
@@ -90,8 +90,8 @@ async def test_gui_core_crashed_error(mocked_stop_tribler: MagicMock, mocked_fee
 
 @patch('tribler.gui.error_handler.FeedbackDialog')
 @patch.object(ErrorHandler, '_stop_tribler')
-async def test_gui_is_not_core_exception(mocked_stop_tribler: MagicMock, mocked_feedback_dialog: MagicMock,
-                                         error_handler: ErrorHandler):
+def test_gui_is_not_core_exception(mocked_stop_tribler: MagicMock, mocked_feedback_dialog: MagicMock,
+                                   error_handler: ErrorHandler):
     # test that gui_error creates FeedbackDialog without stopping the Tribler's work
     error_handler.gui_error(Exception, None, None)
 
@@ -100,8 +100,8 @@ async def test_gui_is_not_core_exception(mocked_stop_tribler: MagicMock, mocked_
 
 
 @patch('tribler.gui.error_handler.FeedbackDialog')
-async def test_core_info_type_in_handled_exceptions(mocked_feedback_dialog: MagicMock, error_handler: ErrorHandler,
-                                                    reported_error: ReportedError):
+def test_core_info_type_in_handled_exceptions(mocked_feedback_dialog: MagicMock, error_handler: ErrorHandler,
+                                              reported_error: ReportedError):
     # test that if exception type in _handled_exceptions then FeedbackDialog is not called
     error_handler._handled_exceptions = {reported_error.type}
     error_handler.core_error(reported_error)
@@ -110,8 +110,8 @@ async def test_core_info_type_in_handled_exceptions(mocked_feedback_dialog: Magi
 
 
 @patch('tribler.gui.error_handler.FeedbackDialog')
-async def test_core_should_stop(mocked_feedback_dialog: MagicMock, error_handler: ErrorHandler,
-                                reported_error: ReportedError):
+def test_core_should_stop(mocked_feedback_dialog: MagicMock, error_handler: ErrorHandler,
+                          reported_error: ReportedError):
     # test that in case of "should_stop=True", Tribler should stop it's work
     error_handler._stop_tribler = MagicMock()
     reported_error.should_stop = True
@@ -120,8 +120,8 @@ async def test_core_should_stop(mocked_feedback_dialog: MagicMock, error_handler
 
 
 @patch('tribler.gui.error_handler.FeedbackDialog')
-async def test_core_error(mocked_feedback_dialog: MagicMock, error_handler: ErrorHandler,
-                          reported_error: ReportedError):
+def test_core_error(mocked_feedback_dialog: MagicMock, error_handler: ErrorHandler,
+                    reported_error: ReportedError):
     # test that core_error creates FeedbackDialog
     error_handler.core_error(reported_error)
     mocked_feedback_dialog.assert_called_once()


### PR DESCRIPTION
This PR removes unnecessary `async` statements from test functions.

Extracted from https://github.com/Tribler/tribler/pull/7127