### PR TITLE
Add the `7.12.1 downloads` badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Tribler
 
 |downloads_7_0| |downloads_7_1| |downloads_7_2| |downloads_7_3| |downloads_7_4|
 |downloads_7_5| |downloads_7_6| |downloads_7_7| |downloads_7_8| |downloads_7_9|
-|downloads_7_10| |downloads_7_11|
+|downloads_7_10| |downloads_7_11| |downloads_7_12|
 
 |doi| |openhub| |discord|
 
@@ -182,6 +182,10 @@ We like to hear your feedback and suggestions. To reach out to us, you can join 
 .. |downloads_7_11| image:: https://img.shields.io/github/downloads/tribler/tribler/v7.11.0/total.svg?style=flat
      :target: https://github.com/Tribler/tribler/releases
      :alt: Downloads(7.11.0)
+
+.. |downloads_7_12| image:: https://img.shields.io/github/downloads/tribler/tribler/v7.12.1/total.svg?style=flat
+     :target: https://github.com/Tribler/tribler/releases
+     :alt: Downloads(7.12.1)
 
 .. |contributors| image:: https://img.shields.io/github/contributors/tribler/tribler.svg?style=flat
     :target: https://github.com/Tribler/tribler/graphs/contributors


### PR DESCRIPTION
This PR adds the `downloads@7.12.1 ` badge to the main readme file.

<img width="466" alt="image" src="https://user-images.githubusercontent.com/13798583/209987504-86b63511-fcc6-4e81-84ea-d7c4f262dff0.png">
