### PR TITLE
Call `app.shutdown()` for rest_api fixture

### DIFF
--- a/src/tribler/core/components/knowledge/restapi/tests/test_knowledge_endpoint.py
+++ b/src/tribler/core/components/knowledge/restapi/tests/test_knowledge_endpoint.py
@@ -30,7 +30,8 @@ def knowledge_endpoint(knowledge_db):
 def rest_api(loop, aiohttp_client, knowledge_endpoint):
     app = Application()
     app.add_subapp('/knowledge', knowledge_endpoint.app)
-    return loop.run_until_complete(aiohttp_client(app))
+    yield loop.run_until_complete(aiohttp_client(app))
+    app.shutdown()
 
 
 def tag_to_statement(tag: str) -> Dict:

--- a/src/tribler/core/components/libtorrent/restapi/tests/test_downloads_endpoint.py
+++ b/src/tribler/core/components/libtorrent/restapi/tests/test_downloads_endpoint.py
@@ -28,7 +28,8 @@ def rest_api(loop, aiohttp_client, mock_dlmgr, metadata_store):  # pylint: disab
 
     app = Application(middlewares=[error_middleware])
     app.add_subapp('/downloads', endpoint.app)
-    return loop.run_until_complete(aiohttp_client(app))
+    yield loop.run_until_complete(aiohttp_client(app))
+    app.shutdown()
 
 
 def get_hex_infohash(tdef):

--- a/src/tribler/core/components/libtorrent/restapi/tests/test_libtorrent_endpoint.py
+++ b/src/tribler/core/components/libtorrent/restapi/tests/test_libtorrent_endpoint.py
@@ -19,7 +19,8 @@ def endpoint(mock_dlmgr, mock_lt_session):
 def rest_api(loop, aiohttp_client, endpoint):  # pylint: disable=unused-argument
     app = Application(middlewares=[error_middleware])
     app.add_subapp('/libtorrent', endpoint.app)
-    return loop.run_until_complete(aiohttp_client(app))
+    yield loop.run_until_complete(aiohttp_client(app))
+    app.shutdown()
 
 
 @pytest.fixture

--- a/src/tribler/core/components/libtorrent/restapi/tests/test_torrentinfo_endpoint.py
+++ b/src/tribler/core/components/libtorrent/restapi/tests/test_torrentinfo_endpoint.py
@@ -53,7 +53,8 @@ def endpoint(download_manager):
 def rest_api(loop, aiohttp_client, endpoint):  # pylint: disable=unused-argument
     app = Application(middlewares=[error_middleware])
     app.add_subapp('/torrentinfo', endpoint.app)
-    return loop.run_until_complete(aiohttp_client(app))
+    yield loop.run_until_complete(aiohttp_client(app))
+    app.shutdown()
 
 
 async def test_get_torrentinfo_escaped_characters(tmp_path, rest_api):

--- a/src/tribler/core/components/metadata_store/restapi/tests/test_channels_endpoint.py
+++ b/src/tribler/core/components/metadata_store/restapi/tests/test_channels_endpoint.py
@@ -57,7 +57,8 @@ def rest_api(loop, aiohttp_client, mock_dlmgr, metadata_store, knowledge_db):  #
     app = Application(middlewares=[error_middleware])
     app.add_subapp('/channels', channels_endpoint.app)
     app.add_subapp('/collections', collections_endpoint.app)
-    return loop.run_until_complete(aiohttp_client(app))
+    yield loop.run_until_complete(aiohttp_client(app))
+    app.shutdown()
 
 
 async def test_get_channels(rest_api, add_fake_torrents_channels, add_subscribed_and_not_downloaded_channel, mock_dlmgr,

--- a/src/tribler/core/components/metadata_store/restapi/tests/test_metadata_endpoint.py
+++ b/src/tribler/core/components/metadata_store/restapi/tests/test_metadata_endpoint.py
@@ -48,7 +48,8 @@ def rest_api(loop, aiohttp_client, torrent_checker, metadata_store):  # pylint: 
 
     app = Application(middlewares=[error_middleware])
     app.add_subapp('/metadata', endpoint.app)
-    return loop.run_until_complete(aiohttp_client(app))
+    yield loop.run_until_complete(aiohttp_client(app))
+    app.shutdown()
 
 
 async def test_update_multiple_metadata_entries(metadata_store, add_fake_torrents_channels, rest_api):

--- a/src/tribler/core/components/metadata_store/restapi/tests/test_remote_query_endpoint.py
+++ b/src/tribler/core/components/metadata_store/restapi/tests/test_remote_query_endpoint.py
@@ -34,7 +34,8 @@ def endpoint(mock_gigachannel_community, metadata_store):  # pylint: disable=W06
 def rest_api(loop, aiohttp_client, endpoint):  # pylint: disable=unused-argument
     app = Application(middlewares=[error_middleware])
     app.add_subapp('/remote_query', endpoint.app)
-    return loop.run_until_complete(aiohttp_client(app))
+    yield loop.run_until_complete(aiohttp_client(app))
+    app.shutdown()
 
 
 async def test_create_remote_search_request(rest_api, endpoint, mock_gigachannel_community):  # pylint: disable=W0621

--- a/src/tribler/core/components/metadata_store/restapi/tests/test_search_endpoint.py
+++ b/src/tribler/core/components/metadata_store/restapi/tests/test_search_endpoint.py
@@ -37,7 +37,8 @@ def rest_api(loop, needle_in_haystack_mds, aiohttp_client, knowledge_db):
     channels_endpoint = SearchEndpoint(needle_in_haystack_mds, knowledge_db=knowledge_db)
     app = Application()
     app.add_subapp('/search', channels_endpoint.app)
-    return loop.run_until_complete(aiohttp_client(app))
+    yield loop.run_until_complete(aiohttp_client(app))
+    app.shutdown()
 
 
 async def test_search_wrong_mdtype(rest_api):

--- a/src/tribler/core/components/restapi/rest/tests/test_create_torrent_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/tests/test_create_torrent_endpoint.py
@@ -20,7 +20,8 @@ def endpoint():
 def rest_api(loop, aiohttp_client, endpoint):  # pylint: disable=unused-argument
     app = Application(middlewares=[error_middleware])
     app.add_subapp('/createtorrent', endpoint.app)
-    return loop.run_until_complete(aiohttp_client(app))
+    yield loop.run_until_complete(aiohttp_client(app))
+    app.shutdown()
 
 
 async def test_create_torrent(rest_api, tmp_path, endpoint):

--- a/src/tribler/core/components/restapi/rest/tests/test_debug_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/tests/test_debug_endpoint.py
@@ -41,7 +41,8 @@ def rest_api(loop, aiohttp_client, mock_tunnel_community, endpoint):  # pylint: 
 
     app = Application(middlewares=[error_middleware])
     app.add_subapp('/debug', endpoint.app)
-    return loop.run_until_complete(aiohttp_client(app))
+    yield loop.run_until_complete(aiohttp_client(app))
+    app.shutdown()
 
 
 async def test_get_slots(rest_api, mock_tunnel_community):

--- a/src/tribler/core/components/restapi/rest/tests/test_settings_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/tests/test_settings_endpoint.py
@@ -24,7 +24,8 @@ def endpoint(tribler_config):
 def rest_api(loop, aiohttp_client, endpoint):  # pylint: disable=unused-argument
     app = Application(middlewares=[error_middleware])
     app.add_subapp('/settings', endpoint.app)
-    return loop.run_until_complete(aiohttp_client(app))
+    yield loop.run_until_complete(aiohttp_client(app))
+    app.shutdown()
 
 
 def verify_settings(settings_dict):

--- a/src/tribler/core/components/restapi/rest/tests/test_shutdown_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/tests/test_shutdown_endpoint.py
@@ -15,10 +15,10 @@ def endpoint():
 
 @pytest.fixture
 def rest_api(loop, aiohttp_client, endpoint):  # pylint: disable=unused-argument
-
     app = Application(middlewares=[error_middleware])
     app.add_subapp('/shutdown', endpoint.app)
-    return loop.run_until_complete(aiohttp_client(app))
+    yield loop.run_until_complete(aiohttp_client(app))
+    app.shutdown()
 
 
 async def test_shutdown(rest_api, endpoint):

--- a/src/tribler/core/components/restapi/rest/tests/test_statistics_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/tests/test_statistics_endpoint.py
@@ -33,7 +33,8 @@ def endpoint():
 def rest_api(loop, aiohttp_client, endpoint):  # pylint: disable=unused-argument
     app = Application(middlewares=[error_middleware])
     app.add_subapp('/statistics', endpoint.app)
-    return loop.run_until_complete(aiohttp_client(app))
+    yield loop.run_until_complete(aiohttp_client(app))
+    app.shutdown()
 
 
 async def test_get_tribler_statistics(rest_api, endpoint, metadata_store):

--- a/src/tribler/core/components/restapi/rest/tests/test_trustview_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/tests/test_trustview_endpoint.py
@@ -25,7 +25,8 @@ def endpoint(bandwidth_db):  # pylint: disable=W0621
 def rest_api(loop, aiohttp_client, endpoint):  # pylint: disable=unused-argument
     app = Application(middlewares=[error_middleware])
     app.add_subapp('/trustview', endpoint.app)
-    return loop.run_until_complete(aiohttp_client(app))
+    yield loop.run_until_complete(aiohttp_client(app))
+    app.shutdown()
 
 
 @pytest.fixture

--- a/src/tribler/core/logger/logger.py
+++ b/src/tribler/core/logger/logger.py
@@ -7,7 +7,6 @@ import yaml
 
 LOG_CONFIG_FILENAME = 'logger.yaml'
 
-
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
This PR partially closes #7122 by adding `app.shutdown()` call for the `rest_api` fixture