### PR TITLE
Fixes #7271: ValueError: "Unable to convert 222222 to QColor" in pyqtgraph/functions.py when starting run_tribler.py

### DIFF
--- a/src/tribler/gui/widgets/trustgraphpage.py
+++ b/src/tribler/gui/widgets/trustgraphpage.py
@@ -98,8 +98,8 @@ class TrustGraphPage(AddBreadcrumbOnShowMixin, QWidget):
         super().hideEvent(QHideEvent)
 
     def initialize_trust_graph(self):
-        pg.setConfigOption('background', '222222')
-        pg.setConfigOption('foreground', '555')
+        pg.setConfigOption('background', '#222222')
+        pg.setConfigOption('foreground', '#555')
         pg.setConfigOption('antialias', True)
 
         graph_layout = pg.GraphicsLayoutWidget()


### PR DESCRIPTION
This PR fixes #7271