### PR TITLE
Extract environment variables into `shared.env`

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,12 +16,6 @@ jobs:
     name: generate and upload
     runs-on: ubuntu-latest
 
-    env:
-      PYTEST_CORE_ARGUMENTS: ./src/tribler/core
-      PYTEST_TUNNELS_ARGUMENTS: ./src/tribler/core/components/tunnel/tests/test_full_session --tunneltests
-
-      PYTEST_COMMON_ARGUMENTS: --looptime --disable-warnings --reruns 1 --reruns-delay 1
-
     steps:
       - uses: actions/checkout@v3
 
@@ -31,11 +25,23 @@ jobs:
           python-version: ${{inputs.python-version}}
           requirements: requirements-test.txt
 
+      - name: Export env
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: ./.github/workflows/vars/pytest.env
+          expand: true
+
+      - name: Add --looptime
+        if: runner.os != 'Windows'
+        run: |
+          echo "PYTEST_CORE_ARGUMENTS=${PYTEST_CORE_ARGUMENTS} --looptime" >> $GITHUB_ENV
+          echo "PYTEST_TUNNELS_ARGUMENTS=${PYTEST_TUNNELS_ARGUMENTS} --looptime" >> $GITHUB_ENV
+
       - name: Run Pytest with Coverage
         timeout-minutes: 10
         run: |
-          coverage run --source=./src/tribler/core -p -m pytest ${PYTEST_CORE_ARGUMENTS} ${PYTEST_COMMON_ARGUMENTS}
-          coverage run --source=./src/tribler/core -p -m pytest ${PYTEST_TUNNELS_ARGUMENTS} ${PYTEST_COMMON_ARGUMENTS}
+          coverage run --source=./src/tribler/core -p -m pytest ${PYTEST_CORE_ARGUMENTS}
+          coverage run --source=./src/tribler/core -p -m pytest ${PYTEST_TUNNELS_ARGUMENTS}
           coverage combine
           coverage xml
 

--- a/.github/workflows/guitest.yml
+++ b/.github/workflows/guitest.yml
@@ -31,9 +31,6 @@ jobs:
 
     timeout-minutes: 10
 
-    env:
-      PYTEST_ARGUMENTS: ./src/tribler/gui --guitests --randomly-seed=1 --disable-warnings --reruns 1 --reruns-delay 1
-
     steps:
       - uses: actions/checkout@v3
 
@@ -56,22 +53,28 @@ jobs:
         if: runner.os == 'Linux'
         uses: pyvista/setup-headless-display-action@v1
 
+      - name: Export env
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: ./.github/workflows/vars/pytest.env
+          expand: true
+
       - name: Add --looptime
         if: runner.os != 'Windows'
         run: |
-          echo "PYTEST_ARGUMENTS=$PYTEST_ARGUMENTS --looptime" >> $GITHUB_ENV
+          echo "PYTEST_GUI_ARGUMENTS=${PYTEST_GUI_ARGUMENTS} --looptime" >> $GITHUB_ENV
 
       - name: Run GUI tests
         if: ${{!inputs.enable-profiling}}
         run: |
-          pytest ${PYTEST_ARGUMENTS}
+          pytest ${PYTEST_GUI_ARGUMENTS}
 
       - name: Run GUI tests (Profiler)
         if: ${{inputs.enable-profiling}}
         uses: ./.github/actions/profile
         with:
           artifact_name: guitests_prof.svg
-          arguments: ${PYTEST_ARGUMENTS}
+          arguments: ${PYTEST_GUI_ARGUMENTS}
 
       - uses: actions/upload-artifact@v3
         if: always()

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -31,12 +31,6 @@ jobs:
 
     timeout-minutes: 10
 
-    env:
-      PYTEST_CORE_ARGUMENTS: ./src/tribler/core
-      PYTEST_TUNNELS_ARGUMENTS: ./src/tribler/core/components/tunnel/tests/test_full_session --tunneltests
-
-      PYTEST_COMMON_ARGUMENTS: --disable-warnings --reruns 1 --reruns-delay 1
-
     steps:
       - uses: actions/checkout@v3
 
@@ -50,31 +44,38 @@ jobs:
         if: runner.os == 'Windows'
         uses: ./.github/actions/windows_dependencies
 
+      - name: Export env
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: ./.github/workflows/vars/pytest.env
+          expand: true
+
       - name: Add --looptime
         if: runner.os != 'Windows'
         run: |
-          echo "PYTEST_COMMON_ARGUMENTS=$PYTEST_COMMON_ARGUMENTS --looptime" >> $GITHUB_ENV
+          echo "PYTEST_CORE_ARGUMENTS=${PYTEST_CORE_ARGUMENTS} --looptime" >> $GITHUB_ENV
+          echo "PYTEST_TUNNELS_ARGUMENTS=${PYTEST_TUNNELS_ARGUMENTS} --looptime" >> $GITHUB_ENV
 
       - name: Run Pytest
         if: ${{!inputs.enable_profiling}}
         run: |
-          pytest ${PYTEST_CORE_ARGUMENTS} ${PYTEST_COMMON_ARGUMENTS}
+          pytest ${PYTEST_CORE_ARGUMENTS}
 
       - name: Run Pytest (Profiler)
         if: ${{inputs.enable_profiling}}
         uses: ./.github/actions/profile
         with:
           artifact_name: pytest_prof.svg
-          arguments: ${PYTEST_CORE_ARGUMENTS} ${PYTEST_COMMON_ARGUMENTS}
+          arguments: ${PYTEST_CORE_ARGUMENTS}
 
       - name: Run Tunnels Tests
         if: ${{!inputs.enable_profiling}}
         run: |
-          pytest ${PYTEST_TUNNELS_ARGUMENTS} ${PYTEST_COMMON_ARGUMENTS}
+          pytest ${PYTEST_TUNNELS_ARGUMENTS}
 
       - name: Run Tunnel Tests (Profiler)
         if: ${{inputs.enable_profiling}}
         uses: ./.github/actions/profile
         with:
           artifact_name: tunneltest_prof.svg
-          arguments: ${PYTEST_TUNNELS_ARGUMENTS} ${PYTEST_COMMON_ARGUMENTS}
+          arguments: ${PYTEST_TUNNELS_ARGUMENTS}

--- a/.github/workflows/pytest_custom_ipv8.yml
+++ b/.github/workflows/pytest_custom_ipv8.yml
@@ -1,6 +1,23 @@
 name: Run pytest with custom ipv8 version
 
 on:
+  workflow_call:
+    inputs:
+      python-version:
+        default: '3.8'
+        type: string
+        required: true
+
+      matrix:
+        default: '{"os":["windows-latest", "macos-latest", "ubuntu-latest"]}'
+        type: string
+        required: false
+
+      ipv8-git-ref:
+        default: 'master'
+        type: string
+        required: true
+
   workflow_dispatch:
     inputs:
       python-version:
@@ -8,6 +25,11 @@ on:
         default: '3.8'
         type: string
         required: true
+
+      matrix:
+        default: '{"os":["windows-latest", "macos-latest", "ubuntu-latest"]}'
+        type: string
+        required: false
 
       ipv8-git-ref:
         description: IPv8 Git Ref
@@ -19,41 +41,51 @@ jobs:
   run:
     runs-on: ${{ matrix.os }}
     strategy:
-      matrix:
-        os: [ macos-latest, windows-latest, ubuntu-latest ]
-        include:
-          - os: macos-latest
-            pytest-arguments: --timeout=300 --looptime
-          - os: windows-latest
-            pytest-arguments: --timeout=300
-          - os: ubuntu-latest
-            pytest-arguments: --timeout=60 --looptime
+      fail-fast: false
+      matrix: ${{fromJson(inputs.matrix)}}
+
+    defaults:
+      run:
+        shell: bash
+
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v4
+      - name: Create python environment
+        uses: ./.github/actions/pyenv
         with:
           python-version: ${{inputs.python-version}}
-
-      - name: Install pip dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements-test.txt
+          requirements: requirements-test.txt
 
       - name: Upgrade pyipv8 to the specified version
         run: |
           python -m pip install --upgrade pyipv8@git+https://github.com/Tribler/py-ipv8.git@${{inputs.ipv8-git-ref}}
           python -m pip show pyipv8
 
-      - name: Install windows dependencies
+      - name: Install dependencies (Windows)
         if: runner.os == 'Windows'
         uses: ./.github/actions/windows_dependencies
 
-      - name: Run Pytest
+      - name: Export env
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: ./.github/workflows/vars/pytest.env
+          expand: true
+
+      - name: Add --looptime
+        if: runner.os != 'Windows'
         run: |
-          pytest ./src/tribler/core ${{matrix.pytest-arguments}}
+          echo "PYTEST_CORE_ARGUMENTS=${PYTEST_CORE_ARGUMENTS} --looptime" >> $GITHUB_ENV
+          echo "PYTEST_TUNNELS_ARGUMENTS=${PYTEST_TUNNELS_ARGUMENTS} --looptime" >> $GITHUB_ENV
+
+      - name: Run Pytest
+        if: ${{!inputs.enable_profiling}}
+        run: |
+          pytest ${PYTEST_CORE_ARGUMENTS}
 
       - name: Run Tunnels Tests
+        if: ${{!inputs.enable_profiling}}
         run: |
-          pytest ./src/tribler/core/components/tunnel/tests/test_full_session --tunneltests ${{matrix.pytest-arguments}}
+          pytest ${PYTEST_TUNNELS_ARGUMENTS}

--- a/.github/workflows/vars/pytest.env
+++ b/.github/workflows/vars/pytest.env
@@ -1,0 +1,5 @@
+PYTEST_COMMON_ARGUMENTS='--randomly-seed=1  --disable-warnings --reruns 1 --reruns-delay 1'
+
+PYTEST_CORE_ARGUMENTS='./src/tribler/core ${PYTEST_COMMON_ARGUMENTS}'
+PYTEST_TUNNELS_ARGUMENTS='./src/tribler/core/components/tunnel/tests/test_full_session --tunneltests ${PYTEST_COMMON_ARGUMENTS}'
+PYTEST_GUI_ARGUMENTS='./src/tribler/gui --guitests ${PYTEST_COMMON_ARGUMENTS}'


### PR DESCRIPTION
During the past two months, we made a lot of small changes to pytest runs. To minimize errors related to these changes (like mistypes), we should leave only one place for defining pytest arguments.

Also this PR updates `pytest_custom_ipv8.yml` and `coverage.yml` to align them to the common style.