### PR TITLE
Add `--reruns-delay 1`

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,7 +20,7 @@ jobs:
       PYTEST_CORE_ARGUMENTS: ./src/tribler/core
       PYTEST_TUNNELS_ARGUMENTS: ./src/tribler/core/components/tunnel/tests/test_full_session --tunneltests
 
-      PYTEST_COMMON_ARGUMENTS: --looptime --disable-warnings --reruns 1
+      PYTEST_COMMON_ARGUMENTS: --looptime --disable-warnings --reruns 1 --reruns-delay 1
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/guitest.yml
+++ b/.github/workflows/guitest.yml
@@ -32,7 +32,7 @@ jobs:
     timeout-minutes: 10
 
     env:
-      PYTEST_ARGUMENTS: ./src/tribler/gui --guitests --randomly-seed=1 --disable-warnings --reruns 1
+      PYTEST_ARGUMENTS: ./src/tribler/gui --guitests --randomly-seed=1 --disable-warnings --reruns 1 --reruns-delay 1
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -35,7 +35,7 @@ jobs:
       PYTEST_CORE_ARGUMENTS: ./src/tribler/core
       PYTEST_TUNNELS_ARGUMENTS: ./src/tribler/core/components/tunnel/tests/test_full_session --tunneltests
 
-      PYTEST_COMMON_ARGUMENTS: --disable-warnings --reruns 1
+      PYTEST_COMMON_ARGUMENTS: --disable-warnings --reruns 1 --reruns-delay 1
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This PR is the continuation of #7169.
It adds `--reruns-delay 1` for pytest runs to increase the stability of the test suite.

https://github.com/Tribler/tribler/actions/runs/3479920176/jobs/5819063518#step:6:230

```python
src/tribler/core/components/popularity/community/tests/test_popularity_community.py . [ 89%]
...R.E.R.E.                                                              [ 90%]
src/tribler/core/components/libtorrent/tests/test_dht_health_manager.py .R [ 90%]
.E.R.E.R.E.R.E.R.E                                                       [ 90%]
src/tribler/core/upgrade/tests/test_upgrader.py ............             [ 91%]
src/tribler/core/utilities/tests/test_dependencies.py ....               [ 92%]
src/tribler/core/upgrade/tests/test_config_upgrade_to_76.py .            [ 92%]
src/tribler/core/components/ipv8/eva/tests/test_protocol.py .R.E.R.E.R.E [ 92%]
.R.E.R.E.R.E.R.E.R.E.R.E.R.E.R.E.R.E.R.E.R.E.R.E.R.E.R.E.R.E.R.E.R.E.R.E [ 94%]
.R.E.R.E.R.E.R.E.R.E.R.E.R.E.R.E.R.E                                     [ 94%]
src/tribler/core/components/socks_servers/socks5/tests/test_conversion.py . [ 94%]
...                                                                      [ 95%]
src/tribler/core/utilities/tests/test_osutils.py .......                 [ 95%]
src/tribler/core/components/socks_servers/socks5/tests/test_connection.py .R [ 95%]
.E.R.E.R.E.R.E.R.E.R.E.R.E                                               [ 96%]
src/tribler/core/components/knowledge/tests/test_knowledge_component.py .R [ 96%]
.E                                                                       [ 96%]
```

Refs:
* https://pypi.org/project/pytest-rerunfailures/#toc-entry-5