### PR TITLE
Skip shutdown request clearing on Tribler shutdown

### DIFF
--- a/src/tribler/gui/core_manager.py
+++ b/src/tribler/gui/core_manager.py
@@ -14,7 +14,7 @@ from tribler.gui import gui_sentry_reporter
 from tribler.gui.app_manager import AppManager
 from tribler.gui.event_request_manager import EventRequestManager
 from tribler.gui.exceptions import CoreCrashedError
-from tribler.gui.tribler_request_manager import TriblerNetworkRequest
+from tribler.gui.tribler_request_manager import ShutdownRequest
 from tribler.gui.utilities import connect
 
 
@@ -192,8 +192,7 @@ class CoreManager(QObject):
                 else:
                     self._logger.warning("Re-sending shutdown request to Tribler Core")
 
-                TriblerNetworkRequest("shutdown", shutdown_request_processed, method="PUT",
-                                      priority=QNetworkRequest.HighPriority, on_cancel=send_shutdown_request)
+                ShutdownRequest(shutdown_request_processed, on_cancel=send_shutdown_request)
 
             send_shutdown_request(initial=True)
 

--- a/src/tribler/gui/tribler_request_manager.py
+++ b/src/tribler/gui/tribler_request_manager.py
@@ -84,8 +84,10 @@ class TriblerRequestManager(QNetworkAccessManager):
         connect(error_dialog.button_clicked, on_close)
         error_dialog.show()
 
-    def clear(self):
+    def clear(self, skip_shutdown_request=True):
         for req in list(self.requests_in_flight.values()):
+            if skip_shutdown_request and req.is_shutdown_request():
+                continue
             req.cancel_request()
 
     def evict_timed_out_requests(self):
@@ -187,6 +189,11 @@ class TriblerNetworkRequest(QObject):
 
         # Pass the newly created object to the manager singleton, so the object can be dispatched immediately
         request_manager.add_request(self)
+
+    def is_shutdown_request(self):
+        return "shutdown" in self.url \
+               and self.method == "PUT" \
+               and self.priority == QNetworkRequest.HighPriority
 
     def on_finished(self, request):
         if self.reply is None:


### PR DESCRIPTION
Tribler can get stuck on shutdown if the request to shutdown is canceled already at the GUI level. Issue and logs are present in https://github.com/Tribler/tribler/issues/7177

This PR excludes the shutdown request from being cleared while shutting down making sure that the shutdown request is sent to the Core. 

Fixes https://github.com/Tribler/tribler/issues/7177