### PR TITLE
Add macos build

### DIFF
--- a/.github/workflows/!PR.yml
+++ b/.github/workflows/!PR.yml
@@ -146,6 +146,16 @@ jobs:
       python-version: ${{needs.env.outputs.python-version}}
       ref: ${{needs.env.outputs.source-ref}}
 
+  mac:
+    needs: [ changes, env ]
+    if: ${{needs.changes.outputs.build == 'true' && !github.event.pull_request.draft}}
+    uses: ./.github/workflows/build_mac.yml
+    with:
+      upload: false
+      os: macos-latest
+      python-version: ${{needs.env.outputs.python-version}}
+      ref: ${{needs.env.outputs.source-ref}}
+
   windows:
     needs: [ changes, env ]
     if: ${{needs.changes.outputs.build == 'true' && !github.event.pull_request.draft}}

--- a/.github/workflows/build_mac.yml
+++ b/.github/workflows/build_mac.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       os:
-        default: macos-10.15
+        default: macos-latest
         type: string
         required: false
 


### PR DESCRIPTION
This PR closes #7146 by enabling mac os build as a part of PR checks.

Previously conflicting `eulagise` (perl) has been replaced by `licenseDMG.py` (python).