### PR TITLE
Re-raise all exception in  the `process_alert()` function as `NoCrashException`

### DIFF
--- a/src/tribler/core/components/libtorrent/tests/test_download.py
+++ b/src/tribler/core/components/libtorrent/tests/test_download.py
@@ -10,6 +10,7 @@ from libtorrent import bencode
 from tribler.core.components.libtorrent.download_manager.download import Download
 from tribler.core.components.libtorrent.download_manager.download_config import DownloadConfig
 from tribler.core.components.libtorrent.utils.torrent_utils import get_info_from_handle
+from tribler.core.components.reporter.exception_handler import NoCrashException
 from tribler.core.exceptions import SaveResumeDataError
 from tribler.core.tests.tools.base_test import MockObject
 from tribler.core.tests.tools.common import TESTS_DATA_DIR
@@ -430,3 +431,11 @@ def test_get_tracker_status_unicode_decode_error(test_download: Download):
     test_download.get_tracker_status()
 
     assert test_download.handle.trackers.called
+
+
+def test_process_alert_no_crash_exception(test_download: Download):
+    """Test that in the case of an error in the method `process_alert`, NoCrashException raises"""
+    with pytest.raises(NoCrashException):
+        # `process_alert` raises "AttributeError: 'str' object has no attribute 'category'" first
+        # because the alert 'alert' has wrong type.
+        test_download.process_alert('alert', 'type')

--- a/src/tribler/core/components/reporter/reported_error.py
+++ b/src/tribler/core/components/reporter/reported_error.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional
 
 
@@ -6,9 +6,9 @@ from typing import Optional
 class ReportedError:
     type: str
     text: str
-    event: dict
+    event: dict = field(repr=False)
 
-    long_text: str = ''
-    context: str = ''
-    last_core_output: str = ''
-    should_stop: Optional[bool] = None
+    long_text: str = field(default='', repr=False)
+    context: str = field(default='', repr=False)
+    last_core_output: str = field(default='', repr=False)
+    should_stop: Optional[bool] = field(default=None)

--- a/src/tribler/core/components/session.py
+++ b/src/tribler/core/components/session.py
@@ -89,13 +89,19 @@ class Session:
             self._reraise_startup_exception_in_separate_task()
 
     def _reraise_startup_exception_in_separate_task(self):
+        self.logger.info('Reraise startup exception in separate task')
+
         async def exception_reraiser():
+            self.logger.info('Exception reraiser')
+
             e = self._startup_exception
             if isinstance(e, ComponentStartupException) and e.component.tribler_should_stop_on_component_error:
+                self.logger.info('Shutdown with exit code 1')
                 self.exit_code = 1
                 self.shutdown_event.set()
 
             # the exception should be intercepted by event loop exception handler
+            self.logger.info(f'Reraise startup exception: {self._startup_exception}')
             raise self._startup_exception
 
         get_event_loop().create_task(exception_reraiser())

--- a/src/tribler/gui/error_handler.py
+++ b/src/tribler/gui/error_handler.py
@@ -28,6 +28,8 @@ class ErrorHandler:
         self._tribler_stopped = False
 
     def gui_error(self, exc_type, exc, tb):
+        self._logger.info(f'Processing GUI error: {exc_type}')
+
         text = "".join(traceback.format_exception(exc_type, exc, tb))
         self._logger.error(text)
 
@@ -77,6 +79,8 @@ class ErrorHandler:
     def core_error(self, reported_error: ReportedError):
         if self._tribler_stopped or reported_error.type in self._handled_exceptions:
             return
+        self._logger.info(f'Processing Core error: {reported_error}')
+
         self._handled_exceptions.add(reported_error.type)
 
         error_text = f'{reported_error.text}\n{reported_error.long_text}'

--- a/src/tribler/gui/tests/test_error_handler.py
+++ b/src/tribler/gui/tests/test_error_handler.py
@@ -1,4 +1,3 @@
-import logging
 from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
@@ -24,46 +23,29 @@ def reported_error():
 
 
 @patch('tribler.gui.error_handler.FeedbackDialog')
-def test_gui_error_tribler_stopped(mocked_feedback_dialog: MagicMock, error_handler: ErrorHandler, caplog):
+def test_gui_error_tribler_stopped(mocked_feedback_dialog: MagicMock, error_handler: ErrorHandler):
     # test that while tribler_stopped is True FeedbackDialog is not called
     error_handler._tribler_stopped = True
     error_handler.gui_error(AssertionError, AssertionError("error text"), None)
     mocked_feedback_dialog.assert_not_called()
 
-    assert caplog.record_tuples == [('ErrorHandler', logging.ERROR, 'AssertionError: error text\n'),
-                                    ('ErrorHandler', logging.INFO, 'Tribler has been stopped')]
-
 
 @patch('tribler.gui.error_handler.FeedbackDialog')
 @patch.object(SentryReporter, 'global_strategy', create=True,
               new=PropertyMock(return_value=SentryStrategy.SEND_SUPPRESSED))
-def test_gui_error_suppressed(mocked_feedback_dialog: MagicMock, error_handler: ErrorHandler, caplog):
+def test_gui_error_suppressed(mocked_feedback_dialog: MagicMock, error_handler: ErrorHandler):
     error_handler.gui_error(AssertionError, AssertionError('error_text'), None)
     mocked_feedback_dialog.assert_not_called()
     assert not error_handler._handled_exceptions
 
-    record_tuples = [
-        ('ErrorHandler', logging.ERROR, 'AssertionError: error_text\n'),
-        ('ErrorHandler', logging.INFO, 'GUI error was suppressed and not sent to Sentry: AssertionError: error_text')
-    ]
-
-    assert caplog.record_tuples == record_tuples
-
 
 @patch('tribler.gui.error_handler.FeedbackDialog')
-def test_gui_info_type_in_handled_exceptions(mocked_feedback_dialog: MagicMock, error_handler: ErrorHandler,
-                                             caplog):
+def test_gui_info_type_in_handled_exceptions(mocked_feedback_dialog: MagicMock, error_handler: ErrorHandler):
     # test that if exception type in _handled_exceptions then FeedbackDialog is not called
     error_handler._handled_exceptions = {AssertionError}
     error_handler.gui_error(AssertionError, AssertionError("error text"), None)
     mocked_feedback_dialog.assert_not_called()
     assert len(error_handler._handled_exceptions) == 1
-
-    record_tuples = [
-        ('ErrorHandler', logging.ERROR, 'AssertionError: error text\n'),
-        ('ErrorHandler', logging.INFO, 'This exception has been handled already')
-    ]
-    assert caplog.record_tuples == record_tuples
 
 
 @patch('tribler.gui.error_handler.FeedbackDialog')


### PR DESCRIPTION
This PR fixes #7136 by reraising all exceptions in the `process_alert()` function as `NoCrashException`.

It doesn't fix the root problem of #7136 but makes Tribler more stable and allows users to send the exception to us and resume the Tribler work after.

During the testing of PR extended logging was also added.