### PR TITLE
Check on an exception `handle.get_peer_info()`

### DIFF
--- a/src/tribler/core/components/libtorrent/download_manager/download.py
+++ b/src/tribler/core/components/libtorrent/download_manager/download.py
@@ -601,10 +601,17 @@ class Download(TaskManager):
 
         # Count DHT and PeX peers
         dht_peers = pex_peers = 0
-        for peer_info in self.handle.get_peer_info():
-            if peer_info.source & peer_info.dht:
+        peer_info = []
+
+        try:
+            peer_info = self.handle.get_peer_info()
+        except Exception as e:  # pylint: disable=broad-except
+            self._logger.exception(e)
+
+        for info in peer_info:
+            if info.source & info.dht:
                 dht_peers += 1
-            if peer_info.source & peer_info.pex:
+            if info.source & info.pex:
                 pex_peers += 1
 
         ltsession = self.dlmgr.get_session(self.config.get_hops())

--- a/src/tribler/core/components/libtorrent/tests/test_download.py
+++ b/src/tribler/core/components/libtorrent/tests/test_download.py
@@ -452,3 +452,16 @@ def test_process_alert_no_crash_exception(test_download: Download):
         # `process_alert` raises "AttributeError: 'str' object has no attribute 'category'" first
         # because the alert 'alert' has wrong type.
         test_download.process_alert('alert', 'type')
+
+
+def test_get_tracker_status_get_peer_info_error(test_download: Download):
+    """ Test that in the case `handle.get_peer_info()` raises an exception, the
+    result of `download.get_tracker_status()` be returned but without a piece of
+    information about peers.
+    """
+    test_download.handle = MagicMock(
+        is_valid=Mock(return_value=True),
+        get_peer_info=Mock(side_effect=RuntimeError)
+    )
+    status = test_download.get_tracker_status()
+    assert status


### PR DESCRIPTION
This PR fixes #7117 by skipping the information in `download.get_tracker_status()` about peers in case this information is unavailable. 