### PR TITLE
Fix Transfer tests

### DIFF
--- a/src/tribler/core/components/ipv8/eva/transfer/tests/test_base.py
+++ b/src/tribler/core/components/ipv8/eva/transfer/tests/test_base.py
@@ -35,7 +35,7 @@ async def transfer():
     container[peer] = transfer
     yield transfer
 
-    await protocol_task_group.cancel()
+    transfer.finish()
     await protocol_task_group.wait()
 
 
@@ -143,7 +143,7 @@ async def test_finish_with_exception_and_result(transfer: Transfer):
     exception = TransferException(message='message', transfer=Mock())
 
     with pytest.raises(InvalidStateError):
-        await transfer.finish(exception=exception, result=Mock())
+        transfer.finish(exception=exception, result=Mock())
 
 
 async def test_terminate_by_timeout_task(transfer: Transfer):


### PR DESCRIPTION
This PR fixes #7192 by fixing the incorrect order of the `task_group` calls.