### PR TITLE
Add `--reruns 1` for pytests

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,6 +15,13 @@ jobs:
   generate_and_upload:
     name: generate and upload
     runs-on: ubuntu-latest
+
+    env:
+      PYTEST_CORE_ARGUMENTS: ./src/tribler/core
+      PYTEST_TUNNELS_ARGUMENTS: ./src/tribler/core/components/tunnel/tests/test_full_session --tunneltests
+
+      PYTEST_COMMON_ARGUMENTS: --looptime --disable-warnings --reruns 1
+
     steps:
       - uses: actions/checkout@v3
 
@@ -27,8 +34,8 @@ jobs:
       - name: Run Pytest with Coverage
         timeout-minutes: 10
         run: |
-          coverage run --source=./src/tribler/core -p -m pytest ./src/tribler/core --looptime --exitfirst --disable-warnings
-          coverage run --source=./src/tribler/core -p -m pytest ./src/tribler/core/components/tunnel/tests/test_full_session --tunneltests --looptime --exitfirst --disable-warnings
+          coverage run --source=./src/tribler/core -p -m pytest ${PYTEST_CORE_ARGUMENTS} ${PYTEST_COMMON_ARGUMENTS}
+          coverage run --source=./src/tribler/core -p -m pytest ${PYTEST_TUNNELS_ARGUMENTS} ${PYTEST_COMMON_ARGUMENTS}
           coverage combine
           coverage xml
 

--- a/.github/workflows/guitest.yml
+++ b/.github/workflows/guitest.yml
@@ -32,7 +32,7 @@ jobs:
     timeout-minutes: 10
 
     env:
-      PYTEST_ARGUMENTS: ./src/tribler/gui --guitests --randomly-seed=1 --exitfirst --disable-warnings
+      PYTEST_ARGUMENTS: ./src/tribler/gui --guitests --randomly-seed=1 --disable-warnings --reruns 1
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -35,7 +35,7 @@ jobs:
       PYTEST_CORE_ARGUMENTS: ./src/tribler/core
       PYTEST_TUNNELS_ARGUMENTS: ./src/tribler/core/components/tunnel/tests/test_full_session --tunneltests
 
-      PYTEST_COMMON_ARGUMENTS: --exitfirst --disable-warnings
+      PYTEST_COMMON_ARGUMENTS: --disable-warnings --reruns 1
 
     steps:
       - uses: actions/checkout@v3

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -7,6 +7,7 @@ pytest-mock==3.10.0
 pytest-randomly==3.12.0
 pytest-timeout==2.1.0
 pytest-freezegun==0.4.2
+pytest-rerunfailures==10.2
 freezegun==1.2.1
 coverage==6.3.2
 looptime==0.2


### PR DESCRIPTION
This PR mask flakiness of our test suite.

Related to:
* https://github.com/Tribler/tribler/issues/7167 
* https://github.com/Tribler/tribler/issues/7164
* https://github.com/Tribler/tribler/issues/7133
* https://github.com/Tribler/tribler/issues/7063

Refs:
* https://github.com/pytest-dev/pytest-rerunfailures