### PR TITLE
Remove `asyncio` logger level specification.

### DIFF
--- a/src/tribler/core/start_core.py
+++ b/src/tribler/core/start_core.py
@@ -151,8 +151,6 @@ def run_tribler_core_session(api_port: str, api_key: str, state_dir: Path, gui_t
     log_dir = config.general.get_path_as_absolute('log_dir', config.state_dir)
     trace_logger = check_and_enable_code_tracing('core', log_dir)
 
-    logging.getLogger('asyncio').setLevel(logging.WARNING)
-
     if sys.platform.startswith('win'):
         # TODO for the moment being, we use the SelectorEventLoop on Windows, since with the ProactorEventLoop, ipv8
         # peer discovery becomes unstable. Also see issue #5485.


### PR DESCRIPTION
This PR removes the `asyncio` logger level specification to make the whole Tribler logger configuration more homogenous. 