### PR TITLE
Refactoring of  the `tiny_tribler_service.py`

### DIFF
--- a/scripts/experiments/tunnel_community/speed_test_exit.py
+++ b/scripts/experiments/tunnel_community/speed_test_exit.py
@@ -11,9 +11,7 @@ from tribler.core.components.ipv8.ipv8_component import Ipv8Component
 from tribler.core.components.key.key_component import KeyComponent
 from tribler.core.components.restapi.restapi_component import RESTComponent
 from tribler.core.components.tunnel.tunnel_component import TunnelsComponent
-from tribler.core.config.tribler_config import TriblerConfig
 from tribler.core.utilities.tiny_tribler_service import TinyTriblerService
-from tribler.core.utilities.utilities import make_async_loop_fragile
 
 EXPERIMENT_NUM_MB = int(os.environ.get('EXPERIMENT_NUM_MB', 25))
 EXPERIMENT_NUM_CIRCUITS = int(os.environ.get('EXPERIMENT_NUM_CIRCUITS', 10))
@@ -21,18 +19,14 @@ EXPERIMENT_NUM_HOPS = int(os.environ.get('EXPERIMENT_NUM_HOPS', 1))
 
 
 class Service(TinyTriblerService, TaskManager):
-    def __init__(self, working_dir, config_path):
-        super().__init__(Service.create_config(working_dir, config_path), working_dir=working_dir,
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs,
                          components=[Ipv8Component(), KeyComponent(), RESTComponent(), TunnelsComponent()])
         TaskManager.__init__(self)
+        self.config.dht.enabled = True
+
         self.results = []
         self.output_file = 'speed_test_exit.txt'
-
-    @staticmethod
-    def create_config(working_dir, config_path):
-        config = TriblerConfig(state_dir=working_dir, file=config_path)
-        config.dht.enabled = True
-        return config
 
     def _graceful_shutdown(self):
         task = asyncio.create_task(self.on_tribler_shutdown())
@@ -92,23 +86,10 @@ class Service(TinyTriblerService, TaskManager):
         return results
 
 
-def run_experiment(arguments):
-    service = Service(working_dir=Path('.Tribler').absolute(), config_path=Path('./tribler.conf'))
-    loop = asyncio.get_event_loop()
-    if arguments.fragile:
-        make_async_loop_fragile(loop)
-
-    loop.create_task(service.start_tribler())
-    try:
-        loop.run_forever()
-    finally:
-        loop.run_until_complete(loop.shutdown_asyncgens())
-        loop.close()
-
-
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Run speed e2e experiment')
     parser.add_argument('--fragile', '-f', help='Fail at the first error', action='store_true')
-    args = parser.parse_args()
+    arguments = parser.parse_args()
 
-    run_experiment(args)
+    service = Service(state_dir=Path('.Tribler'))
+    service.run(fragile=arguments.fragile)

--- a/src/tribler/core/utilities/tiny_tribler_service.py
+++ b/src/tribler/core/utilities/tiny_tribler_service.py
@@ -6,8 +6,10 @@ from typing import List, Optional
 
 from tribler.core.components.component import Component
 from tribler.core.components.session import Session
+from tribler.core.config.tribler_config import TriblerConfig
 from tribler.core.utilities.osutils import get_root_state_directory
 from tribler.core.utilities.process_checker import ProcessChecker
+from tribler.core.utilities.utilities import make_async_loop_fragile
 
 
 class TinyTriblerService:
@@ -16,13 +18,12 @@ class TinyTriblerService:
     All overlays are disabled by default.
     """
 
-    def __init__(self, config, components: List[Component], timeout_in_sec=None, working_dir=Path('/tmp/tribler')):
+    def __init__(self, components: List[Component], timeout_in_sec=None, state_dir=Path('/tmp/tribler')):
         self.logger = logging.getLogger(self.__class__.__name__)
 
         self.session = None
         self.process_checker: Optional[ProcessChecker] = None
-        self.working_dir = working_dir
-        self.config = config
+        self.config = TriblerConfig(state_dir=state_dir.absolute())
         self.timeout_in_sec = timeout_in_sec
         self.components = components
 
@@ -32,17 +33,29 @@ class TinyTriblerService:
         It is good place to add a custom code.
         """
 
-    async def start_tribler(self):
-        self.logger.info(f'Starting tribler instance in directory: {self.working_dir}')
+    def run(self, fragile: bool = False):
+        async def start_tribler():
+            self.logger.info(f'Starting tribler instance in directory: {self.config.state_dir}')
 
-        self._check_already_running()
-        await self._start_session()
+            self._check_already_running()
+            await self._start_session()
 
-        if self.timeout_in_sec:
-            asyncio.create_task(self._terminate_by_timeout())
+            if self.timeout_in_sec:
+                asyncio.create_task(self._terminate_by_timeout())
 
-        self._enable_graceful_shutdown()
-        await self.on_tribler_started()
+            self._enable_graceful_shutdown()
+            await self.on_tribler_started()
+
+        loop = asyncio.get_event_loop()
+        if fragile:
+            make_async_loop_fragile(loop)
+
+        loop.create_task(start_tribler())
+        try:
+            loop.run_forever()
+        finally:
+            loop.run_until_complete(loop.shutdown_asyncgens())
+            loop.close()
 
     async def _start_session(self):
         self.logger.info(f"Starting Tribler session with config: {self.config}")
@@ -52,7 +65,7 @@ class TinyTriblerService:
         self.logger.info("Tribler session started")
 
     def _check_already_running(self):
-        self.logger.info(f'Check if we are already running a Tribler instance in: {self.working_dir}')
+        self.logger.info(f'Check if we are already running a Tribler instance in: {self.config.state_dir}')
 
         root_state_dir = get_root_state_directory()
         self.process_checker = ProcessChecker(root_state_dir)


### PR DESCRIPTION
The `TinyTriblerService` was introduced in 2020 and was aimed to simplify developers' work when they have to do experiments.

2 years later, we have a history of the `TinyTriblerService` usage that makes it possible to simplify work with the `TinyTriblerService` even more. Thanks for https://github.com/Tribler/tribler/pull/7105 it could be done in a safe manner.

So the most minimalistic Tribler's run now is:

```python
from pathlib import Path

from tribler.core.components.ipv8.ipv8_component import Ipv8Component
from tribler.core.components.key.key_component import KeyComponent
from tribler.core.utilities.tiny_tribler_service import TinyTriblerService

tribler = TinyTriblerService(
    working_dir=Path('.Tribler'),
    components=[
        Ipv8Component(),
        KeyComponent()
    ]
)

tribler.run()

```