### PR TITLE
Find the running core port and use it in GUI

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -18,3 +18,5 @@ looptime==0.2
 asynctest==0.13.0 # this library has to be installed to properly work with ipv8 TestBase.
 
 scipy==1.8.0
+
+pytest-qt==4.2.0

--- a/src/tribler/gui/core_manager.py
+++ b/src/tribler/gui/core_manager.py
@@ -136,6 +136,8 @@ class CoreManager(QObject):
     def port_checker_callback(self, detected_port):
         request_manager.port = detected_port
         self.events_manager.update_port(detected_port)
+        os.environ['TRIBLER_API_PORT_INITIAL'] = str(self.api_port)
+        os.environ['TRIBLER_API_PORT_DETECTED'] = str(detected_port)
 
     def on_core_stdout_read_ready(self):
         if self.app_manager.quitting_app:

--- a/src/tribler/gui/port_checker.py
+++ b/src/tribler/gui/port_checker.py
@@ -1,3 +1,4 @@
+import logging
 import socket
 from typing import Callable
 
@@ -28,6 +29,7 @@ class PortChecker(QObject):
                  check_interval_in_ms: int = 1000,
                  timeout_in_ms: int = 120000):
         QObject.__init__(self, None)
+        self._logger = logging.getLogger(self.__class__.__name__)
         self._process = self.get_process_from_pid(pid)
         self._callback = callback
 
@@ -42,6 +44,7 @@ class PortChecker(QObject):
         self._timeout_timer = None
 
     def start_checking(self):
+        self._logger.info("Starting port checker")
         self._checker_timer = QTimer()
         self._checker_timer.setSingleShot(True)
         connect(self._checker_timer.timeout, self.check_port)
@@ -54,14 +57,17 @@ class PortChecker(QObject):
         self._timeout_timer.start(self.timeout_in_ms)
 
     def stop_checking(self):
+        self._logger.info("Stopping port checker")
         if self._checker_timer:
             self._checker_timer.stop()
         if self._timeout_timer:
             self._timeout_timer.stop()
 
     def check_port(self):
+        self._logger.info(f"Checking ports; Base Port: {self.base_port}")
         self.detect_port_from_process()
         if self.detected_port and self._callback:
+            self._logger.info(f"Detected Port: {self.detected_port}; Base Port: {self.base_port}; Calling callback.")
             self._callback(self.detected_port)
         elif self._checker_timer:
             self._checker_timer.start(self.check_interval_in_ms)

--- a/src/tribler/gui/port_checker.py
+++ b/src/tribler/gui/port_checker.py
@@ -1,0 +1,91 @@
+import socket
+from typing import Callable
+
+import psutil
+from PyQt5.QtCore import QObject, QTimer
+
+from tribler.gui.utilities import connect
+
+
+class PortChecker(QObject):
+    """
+    PortChecker finds the closest port opened by a process identified by given pid and the base port.
+    A callback can also be set which is triggered when the port is detected.
+
+    Usage:
+    port_checker = PortChecker(pid, base_port, callback)
+    port_checker.start_checking()
+
+    # The detected port can be retrieved as:
+    port_checker.detected_port
+    """
+
+    def __init__(self,
+                 pid: int,
+                 base_port: int,
+                 callback: Callable[[int], None] = None,
+                 num_ports_to_check: int = 10,
+                 check_interval_in_ms: int = 1000,
+                 timeout_in_ms: int = 120000):
+        QObject.__init__(self, None)
+        self._process = self.get_process_from_pid(pid)
+        self._callback = callback
+
+        self.base_port = base_port
+        self.detected_port = None
+
+        self.num_ports_to_check = num_ports_to_check
+        self.check_interval_in_ms = check_interval_in_ms
+        self.timeout_in_ms = timeout_in_ms
+
+        self._checker_timer = None
+        self._timeout_timer = None
+
+    def start_checking(self):
+        self._checker_timer = QTimer()
+        self._checker_timer.setSingleShot(True)
+        connect(self._checker_timer.timeout, self.check_port)
+
+        self._timeout_timer = QTimer()
+        self._timeout_timer.setSingleShot(True)
+        connect(self._timeout_timer.timeout, self.stop_checking)
+
+        self._checker_timer.start(self.check_interval_in_ms)
+        self._timeout_timer.start(self.timeout_in_ms)
+
+    def stop_checking(self):
+        if self._checker_timer:
+            self._checker_timer.stop()
+        if self._timeout_timer:
+            self._timeout_timer.stop()
+
+    def check_port(self):
+        self.detect_port_from_process()
+        if self.detected_port and self._callback:
+            self._callback(self.detected_port)
+        elif self._checker_timer:
+            self._checker_timer.start(self.check_interval_in_ms)
+
+    @classmethod
+    def get_process_from_pid(cls, pid):
+        try:
+            return psutil.Process(pid)
+        except psutil.NoSuchProcess:
+            return None
+
+    def detect_port_from_process(self):
+        if not self._process:
+            return
+
+        connections = self._process.connections(kind='inet4')
+        candidate_ports = [connection.laddr.port for connection in connections
+                           if self._is_connection_in_range(connection)]
+
+        if candidate_ports:
+            self.detected_port = min(candidate_ports)
+
+    def _is_connection_in_range(self, connection):
+        return connection.laddr.ip == '127.0.0.1' \
+               and connection.status == 'LISTEN' \
+               and connection.type == socket.SocketKind.SOCK_STREAM \
+               and self.base_port <= connection.laddr.port < self.base_port + self.num_ports_to_check

--- a/src/tribler/gui/tests/test_port_checker.py
+++ b/src/tribler/gui/tests/test_port_checker.py
@@ -1,0 +1,116 @@
+import socket
+from unittest.mock import Mock, patch
+
+import pytest
+from PyQt5 import QtTest
+
+from tribler.gui.port_checker import PortChecker
+
+
+@pytest.fixture(name="base_port")
+def mock_base_port():
+    return 52194
+
+
+@pytest.fixture(name="mock_callback")
+def mock_callback():
+    return Mock()
+
+
+@pytest.fixture(name="port_checker_helpers")
+@patch('psutil.Process')
+def port_checker_helpers(mock_process, base_port, mock_callback):
+    mock_pid = 123
+    check_interval_in_ms = 10
+    timeout_in_ms = 100
+    port_checker = PortChecker(mock_pid,
+                               base_port,
+                               callback=mock_callback,
+                               check_interval_in_ms=check_interval_in_ms,
+                               timeout_in_ms=timeout_in_ms)
+    return port_checker, mock_process, mock_callback
+
+
+def test_detect_port_with_no_connections(port_checker_helpers):
+    port_checker, mock_process, _ = port_checker_helpers
+
+    mock_process.return_value.connections.return_value = []
+
+    port_checker.check_port()
+
+    assert port_checker.detected_port is None
+
+
+def test_detect_port_with_out_of_range_connections(base_port, port_checker_helpers):
+    port_checker, mock_process, _ = port_checker_helpers
+
+    mock_process.return_value.connections.return_value = [
+        mock_connection(base_port + port_checker.num_ports_to_check + 1),  # out of range port
+        mock_connection(base_port + port_checker.num_ports_to_check + 2),  # out of range port
+    ]
+
+    port_checker.check_port()
+
+    assert port_checker.detected_port is None
+
+
+def test_detect_port_with_in_range_connections(base_port, port_checker_helpers):
+    port_checker, mock_process, _ = port_checker_helpers
+
+    port_in_range_1 = base_port + port_checker.num_ports_to_check - 1
+    port_in_range_2 = base_port + port_checker.num_ports_to_check - 2
+    mock_process.return_value.connections.return_value = [
+        mock_connection(port_in_range_1),  # port within range
+        mock_connection(port_in_range_2),  # closest port to the base port expected to be detected
+    ]
+
+    port_checker.check_port()
+
+    assert port_checker.detected_port == port_in_range_2
+
+
+def test_check_port_detected(base_port, port_checker_helpers):
+    port_checker, mock_process, callback = port_checker_helpers
+
+    port_checker.check_port()
+    callback.assert_not_called()
+
+    # If the port is detected, callback should be called
+    port_checker.detected_port = base_port
+    port_checker.check_port()
+
+    callback.assert_called_once()
+    callback.assert_called_with(base_port)
+
+
+async def test_start_checking(base_port, port_checker_helpers, qapp):
+    port_checker, mock_process, callback = port_checker_helpers
+
+    mock_process.return_value.connections.return_value = [
+        mock_connection(base_port)
+    ]
+
+    port_checker.start_checking()
+    QtTest.QTest.qWait(port_checker.timeout_in_ms)
+
+    assert port_checker.detected_port == base_port
+    callback.assert_called_with(base_port)
+    callback.assert_called_once()
+
+
+async def test_start_checking_no_port_detected(base_port, port_checker_helpers, qapp):
+    port_checker, mock_process, callback = port_checker_helpers
+
+    port_checker.start_checking()
+    QtTest.QTest.qWait(port_checker.timeout_in_ms)
+
+    assert port_checker.detected_port is None
+
+
+def mock_connection(port):
+    mock_connection = Mock()
+    mock_connection.laddr.ip = '127.0.0.1'
+    mock_connection.laddr.port = port
+    mock_connection.status = 'LISTEN'
+    mock_connection.type = socket.SocketKind.SOCK_STREAM
+    return mock_connection

--- a/src/tribler/gui/tests/test_port_checker.py
+++ b/src/tribler/gui/tests/test_port_checker.py
@@ -8,18 +8,18 @@ from tribler.gui.port_checker import PortChecker
 
 
 @pytest.fixture(name="base_port")
-def mock_base_port():
+def fixture_base_port():
     return 52194
 
 
 @pytest.fixture(name="mock_callback")
-def mock_callback():
+def fixture_callback():
     return Mock()
 
 
 @pytest.fixture(name="port_checker_helpers")
 @patch('psutil.Process')
-def port_checker_helpers(mock_process, base_port, mock_callback):
+def fixture_port_checker_helpers(mock_process, base_port, mock_callback):
     mock_pid = 123
     check_interval_in_ms = 10
     timeout_in_ms = 100
@@ -70,7 +70,7 @@ def test_detect_port_with_in_range_connections(base_port, port_checker_helpers):
 
 
 def test_check_port_detected(base_port, port_checker_helpers):
-    port_checker, mock_process, callback = port_checker_helpers
+    port_checker, _, callback = port_checker_helpers
 
     port_checker.check_port()
     callback.assert_not_called()
@@ -98,7 +98,7 @@ async def test_start_checking(base_port, port_checker_helpers, qapp):
     callback.assert_called_once()
 
 
-async def test_start_checking_no_port_detected(base_port, port_checker_helpers, qapp):
+async def test_start_checking_no_port_detected(port_checker_helpers, qapp):
     port_checker, mock_process, callback = port_checker_helpers
 
     port_checker.start_checking()
@@ -108,9 +108,9 @@ async def test_start_checking_no_port_detected(base_port, port_checker_helpers, 
 
 
 def mock_connection(port):
-    mock_connection = Mock()
-    mock_connection.laddr.ip = '127.0.0.1'
-    mock_connection.laddr.port = port
-    mock_connection.status = 'LISTEN'
-    mock_connection.type = socket.SocketKind.SOCK_STREAM
-    return mock_connection
+    connection = Mock()
+    connection.laddr.ip = '127.0.0.1'
+    connection.laddr.port = port
+    connection.status = 'LISTEN'
+    connection.type = socket.SocketKind.SOCK_STREAM
+    return connection

--- a/src/tribler/gui/tests/test_port_checker.py
+++ b/src/tribler/gui/tests/test_port_checker.py
@@ -84,6 +84,8 @@ def test_check_port_detected(base_port, port_checker_helpers):
 
 
 async def test_start_checking(base_port, port_checker_helpers, qapp):
+    # pylint: disable=unused-argument
+    # 'qapp' is required to run this test on QT context
     port_checker, mock_process, callback = port_checker_helpers
 
     mock_process.return_value.connections.return_value = [
@@ -99,7 +101,9 @@ async def test_start_checking(base_port, port_checker_helpers, qapp):
 
 
 async def test_start_checking_no_port_detected(port_checker_helpers, qapp):
-    port_checker, mock_process, callback = port_checker_helpers
+    # pylint: disable=unused-argument
+    # 'qapp' is required to run this test on QT context
+    port_checker, _, _ = port_checker_helpers
 
     port_checker.start_checking()
     QtTest.QTest.qWait(port_checker.timeout_in_ms)


### PR DESCRIPTION
This PR adds a PortChecker class that finds the closest port opened by a process identified by given pid and the base port. 
A callback can also be set which is triggered when the port is detected.
```python3
    port_checker = PortChecker(pid, base_port, callback)
    port_checker.start_checking()

    # The detected port can be retrieved as:
    port_checker.detected_port
```
The port checker is used by the CoreManager to find the core API port. 

When the port is detected, request manager and event manager are updated so they can operate with the correct port. 

Further, it also adds two environment variables `TRIBLER_API_PORT_INITIAL` and `TRIBLER_API_PORT_DETECTED` with values initial and detected api port values. This is so that these variables will be made available in sentry report if there is a crash.

Fixes https://github.com/Tribler/tribler/issues/7137