### PR TITLE
Replace the `loop` fixture with the `event_loop` fixture.

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,7 +2,7 @@
 
 pytest==7.2.0
 pytest-aiohttp==1.0.4
-pytest-asyncio==0.20.1
+pytest-asyncio==0.20.2
 pytest-mock==3.10.0
 pytest-randomly==3.12.0
 pytest-timeout==2.1.0

--- a/src/tribler/core/components/knowledge/restapi/tests/test_knowledge_endpoint.py
+++ b/src/tribler/core/components/knowledge/restapi/tests/test_knowledge_endpoint.py
@@ -27,10 +27,10 @@ def knowledge_endpoint(knowledge_db):
 
 
 @pytest.fixture
-def rest_api(loop, aiohttp_client, knowledge_endpoint):
+def rest_api(event_loop, aiohttp_client, knowledge_endpoint):
     app = Application()
     app.add_subapp('/knowledge', knowledge_endpoint.app)
-    yield loop.run_until_complete(aiohttp_client(app))
+    yield event_loop.run_until_complete(aiohttp_client(app))
     app.shutdown()
 
 

--- a/src/tribler/core/components/libtorrent/restapi/tests/test_downloads_endpoint.py
+++ b/src/tribler/core/components/libtorrent/restapi/tests/test_downloads_endpoint.py
@@ -22,13 +22,13 @@ from tribler.core.utilities.unicode import hexlify
 
 
 @pytest.fixture
-def rest_api(loop, aiohttp_client, mock_dlmgr, metadata_store):  # pylint: disable=unused-argument
+def rest_api(event_loop, aiohttp_client, mock_dlmgr, metadata_store):  # pylint: disable=unused-argument
 
     endpoint = DownloadsEndpoint(mock_dlmgr, metadata_store=metadata_store)
 
     app = Application(middlewares=[error_middleware])
     app.add_subapp('/downloads', endpoint.app)
-    yield loop.run_until_complete(aiohttp_client(app))
+    yield event_loop.run_until_complete(aiohttp_client(app))
     app.shutdown()
 
 

--- a/src/tribler/core/components/libtorrent/restapi/tests/test_libtorrent_endpoint.py
+++ b/src/tribler/core/components/libtorrent/restapi/tests/test_libtorrent_endpoint.py
@@ -16,10 +16,10 @@ def endpoint(mock_dlmgr, mock_lt_session):
 
 
 @pytest.fixture
-def rest_api(loop, aiohttp_client, endpoint):  # pylint: disable=unused-argument
+def rest_api(event_loop, aiohttp_client, endpoint):  # pylint: disable=unused-argument
     app = Application(middlewares=[error_middleware])
     app.add_subapp('/libtorrent', endpoint.app)
-    yield loop.run_until_complete(aiohttp_client(app))
+    yield event_loop.run_until_complete(aiohttp_client(app))
     app.shutdown()
 
 

--- a/src/tribler/core/components/libtorrent/restapi/tests/test_torrentinfo_endpoint.py
+++ b/src/tribler/core/components/libtorrent/restapi/tests/test_torrentinfo_endpoint.py
@@ -50,10 +50,10 @@ def endpoint(download_manager):
 
 
 @pytest.fixture
-def rest_api(loop, aiohttp_client, endpoint):  # pylint: disable=unused-argument
+def rest_api(event_loop, aiohttp_client, endpoint):  # pylint: disable=unused-argument
     app = Application(middlewares=[error_middleware])
     app.add_subapp('/torrentinfo', endpoint.app)
-    yield loop.run_until_complete(aiohttp_client(app))
+    yield event_loop.run_until_complete(aiohttp_client(app))
     app.shutdown()
 
 

--- a/src/tribler/core/components/metadata_store/restapi/tests/test_channels_endpoint.py
+++ b/src/tribler/core/components/metadata_store/restapi/tests/test_channels_endpoint.py
@@ -39,7 +39,7 @@ PNG_DATA = unhexlify(
 
 
 @pytest.fixture
-def rest_api(loop, aiohttp_client, mock_dlmgr, metadata_store, knowledge_db):  # pylint: disable=unused-argument
+def rest_api(event_loop, aiohttp_client, mock_dlmgr, metadata_store, knowledge_db):  # pylint: disable=unused-argument
     mock_gigachannel_manager = Mock()
     mock_gigachannel_community = Mock()
 
@@ -57,7 +57,7 @@ def rest_api(loop, aiohttp_client, mock_dlmgr, metadata_store, knowledge_db):  #
     app = Application(middlewares=[error_middleware])
     app.add_subapp('/channels', channels_endpoint.app)
     app.add_subapp('/collections', collections_endpoint.app)
-    yield loop.run_until_complete(aiohttp_client(app))
+    yield event_loop.run_until_complete(aiohttp_client(app))
     app.shutdown()
 
 

--- a/src/tribler/core/components/metadata_store/restapi/tests/test_metadata_endpoint.py
+++ b/src/tribler/core/components/metadata_store/restapi/tests/test_metadata_endpoint.py
@@ -22,7 +22,7 @@ from tribler.core.utilities.utilities import has_bep33_support, random_infohash
 
 
 @pytest.fixture
-async def torrent_checker(loop, mock_dlmgr, metadata_store):
+async def torrent_checker(mock_dlmgr, metadata_store):
     # Initialize the torrent checker
     config = TriblerConfig()
     config.download_defaults.number_hops = 0
@@ -43,12 +43,12 @@ async def torrent_checker(loop, mock_dlmgr, metadata_store):
 
 
 @pytest.fixture
-def rest_api(loop, aiohttp_client, torrent_checker, metadata_store):  # pylint: disable=unused-argument
+def rest_api(event_loop, aiohttp_client, torrent_checker, metadata_store):  # pylint: disable=unused-argument
     endpoint = MetadataEndpoint(torrent_checker, metadata_store)
 
     app = Application(middlewares=[error_middleware])
     app.add_subapp('/metadata', endpoint.app)
-    yield loop.run_until_complete(aiohttp_client(app))
+    yield event_loop.run_until_complete(aiohttp_client(app))
     app.shutdown()
 
 

--- a/src/tribler/core/components/metadata_store/restapi/tests/test_remote_query_endpoint.py
+++ b/src/tribler/core/components/metadata_store/restapi/tests/test_remote_query_endpoint.py
@@ -31,10 +31,10 @@ def endpoint(mock_gigachannel_community, metadata_store):  # pylint: disable=W06
 
 
 @pytest.fixture
-def rest_api(loop, aiohttp_client, endpoint):  # pylint: disable=unused-argument
+def rest_api(event_loop, aiohttp_client, endpoint):  # pylint: disable=unused-argument
     app = Application(middlewares=[error_middleware])
     app.add_subapp('/remote_query', endpoint.app)
-    yield loop.run_until_complete(aiohttp_client(app))
+    yield event_loop.run_until_complete(aiohttp_client(app))
     app.shutdown()
 
 

--- a/src/tribler/core/components/metadata_store/restapi/tests/test_search_endpoint.py
+++ b/src/tribler/core/components/metadata_store/restapi/tests/test_search_endpoint.py
@@ -33,11 +33,11 @@ def needle_in_haystack_mds(metadata_store):
 
 
 @pytest.fixture
-def rest_api(loop, needle_in_haystack_mds, aiohttp_client, knowledge_db):
+def rest_api(event_loop, needle_in_haystack_mds, aiohttp_client, knowledge_db):
     channels_endpoint = SearchEndpoint(needle_in_haystack_mds, knowledge_db=knowledge_db)
     app = Application()
     app.add_subapp('/search', channels_endpoint.app)
-    yield loop.run_until_complete(aiohttp_client(app))
+    yield event_loop.run_until_complete(aiohttp_client(app))
     app.shutdown()
 
 

--- a/src/tribler/core/components/metadata_store/tests/test_channel_download.py
+++ b/src/tribler/core/components/metadata_store/tests/test_channel_download.py
@@ -26,7 +26,7 @@ def channel_tdef():
 
 
 @pytest.fixture
-async def channel_seeder(channel_tdef, loop, tmp_path_factory):  # pylint: disable=unused-argument, redefined-outer-name
+async def channel_seeder(channel_tdef, tmp_path_factory):  # pylint: disable=unused-argument, redefined-outer-name
     config = LibtorrentSettings()
     config.dht = False
     config.upnp = False

--- a/src/tribler/core/components/restapi/rest/tests/test_create_torrent_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/tests/test_create_torrent_endpoint.py
@@ -17,10 +17,10 @@ def endpoint():
 
 
 @pytest.fixture
-def rest_api(loop, aiohttp_client, endpoint):  # pylint: disable=unused-argument
+def rest_api(event_loop, aiohttp_client, endpoint):  # pylint: disable=unused-argument
     app = Application(middlewares=[error_middleware])
     app.add_subapp('/createtorrent', endpoint.app)
-    yield loop.run_until_complete(aiohttp_client(app))
+    yield event_loop.run_until_complete(aiohttp_client(app))
     app.shutdown()
 
 

--- a/src/tribler/core/components/restapi/rest/tests/test_debug_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/tests/test_debug_endpoint.py
@@ -36,12 +36,12 @@ async def core_resource_monitor(tmp_path):
 
 
 @pytest.fixture
-def rest_api(loop, aiohttp_client, mock_tunnel_community, endpoint):  # pylint: disable=unused-argument
+def rest_api(event_loop, aiohttp_client, mock_tunnel_community, endpoint):  # pylint: disable=unused-argument
     endpoint.tunnel_community = mock_tunnel_community
 
     app = Application(middlewares=[error_middleware])
     app.add_subapp('/debug', endpoint.app)
-    yield loop.run_until_complete(aiohttp_client(app))
+    yield event_loop.run_until_complete(aiohttp_client(app))
     app.shutdown()
 
 

--- a/src/tribler/core/components/restapi/rest/tests/test_events_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/tests/test_events_endpoint.py
@@ -25,8 +25,8 @@ def fixture_api_port(free_port):
 
 
 @pytest.fixture(name='notifier')
-def fixture_notifier(loop):
-    return Notifier(loop=loop)
+def fixture_notifier(event_loop):
+    return Notifier(loop=event_loop)
 
 
 @pytest.fixture(name='endpoint')

--- a/src/tribler/core/components/restapi/rest/tests/test_settings_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/tests/test_settings_endpoint.py
@@ -21,10 +21,10 @@ def endpoint(tribler_config):
 
 
 @pytest.fixture
-def rest_api(loop, aiohttp_client, endpoint):  # pylint: disable=unused-argument
+def rest_api(event_loop, aiohttp_client, endpoint):  # pylint: disable=unused-argument
     app = Application(middlewares=[error_middleware])
     app.add_subapp('/settings', endpoint.app)
-    yield loop.run_until_complete(aiohttp_client(app))
+    yield event_loop.run_until_complete(aiohttp_client(app))
     app.shutdown()
 
 

--- a/src/tribler/core/components/restapi/rest/tests/test_shutdown_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/tests/test_shutdown_endpoint.py
@@ -14,10 +14,10 @@ def endpoint():
 
 
 @pytest.fixture
-def rest_api(loop, aiohttp_client, endpoint):  # pylint: disable=unused-argument
+def rest_api(event_loop, aiohttp_client, endpoint):  # pylint: disable=unused-argument
     app = Application(middlewares=[error_middleware])
     app.add_subapp('/shutdown', endpoint.app)
-    yield loop.run_until_complete(aiohttp_client(app))
+    yield event_loop.run_until_complete(aiohttp_client(app))
     app.shutdown()
 
 

--- a/src/tribler/core/components/restapi/rest/tests/test_statistics_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/tests/test_statistics_endpoint.py
@@ -30,10 +30,10 @@ def endpoint():
 
 
 @pytest.fixture
-def rest_api(loop, aiohttp_client, endpoint):  # pylint: disable=unused-argument
+def rest_api(event_loop, aiohttp_client, endpoint):  # pylint: disable=unused-argument
     app = Application(middlewares=[error_middleware])
     app.add_subapp('/statistics', endpoint.app)
-    yield loop.run_until_complete(aiohttp_client(app))
+    yield event_loop.run_until_complete(aiohttp_client(app))
     app.shutdown()
 
 

--- a/src/tribler/core/components/restapi/rest/tests/test_trustview_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/tests/test_trustview_endpoint.py
@@ -22,10 +22,10 @@ def endpoint(bandwidth_db):  # pylint: disable=W0621
 
 
 @pytest.fixture
-def rest_api(loop, aiohttp_client, endpoint):  # pylint: disable=unused-argument
+def rest_api(event_loop, aiohttp_client, endpoint):  # pylint: disable=unused-argument
     app = Application(middlewares=[error_middleware])
     app.add_subapp('/trustview', endpoint.app)
-    yield loop.run_until_complete(aiohttp_client(app))
+    yield event_loop.run_until_complete(aiohttp_client(app))
     app.shutdown()
 
 

--- a/src/tribler/core/components/socks_servers/socks5/tests/test_connection.py
+++ b/src/tribler/core/components/socks_servers/socks5/tests/test_connection.py
@@ -37,9 +37,9 @@ class MockTransport(MockObject):
 
 
 @pytest.fixture
-def connection(loop):
+def connection(event_loop):
     connection = Socks5Connection(None)
-    connection.transport = MockTransport(loop)
+    connection.transport = MockTransport(event_loop)
     yield connection
     if connection.udp_connection:  # Close opened UDP sockets
         connection.udp_connection.close()

--- a/src/tribler/core/components/tests/test_base_component.py
+++ b/src/tribler/core/components/tests/test_base_component.py
@@ -116,7 +116,7 @@ async def test_component_shutdown_failure(tribler_config):
         assert component.stopped
 
 
-async def test_maybe_component(loop, tribler_config):  # pylint: disable=unused-argument
+async def test_maybe_component(tribler_config):  # pylint: disable=unused-argument
     session = Session(tribler_config, [ComponentA()])
     async with session:
         component_a = await session.get_instance(ComponentA).maybe_component(ComponentA)

--- a/src/tribler/core/conftest.py
+++ b/src/tribler/core/conftest.py
@@ -1,6 +1,6 @@
 import asyncio
 import os
-import os
+import platform
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -232,9 +232,16 @@ def test_tdef(state_dir):
     return tdef
 
 
-@pytest.fixture()
-def loop():
-    return asyncio.get_event_loop()
+@pytest.fixture
+def event_loop():
+    if platform.system() == 'Windows':
+        # to prevent the "Loop is closed" error
+        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+
+    policy = asyncio.get_event_loop_policy()
+    loop = policy.new_event_loop()
+    yield loop
+    loop.close()
 
 
 @pytest.fixture

--- a/src/tribler/core/utilities/tests/test_notifier.py
+++ b/src/tribler/core/utilities/tests/test_notifier.py
@@ -241,7 +241,7 @@ def test_notify():
     assert calls == [('generic2', topic_b, 222, '{}')]
 
 
-async def test_notify_async(loop):
+async def test_notify_async(event_loop):
     def topic_a(a: int, b: str):
         pass
 
@@ -265,7 +265,7 @@ async def test_notify_async(loop):
     def generic_2(*args, **kwargs):
         calls.append((('generic2',) + args + (repr(kwargs),)))
 
-    notifier = Notifier(loop=loop)
+    notifier = Notifier(loop=event_loop)
     notifier.add_observer(topic_a, observer_a1)  # add an observer
     notifier.add_observer(topic_a, observer_a1)  # adding the same observer multiple times should affect nothing
     notifier.add_generic_observer(generic_1)     # add a generic observer
@@ -316,7 +316,7 @@ async def test_notify_async(loop):
     assert set(calls) == {('generic2', topic_b, 222, '{}')}
 
 
-async def test_notify_with_exception(loop):
+async def test_notify_with_exception(event_loop):
     # test that notify works as expected even if one of callbacks will raise an exception
 
     def topic(x: int):
@@ -346,7 +346,7 @@ async def test_notify_with_exception(loop):
     assert calls == [('observer1', 123), ('observer2', 123), ('observer3', 123)]
     calls.clear()
 
-    notifier = Notifier(loop=loop)  # Now, let's create a notifier tied to a loop
+    notifier = Notifier(loop=event_loop)  # Now, let's create a notifier tied to a loop
 
     notifier.add_observer(topic, observer1)
     notifier.add_observer(topic, observer2)
@@ -363,8 +363,8 @@ async def test_notify_with_exception(loop):
     assert set(calls) == {('observer1', 123), ('observer2', 123), ('observer3', 123)}
 
 
-def test_notify_call_soon_threadsafe_with_exception(loop):
-    notifier = Notifier(loop=loop)
+def test_notify_call_soon_threadsafe_with_exception(event_loop):
+    notifier = Notifier(loop=event_loop)
 
     notifier.logger = MagicMock()
     notifier.loop = MagicMock(call_soon_threadsafe=MagicMock(side_effect=RuntimeError))


### PR DESCRIPTION
This PR fixes the "Event loop is closed" error (occurs only on Windows):

<img width="532" alt="image" src="https://user-images.githubusercontent.com/13798583/201917199-b1555d4e-8ca5-44b1-a0b8-a1c7b17c8feb.png">

The error is a consequence of merging https://github.com/Tribler/tribler/pull/7143

The template of the `event_loop` fixture has been taken from https://github.com/pytest-dev/pytest-asyncio/releases/tag/v0.20.2.

Refs:
* https://stackoverflow.com/questions/45600579/asyncio-event-loop-is-closed-when-getting-loop
