### PR TITLE
Downgrade `pyqtgraph` version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@
 Pillow==9.4.0
 PyQt5==5.15.7
 PyQt5-sip==12.11.0
-pyqtgraph==0.13.1
+pyqtgraph==0.12.4
 PyQtWebEngine==5.15.6


### PR DESCRIPTION
This PR fixes failed GUI tests in https://github.com/Tribler/tribler/pull/7257 and https://github.com/Tribler/tribler/pull/7259.

The root cause of the problem was the fact that `pyqtgraph` version `0.13.x` doesn't work properly with our GUI tests.