### PR TITLE
Update versions of Qt libraries

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 -r requirements-core.txt
 
-Pillow==9.3.0
-PyQt5==5.15.1
-PyQt5-sip==12.8.1
-pyqtgraph==0.12.3
-PyQtWebEngine==5.15.2
+Pillow==9.4.0
+PyQt5==5.15.7
+PyQt5-sip==12.11.0
+pyqtgraph==0.13.1
+PyQtWebEngine==5.15.6

--- a/tribler.spec
+++ b/tribler.spec
@@ -161,4 +161,4 @@ if sys.platform == 'darwin':
 
 # On Windows 10, we have to make sure that qwindows.dll is in the right path
 if sys.platform == 'win32':
-    shutil.copytree(os.path.join('dist', 'tribler', 'PyQt5', 'Qt', 'plugins', 'platforms'), os.path.join('dist', 'tribler', 'platforms'))
+    shutil.copytree(os.path.join('dist', 'tribler', 'PyQt5', 'Qt5', 'plugins', 'platforms'), os.path.join('dist', 'tribler', 'platforms'))


### PR DESCRIPTION
This PR updates versions of Qt libraries.

Now they are aligned with the pyqt@5 versions from the brew which makes it easier to build Tribler on Apple Silicone.

Related to: https://github.com/Tribler/tribler/issues/7252