### PR TITLE
Refactoring of the `tail` function

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -21,6 +21,9 @@ import logging
 import os
 import sys
 
+logging.basicConfig(level=logging.INFO)
+logging.info('Start to execute conf.py')
+
 # pylint: disable=wrong-import-position
 root_dir = os.path.abspath(os.path.join(os.path.dirname(__name__), '..'))
 tribler_components = [
@@ -28,25 +31,28 @@ tribler_components = [
     os.path.join(root_dir, "doc"),
 ]
 for component in tribler_components:
+    logging.info(f'Add component: {component}')
+
     sys.path.append(str(component))
 
-from tribler.core.utilities.dependencies import Scope, get_dependencies
 from tribler.core.utilities.patch_import import patch_import
 
-logging.basicConfig(level=logging.INFO)
-modules_to_mock = set(get_dependencies(scope=Scope.core)) | {'libtorrent', 'validate', 'file_read_backwards'}
+# patch extra imports that can not be extracted from the `requirements-core.txt` file
+with patch_import(modules={'libtorrent', 'validate', 'file_read_backwards'}):
+    from tribler.core.utilities.dependencies import Scope, get_dependencies
 
-with patch_import(modules=modules_to_mock):
-    from tribler.core.components.restapi.rest.root_endpoint import RootEndpoint
+    # patch imports that can be extracted from the `requirements-core.txt` file
+    with patch_import(modules=set(get_dependencies(scope=Scope.core))):
+        from tribler.core.components.restapi.rest.root_endpoint import RootEndpoint
 
-    add_endpoint = RootEndpoint.add_endpoint
-    RootEndpoint.add_endpoint = lambda self, path, ep: add_endpoint(self, path, ep) \
-        if path not in ['/ipv8', '/market', '/wallets'] else None
+        add_endpoint = RootEndpoint.add_endpoint
+        RootEndpoint.add_endpoint = lambda self, path, ep: add_endpoint(self, path, ep) \
+            if path not in ['/ipv8', '/market', '/wallets'] else None
 
-    # Extract Swagger docs
-    from extract_swagger import extract_swagger  # noqa: I100
+        # Extract Swagger docs
+        from extract_swagger import extract_swagger  
 
-    asyncio.run(extract_swagger('restapi/swagger.yaml'))
+        asyncio.run(extract_swagger('restapi/swagger.yaml'))
 
 # -- General configuration ------------------------------------------------
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -34,7 +34,7 @@ from tribler.core.utilities.dependencies import Scope, get_dependencies
 from tribler.core.utilities.patch_import import patch_import
 
 logging.basicConfig(level=logging.INFO)
-modules_to_mock = set(get_dependencies(scope=Scope.core)) | {'libtorrent', 'validate'}
+modules_to_mock = set(get_dependencies(scope=Scope.core)) | {'libtorrent', 'validate', 'file_read_backwards'}
 
 with patch_import(modules=modules_to_mock):
     from tribler.core.components.restapi.rest.root_endpoint import RootEndpoint

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -24,3 +24,4 @@ yarl==1.7.2 # keep this dependency higher than 1.6.3. See: https://github.com/ai
 bitarray==2.5.1
 pyipv8==2.8.0
 libtorrent==1.2.15
+file-read-backwards==2.0.0

--- a/src/tribler/core/utilities/path_util.py
+++ b/src/tribler/core/utilities/path_util.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 import pathlib
 import sys
 import tempfile
+from itertools import islice
+from typing import Union
+
+from file_read_backwards import FileReadBackwards
 
 
 class Path(type(pathlib.Path())):
@@ -48,3 +52,11 @@ class PosixPath(Path, pathlib.PurePosixPath):
 
 class WindowsPath(Path, pathlib.PureWindowsPath):
     __slots__ = ()
+
+
+def tail(file_name: Union[str, Path], count: int = 1) -> str:
+    """Tail a file and get X lines from the end"""
+
+    with FileReadBackwards(file_name) as f:
+        lines = list(islice(f, count))
+        return '\n'.join(reversed(lines))

--- a/src/tribler/core/utilities/tests/test_path_utils.py
+++ b/src/tribler/core/utilities/tests/test_path_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from tribler.core.utilities.path_util import Path
+from tribler.core.utilities.path_util import Path, tail
 
 
 def test_put_path_relative(tmpdir):
@@ -15,3 +15,51 @@ def test_normalize_to(tmpdir):
     assert Path(tmpdir).normalize_to(None) == Path(tmpdir)
     assert Path(tmpdir).normalize_to('') == Path(tmpdir)
     assert Path(tmpdir / '1' / '2').normalize_to(Path(tmpdir)) == Path('1') / '2'
+
+
+def test_tail_no_file():
+    """Test that in the case of missed file, an exception raises"""
+    with pytest.raises(FileNotFoundError):
+        tail('missed_file.txt')
+
+
+def test_tail_small_file(tmpdir: Path):
+    """Test that tail works correct with a small file """
+    log_file = tmpdir / 'log.txt'
+    log_file.write_text('text', 'utf-8')
+    assert tail(log_file) == 'text'
+
+
+def test_tail_count(tmpdir: Path):
+    """Test that tail returns desired count of lines"""
+    log_file = tmpdir / 'log.txt'
+
+    # add 100 lines
+    content = '\n'.join(f'{i}' for i in range(100))
+    log_file.write_text(content, 'utf-8')
+
+    assert tail(log_file, 0) == ''
+    assert tail(log_file, 1) == '99'
+    assert tail(log_file, 2) == '98\n99'
+    assert tail(log_file, 1000) == content
+
+    with pytest.raises(ValueError):
+        tail(log_file, -1)
+
+
+def test_tail_encodings(tmpdir: Path):
+    """Test that the `tail` function can read logs with "utf-8", "ascii", "latin-1" encodings """
+    encodings = ["utf-8", "ascii", "latin-1"]
+    log_files = []
+
+    content = '\n'.join(f'{i}' for i in range(100))
+
+    # create files for all available encodings
+    for encoding in encodings:
+        path = tmpdir / encoding
+        path.write_text(content, encoding)
+        log_files.append(path)
+
+    # make sure they were read all encoding correctly
+    for log in log_files:
+        assert tail(log, 100) == content


### PR DESCRIPTION
This PR related to #7067

I haven't found any problems with the current implementation of the `tail` function. The PR contains only refactoring and tests.

I'm not sure if we need to merge it.

---

The error occurred in this line:
https://github.com/Tribler/tribler/blob/52a7f97e7f2a8ad7aebb24e87de84ddc55f897d2/src/tribler/core/components/restapi/rest/debug_endpoint.py#L311

Variables of the function:


name | value
-- | --
byte_buffer | '1024'
file_handler | "<_io.TextIOWrapper name='C:\\\\Users\\\\<user>\\\\AppData\\\\Roaming\\\\.Tribler\\\\tribler-core-info.log' mode='r' encoding='cp1251'>"
lines | '100'
lines_found | []
block_counter | '-1'

The `tail` method could be used in #7158

Refs:
* https://github.com/RobinNil/file_read_backwards