### PR TITLE
Change scope for the window fixture

### DIFF
--- a/src/tribler/gui/tests/test_gui.py
+++ b/src/tribler/gui/tests/test_gui.py
@@ -35,7 +35,7 @@ TORRENT_WITH_DIRS = TESTS_DATA_DIR / "multi_entries.torrent"
 
 # pylint: disable=protected-access
 
-@pytest.fixture(name='window', scope="module")
+@pytest.fixture(name='window')
 def fixture_window(tmpdir_factory):
     api_key = hexlify(os.urandom(16))
     root_state_dir = str(tmpdir_factory.mktemp('tribler_state_dir'))


### PR DESCRIPTION
This PR fixes https://github.com/Tribler/tribler/issues/7132.

We see quite strange behavior for GUI tests that looks like a deadlock that occurs spontaneously. It could be related to the fact that the `windows` fixture used to have module scope. 
In this PR I changes this scope to the default (function) in the hope that this fixes the bug.

Refs:
* https://docs.pytest.org/en/6.2.x/fixture.html#scope-sharing-fixtures-across-classes-modules-packages-or-session