### PR TITLE
Fix #7253: Tribler does not run if the state directory does not already exist

### DIFF
--- a/scripts/exit_node/run_exit_node.py
+++ b/scripts/exit_node/run_exit_node.py
@@ -51,7 +51,7 @@ def make_config(options) -> TriblerConfig:
         else:
             raise ValueError('ipv8_port option is not set, and HELPER_BASE/HELPER_INDEX env vars are not defined')
 
-    statedir = Path(os.path.join(get_root_state_directory(), "tunnel-%d") % ipv8_port)
+    statedir = Path(os.path.join(get_root_state_directory(create=True), "tunnel-%d") % ipv8_port)
     config = TriblerConfig.load(state_dir=statedir)
     config.tunnel_community.random_slots = options.random_slots
     config.tunnel_community.competing_slots = options.competing_slots

--- a/src/run_tribler.py
+++ b/src/run_tribler.py
@@ -79,7 +79,7 @@ if __name__ == "__main__":
     parsed_args = RunTriblerArgsParser().parse_args()
     logger.info(f'Run Tribler: {parsed_args}')
 
-    root_state_dir = get_root_state_directory()
+    root_state_dir = get_root_state_directory(create=True)
     logger.info(f'Root state dir: {root_state_dir}')
 
     api_port = os.environ.get('CORE_API_PORT')

--- a/src/run_tribler_headless.py
+++ b/src/run_tribler_headless.py
@@ -74,7 +74,7 @@ class TriblerService:
         config = TriblerConfig.load(state_dir=statedir)
 
         # Check if we are already running a Tribler instance
-        root_state_dir = get_root_state_directory()
+        root_state_dir = get_root_state_directory(create=True)
 
         current_process = TriblerProcess.current_process(ProcessKind.Core)
         self.process_manager = ProcessManager(root_state_dir, current_process)

--- a/src/tribler/core/utilities/osutils.py
+++ b/src/tribler/core/utilities/osutils.py
@@ -220,9 +220,19 @@ def merge_dir(src_dir, dest_dir):
             shutil.copy(src_file, dest_sub_dir)
 
 
-def get_root_state_directory(home_dir_postfix='.Tribler'):
+def get_root_state_directory(home_dir_postfix='.Tribler', create=False) -> Path:
     """Get the default application state directory."""
-    if 'TSTATEDIR' in os.environ:
-        path = os.environ['TSTATEDIR']
-        return Path(path) if os.path.isabs(path) else Path(os.getcwd(), path)
-    return Path(get_appstate_dir(), home_dir_postfix)
+    if state_dir := os.environ.get('TSTATEDIR'):
+        root_state_dir = Path(state_dir) if os.path.isabs(state_dir) else Path(os.getcwd(), state_dir)
+    else:
+        root_state_dir = Path(get_appstate_dir(), home_dir_postfix)
+
+    if root_state_dir.exists():
+        if not root_state_dir.is_dir():
+            raise OSError(errno.ENOTDIR, 'Root state path is not a directory', str(root_state_dir))
+    elif create:
+        root_state_dir.mkdir(parents=True, exist_ok=True)
+    else:
+        raise OSError(errno.ENOENT, 'Root directory does not exist', str(root_state_dir))
+
+    return root_state_dir

--- a/src/tribler/core/utilities/tiny_tribler_service.py
+++ b/src/tribler/core/utilities/tiny_tribler_service.py
@@ -68,7 +68,7 @@ class TinyTriblerService:
     def _check_already_running(self):
         self.logger.info(f'Check if we are already running a Tribler instance in: {self.config.state_dir}')
 
-        root_state_dir = get_root_state_directory()
+        root_state_dir = get_root_state_directory(create=True)
         current_process = TriblerProcess.current_process(ProcessKind.Core)
         self.process_manager = ProcessManager(root_state_dir, current_process)
         set_global_process_manager(self.process_manager)


### PR DESCRIPTION
This PR fixes #7253 by adding a possibility to specify the `create=True` option for `get_root_state_directory()`.

The `get_root_state_directory` function now raises an exception if the state directory does not exist or is not a directory.

Also, the `run_tribler_headless.py` script was updated to use `ProcessManager` instead of the removed `ProcessChecker`.