### PR TITLE
100x speedup for full-text search queries without quality loss

### DIFF
--- a/src/tribler/core/components/metadata_store/db/store.py
+++ b/src/tribler/core/components/metadata_store/db/store.py
@@ -806,7 +806,7 @@ class MetadataStore:
 
     fts_keyword_search_re = re.compile(r'\w+', re.UNICODE)
 
-    def get_auto_complete_terms(self, text, max_terms, limit=10):
+    def get_auto_complete_terms(self, text, max_terms, limit=200):
         if not text:
             return []
 
@@ -822,11 +822,11 @@ class MetadataStore:
             titles = self.db.select("""
                 cn.title
                 FROM ChannelNode cn
-                INNER JOIN FtsIndex ON cn.rowid = FtsIndex.rowid
                 LEFT JOIN TorrentState ts ON cn.health = ts.rowid
-                WHERE FtsIndex MATCH $fts_query
+                WHERE cn.rowid in (
+                    SELECT rowid FROM FtsIndex WHERE FtsIndex MATCH $fts_query ORDER BY rowid DESC LIMIT $limit
+                )
                 ORDER BY coalesce(ts.seeders, 0) DESC
-                LIMIT $limit
             """)
 
         result = []


### PR DESCRIPTION
The full-text-search query can find hundreds of thousands of matching torrents in the database. In that case, the proper ranking and ordering of all these torrents may be pretty slow. I have seen queries that required 20 seconds for execution.

In this PR, I speed up the queries by two order magnitudes (from 20 seconds to 0.2 seconds) without a noticeable loss in quality. To do this, I perform filtering of torrents in a sequence of steps:
* First, if a direct full-text query to the database finds more than 10000 torrents, only the most recent 10000 torrents are considered.
* Among these selected torrents, the ones with known seeders get priority, and 1000 torrents are selected for further consideration. When no information about seeders is available, the most recent torrents get priority.
* The selected 1000 torrents are properly ranked by taking into account name similarity, the number of seeders and leechers, the torrent creation date, and the torrents that ranked most are shown to the user.

As a result, the query executed two hundred times faster, and as a result, a user sees torrents with a bin number of seeders and good matching for a torrent title.