### PR TITLE
Core Tribler notifier should work in async mode

### DIFF
--- a/src/tribler/core/components/session.py
+++ b/src/tribler/core/components/session.py
@@ -32,7 +32,7 @@ class Session:
         self.logger = logging.getLogger(self.__class__.__name__)
         self.config: TriblerConfig = config or TriblerConfig()
         self.shutdown_event: Event = shutdown_event or Event()
-        self.notifier: Notifier = notifier or Notifier()
+        self.notifier: Notifier = notifier or Notifier(loop=get_event_loop())
         self.components: Dict[Type[Component], Component] = {}
         for component in components:
             self.register(component.__class__, component)


### PR DESCRIPTION
This PR fixes #7149. The core notifier should receive the `loop` argument to process notifications in asynchronous mode. The error remains unnoticed for some time because most notifications work fine in synchronous mode as well.