### PR TITLE
Fix workflows context

### DIFF
--- a/.github/actions/pyenv/action.yml
+++ b/.github/actions/pyenv/action.yml
@@ -16,6 +16,11 @@ inputs:
     description: 'Requirements-files to use for building the cache key'
     required: false
 
+  custom_cache_key_element:
+    default: ${{github.ref_name}}
+    description: 'Custom element that will be used when constructing the cache key'
+    required: false
+
 outputs:
   virtualenv-directory:
     description: 'The path to the restored or created virtualenv'
@@ -33,7 +38,7 @@ runs:
       id: cache-virtualenv
       with:
         requirement_files: ${{inputs.requirements-key}}
-        custom_cache_key_element: ${{github.ref_name}}:${{inputs.requirements}}
+        custom_cache_key_element: ${{inputs.custom_cache_key_element}}:${{inputs.requirements}}
 
     - name: Install pip dependencies
       if: steps.cache-virtualenv.outputs.cache-hit != 'true'
@@ -41,3 +46,8 @@ runs:
       run: |
         python -m pip install --upgrade pip
         pip install -r ${{inputs.requirements}}
+
+    - name: Print installed packages
+      shell: bash
+      run: |
+        pip list

--- a/.github/workflows/!PR.yml
+++ b/.github/workflows/!PR.yml
@@ -11,25 +11,17 @@ on:
 jobs:
   env: # setup shared env
     runs-on: ubuntu-latest
-    env:
-      # https://github.com/actions/runner-images#available-images
-      WINDOWS_IMAGE: windows-latest
-      MACOS_IMAGE: macos-latest
-      UBUNTU_IMAGE: ubuntu-latest
-
+    permissions: { }
     outputs:
       python-version: '3.8'
-      matrix-for-draft: '{"os": ["${{env.WINDOWS_IMAGE}}"]}'
-      matrix-for-ready: '{"os": ["${{env.UBUNTU_IMAGE}}", "${{env.MACOS_IMAGE}}"]}'
-      windows-image: ${{env.WINDOWS_IMAGE}}
-      ubuntu-image: ${{env.UBUNTU_IMAGE}}
-      macos-image: ${{env.MACOS_IMAGE}}
-
+      source-ref: refs/pull/${{github.event.pull_request.number}}/merge
     steps:
-      - run: echo successfully
+      - run: echo done
 
   changes: # detect changes
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       src: ${{ steps.filter.outputs.src }}
       scripts: ${{ steps.filter.outputs.scripts }}
@@ -68,6 +60,7 @@ jobs:
 
   gatekeeper: # check user's permissions
     runs-on: ubuntu-latest
+    permissions: read-all
     steps:
       - name: Check if PR has label
         id: label_check
@@ -87,33 +80,6 @@ jobs:
 
   # ----------------------------------------------------------------------------
   # PR stage: Draft
-  pytest:
-    needs: [ changes, gatekeeper, env ]
-    if: ${{ needs.changes.outputs.src == 'true' }}
-    uses: ./.github/workflows/pytest.yml
-    secrets:
-      PYTEST_SENTRY_DSN: ${{secrets.PYTEST_SENTRY_DSN}}
-    with:
-      python-version: ${{needs.env.outputs.python-version}}
-      matrix: ${{needs.env.outputs.matrix-for-draft}}
-
-  guitest:
-    needs: [ changes, gatekeeper, env ]
-    if: ${{ needs.changes.outputs.src == 'true' }}
-    uses: ./.github/workflows/guitest.yml
-    secrets:
-      PYTEST_SENTRY_DSN: ${{secrets.PYTEST_SENTRY_DSN}}
-    with:
-      python-version: ${{needs.env.outputs.python-version}}
-      matrix: ${{needs.env.outputs.matrix-for-draft}}
-
-  scripttest:
-    needs: [ changes, env ]
-    if: ${{ needs.changes.outputs.scripts == 'true' }}
-    uses: ./.github/workflows/scripttest.yml
-    with:
-      python-version: ${{needs.env.outputs.python-version}}
-
   coverage:
     needs: [ changes, gatekeeper, env ]
     if: ${{ needs.changes.outputs.src == 'true' }}
@@ -123,10 +89,31 @@ jobs:
       CODACY_PROJECT_TOKEN: ${{secrets.CODACY_PROJECT_TOKEN}}
     with:
       python-version: ${{needs.env.outputs.python-version}}
+      ref: ${{needs.env.outputs.source-ref}}
+
+  guitest:
+    needs: [ changes, gatekeeper, env ]
+    if: ${{ needs.changes.outputs.src == 'true' }}
+    uses: ./.github/workflows/guitest.yml
+    secrets:
+      PYTEST_SENTRY_DSN: ${{secrets.PYTEST_SENTRY_DSN}}
+    with:
+      python-version: ${{needs.env.outputs.python-version}}
+      matrix: '{"os": ["windows-latest"]}'
+      ref: ${{needs.env.outputs.source-ref}}
+
+  scripttest:
+    needs: [ changes, env ]
+    if: ${{ needs.changes.outputs.scripts == 'true' }}
+    uses: ./.github/workflows/scripttest.yml
+    with:
+      python-version: ${{needs.env.outputs.python-version}}
+      ref: ${{needs.env.outputs.source-ref}}
+
 
   # ----------------------------------------------------------------------------
   # PR stage: Ready
-  pytest_nix:
+  pytest:
     needs: [ changes, gatekeeper, env ]
     if: ${{needs.changes.outputs.src == 'true' && !github.event.pull_request.draft}}
     uses: ./.github/workflows/pytest.yml
@@ -134,7 +121,8 @@ jobs:
       PYTEST_SENTRY_DSN: ${{secrets.PYTEST_SENTRY_DSN}}
     with:
       python-version: ${{needs.env.outputs.python-version}}
-      matrix: ${{needs.env.outputs.matrix-for-ready}}
+      matrix: '{"os": ["windows-latest", "macos-latest"]}'
+      ref: ${{needs.env.outputs.source-ref}}
 
   guitest_nix:
     needs: [ changes, gatekeeper, env ]
@@ -144,7 +132,8 @@ jobs:
       PYTEST_SENTRY_DSN: ${{secrets.PYTEST_SENTRY_DSN}}
     with:
       python-version: ${{needs.env.outputs.python-version}}
-      matrix: ${{needs.env.outputs.matrix-for-ready}}
+      matrix: '{"os": ["ubuntu-latest", "macos-latest"]}'
+      ref: ${{needs.env.outputs.source-ref}}
 
   # build binaries
   ubuntu:
@@ -155,6 +144,7 @@ jobs:
       upload: false
       os: ${{needs.env.outputs.ubuntu-image}}
       python-version: ${{needs.env.outputs.python-version}}
+      ref: ${{needs.env.outputs.source-ref}}
 
   windows:
     needs: [ changes, env ]
@@ -164,6 +154,7 @@ jobs:
       upload: false
       os: ${{needs.env.outputs.windows-image}}
       python-version: ${{needs.env.outputs.python-version}}
+      ref: ${{needs.env.outputs.source-ref}}
 
   # check documentation build
   documentation:
@@ -172,3 +163,4 @@ jobs:
     uses: ./.github/workflows/documentation.yml
     with:
       python-version: ${{needs.env.outputs.python-version}}
+      ref: ${{needs.env.outputs.source-ref}}

--- a/.github/workflows/build_mac.yml
+++ b/.github/workflows/build_mac.yml
@@ -18,6 +18,10 @@ on:
         type: boolean
         required: false
 
+      ref:
+        type: string
+        required: true
+
   workflow_dispatch:
     inputs:
       os:
@@ -38,6 +42,9 @@ on:
         type: boolean
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ${{ github.event.inputs.os || inputs.os }}
@@ -45,7 +52,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          ref: ${{github.event.pull_request.head.sha}}
+          ref: ${{inputs.ref}}
 
       - uses: actions/setup-python@v4
         with:

--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -17,6 +17,11 @@ on:
         default: false
         type: boolean
         required: false
+
+      ref:
+        type: string
+        required: true
+
     secrets:
       SENTRY_URL:
         required: false
@@ -41,6 +46,9 @@ on:
         type: boolean
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ${{ github.event.inputs.os || inputs.os }}
@@ -48,7 +56,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          ref: ${{github.event.pull_request.head.sha}}
+          ref: ${{inputs.ref}}
 
       - name: Create python environment
         id: pyenv
@@ -56,6 +64,7 @@ jobs:
         with:
           python-version: ${{ github.event.inputs.python-version || inputs.python-version }}
           requirements: requirements-build.txt
+          custom_cache_key_element: ${{inputs.ref || github.ref_name}}
 
       - uses: ./.github/actions/save_git_info
 

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -18,6 +18,10 @@ on:
         type: boolean
         required: false
 
+      ref:
+        type: string
+        required: true
+
   workflow_dispatch:
     inputs:
       os:
@@ -38,6 +42,9 @@ on:
         type: boolean
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ${{ github.event.inputs.os || inputs.os }}
@@ -46,7 +53,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          ref: ${{github.event.pull_request.head.sha}}
+          ref: ${{inputs.ref}}
 
       - name: Modify PATH
         run: |

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -5,6 +5,10 @@ on:
     secrets:
       CODACY_PROJECT_TOKEN:
         required: true
+
+permissions:
+  contents: read
+
 jobs:
   analyse:
     runs-on: ubuntu-latest

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,11 +7,19 @@ on:
         default: 3.8
         type: string
         required: false
+
+      ref:
+        type: string
+        required: true
+
     secrets:
       CODACY_PROJECT_TOKEN:
         required: false
       PYTEST_SENTRY_DSN:
         required: false
+
+permissions:
+  contents: read
 
 jobs:
   generate_and_upload:
@@ -23,12 +31,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{inputs.ref}}
 
       - name: Create python environment
         uses: ./.github/actions/pyenv
         with:
           python-version: ${{inputs.python-version}}
           requirements: requirements-test.txt
+          custom_cache_key_element: ${{inputs.ref}}
 
       - name: Export env
         uses: cardinalby/export-env-action@v2

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -8,11 +8,20 @@ on:
         type: string
         required: false
 
+      ref:
+        type: string
+        required: true
+
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{inputs.ref}}
 
       - name: Create python environment
         uses: ./.github/actions/pyenv
@@ -20,6 +29,7 @@ jobs:
           python-version: ${{inputs.python-version}}
           requirements: ./doc/requirements.txt
           requirements-key: ./doc/requirements*.txt
+          custom_cache_key_element: ${{inputs.ref}}
 
       - name: Build documentation
         run: |

--- a/.github/workflows/guitest.yml
+++ b/.github/workflows/guitest.yml
@@ -18,9 +18,16 @@ on:
         type: boolean
         required: false
 
+      ref:
+        type: string
+        required: true
+
     secrets:
       PYTEST_SENTRY_DSN:
         required: false
+
+permissions:
+  contents: read
 
 jobs:
   run:
@@ -40,12 +47,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{inputs.ref}}
 
       - name: Create python environment
         uses: ./.github/actions/pyenv
         with:
           python-version: ${{inputs.python-version}}
           requirements: requirements-test.txt
+          custom_cache_key_element: ${{inputs.ref}}
 
       - name: Install dependencies (Win)
         if: runner.os == 'Windows'

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -18,9 +18,16 @@ on:
         type: boolean
         required: false
 
+      ref:
+        type: string
+        required: true
+
     secrets:
       PYTEST_SENTRY_DSN:
         required: false
+
+permissions:
+  contents: read
 
 jobs:
   run:
@@ -40,12 +47,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{inputs.ref}}
 
       - name: Create python environment
         uses: ./.github/actions/pyenv
         with:
           python-version: ${{inputs.python-version}}
           requirements: requirements-test.txt
+          custom_cache_key_element: ${{inputs.ref}}
 
       - name: Install dependencies (Windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/pytest_custom_ipv8.yml
+++ b/.github/workflows/pytest_custom_ipv8.yml
@@ -37,6 +37,9 @@ on:
         type: string
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   run:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/scripttest.yml
+++ b/.github/workflows/scripttest.yml
@@ -13,18 +13,28 @@ on:
         type: string
         required: false
 
+      ref:
+        type: string
+        required: true
+
+permissions:
+  contents: read
+
 jobs:
   run:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{inputs.ref}}
 
       - name: Create python environment
         uses: ./.github/actions/pyenv
         with:
           python-version: ${{inputs.python-version}}
           requirements: requirements-core.txt
+          custom_cache_key_element: ${{inputs.ref}}
 
       - name: Set PYTHONPATH
         run: |


### PR DESCRIPTION
This PR fixes the incorrect use of [context](https://docs.github.com/en/actions/learn-github-actions/contexts) that was introduced in https://github.com/Tribler/tribler/pull/7186

Now a PR workflow is the following:
1. GitHub actions checkout the code of the target branch (usually it is `main`)
2. The gatekeeper job checks that the author of the PR has a write-access to the repo or the PR has a label `PR: safe to check`
3. GitHub actions checkout the code of the source branch
4. GitHub actions execute all the checks (with read-only permissions) by using the source branch

This PR unmask the error described here https://github.com/Tribler/tribler/pull/7265

The checks in this PR are failed. It is intended, because this fix has to be in the 'main' branch to be applied.