### PR TITLE
Add a workaround for Apple Silicon

### DIFF
--- a/doc/development/development_on_osx.rst
+++ b/doc/development/development_on_osx.rst
@@ -54,3 +54,20 @@ Help
 ~~~~
 
 If there are any problems with the guide above, please feel free to fix any errors or `create an issue <https://github.com/Tribler/tribler/issues/new>`_ so we can look into it.
+
+Apple Silicon
+-------
+There are currently no python bindings available to install from pip.
+Therefore you need to build them from source.
+
+To do this, please install openssl and boost first:
+
+.. code-block:: bash
+    brew install openssl boost boost-build boost-python3
+
+And then follow the `instruction <https://github.com/arvidn/libtorrent/blob/v1.2.18/docs/python_binding.rst>`_.
+
+This instruction was checked for the following versions:
+
+* python 3.11
+* libtorrent 1.2.18

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -17,4 +17,4 @@ looptime==0.2
 
 asynctest==0.13.0 # this library has to be installed to properly work with ipv8 TestBase.
 
-scipy==1.8.0
+scipy==1.10.0


### PR DESCRIPTION
This PR adds a workaround for building Tribler on Apple Silicon.