### PR TITLE
Fix gui tests

### DIFF
--- a/.github/workflows/guitest.yml
+++ b/.github/workflows/guitest.yml
@@ -54,6 +54,7 @@ jobs:
       - name: Install dependencies (Linux)
         if: runner.os == 'Linux'
         run: |
+          sudo apt-get update
           sudo apt install pyqt5-dev-tools
 
       - name: Setup headless display (Linux)


### PR DESCRIPTION
This PR fixes Ubuntu GUI tests:
https://github.com/Tribler/tribler/actions/runs/3895935287/jobs/6651858598

The test is failing in this PR because the checks use the version of workflow from the main branch (after the merging they will be green).

```python
6s
Run sudo apt install pyqt5-dev-tools

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

Reading package lists...
Building dependency tree...
Reading state information...
The following additional packages will be installed:
  libdouble-conversion3 libegl-mesa0 libegl[1](https://github.com/Tribler/tribler/actions/runs/3895935287/jobs/6651858598#step:5:1) libevdev2 libinput-bin libinput10
  libmd4c0 libmtdev1 libqt5core5a libqt5dbus5 libqt5designer5 libqt5gui5
  libqt5help5 libqt5network5 libqt5printsupport5 libqt5sql5 libqt5sql5-sqlite
  libqt5svg5 libqt5test5 libqt5widgets5 libqt5xml5 libwacom-bin
  libwacom-common libwacom9 libxcb-icccm4 libxcb-image0 libxcb-keysyms1
  libxcb-randr0 libxcb-render-util0 libxcb-shape0 libxcb-util1
  libxcb-xinerama0 libxcb-xinput0 libxcb-xkb1 libxkbcommon-x11-0 python3-pyqt5
  python3-pyqt5.sip qt5-gtk-platformtheme qttranslations5-l10n
Suggested packages:
  qt5-image-formats-plugins qtwayland5
The following NEW packages will be installed:
  libdouble-conversion3 libegl-mesa0 libegl1 libevdev2 libinput-bin libinput10
  libmd4c0 libmtdev1 libqt5core5a libqt5dbus5 libqt5designer5 libqt5gui5
  libqt5help5 libqt5network5 libqt5printsupport5 libqt5sql5 libqt5sql5-sqlite
  libqt5svg5 libqt5test5 libqt5widgets5 libqt5xml5 libwacom-bin
  libwacom-common libwacom9 libxcb-icccm4 libxcb-image0 libxcb-keysyms1
  libxcb-randr0 libxcb-render-util0 libxcb-shape0 libxcb-util1
  libxcb-xinerama0 libxcb-xinput0 libxcb-xkb1 libxkbcommon-x11-0
  pyqt5-dev-tools python3-pyqt5 python3-pyqt5.sip qt5-gtk-platformtheme
  qttranslations5-l10n
0 upgraded, 40 newly installed, 0 to remove and 9 not upgraded.
Need to get 18.8 MB of archives.
After this operation, 75.6 MB of additional disk space will be used.
Get:1 http://azure.archive.ubuntu.com/ubuntu jammy/universe amd64 libdouble-conversion3 amd64 3.1.7-4 [39.0 kB]
Get:2 http://azure.archive.ubuntu.com/ubuntu jammy-updates/universe amd64 libqt5core5a amd64 5.15.3+dfsg-2ubuntu0.2 [2006 kB]
Err:3 http://azure.archive.ubuntu.com/ubuntu jammy-updates/main amd64 libegl-mesa0 amd64 22.0.5-0ubuntu0.1
  404  Not Found [IP: 52.147.219.192 80]
Get:4 http://azure.archive.ubuntu.com/ubuntu jammy/main amd64 libegl1 amd64 1.4.0-1 [28.6 kB]
Get:5 http://azure.archive.ubuntu.com/ubuntu jammy/main amd64 libevdev2 amd64 1.12.1+dfsg-1 [39.5 kB]
Get:6 http://azure.archive.ubuntu.com/ubuntu jammy/main amd64 libmtdev1 amd64 1.1.6-1build4 [14.5 kB]
Get:7 http://azure.archive.ubuntu.com/ubuntu jammy/main amd64 libwacom-common all 2.2.0-1 [54.3 kB]
Get:8 http://azure.archive.ubuntu.com/ubuntu jammy/main amd64 libwacom9 amd64 2.2.0-1 [22.0 kB]
Get:9 http://azure.archive.ubuntu.com/ubuntu jammy-updates/main amd64 libinput-bin amd64 1.20.0-1ubuntu0.1 [19.9 kB]
Get:10 http://azure.archive.ubuntu.com/ubuntu jammy-updates/main amd64 libinput10 amd64 1.20.0-1ubuntu0.1 [[13](https://github.com/Tribler/tribler/actions/runs/3895935287/jobs/6651858598#step:5:14)1 kB]
Get:11 http://azure.archive.ubuntu.com/ubuntu jammy/universe amd64 libmd4c0 amd64 0.4.8-1 [42.0 kB]
Get:12 http://azure.archive.ubuntu.com/ubuntu jammy-updates/universe amd64 libqt5dbus5 amd64 5.15.3+dfsg-2ubuntu0.2 [222 kB]
Get:13 http://azure.archive.ubuntu.com/ubuntu jammy-updates/universe amd64 libqt5network5 amd64 5.15.3+dfsg-2ubuntu0.2 [731 kB]
Get:[14](https://github.com/Tribler/tribler/actions/runs/3895935287/jobs/6651858598#step:5:15) http://azure.archive.ubuntu.com/ubuntu jammy/main amd64 libxcb-icccm4 amd64 0.4.1-1.1build2 [11.5 kB]
Get:[15](https://github.com/Tribler/tribler/actions/runs/3895935287/jobs/6651858598#step:5:16) http://azure.archive.ubuntu.com/ubuntu jammy/main amd64 libxcb-util1 amd64 0.4.0-1build2 [11.4 kB]
Get:[16](https://github.com/Tribler/tribler/actions/runs/3895935287/jobs/6651858598#step:5:17) http://azure.archive.ubuntu.com/ubuntu jammy/main amd64 libxcb-image0 amd64 0.4.0-2 [11.5 kB]
Get:[17](https://github.com/Tribler/tribler/actions/runs/3895935287/jobs/6651858598#step:5:18) http://azure.archive.ubuntu.com/ubuntu jammy/main amd64 libxcb-keysyms1 amd64 0.4.0-1build3 [8746 B]
Get:[18](https://github.com/Tribler/tribler/actions/runs/3895935287/jobs/6651858598#step:5:19) http://azure.archive.ubuntu.com/ubuntu jammy/main amd64 libxcb-randr0 amd64 1.14-3ubuntu3 [18.3 kB]
Get:[19](https://github.com/Tribler/tribler/actions/runs/3895935287/jobs/6651858598#step:5:20) http://azure.archive.ubuntu.com/ubuntu jammy/main amd64 libxcb-render-util0 amd64 0.3.9-1build3 [10.3 kB]
Get:[20](https://github.com/Tribler/tribler/actions/runs/3895935287/jobs/6651858598#step:5:21) http://azure.archive.ubuntu.com/ubuntu jammy/main amd64 libxcb-shape0 amd64 1.14-3ubuntu3 [6158 B]
Get:[21](https://github.com/Tribler/tribler/actions/runs/3895935287/jobs/6651858598#step:5:22) http://azure.archive.ubuntu.com/ubuntu jammy/main amd64 libxcb-xinerama0 amd64 1.14-3ubuntu3 [5414 B]
Get:[22](https://github.com/Tribler/tribler/actions/runs/3895935287/jobs/6651858598#step:5:23) http://azure.archive.ubuntu.com/ubuntu jammy/main amd64 libxcb-xinput0 amd64 1.14-3ubuntu3 [34.3 kB]
Get:[23](https://github.com/Tribler/tribler/actions/runs/3895935287/jobs/6651858598#step:5:24) http://azure.archive.ubuntu.com/ubuntu jammy/main amd64 libxcb-xkb1 amd64 1.14-3ubuntu3 [32.8 kB]
Get:[24](https://github.com/Tribler/tribler/actions/runs/3895935287/jobs/6651858598#step:5:25) http://azure.archive.ubuntu.com/ubuntu jammy/main amd64 libxkbcommon-x11-0 amd64 1.4.0-1 [14.4 kB]
Get:[25](https://github.com/Tribler/tribler/actions/runs/3895935287/jobs/6651858598#step:5:26) http://azure.archive.ubuntu.com/ubuntu jammy-updates/universe amd64 libqt5gui5 amd64 5.15.3+dfsg-2ubuntu0.2 [3722 kB]
Get:[26](https://github.com/Tribler/tribler/actions/runs/3895935287/jobs/6651858598#step:5:27) http://azure.archive.ubuntu.com/ubuntu jammy-updates/universe amd64 libqt5widgets5 amd64 5.15.3+dfsg-2ubuntu0.2 [2561 kB]
Get:[27](https://github.com/Tribler/tribler/actions/runs/3895935287/jobs/6651858598#step:5:28) http://azure.archive.ubuntu.com/ubuntu jammy/universe amd64 libqt5svg5 amd64 5.15.3-1 [149 kB]
Get:[28](https://github.com/Tribler/tribler/actions/runs/3895935287/jobs/6651858598#step:5:29) http://azure.archive.ubuntu.com/ubuntu jammy-updates/universe amd64 libqt5xml5 amd64 5.15.3+dfsg-2ubuntu0.2 [124 kB]
Get:[29](https://github.com/Tribler/tribler/actions/runs/3895935287/jobs/6651858598#step:5:30) http://azure.archive.ubuntu.com/ubuntu jammy/universe amd64 libqt5designer5 amd64 5.15.3-1 [2832 kB]
Get:[30](https://github.com/Tribler/tribler/actions/runs/3895935287/jobs/6651858598#step:5:31) http://azure.archive.ubuntu.com/ubuntu jammy-updates/universe amd64 libqt5sql5 amd64 5.15.3+dfsg-2ubuntu0.2 [123 kB]
Get:[31](https://github.com/Tribler/tribler/actions/runs/3895935287/jobs/6651858598#step:5:32) http://azure.archive.ubuntu.com/ubuntu jammy/universe amd64 libqt5help5 amd64 5.15.3-1 [162 kB]
Get:[32](https://github.com/Tribler/tribler/actions/runs/3895935287/jobs/6651858598#step:5:33) http://azure.archive.ubuntu.com/ubuntu jammy-updates/universe amd64 libqt5printsupport5 amd64 5.15.3+dfsg-2ubuntu0.2 [214 kB]
Get:[33](https://github.com/Tribler/tribler/actions/runs/3895935287/jobs/6651858598#step:5:34) http://azure.archive.ubuntu.com/ubuntu jammy-updates/universe amd64 libqt5sql5-sqlite amd64 5.15.3+dfsg-2ubuntu0.2 [53.0 kB]
Get:[34](https://github.com/Tribler/tribler/actions/runs/3895935287/jobs/6651858598#step:5:35) http://azure.archive.ubuntu.com/ubuntu jammy-updates/universe amd64 libqt5test5 amd64 5.15.3+dfsg-2ubuntu0.2 [152 kB]
Get:[35](https://github.com/Tribler/tribler/actions/runs/3895935287/jobs/6651858598#step:5:36) http://azure.archive.ubuntu.com/ubuntu jammy/main amd64 libwacom-bin amd64 2.2.0-1 [13.6 kB]
Get:[36](https://github.com/Tribler/tribler/actions/runs/3895935287/jobs/6651858598#step:5:37) http://azure.archive.ubuntu.com/ubuntu jammy/universe amd64 python3-pyqt5.sip amd64 12.9.1-1build1 [61.1 kB]
Get:[37](https://github.com/Tribler/tribler/actions/runs/3895935287/jobs/6651858598#step:5:38) http://azure.archive.ubuntu.com/ubuntu jammy/universe amd64 python3-pyqt5 amd64 5.15.6+dfsg-1ubuntu3 [2822 kB]
Get:[38](https://github.com/Tribler/tribler/actions/runs/3895935287/jobs/6651858598#step:5:39) http://azure.archive.ubuntu.com/ubuntu jammy/universe amd64 pyqt5-dev-tools amd64 5.15.6+dfsg-1ubuntu3 [70.0 kB]
Get:[39](https://github.com/Tribler/tribler/actions/runs/3895935287/jobs/6651858598#step:5:40) http://azure.archive.ubuntu.com/ubuntu jammy-updates/universe amd64 qt5-gtk-platformtheme amd64 5.15.3+dfsg-2ubuntu0.2 [130 kB]
Get:[40](https://github.com/Tribler/tribler/actions/runs/3895935287/jobs/6651858598#step:5:41) http://azure.archive.ubuntu.com/ubuntu jammy/universe amd64 qttranslations5-l10n all 5.15.3-1 [1983 kB]
Fetched 18.7 MB in 4s ([41](https://github.com/Tribler/tribler/actions/runs/3895935287/jobs/6651858598#step:5:42)83 kB/s)
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/m/mesa/libegl-mesa0_22.0.5-0ubuntu0.1_amd64.deb  404  Not Found [IP: 52.147.219.192 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Error: Process completed with exit code 100.
```