### PR TITLE
Pass the number of the opened REST API port from Core to GUI

### DIFF
--- a/src/tribler/core/components/restapi/rest/rest_manager.py
+++ b/src/tribler/core/components/restapi/rest/rest_manager.py
@@ -98,7 +98,7 @@ class RESTManager:
         """
         Starts the HTTP API with the listen port as specified in the session configuration.
         """
-        self._logger.info(f'Start {self.http_host}:{self.config.http_port}')
+        self._logger.info(f'An attempt to start REST API on {self.http_host}:{self.config.http_port}')
 
         # Not using setup_aiohttp_apispec here, as we need access to the APISpec to set the security scheme
         aiohttp_apispec = AiohttpApiSpec(
@@ -135,6 +135,7 @@ class RESTManager:
                 self.set_api_port(api_port)
                 await self.site.start()
             else:
+                self._logger.info(f"Searching for a free port starting from {api_port}")
                 bind_attempts = 0
                 while bind_attempts < 10:
                     try:

--- a/src/tribler/core/components/restapi/rest/settings.py
+++ b/src/tribler/core/components/restapi/rest/settings.py
@@ -13,6 +13,6 @@ class APISettings(TriblerConfigSection):
     https_port: int = -1
     https_certfile: str = ''
     key: Optional[str] = None
-    retry_port: bool = False
+    retry_port: bool = True
 
     _port_validator = validator('http_port', 'https_port', allow_reuse=True)(validate_port_with_minus_one)

--- a/src/tribler/gui/event_request_manager.py
+++ b/src/tribler/gui/event_request_manager.py
@@ -37,9 +37,9 @@ class EventRequestManager(QNetworkAccessManager):
 
     def __init__(self, api_port, api_key, error_handler):
         QNetworkAccessManager.__init__(self)
-        url = QUrl("http://localhost:%d/events" % api_port)
-        self.request = QNetworkRequest(url)
-        self.request.setRawHeader(b'X-Api-Key', api_key.encode('ascii'))
+        self.api_port = api_port
+        self.api_key = api_key
+        self.request = self.create_request()
         self.start_time = time.time()
         self.connect_timer = QTimer()
         self.current_event_string = ""
@@ -64,6 +64,16 @@ class EventRequestManager(QNetworkAccessManager):
         notifier.add_observer(notifications.remote_query_results, self.on_remote_query_results)
         notifier.add_observer(notifications.tribler_shutdown_state, self.on_tribler_shutdown_state)
         notifier.add_observer(notifications.report_config_error, self.on_report_config_error)
+
+    def create_request(self) -> QNetworkRequest:
+        url = QUrl(f"http://localhost:{self.api_port}/events")
+        request = QNetworkRequest(url)
+        request.setRawHeader(b'X-Api-Key', self.api_key.encode('ascii'))
+        return request
+
+    def set_api_port(self, api_port: int):
+        self.api_port = api_port
+        self.request = self.create_request()
 
     def on_events_start(self, public_key: str, version: str):
         # if public key format is changed, don't forget to change it at the core side as well

--- a/src/tribler/gui/tribler_window.py
+++ b/src/tribler/gui/tribler_window.py
@@ -202,7 +202,8 @@ class TriblerWindow(QMainWindow):
 
         self.error_handler = ErrorHandler(self)
         self.events_manager = EventRequestManager(api_port, api_key, self.error_handler)
-        self.core_manager = CoreManager(self.root_state_dir, api_port, api_key, app_manager, self.events_manager)
+        self.core_manager = CoreManager(self.root_state_dir, api_port, api_key,
+                                        app_manager, process_manager, self.events_manager)
         self.version_history = VersionHistory(self.root_state_dir)
         self.upgrade_manager = UpgradeManager(self.version_history)
         self.pending_requests = {}
@@ -1212,7 +1213,7 @@ class TriblerWindow(QMainWindow):
         e.accept()
 
     def clicked_force_shutdown(self):
-        self.core_manager.kill_core_process_and_remove_the_lock_file()
+        self.core_manager.kill_core_process()
         self.app_manager.quit_application()
 
     def clicked_skip_conversion(self):


### PR DESCRIPTION
This PR is based on @xoriole's PR #7162 and fixes #7137. What is different is the way how GUI determines the opened API port. In the current PR, GUI takes the `api_port` value from the processes database.

Previously, EventRequestManager initially attempted to connect to the already running independently launched Core. Then in case a new Core process is started, EventRequestManager immediately starts repeated attempts to connect to it.

Now, EventRequestManager connects to the launched Core only after the Core REST API manager is started. Before that, CoreManager periodically attempts to read the `api_port` value from the processes database.

In case of a crash, the API port values (an initial value suggested by GUI and an actual value used by Core) are available in the error report as part of process information (in the `last_processes` section).