### PR TITLE
Add `pytest-sentry` for pytest runs

### DIFF
--- a/.github/workflows/!PR.yml
+++ b/.github/workflows/!PR.yml
@@ -1,7 +1,7 @@
 name: PR
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - synchronize
@@ -45,21 +45,35 @@ jobs:
               - 'build/**'
               - 'src/**'
               - 'requirements*'
-  
-  
+
+  gatekeeper: # check user's permissions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if user has write access
+        uses: lannonbr/repo-permission-check-action@2bb8c89ba8bf115c4bfab344d6a6f442b24c9a1f
+        with:
+          permission: write
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # ----------------------------------------------------------------------------
   # PR is Draft and PR is Ready
   pytest:
-    needs: changes
+    needs: [changes, gatekeeper]
     if: ${{ needs.changes.outputs.src == 'true' }}
     uses: ./.github/workflows/pytest.yml
+    secrets:
+      PYTEST_SENTRY_DSN: ${{secrets.PYTEST_SENTRY_DSN}}
     with:
       python-version: 3.8
       matrix: '{"os": ["windows-latest"]}'
 
   guitest:
-    needs: changes
+    needs: [ changes, gatekeeper ]
     if: ${{ needs.changes.outputs.src == 'true' }}
     uses: ./.github/workflows/guitest.yml
+    secrets:
+      PYTEST_SENTRY_DSN: ${{secrets.PYTEST_SENTRY_DSN}}
     with:
       python-version: 3.8
       matrix: '{"os": ["windows-latest"]}'
@@ -72,25 +86,33 @@ jobs:
       python-version: 3.8
 
   coverage:
-    needs: changes
+    needs: [ changes, gatekeeper ]
     if: ${{ needs.changes.outputs.src == 'true' }}
     uses: ./.github/workflows/coverage.yml
+    secrets:
+      PYTEST_SENTRY_DSN: ${{secrets.PYTEST_SENTRY_DSN}}
+      CODACY_PROJECT_TOKEN: ${{secrets.CODACY_PROJECT_TOKEN}}
     with:
       python-version: 3.8
 
+  # ----------------------------------------------------------------------------
   # PR is Ready only
   pytest_nix:
-    needs: changes
+    needs: [changes, gatekeeper]
     if: ${{needs.changes.outputs.src == 'true' && !github.event.pull_request.draft}}
     uses: ./.github/workflows/pytest.yml
+    secrets:
+      PYTEST_SENTRY_DSN: ${{secrets.PYTEST_SENTRY_DSN}}
     with:
       python-version: 3.8
       matrix: '{"os": ["macos-latest", "ubuntu-latest"]}'
 
   guitest_nix:
-    needs: changes
+    needs: [changes, gatekeeper]
     if: ${{needs.changes.outputs.src == 'true' && !github.event.pull_request.draft}}
     uses: ./.github/workflows/guitest.yml
+    secrets:
+      PYTEST_SENTRY_DSN: ${{secrets.PYTEST_SENTRY_DSN}}
     with:
       python-version: 3.8
       matrix: '{"os": ["macos-latest", "ubuntu-latest"]}'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,11 +10,16 @@ on:
     secrets:
       CODACY_PROJECT_TOKEN:
         required: false
+      PYTEST_SENTRY_DSN:
+        required: false
 
 jobs:
   generate_and_upload:
     name: generate and upload
     runs-on: ubuntu-latest
+
+    env:
+      PYTEST_SENTRY_DSN: ${{secrets.PYTEST_SENTRY_DSN}}
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/guitest.yml
+++ b/.github/workflows/guitest.yml
@@ -18,6 +18,10 @@ on:
         type: boolean
         required: false
 
+    secrets:
+      PYTEST_SENTRY_DSN:
+        required: false
+
 jobs:
   run:
     runs-on: ${{ matrix.os }}
@@ -28,6 +32,9 @@ jobs:
     defaults:
       run:
         shell: bash
+
+    env:
+      PYTEST_SENTRY_DSN: ${{secrets.PYTEST_SENTRY_DSN}}
 
     timeout-minutes: 10
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -18,6 +18,10 @@ on:
         type: boolean
         required: false
 
+    secrets:
+      PYTEST_SENTRY_DSN:
+        required: false
+
 jobs:
   run:
     runs-on: ${{ matrix.os }}
@@ -28,6 +32,9 @@ jobs:
     defaults:
       run:
         shell: bash
+
+    env:
+      PYTEST_SENTRY_DSN: ${{secrets.PYTEST_SENTRY_DSN}}
 
     timeout-minutes: 10
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -8,6 +8,9 @@ pytest-randomly==3.12.0
 pytest-timeout==2.1.0
 pytest-freezegun==0.4.2
 pytest-rerunfailures==10.2
+pytest-sentry==0.1.10
+pytest-profiling==1.7.0 # for pytest profiling
+
 freezegun==1.2.1
 coverage==6.3.2
 looptime==0.2
@@ -15,5 +18,3 @@ looptime==0.2
 asynctest==0.13.0 # this library has to be installed to properly work with ipv8 TestBase.
 
 scipy==1.8.0
-
-pytest-profiling==1.7.0 # for pytest profiling


### PR DESCRIPTION
This PR helps us to collect statistics about flaky tests.

> Let's say you have a testsuite with some flaky tests that randomly break your CI build due to network issues, race conditions or other stuff that you don't want to fix immediately. The known workaround is to retry those tests automatically, for example using [pytest-rerunfailures](https://github.com/pytest-dev/pytest-rerunfailures).
One concern against plugins like this is that they just hide the bugs in your testsuite or even other code. After all your CI build is green and your code probably works most of the time.
pytest-sentry tries to make that choice a bit easier by tracking flaky test failures in a place separate from your build status. Sentry is already a good choice for keeping tabs on all kinds of errors, important or not, in production, so let's try to use it in testsuites too.

For the `pytest-sentry` it is necessary to specify `PYTEST_SENTRY_DSN`. 
There are several options for implementing it in our GitHub Actions. We discussed all of them within the `dev` team and came to a conclusion to store the `PYTEST_SENTRY_DSN` as a repository secret. 
For the secret to be accessible from `!PR.yml` it is necessary to change the environment in which this workflow runs from unprivileged to privileged (from `pull_request` to `pull_request_target`). To protect access from the forks PR to the main secrets, the `gatekeeper` job was introduced. 
It is only possible to pass the gatekeeper for users with the "write" (or higher) permission.

In the case, the user doesn't have write access, the gatekeeper will not allow the user to perform some of the tests:

<img width="603" alt="image" src="https://user-images.githubusercontent.com/13798583/203260668-3f936459-375a-4027-9b3a-7cd6143d11d4.png">


Related:
* https://github.com/Tribler/tribler/issues/7164
* https://github.com/Tribler/tribler/issues/7134
* https://github.com/Tribler/tribler/issues/7111
* https://github.com/Tribler/tribler/issues/7063

Refs: 
* https://github.com/getsentry/pytest-sentry
* https://nathandavison.com/blog/github-actions-and-the-threat-of-malicious-pull-requests
* https://blog.gitguardian.com/github-actions-security-cheat-sheet/
* https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
* https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
* https://github.com/lannonbr/repo-permission-check-action
* https://docs.github.com/en/actions/using-workflows/reusing-workflows#passing-inputs-and-secrets-to-a-reusable-workflow