### PR TITLE
`Torrent Checker` refactoring

### DIFF
--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -26,3 +26,4 @@ pyipv8==2.10.0
 libtorrent==1.2.15
 file-read-backwards==2.0.0
 Brotli==1.0.9 # to prevent AttributeError on macOs: module 'brotli' has no attribute 'error' (in urllib3.response)
+human-readable==1.3.2

--- a/src/tribler/core/components/libtorrent/download_manager/dht_health_manager.py
+++ b/src/tribler/core/components/libtorrent/download_manager/dht_health_manager.py
@@ -5,7 +5,7 @@ from typing import Awaitable
 from ipv8.taskmanager import TaskManager
 
 from tribler.core.components.libtorrent.utils.libtorrent_helper import libtorrent as lt
-from tribler.core.components.torrent_checker.torrent_checker.torrentchecker_session import InfohashHealth
+from tribler.core.components.torrent_checker.torrent_checker.dataclasses import InfohashHealth
 from tribler.core.utilities.unicode import hexlify
 
 

--- a/src/tribler/core/components/libtorrent/download_manager/dht_health_manager.py
+++ b/src/tribler/core/components/libtorrent/download_manager/dht_health_manager.py
@@ -1,4 +1,5 @@
 import math
+import time
 from asyncio import Future
 from typing import Awaitable
 
@@ -64,7 +65,8 @@ class DHTHealthManager(TaskManager):
         seeders = DHTHealthManager.get_size_from_bloomfilter(bf_seeders)
         peers = DHTHealthManager.get_size_from_bloomfilter(bf_peers)
         if not self.lookup_futures[infohash].done():
-            self.lookup_futures[infohash].set_result(InfohashHealth(infohash=infohash, seeders=seeders, leechers=peers))
+            health = InfohashHealth(infohash, last_check=int(time.time()), seeders=seeders, leechers=peers)
+            self.lookup_futures[infohash].set_result(health)
 
         self.lookup_futures.pop(infohash, None)
 

--- a/src/tribler/core/components/libtorrent/download_manager/dht_health_manager.py
+++ b/src/tribler/core/components/libtorrent/download_manager/dht_health_manager.py
@@ -6,7 +6,7 @@ from typing import Awaitable
 from ipv8.taskmanager import TaskManager
 
 from tribler.core.components.libtorrent.utils.libtorrent_helper import libtorrent as lt
-from tribler.core.components.torrent_checker.torrent_checker.dataclasses import InfohashHealth
+from tribler.core.components.torrent_checker.torrent_checker.dataclasses import HealthInfo
 from tribler.core.utilities.unicode import hexlify
 
 
@@ -27,7 +27,7 @@ class DHTHealthManager(TaskManager):
         self.outstanding = {}  # Map from transaction_id to infohash
         self.lt_session = lt_session
 
-    def get_health(self, infohash, timeout=15) -> Awaitable[InfohashHealth]:
+    def get_health(self, infohash, timeout=15) -> Awaitable[HealthInfo]:
         """
         Lookup the health of a given infohash.
         :param infohash: The 20-byte infohash to lookup.
@@ -65,7 +65,7 @@ class DHTHealthManager(TaskManager):
         seeders = DHTHealthManager.get_size_from_bloomfilter(bf_seeders)
         peers = DHTHealthManager.get_size_from_bloomfilter(bf_peers)
         if not self.lookup_futures[infohash].done():
-            health = InfohashHealth(infohash, last_check=int(time.time()), seeders=seeders, leechers=peers)
+            health = HealthInfo(infohash, last_check=int(time.time()), seeders=seeders, leechers=peers)
             self.lookup_futures[infohash].set_result(health)
 
         self.lookup_futures.pop(infohash, None)

--- a/src/tribler/core/components/libtorrent/tests/test_dht_health_manager.py
+++ b/src/tribler/core/components/libtorrent/tests/test_dht_health_manager.py
@@ -5,8 +5,9 @@ from unittest.mock import Mock
 import pytest
 
 from tribler.core.components.libtorrent.download_manager.dht_health_manager import DHTHealthManager
-from tribler.core.utilities.unicode import hexlify
 
+
+# pylint: disable=redefined-outer-name
 
 @pytest.fixture
 async def dht_health_manager():
@@ -15,14 +16,12 @@ async def dht_health_manager():
     await manager.shutdown_task_manager()
 
 
-async def test_get_health(dht_health_manager):
+async def test_get_health(dht_health_manager: DHTHealthManager):
     """
     Test fetching the health of a trackerless torrent.
     """
-    response = await dht_health_manager.get_health(b'a' * 20, timeout=0.1)
-    assert isinstance(response, dict)
-    assert 'DHT' in response
-    assert response['DHT'][0]['infohash'] == hexlify(b'a' * 20)
+    health = await dht_health_manager.get_health(b'a' * 20, timeout=0.1)
+    assert health.infohash == b'a' * 20
 
 
 async def test_existing_get_health(dht_health_manager):

--- a/src/tribler/core/components/libtorrent/tests/test_download.py
+++ b/src/tribler/core/components/libtorrent/tests/test_download.py
@@ -38,7 +38,7 @@ async def test_download_resume_in_upload_mode(mock_handle, mock_download_config,
     test_download.handle.set_upload_mode.assert_called_with(test_download.get_upload_mode())
 
 
-async def test_save_resume(mock_handle, test_download, test_tdef):
+async def test_save_resume(mock_handle, test_download: Download, test_tdef):
     """
     testing call resume data alert
     """
@@ -49,7 +49,7 @@ async def test_save_resume(mock_handle, test_download, test_tdef):
     alert = Mock(resume_data={b'info-hash': test_tdef.get_infohash()})
     await test_download.save_resume_data()
     basename = hexlify(test_tdef.get_infohash()) + '.conf'
-    filename = test_download.dlmgr.get_checkpoint_dir() / basename
+    filename = test_download.download_manager.get_checkpoint_dir() / basename
     dcfg = DownloadConfig.load(str(filename))
     assert test_tdef.get_infohash() == dcfg.get_engineresumedata().get(b'info-hash')
 
@@ -78,7 +78,7 @@ def test_move_storage(mock_handle, test_download, test_tdef, test_tdef_no_metain
 async def test_save_checkpoint(test_download, test_tdef):
     await test_download.checkpoint()
     basename = hexlify(test_tdef.get_infohash()) + '.conf'
-    filename = Path(test_download.dlmgr.get_checkpoint_dir() / basename)
+    filename = Path(test_download.download_manager.get_checkpoint_dir() / basename)
     assert filename.is_file()
 
 

--- a/src/tribler/core/components/metadata_store/db/orm_bindings/torrent_state.py
+++ b/src/tribler/core/components/metadata_store/db/orm_bindings/torrent_state.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pony import orm
-from tribler.core.components.torrent_checker.torrent_checker.dataclasses import InfohashHealth
+from tribler.core.components.torrent_checker.torrent_checker.dataclasses import HealthInfo
 
 
 def define_binding(db):
@@ -21,12 +21,12 @@ def define_binding(db):
         trackers = orm.Set('TrackerState', reverse='torrents')
 
         @classmethod
-        def from_health(cls, health: InfohashHealth):
+        def from_health(cls, health: HealthInfo):
             return cls(infohash=health.infohash, seeders=health.seeders, leechers=health.leechers,
                        last_check=health.last_check)
 
-        def to_health(self) -> InfohashHealth:
-            return InfohashHealth(infohash=self.infohash, last_check=self.last_check,
-                                  seeders=self.seeders, leechers=self.leechers)
+        def to_health(self) -> HealthInfo:
+            return HealthInfo(infohash=self.infohash, last_check=self.last_check,
+                              seeders=self.seeders, leechers=self.leechers)
 
     return TorrentState

--- a/src/tribler/core/components/metadata_store/db/orm_bindings/torrent_state.py
+++ b/src/tribler/core/components/metadata_store/db/orm_bindings/torrent_state.py
@@ -26,7 +26,7 @@ def define_binding(db):
                        last_check=health.last_check)
 
         def to_health(self) -> InfohashHealth:
-            return InfohashHealth(infohash=self.infohash, seeders=self.seeders, leechers=self.leechers,
-                                  last_check=self.last_check)
+            return InfohashHealth(infohash=self.infohash, last_check=self.last_check,
+                                  seeders=self.seeders, leechers=self.leechers)
 
     return TorrentState

--- a/src/tribler/core/components/metadata_store/db/orm_bindings/torrent_state.py
+++ b/src/tribler/core/components/metadata_store/db/orm_bindings/torrent_state.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 from pony import orm
+from tribler.core.components.torrent_checker.torrent_checker.dataclasses import InfohashHealth
 
 
 def define_binding(db):
@@ -16,5 +19,14 @@ def define_binding(db):
         has_data = orm.Required(bool, default=False, sql_default='0', volatile=True)
         metadata = orm.Set('TorrentMetadata', reverse='health')
         trackers = orm.Set('TrackerState', reverse='torrents')
+
+        @classmethod
+        def from_health(cls, health: InfohashHealth):
+            return cls(infohash=health.infohash, seeders=health.seeders, leechers=health.leechers,
+                       last_check=health.last_check)
+
+        def to_health(self) -> InfohashHealth:
+            return InfohashHealth(infohash=self.infohash, seeders=self.seeders, leechers=self.leechers,
+                                  last_check=self.last_check)
 
     return TorrentState

--- a/src/tribler/core/components/metadata_store/db/store.py
+++ b/src/tribler/core/components/metadata_store/db/store.py
@@ -44,7 +44,7 @@ from tribler.core.components.metadata_store.db.serialization import (
     read_payload_with_offset,
 )
 from tribler.core.components.metadata_store.remote_query_community.payload_checker import process_payload
-from tribler.core.components.torrent_checker.torrent_checker.dataclasses import InfohashHealth
+from tribler.core.components.torrent_checker.torrent_checker.dataclasses import HealthInfo
 from tribler.core.exceptions import InvalidSignatureException
 from tribler.core.utilities.notifier import Notifier
 from tribler.core.utilities.path_util import Path
@@ -472,7 +472,7 @@ class MetadataStore:
 
         return self.process_squashed_mdblob(decompressed_data, health_info=health_info, **kwargs)
 
-    def process_torrent_health(self, health: InfohashHealth) -> bool:
+    def process_torrent_health(self, health: HealthInfo) -> bool:
         """
         Adds or updates information about a torrent health for the torrent with the specified infohash value
         :param health: a health info of a torrent
@@ -511,8 +511,8 @@ class MetadataStore:
             with db_session:
                 for payload, (seeders, leechers, last_check) in zip(payload_list, health_info):
                     if hasattr(payload, 'infohash'):
-                        health = InfohashHealth(payload.infohash, last_check=last_check,
-                                                seeders=seeders, leechers=leechers)
+                        health = HealthInfo(payload.infohash, last_check=last_check,
+                                            seeders=seeders, leechers=leechers)
                         self.process_torrent_health(health)
 
         result = []

--- a/src/tribler/core/components/metadata_store/db/store.py
+++ b/src/tribler/core/components/metadata_store/db/store.py
@@ -478,6 +478,10 @@ class MetadataStore:
         :param health: a health info of a torrent
         :return: True if a new TorrentState object was added
         """
+        if not health.is_valid():
+            self._logger.warning(f'Invalid health info ignored: {health}')
+            return False
+
         torrent_state = self.TorrentState.get_for_update(infohash=health.infohash)
         if torrent_state and health.last_check > torrent_state.last_check:
             torrent_state.set(seeders=health.seeders, leechers=health.leechers, last_check=health.last_check,

--- a/src/tribler/core/components/metadata_store/db/store.py
+++ b/src/tribler/core/components/metadata_store/db/store.py
@@ -483,8 +483,7 @@ class MetadataStore:
             torrent_state.set(seeders=health.seeders, leechers=health.leechers, last_check=health.last_check)
             self._logger.debug(f"Update health info {health}")
         elif not torrent_state:
-            self.TorrentState(infohash=health.infohash, seeders=health.seeders, leechers=health.leechers,
-                              last_check=health.last_check)
+            self.TorrentState.from_health(health)
             self._logger.debug(f"Add health info {health}")
             return True
         return False

--- a/src/tribler/core/components/metadata_store/db/store.py
+++ b/src/tribler/core/components/metadata_store/db/store.py
@@ -480,7 +480,8 @@ class MetadataStore:
         """
         torrent_state = self.TorrentState.get_for_update(infohash=health.infohash)
         if torrent_state and health.last_check > torrent_state.last_check:
-            torrent_state.set(seeders=health.seeders, leechers=health.leechers, last_check=health.last_check)
+            torrent_state.set(seeders=health.seeders, leechers=health.leechers, last_check=health.last_check,
+                              self_checked=False)
             self._logger.debug(f"Update health info {health}")
         elif not torrent_state:
             self.TorrentState.from_health(health)

--- a/src/tribler/core/components/metadata_store/db/store.py
+++ b/src/tribler/core/components/metadata_store/db/store.py
@@ -511,8 +511,8 @@ class MetadataStore:
             with db_session:
                 for payload, (seeders, leechers, last_check) in zip(payload_list, health_info):
                     if hasattr(payload, 'infohash'):
-                        health = InfohashHealth(infohash=payload.infohash, seeders=seeders, leechers=leechers,
-                                                last_check=last_check)
+                        health = InfohashHealth(payload.infohash, last_check=last_check,
+                                                seeders=seeders, leechers=leechers)
                         self.process_torrent_health(health)
 
         result = []

--- a/src/tribler/core/components/metadata_store/restapi/metadata_endpoint.py
+++ b/src/tribler/core/components/metadata_store/restapi/metadata_endpoint.py
@@ -191,24 +191,6 @@ class MetadataEndpoint(MetadataEndpointBase, UpdateEntryMixin):
                 'default': 20,
                 'required': False,
             },
-            {
-                'in': 'query',
-                'name': 'refresh',
-                'description': 'Whether or not to force a health recheck. Settings this to 0 means that the '
-                               'health of a torrent will not be checked again if it was recently checked.',
-                'type': 'integer',
-                'enum': [0, 1],
-                'required': False,
-            },
-            {
-                'in': 'query',
-                'name': 'nowait',
-                'description': 'Whether or not to return immediately. If enabled, results '
-                               'will be passed through to the events endpoint.',
-                'type': 'integer',
-                'enum': [0, 1],
-                'required': False,
-            },
         ],
         responses={
             200: {

--- a/src/tribler/core/components/metadata_store/restapi/metadata_endpoint.py
+++ b/src/tribler/core/components/metadata_store/restapi/metadata_endpoint.py
@@ -1,4 +1,4 @@
-import asyncio
+from asyncio import create_task
 from binascii import unhexlify
 
 from aiohttp import ContentTypeError, web
@@ -228,6 +228,5 @@ class MetadataEndpoint(MetadataEndpointBase, UpdateEntryMixin):
             return RESTResponse({"error": f"Error processing timeout parameter '{timeout}'"}, status=HTTP_BAD_REQUEST)
 
         infohash = unhexlify(request.match_info['infohash'])
-        task = self.torrent_checker.check_torrent_health(infohash, timeout=timeout, scrape_now=True)
-        asyncio.get_event_loop().create_task(task)
+        create_task(self.torrent_checker.check_torrent_health(infohash, timeout=timeout, scrape_now=True))
         return RESTResponse({'checking': '1'})

--- a/src/tribler/core/components/metadata_store/restapi/metadata_endpoint.py
+++ b/src/tribler/core/components/metadata_store/restapi/metadata_endpoint.py
@@ -218,14 +218,11 @@ class MetadataEndpoint(MetadataEndpointBase, UpdateEntryMixin):
         },
     )
     async def get_torrent_health(self, request):
-        self._logger.info(f'Get torrent health: {request}')
-        timeout = request.query.get('timeout')
-        if not timeout:
-            timeout = TORRENT_CHECK_TIMEOUT
-        elif timeout.isdigit():
-            timeout = int(timeout)
-        else:
-            return RESTResponse({"error": f"Error processing timeout parameter '{timeout}'"}, status=HTTP_BAD_REQUEST)
+        self._logger.info(f'Get torrent health request: {request}')
+        try:
+            timeout = int(request.query.get('timeout', TORRENT_CHECK_TIMEOUT))
+        except ValueError as e:
+            return RESTResponse({"error": f"Error processing timeout parameter: {e}"}, status=HTTP_BAD_REQUEST)
 
         infohash = unhexlify(request.match_info['infohash'])
         create_task(self.torrent_checker.check_torrent_health(infohash, timeout=timeout, scrape_now=True))

--- a/src/tribler/core/components/popularity/community/payload.py
+++ b/src/tribler/core/components/popularity/community/payload.py
@@ -1,6 +1,10 @@
+from typing import List
+
 from ipv8.messaging.lazy_payload import VariablePayload, vp_compile
 from ipv8.messaging.payload_dataclass import dataclass
 from ipv8.messaging.serialization import default_serializer
+
+from tribler.core.components.torrent_checker.torrent_checker.dataclasses import InfohashHealth
 
 
 @vp_compile
@@ -40,9 +44,13 @@ class TorrentsHealthPayload(VariablePayload):
         return [payload.to_tuple() for payload in TorrentInfoFormat.from_list_bytes(value)]
 
     @classmethod
-    def create(cls, random_torrents_checked, popular_torrents_checked):
+    def create(cls, random_torrents_checked: List[InfohashHealth], popular_torrents_checked: List[InfohashHealth]):
+        random_torrent_tuples = [(health.infohash, health.seeders, health.leechers, health.last_check)
+                                 for health in random_torrents_checked]
+        popular_torrent_tuples = [(health.infohash, health.seeders, health.leechers, health.last_check)
+                                  for health in popular_torrents_checked]
         return cls(len(random_torrents_checked), len(popular_torrents_checked),
-                   random_torrents_checked, popular_torrents_checked)
+                   random_torrent_tuples, popular_torrent_tuples)
 
 
 @dataclass(msg_id=2)

--- a/src/tribler/core/components/popularity/community/payload.py
+++ b/src/tribler/core/components/popularity/community/payload.py
@@ -4,7 +4,7 @@ from ipv8.messaging.lazy_payload import VariablePayload, vp_compile
 from ipv8.messaging.payload_dataclass import dataclass
 from ipv8.messaging.serialization import default_serializer
 
-from tribler.core.components.torrent_checker.torrent_checker.dataclasses import InfohashHealth
+from tribler.core.components.torrent_checker.torrent_checker.dataclasses import HealthInfo
 
 
 @vp_compile
@@ -44,7 +44,7 @@ class TorrentsHealthPayload(VariablePayload):
         return [payload.to_tuple() for payload in TorrentInfoFormat.from_list_bytes(value)]
 
     @classmethod
-    def create(cls, random_torrents_checked: List[InfohashHealth], popular_torrents_checked: List[InfohashHealth]):
+    def create(cls, random_torrents_checked: List[HealthInfo], popular_torrents_checked: List[HealthInfo]):
         random_torrent_tuples = [(health.infohash, health.seeders, health.leechers, health.last_check)
                                  for health in random_torrents_checked]
         popular_torrent_tuples = [(health.infohash, health.seeders, health.leechers, health.last_check)

--- a/src/tribler/core/components/popularity/community/popularity_community.py
+++ b/src/tribler/core/components/popularity/community/popularity_community.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import random
 from binascii import unhexlify
+from typing import List, TYPE_CHECKING
 
 from ipv8.lazy_community import lazy_wrapper
 from pony.orm import db_session
@@ -10,6 +13,11 @@ from tribler.core.components.popularity.community.version_community_mixin import
 from tribler.core.utilities.pony_utils import run_threaded
 from tribler.core.utilities.unicode import hexlify
 from tribler.core.utilities.utilities import get_normally_distributed_positive_integers
+
+
+if TYPE_CHECKING:
+    from tribler.core.components.torrent_checker.torrent_checker.torrentchecker_session import InfohashHealth
+    from tribler.core.components.torrent_checker.torrent_checker.torrent_checker import TorrentChecker
 
 
 class PopularityCommunity(RemoteQueryCommunity, VersionCommunityMixin):
@@ -33,7 +41,7 @@ class PopularityCommunity(RemoteQueryCommunity, VersionCommunityMixin):
     def __init__(self, *args, torrent_checker=None, **kwargs):
         # Creating a separate instance of Network for this community to find more peers
         super().__init__(*args, **kwargs)
-        self.torrent_checker = torrent_checker
+        self.torrent_checker: TorrentChecker = torrent_checker
 
         self.add_message_handler(TorrentsHealthPayload, self.on_torrents_health)
         self.add_message_handler(PopularTorrentsRequest, self.on_popular_torrents_request)
@@ -50,13 +58,12 @@ class PopularityCommunity(RemoteQueryCommunity, VersionCommunityMixin):
         # Send request to peer to send popular torrents
         self.ez_send(peer, PopularTorrentsRequest())
 
-    def get_alive_checked_torrents(self):
-        if not self.torrent_checker or not self.torrent_checker.torrents_checked:
+    def get_alive_checked_torrents(self) -> List[InfohashHealth]:
+        if not self.torrent_checker:
             return []
 
         # Filter torrents that have seeders
-        alive = {(_, seeders, *rest) for (_, seeders, *rest) in self.torrent_checker.torrents_checked if seeders > 0}
-        return alive
+        return [health for health in self.torrent_checker.torrents_checked.values() if health.seeders > 0]
 
     def gossip_random_torrents_health(self):
         """
@@ -97,20 +104,20 @@ class PopularityCommunity(RemoteQueryCommunity, VersionCommunityMixin):
         popular_torrents = self.get_likely_popular_torrents()
         self.ez_send(peer, TorrentsHealthPayload.create({}, popular_torrents))
 
-    def get_likely_popular_torrents(self):
+    def get_likely_popular_torrents(self) -> List[InfohashHealth]:
         checked_and_alive = self.get_alive_checked_torrents()
         if not checked_and_alive:
-            return {}
+            return []
 
         num_torrents = len(checked_and_alive)
         num_torrents_to_send = min(PopularityCommunity.GOSSIP_RANDOM_TORRENT_COUNT, num_torrents)
         likely_popular_indices = self._get_likely_popular_indices(num_torrents_to_send, num_torrents)
 
-        sorted_torrents = sorted(list(checked_and_alive), key=lambda t: -t[1])
-        likely_popular_torrents = {sorted_torrents[i] for i in likely_popular_indices}
+        sorted_torrents = sorted(list(checked_and_alive), key=lambda health: -health.seeders)
+        likely_popular_torrents = [sorted_torrents[i] for i in likely_popular_indices]
         return likely_popular_torrents
 
-    def _get_likely_popular_indices(self, size, limit):
+    def _get_likely_popular_indices(self, size, limit) -> List[int]:
         """
         Returns a list of indices favoring the lower value numbers.
 
@@ -122,13 +129,13 @@ class PopularityCommunity(RemoteQueryCommunity, VersionCommunityMixin):
         """
         return get_normally_distributed_positive_integers(size=size, upper_limit=limit)
 
-    def get_random_torrents(self):
+    def get_random_torrents(self) -> List[InfohashHealth]:
         checked_and_alive = list(self.get_alive_checked_torrents())
         if not checked_and_alive:
-            return {}
+            return []
 
         num_torrents = len(checked_and_alive)
         num_torrents_to_send = min(PopularityCommunity.GOSSIP_RANDOM_TORRENT_COUNT, num_torrents)
 
-        random_torrents = set(random.sample(checked_and_alive, num_torrents_to_send))
+        random_torrents = random.sample(checked_and_alive, num_torrents_to_send)
         return random_torrents

--- a/src/tribler/core/components/popularity/community/popularity_community.py
+++ b/src/tribler/core/components/popularity/community/popularity_community.py
@@ -1,13 +1,11 @@
-import heapq
 import random
 from binascii import unhexlify
 
 from ipv8.lazy_community import lazy_wrapper
-
 from pony.orm import db_session
 
 from tribler.core.components.metadata_store.remote_query_community.remote_query_community import RemoteQueryCommunity
-from tribler.core.components.popularity.community.payload import TorrentsHealthPayload, PopularTorrentsRequest
+from tribler.core.components.popularity.community.payload import PopularTorrentsRequest, TorrentsHealthPayload
 from tribler.core.components.popularity.community.version_community_mixin import VersionCommunityMixin
 from tribler.core.utilities.pony_utils import run_threaded
 from tribler.core.utilities.unicode import hexlify
@@ -75,8 +73,8 @@ class PopularityCommunity(RemoteQueryCommunity, VersionCommunityMixin):
     @lazy_wrapper(TorrentsHealthPayload)
     async def on_torrents_health(self, peer, payload):
         self.logger.debug(f"Received torrent health information for "
-                         f"{len(payload.torrents_checked)} popular torrents and"
-                         f" {len(payload.random_torrents)} random torrents")
+                          f"{len(payload.torrents_checked)} popular torrents and"
+                          f" {len(payload.random_torrents)} random torrents")
 
         torrents = payload.random_torrents + payload.torrents_checked
 

--- a/src/tribler/core/components/popularity/community/popularity_community.py
+++ b/src/tribler/core/components/popularity/community/popularity_community.py
@@ -84,7 +84,7 @@ class PopularityCommunity(RemoteQueryCommunity, VersionCommunityMixin):
                           f" {len(payload.random_torrents)} random torrents")
 
         health_tuples = payload.random_torrents + payload.torrents_checked
-        health_list = [InfohashHealth(infohash, seeders=seeders, leechers=leechers, last_check=last_check)
+        health_list = [InfohashHealth(infohash, last_check=last_check, seeders=seeders, leechers=leechers)
                        for infohash, seeders, leechers, last_check in health_tuples]
 
         for infohash in await run_threaded(self.mds.db, self.process_torrents_health, health_list):

--- a/src/tribler/core/components/popularity/community/tests/test_popularity_community.py
+++ b/src/tribler/core/components/popularity/community/tests/test_popularity_community.py
@@ -1,6 +1,6 @@
 import time
 from random import randint
-from typing import Set, Tuple
+from typing import List
 from unittest.mock import Mock
 
 from ipv8.keyvault.crypto import default_eccrypto
@@ -12,12 +12,13 @@ from pony.orm import db_session
 from tribler.core.components.metadata_store.db.store import MetadataStore
 from tribler.core.components.metadata_store.remote_query_community.settings import RemoteQueryCommunitySettings
 from tribler.core.components.popularity.community.popularity_community import PopularityCommunity
+from tribler.core.components.torrent_checker.torrent_checker.torrentchecker_session import InfohashHealth
 from tribler.core.tests.tools.base_test import MockObject
 from tribler.core.utilities.path_util import Path
 from tribler.core.utilities.utilities import random_infohash
 
 
-def _generate_single_checked_torrent(status: str = None) -> Tuple:
+def _generate_single_checked_torrent(status: str = None) -> InfohashHealth:
     """
     Assumptions
     DEAD    -> peers: 0
@@ -31,12 +32,12 @@ def _generate_single_checked_torrent(status: str = None) -> Tuple:
             return randint(101, 1000)
         return randint(1, 100)
 
-    # checked torrent structure is (infohash, seeders, leechers, last_check)
-    return random_infohash(), get_peers_for(status), get_peers_for(status), int(time.time())
+    return InfohashHealth(random_infohash(), seeders=get_peers_for(status), leechers=get_peers_for(status),
+                          last_check=int(time.time()))
 
 
-def _generate_checked_torrents(count: int, status: str = None) -> Set:
-    return {_generate_single_checked_torrent(status) for _ in range(count)}
+def _generate_checked_torrents(count: int, status: str = None) -> List[InfohashHealth]:
+    return [_generate_single_checked_torrent(status) for _ in range(count)]
 
 
 class TestPopularityCommunity(TestBase):
@@ -59,7 +60,7 @@ class TestPopularityCommunity(TestBase):
                             default_eccrypto.generate_key("curve25519"))
         self.metadata_store_set.add(mds)
         torrent_checker = MockObject()
-        torrent_checker.torrents_checked = set()
+        torrent_checker.torrents_checked = {}
 
         self.count += 1
 
@@ -76,8 +77,8 @@ class TestPopularityCommunity(TestBase):
             metadata_store.TorrentState(
                 infohash=str(torrent_ind).encode() * 20, seeders=torrent_ind + 1, last_check=last_check)
 
-    async def init_first_node_and_gossip(self, checked_torrent_info, deliver_timeout=.1):
-        self.nodes[0].overlay.torrent_checker.torrents_checked.add(checked_torrent_info)
+    async def init_first_node_and_gossip(self, checked_torrent_info: InfohashHealth, deliver_timeout: float = 0.1):
+        self.nodes[0].overlay.torrent_checker.torrents_checked[checked_torrent_info.infohash] = checked_torrent_info
         await self.introduce_nodes()
 
         self.nodes[0].overlay.gossip_random_torrents_health()
@@ -88,7 +89,7 @@ class TestPopularityCommunity(TestBase):
         """
         Test whether torrent health information is correctly gossiped around
         """
-        checked_torrent_info = (b'a' * 20, 200, 0, int(time.time()))
+        checked_torrent_info = InfohashHealth(b'a' * 20, seeders=200, leechers=0, last_check=int(time.time()))
         node0_db = self.nodes[0].overlay.mds.TorrentState
         node1_db2 = self.nodes[1].overlay.mds.TorrentState
 
@@ -101,21 +102,22 @@ class TestPopularityCommunity(TestBase):
         # Check whether node 1 has new torrent health information
         with db_session:
             torrent = node1_db2.select().first()
-            assert torrent.infohash == checked_torrent_info[0]
-            assert torrent.seeders == checked_torrent_info[1]
-            assert torrent.leechers == checked_torrent_info[2]
-            assert torrent.last_check == checked_torrent_info[3]
+            assert torrent.infohash == checked_torrent_info.infohash
+            assert torrent.seeders == checked_torrent_info.seeders
+            assert torrent.leechers == checked_torrent_info.leechers
+            assert torrent.last_check == checked_torrent_info.last_check
 
     def test_get_alive_torrents(self):
         dead_torrents = _generate_checked_torrents(100, 'DEAD')
         popular_torrents = _generate_checked_torrents(100, 'POPULAR')
         alive_torrents = _generate_checked_torrents(100)
 
-        all_checked_torrents = dead_torrents | alive_torrents | popular_torrents
-        self.nodes[0].overlay.torrent_checker.torrents_checked.update(all_checked_torrents)
+        all_checked_torrents = dead_torrents + alive_torrents + popular_torrents
+        self.nodes[0].overlay.torrent_checker.torrents_checked.update(
+            {health.infohash: health for health in all_checked_torrents})
 
         actual_alive_torrents = self.nodes[0].overlay.get_alive_checked_torrents()
-        assert len(actual_alive_torrents) == len(alive_torrents | popular_torrents)
+        assert len(actual_alive_torrents) == len(alive_torrents + popular_torrents)
 
     async def test_torrents_health_gossip_multiple(self):
         """
@@ -125,7 +127,7 @@ class TestPopularityCommunity(TestBase):
         popular_torrents = _generate_checked_torrents(100, 'POPULAR')
         alive_torrents = _generate_checked_torrents(100)
 
-        all_checked_torrents = dead_torrents | alive_torrents | popular_torrents
+        all_checked_torrents = dead_torrents + alive_torrents + popular_torrents
 
         node0_db = self.nodes[0].overlay.mds.TorrentState
         node1_db = self.nodes[1].overlay.mds.TorrentState
@@ -138,7 +140,8 @@ class TestPopularityCommunity(TestBase):
             assert node1_count == 0
 
         # Setup, node 0 checks some torrents, both dead and alive (including popular ones).
-        self.nodes[0].overlay.torrent_checker.torrents_checked.update(all_checked_torrents)
+        self.nodes[0].overlay.torrent_checker.torrents_checked.update(
+            {health.infohash: health for health in all_checked_torrents})
 
         # Nodes are introduced
         await self.introduce_nodes()
@@ -177,7 +180,7 @@ class TestPopularityCommunity(TestBase):
         """
         self.fill_database(self.nodes[1].overlay.mds)
 
-        checked_torrent_info = (b'0' * 20, 200, 0, int(time.time()))
+        checked_torrent_info = InfohashHealth(b'0' * 20, seeders=200, leechers=0, last_check=int(time.time()))
         await self.init_first_node_and_gossip(checked_torrent_info, deliver_timeout=0.5)
 
         # Check whether node 1 has new torrent health information
@@ -193,7 +196,8 @@ class TestPopularityCommunity(TestBase):
         infohash = b'1' * 20
         with db_session:
             self.nodes[0].overlay.mds.TorrentMetadata(infohash=infohash)
-        await self.init_first_node_and_gossip((infohash, 200, 0, int(time.time())))
+        await self.init_first_node_and_gossip(
+            InfohashHealth(infohash, seeders=200, leechers=0, last_check=int(time.time())))
         with db_session:
             assert self.nodes[1].overlay.mds.TorrentMetadata.get()
 
@@ -204,5 +208,6 @@ class TestPopularityCommunity(TestBase):
             self.nodes[0].overlay.mds.TorrentMetadata(infohash=infohash)
             self.nodes[1].overlay.mds.TorrentMetadata(infohash=infohash)
         self.nodes[1].overlay.send_remote_select = Mock()
-        await self.init_first_node_and_gossip((infohash, 200, 0, int(time.time())))
+        await self.init_first_node_and_gossip(
+            InfohashHealth(infohash, seeders=200, leechers=0, last_check=int(time.time())))
         self.nodes[1].overlay.send_remote_select.assert_not_called()

--- a/src/tribler/core/components/popularity/community/tests/test_popularity_community.py
+++ b/src/tribler/core/components/popularity/community/tests/test_popularity_community.py
@@ -12,13 +12,13 @@ from pony.orm import db_session
 from tribler.core.components.metadata_store.db.store import MetadataStore
 from tribler.core.components.metadata_store.remote_query_community.settings import RemoteQueryCommunitySettings
 from tribler.core.components.popularity.community.popularity_community import PopularityCommunity
-from tribler.core.components.torrent_checker.torrent_checker.torrentchecker_session import InfohashHealth
+from tribler.core.components.torrent_checker.torrent_checker.torrentchecker_session import HealthInfo
 from tribler.core.tests.tools.base_test import MockObject
 from tribler.core.utilities.path_util import Path
 from tribler.core.utilities.utilities import random_infohash
 
 
-def _generate_single_checked_torrent(status: str = None) -> InfohashHealth:
+def _generate_single_checked_torrent(status: str = None) -> HealthInfo:
     """
     Assumptions
     DEAD    -> peers: 0
@@ -32,11 +32,11 @@ def _generate_single_checked_torrent(status: str = None) -> InfohashHealth:
             return randint(101, 1000)
         return randint(1, 100)
 
-    return InfohashHealth(random_infohash(), last_check=int(time.time()),
-                          seeders=get_peers_for(status), leechers=get_peers_for(status))
+    return HealthInfo(random_infohash(), last_check=int(time.time()),
+                      seeders=get_peers_for(status), leechers=get_peers_for(status))
 
 
-def _generate_checked_torrents(count: int, status: str = None) -> List[InfohashHealth]:
+def _generate_checked_torrents(count: int, status: str = None) -> List[HealthInfo]:
     return [_generate_single_checked_torrent(status) for _ in range(count)]
 
 
@@ -77,7 +77,7 @@ class TestPopularityCommunity(TestBase):
             metadata_store.TorrentState(
                 infohash=str(torrent_ind).encode() * 20, seeders=torrent_ind + 1, last_check=last_check)
 
-    async def init_first_node_and_gossip(self, checked_torrent_info: InfohashHealth, deliver_timeout: float = 0.1):
+    async def init_first_node_and_gossip(self, checked_torrent_info: HealthInfo, deliver_timeout: float = 0.1):
         self.nodes[0].overlay.torrent_checker.torrents_checked[checked_torrent_info.infohash] = checked_torrent_info
         await self.introduce_nodes()
 
@@ -89,7 +89,7 @@ class TestPopularityCommunity(TestBase):
         """
         Test whether torrent health information is correctly gossiped around
         """
-        checked_torrent_info = InfohashHealth(b'a' * 20, seeders=200, leechers=0, last_check=int(time.time()))
+        checked_torrent_info = HealthInfo(b'a' * 20, seeders=200, leechers=0, last_check=int(time.time()))
         node0_db = self.nodes[0].overlay.mds.TorrentState
         node1_db2 = self.nodes[1].overlay.mds.TorrentState
 
@@ -180,7 +180,7 @@ class TestPopularityCommunity(TestBase):
         """
         self.fill_database(self.nodes[1].overlay.mds)
 
-        checked_torrent_info = InfohashHealth(b'0' * 20, seeders=200, leechers=0, last_check=int(time.time()))
+        checked_torrent_info = HealthInfo(b'0' * 20, seeders=200, leechers=0, last_check=int(time.time()))
         await self.init_first_node_and_gossip(checked_torrent_info, deliver_timeout=0.5)
 
         # Check whether node 1 has new torrent health information
@@ -197,7 +197,7 @@ class TestPopularityCommunity(TestBase):
         with db_session:
             self.nodes[0].overlay.mds.TorrentMetadata(infohash=infohash)
         await self.init_first_node_and_gossip(
-            InfohashHealth(infohash, seeders=200, leechers=0, last_check=int(time.time())))
+            HealthInfo(infohash, seeders=200, leechers=0, last_check=int(time.time())))
         with db_session:
             assert self.nodes[1].overlay.mds.TorrentMetadata.get()
 
@@ -209,5 +209,5 @@ class TestPopularityCommunity(TestBase):
             self.nodes[1].overlay.mds.TorrentMetadata(infohash=infohash)
         self.nodes[1].overlay.send_remote_select = Mock()
         await self.init_first_node_and_gossip(
-            InfohashHealth(infohash, seeders=200, leechers=0, last_check=int(time.time())))
+            HealthInfo(infohash, seeders=200, leechers=0, last_check=int(time.time())))
         self.nodes[1].overlay.send_remote_select.assert_not_called()

--- a/src/tribler/core/components/popularity/community/tests/test_popularity_community.py
+++ b/src/tribler/core/components/popularity/community/tests/test_popularity_community.py
@@ -32,8 +32,8 @@ def _generate_single_checked_torrent(status: str = None) -> InfohashHealth:
             return randint(101, 1000)
         return randint(1, 100)
 
-    return InfohashHealth(random_infohash(), seeders=get_peers_for(status), leechers=get_peers_for(status),
-                          last_check=int(time.time()))
+    return InfohashHealth(random_infohash(), last_check=int(time.time()),
+                          seeders=get_peers_for(status), leechers=get_peers_for(status))
 
 
 def _generate_checked_torrents(count: int, status: str = None) -> List[InfohashHealth]:

--- a/src/tribler/core/components/restapi/rest/events_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/events_endpoint.py
@@ -109,7 +109,7 @@ class EventsEndpoint(RESTEndpoint, TaskManager):
         if not self.has_connection_to_gui():
             return
         try:
-            self._logger.info(f'Write message: {message}')
+            self._logger.debug(f'Write message: {message}')
             message_bytes = self.encode_message(message)
         except Exception as e:  # pylint: disable=broad-except
             # if a notification arguments contains non-JSON-serializable data, the exception should be logged

--- a/src/tribler/core/components/restapi/rest/events_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/events_endpoint.py
@@ -109,6 +109,7 @@ class EventsEndpoint(RESTEndpoint, TaskManager):
         if not self.has_connection_to_gui():
             return
         try:
+            self._logger.info(f'Write message: {message}')
             message_bytes = self.encode_message(message)
         except Exception as e:  # pylint: disable=broad-except
             # if a notification arguments contains non-JSON-serializable data, the exception should be logged

--- a/src/tribler/core/components/torrent_checker/torrent_checker/__init__.py
+++ b/src/tribler/core/components/torrent_checker/torrent_checker/__init__.py
@@ -1,3 +1,4 @@
 """
 The TorrentChecker package contains code that checks and schedules torrents.
 """
+DHT = "DHT"

--- a/src/tribler/core/components/torrent_checker/torrent_checker/dataclasses.py
+++ b/src/tribler/core/components/torrent_checker/torrent_checker/dataclasses.py
@@ -8,9 +8,9 @@ from tribler.core.utilities.unicode import hexlify
 class InfohashHealth:
     infohash: bytes = field(repr=False)
     infohash_hex: str = field(init=False)
+    last_check: int
     seeders: int = 0
     leechers: int = 0
-    last_check: int = 0
 
     def __post_init__(self):
         self.infohash_hex = hexlify(self.infohash)

--- a/src/tribler/core/components/torrent_checker/torrent_checker/dataclasses.py
+++ b/src/tribler/core/components/torrent_checker/torrent_checker/dataclasses.py
@@ -7,6 +7,9 @@ import human_readable
 from tribler.core.utilities.unicode import hexlify
 
 
+TOLERABLE_TIME_DRIFT = 60  # one minute
+
+
 @dataclass
 class HealthInfo:
     infohash: bytes = field(repr=False)
@@ -38,6 +41,9 @@ class HealthInfo:
     @property
     def infohash_hex(self):
         return hexlify(self.infohash)
+
+    def is_valid(self) -> bool:
+        return self.last_check < int(time.time()) + TOLERABLE_TIME_DRIFT
 
 
 @dataclass

--- a/src/tribler/core/components/torrent_checker/torrent_checker/dataclasses.py
+++ b/src/tribler/core/components/torrent_checker/torrent_checker/dataclasses.py
@@ -8,7 +8,7 @@ from tribler.core.utilities.unicode import hexlify
 
 
 @dataclass
-class InfohashHealth:
+class HealthInfo:
     infohash: bytes = field(repr=False)
     last_check: int
     seeders: int = 0
@@ -43,4 +43,4 @@ class InfohashHealth:
 @dataclass
 class TrackerResponse:
     url: str
-    torrent_health_list: List[InfohashHealth]
+    torrent_health_list: List[HealthInfo]

--- a/src/tribler/core/components/torrent_checker/torrent_checker/dataclasses.py
+++ b/src/tribler/core/components/torrent_checker/torrent_checker/dataclasses.py
@@ -1,0 +1,22 @@
+from dataclasses import dataclass, field
+from typing import List
+
+from tribler.core.utilities.unicode import hexlify
+
+
+@dataclass
+class InfohashHealth:
+    infohash: bytes = field(repr=False)
+    infohash_hex: str = field(init=False)
+    seeders: int = 0
+    leechers: int = 0
+    last_check: int = 0
+
+    def __post_init__(self):
+        self.infohash_hex = hexlify(self.infohash)
+
+
+@dataclass
+class TrackerResponse:
+    url: str
+    torrent_health_list: List[InfohashHealth]

--- a/src/tribler/core/components/torrent_checker/torrent_checker/dataclasses.py
+++ b/src/tribler/core/components/torrent_checker/torrent_checker/dataclasses.py
@@ -1,5 +1,8 @@
+import time
 from dataclasses import dataclass, field
 from typing import List
+
+import human_readable
 
 from tribler.core.utilities.unicode import hexlify
 
@@ -7,13 +10,34 @@ from tribler.core.utilities.unicode import hexlify
 @dataclass
 class InfohashHealth:
     infohash: bytes = field(repr=False)
-    infohash_hex: str = field(init=False)
     last_check: int
     seeders: int = 0
     leechers: int = 0
 
-    def __post_init__(self):
-        self.infohash_hex = hexlify(self.infohash)
+    def __repr__(self):
+        infohash_repr = hexlify(self.infohash[:4])
+        age = self._last_check_repr(self.last_check)
+        return f"{self.__class__.__name__}('{infohash_repr}', {self.seeders}/{self.leechers}, {age})"
+
+    @staticmethod
+    def _last_check_repr(last_check: int) -> str:
+        if last_check < 0:
+            return 'invalid time'
+
+        if last_check == 0:
+            return 'never checked'
+
+        now = int(time.time())
+        diff = now - last_check
+        if diff == 0:
+            return 'just checked'
+
+        age = human_readable.time_delta(diff, use_months=False)
+        return age + (' ago' if diff > 0 else ' in the future')
+
+    @property
+    def infohash_hex(self):
+        return hexlify(self.infohash)
 
 
 @dataclass

--- a/src/tribler/core/components/torrent_checker/torrent_checker/tests/test_torrentchecker.py
+++ b/src/tribler/core/components/torrent_checker/torrent_checker/tests/test_torrentchecker.py
@@ -105,16 +105,19 @@ def test_load_torrents_check_from_db(torrent_checker):  # pylint: disable=unused
     # Case 1: Save random 10 non-self checked torrents
     # Expected: empty set, since only self checked torrents are considered.
     save_random_torrent_state(last_checked=now, self_checked=False, count=10)
+    torrent_checker._torrents_checked = None  # pylint: disable=protected-access
     assert not torrent_checker.torrents_checked
 
     # Case 2: Save 10 self checked torrent but not within the freshness period
     # Expected: empty set, since only self checked fresh torrents are considered.
     save_random_torrent_state(last_checked=before_threshold, self_checked=True, count=10)
+    torrent_checker._torrents_checked = None  # pylint: disable=protected-access
     assert not torrent_checker.torrents_checked
 
     # Case 3: Save 10 self checked fresh torrents
     # Expected: 10 torrents, since there are 10 self checked and fresh torrents
     save_random_torrent_state(last_checked=after_threshold, self_checked=True, count=10)
+    torrent_checker._torrents_checked = None  # pylint: disable=protected-access
     assert len(torrent_checker.torrents_checked) == 10
 
     # Case 4: Save some more self checked fresh torrents
@@ -125,7 +128,7 @@ def test_load_torrents_check_from_db(torrent_checker):  # pylint: disable=unused
     # Case 5: Clear the torrent_checked set (private variable),
     # and save freshly self checked torrents more than max return size (10 more).
     # Expected: max (return size) torrents, since limit is placed on how many to load.
-    torrent_checker._torrents_checked = {}  # pylint: disable=protected-access
+    torrent_checker._torrents_checked = None  # pylint: disable=protected-access
     return_size = torrent_checker_module.TORRENTS_CHECKED_RETURN_SIZE
     save_random_torrent_state(last_checked=after_threshold, self_checked=True, count=return_size + 10)
     assert len(torrent_checker.torrents_checked) == return_size

--- a/src/tribler/core/components/torrent_checker/torrent_checker/tests/test_torrentchecker.py
+++ b/src/tribler/core/components/torrent_checker/torrent_checker/tests/test_torrentchecker.py
@@ -242,13 +242,15 @@ def test_filter_non_exceptions():
 def test_update_health(torrent_checker: TorrentChecker):
     infohash = b'\xee' * 20
 
+    now = int(time.time())
     responses = [
         TrackerResponse(
             url='udp://localhost:2801',
-            torrent_health_list=[InfohashHealth(leechers=1, seeders=2, infohash=infohash)]
+            torrent_health_list=[InfohashHealth(infohash, last_check=now, leechers=1, seeders=2)]
         ),
         TrackerResponse(
-            url='DHT', torrent_health_list=[InfohashHealth(leechers=12, seeders=13, infohash=infohash)]
+            url='DHT',
+            torrent_health_list=[InfohashHealth(infohash, last_check=now, leechers=12, seeders=13)]
         ),
     ]
 

--- a/src/tribler/core/components/torrent_checker/torrent_checker/tests/test_torrentchecker.py
+++ b/src/tribler/core/components/torrent_checker/torrent_checker/tests/test_torrentchecker.py
@@ -9,9 +9,10 @@ from ipv8.util import succeed
 from pony.orm import db_session
 
 import tribler.core.components.torrent_checker.torrent_checker.torrent_checker as torrent_checker_module
+from tribler.core.components.torrent_checker.torrent_checker.dataclasses import InfohashHealth, TrackerResponse
 from tribler.core.components.torrent_checker.torrent_checker.torrent_checker import TorrentChecker
-from tribler.core.components.torrent_checker.torrent_checker.torrentchecker_session import HttpTrackerSession, \
-    InfohashHealth, TrackerResponse, UdpSocketManager
+from tribler.core.components.torrent_checker.torrent_checker.torrentchecker_session import \
+    HttpTrackerSession, UdpSocketManager
 from tribler.core.components.torrent_checker.torrent_checker.tracker_manager import TrackerManager
 
 

--- a/src/tribler/core/components/torrent_checker/torrent_checker/tests/test_torrentchecker.py
+++ b/src/tribler/core/components/torrent_checker/torrent_checker/tests/test_torrentchecker.py
@@ -9,7 +9,7 @@ from ipv8.util import succeed
 from pony.orm import db_session
 
 import tribler.core.components.torrent_checker.torrent_checker.torrent_checker as torrent_checker_module
-from tribler.core.components.torrent_checker.torrent_checker.dataclasses import InfohashHealth, TrackerResponse
+from tribler.core.components.torrent_checker.torrent_checker.dataclasses import HealthInfo, TrackerResponse
 from tribler.core.components.torrent_checker.torrent_checker.utils import aggregate_responses_for_infohash, \
     filter_non_exceptions
 from tribler.core.components.torrent_checker.torrent_checker.torrent_checker import TorrentChecker
@@ -249,11 +249,11 @@ def test_update_health(torrent_checker: TorrentChecker):
     responses = [
         TrackerResponse(
             url='udp://localhost:2801',
-            torrent_health_list=[InfohashHealth(infohash, last_check=now, leechers=1, seeders=2)]
+            torrent_health_list=[HealthInfo(infohash, last_check=now, leechers=1, seeders=2)]
         ),
         TrackerResponse(
             url='DHT',
-            torrent_health_list=[InfohashHealth(infohash, last_check=now, leechers=12, seeders=13)]
+            torrent_health_list=[HealthInfo(infohash, last_check=now, leechers=12, seeders=13)]
         ),
     ]
 

--- a/src/tribler/core/components/torrent_checker/torrent_checker/tests/test_torrentchecker.py
+++ b/src/tribler/core/components/torrent_checker/torrent_checker/tests/test_torrentchecker.py
@@ -159,7 +159,7 @@ async def test_check_random_tracker_not_alive(torrent_checker):
     assert not result
 
     with db_session:
-        tracker = torrent_checker.tracker_manager.tracker_store.get()
+        tracker = torrent_checker.tracker_manager.TrackerState.get()
         assert not tracker.alive
 
 

--- a/src/tribler/core/components/torrent_checker/torrent_checker/tests/test_torrentchecker.py
+++ b/src/tribler/core/components/torrent_checker/torrent_checker/tests/test_torrentchecker.py
@@ -125,7 +125,7 @@ def test_load_torrents_check_from_db(torrent_checker):  # pylint: disable=unused
     # Case 5: Clear the torrent_checked set (private variable),
     # and save freshly self checked torrents more than max return size (10 more).
     # Expected: max (return size) torrents, since limit is placed on how many to load.
-    torrent_checker._torrents_checked = dict()  # pylint: disable=protected-access
+    torrent_checker._torrents_checked = {}  # pylint: disable=protected-access
     return_size = torrent_checker_module.TORRENTS_CHECKED_RETURN_SIZE
     save_random_torrent_state(last_checked=after_threshold, self_checked=True, count=return_size + 10)
     assert len(torrent_checker.torrents_checked) == return_size

--- a/src/tribler/core/components/torrent_checker/torrent_checker/tests/test_torrentchecker.py
+++ b/src/tribler/core/components/torrent_checker/torrent_checker/tests/test_torrentchecker.py
@@ -61,7 +61,7 @@ async def test_health_check_blacklisted_trackers(torrent_checker):
 
     torrent_checker.tracker_manager.blacklist.append("http://localhost/tracker")
     result = await torrent_checker.check_torrent_health(b'a' * 20)
-    assert {'db'} == set(result.keys())
+    assert result.keys() == {'db'}
     assert result['db']['seeders'] == 5
     assert result['db']['leechers'] == 10
 
@@ -76,7 +76,7 @@ async def test_health_check_cached(torrent_checker):
                                          last_check=int(time.time()))
 
     result = await torrent_checker.check_torrent_health(b'a' * 20)
-    assert 'db' in result
+    assert result.keys() == {'db'}
     assert result['db']['seeders'] == 5
     assert result['db']['leechers'] == 10
 

--- a/src/tribler/core/components/torrent_checker/torrent_checker/tests/test_torrentchecker_session.py
+++ b/src/tribler/core/components/torrent_checker/torrent_checker/tests/test_torrentchecker_session.py
@@ -1,5 +1,6 @@
 import socket
 import struct
+import time
 from asyncio import CancelledError, DatagramProtocol, Future, ensure_future, get_event_loop, sleep, start_server
 from unittest.mock import Mock
 
@@ -361,7 +362,7 @@ async def test_connect_to_tracker_bep33(bep33_session, mock_dlmgr):
     Test the metainfo lookup of the BEP33 DHT session
     """
     infohash = b'a' * 20
-    infohash_health = InfohashHealth(infohash=infohash, seeders=1, leechers=2)
+    infohash_health = InfohashHealth(infohash, last_check=int(time.time()), seeders=1, leechers=2)
 
     mock_dlmgr.dht_health_manager = Mock()
     mock_dlmgr.dht_health_manager.get_health = lambda *_, **__: succeed(infohash_health)

--- a/src/tribler/core/components/torrent_checker/torrent_checker/tests/test_torrentchecker_session.py
+++ b/src/tribler/core/components/torrent_checker/torrent_checker/tests/test_torrentchecker_session.py
@@ -9,7 +9,7 @@ from aiohttp.web_exceptions import HTTPBadRequest
 from ipv8.util import succeed
 from libtorrent import bencode
 
-from tribler.core.components.torrent_checker.torrent_checker.dataclasses import InfohashHealth
+from tribler.core.components.torrent_checker.torrent_checker.dataclasses import HealthInfo
 from tribler.core.components.torrent_checker.torrent_checker.torrentchecker_session import \
     FakeBep33DHTSession, FakeDHTSession, HttpTrackerSession, UdpSocketManager, UdpTrackerSession
 
@@ -362,7 +362,7 @@ async def test_connect_to_tracker_bep33(bep33_session, mock_dlmgr):
     Test the metainfo lookup of the BEP33 DHT session
     """
     infohash = b'a' * 20
-    infohash_health = InfohashHealth(infohash, last_check=int(time.time()), seeders=1, leechers=2)
+    infohash_health = HealthInfo(infohash, last_check=int(time.time()), seeders=1, leechers=2)
 
     mock_dlmgr.dht_health_manager = Mock()
     mock_dlmgr.dht_health_manager.get_health = lambda *_, **__: succeed(infohash_health)

--- a/src/tribler/core/components/torrent_checker/torrent_checker/tests/test_torrentchecker_session.py
+++ b/src/tribler/core/components/torrent_checker/torrent_checker/tests/test_torrentchecker_session.py
@@ -8,14 +8,9 @@ from aiohttp.web_exceptions import HTTPBadRequest
 from ipv8.util import succeed
 from libtorrent import bencode
 
-from tribler.core.components.torrent_checker.torrent_checker.torrentchecker_session import (
-    FakeBep33DHTSession,
-    FakeDHTSession,
-    HttpTrackerSession,
-    InfohashHealth, UdpSocketManager,
-    UdpTrackerSession,
-)
-from tribler.core.utilities.unicode import hexlify
+from tribler.core.components.torrent_checker.torrent_checker.dataclasses import InfohashHealth
+from tribler.core.components.torrent_checker.torrent_checker.torrentchecker_session import \
+    FakeBep33DHTSession, FakeDHTSession, HttpTrackerSession, UdpSocketManager, UdpTrackerSession
 
 
 # pylint: disable=redefined-outer-name

--- a/src/tribler/core/components/torrent_checker/torrent_checker/tests/test_tracker_manager.py
+++ b/src/tribler/core/components/torrent_checker/torrent_checker/tests/test_tracker_manager.py
@@ -62,21 +62,21 @@ def test_get_tracker_for_check(tracker_manager):
     """
     Test whether the correct tracker is returned when fetching the next eligable tracker for the auto check
     """
-    assert not tracker_manager.get_next_tracker_for_auto_check()
+    assert not tracker_manager.get_next_tracker()
 
     tracker_manager.add_tracker("http://test1.com:80/announce")
-    assert tracker_manager.get_next_tracker_for_auto_check().url == 'http://test1.com/announce'
+    assert tracker_manager.get_next_tracker().url == 'http://test1.com/announce'
 
 
 def test_get_tracker_for_check_blacklist(tracker_manager):
     """
     Test whether the next tracker for autocheck is not in the blacklist
     """
-    assert not tracker_manager.get_next_tracker_for_auto_check()
+    assert not tracker_manager.get_next_tracker()
 
     tracker_manager.add_tracker("http://test1.com:80/announce")
     tracker_manager.blacklist.append("http://test1.com/announce")
-    assert not tracker_manager.get_next_tracker_for_auto_check()
+    assert not tracker_manager.get_next_tracker()
 
 
 def test_load_blacklist_from_file_none(tracker_manager):

--- a/src/tribler/core/components/torrent_checker/torrent_checker/torrent_checker.py
+++ b/src/tribler/core/components/torrent_checker/torrent_checker/torrent_checker.py
@@ -178,6 +178,9 @@ class TorrentChecker(TaskManager):
     def torrents_checked(self) -> Dict[bytes, HealthInfo]:
         if self._torrents_checked is None:
             self._torrents_checked = self.load_torrents_checked_from_db()
+            lines = '\n'.join(f'    {health}' for health in sorted(self._torrents_checked.values(),
+                                                                   key=lambda health: -health.last_check))
+            self._logger.info(f'Initially loaded self-checked torrents:\n{lines}')
         return self._torrents_checked
 
     @db_session

--- a/src/tribler/core/components/torrent_checker/torrent_checker/torrent_checker.py
+++ b/src/tribler/core/components/torrent_checker/torrent_checker/torrent_checker.py
@@ -359,7 +359,7 @@ class TorrentChecker(TaskManager):
         self._logger.debug(f'Update torrent health: {health}')
         with db_session:
             # Update torrent state
-            torrent_state = self.mds.TorrentState.get(infohash=health.infohash)
+            torrent_state = self.mds.TorrentState.get_for_update(infohash=health.infohash)
             if not torrent_state:
                 self._logger.warning(f"Unknown torrent: {hexlify(health.infohash)}")
                 return False

--- a/src/tribler/core/components/torrent_checker/torrent_checker/torrent_checker.py
+++ b/src/tribler/core/components/torrent_checker/torrent_checker/torrent_checker.py
@@ -44,7 +44,7 @@ TORRENTS_CHECKED_RETURN_SIZE = 240  # Estimated torrents checked on default 4 ho
 
 
 def filter_non_exceptions(responses: Sequence):
-    return [r for r in responses if not isinstance(r, Exception)]
+    return [r for r in responses if not isinstance(r, BaseException)]
 
 
 class TorrentChecker(TaskManager):

--- a/src/tribler/core/components/torrent_checker/torrent_checker/torrent_checker.py
+++ b/src/tribler/core/components/torrent_checker/torrent_checker/torrent_checker.py
@@ -362,6 +362,10 @@ class TorrentChecker(TaskManager):
         Updates the torrent state in the database if it already exists, otherwise do nothing.
         Returns True if the update was successful, False otherwise.
         """
+        if not health.is_valid():
+            self._logger.warning(f'Invalid health info ignored: {health}')
+            return False
+
         self._logger.debug(f'Update torrent health: {health}')
         with db_session:
             # Update torrent state

--- a/src/tribler/core/components/torrent_checker/torrent_checker/torrent_checker.py
+++ b/src/tribler/core/components/torrent_checker/torrent_checker/torrent_checker.py
@@ -159,7 +159,6 @@ class TorrentChecker(TaskManager):
         else:
             self._logger.info(f'Random tracker check result: {response}')
             for health in aggregate_health_by_infohash(response.torrent_health_list):
-                health.last_check = int(time.time())
                 self.update_torrent_health(health)
 
     async def get_tracker_response(self, session: TrackerSession) -> TrackerResponse:
@@ -324,7 +323,6 @@ class TorrentChecker(TaskManager):
 
         if successful_responses := filter_non_exceptions(responses):
             health = aggregate_responses_for_infohash(infohash, successful_responses)
-            health.last_check = int(time.time())
             self.update_torrent_health(health)
         else:
             self.notifier[notifications.channel_entity_updated]({

--- a/src/tribler/core/components/torrent_checker/torrent_checker/torrent_checker.py
+++ b/src/tribler/core/components/torrent_checker/torrent_checker/torrent_checker.py
@@ -379,6 +379,8 @@ class TorrentChecker(TaskManager):
 
         if health.seeders > 0:
             self.torrents_checked[health.infohash] = health
+        else:
+            self.torrents_checked.pop(health.infohash, None)
 
         self.notifier[notifications.channel_entity_updated]({
             'infohash': health.infohash_hex,

--- a/src/tribler/core/components/torrent_checker/torrent_checker/torrent_checker.py
+++ b/src/tribler/core/components/torrent_checker/torrent_checker/torrent_checker.py
@@ -169,6 +169,7 @@ class TorrentChecker(TaskManager):
             return response
         except CancelledError:
             self._logger.info(f"Tracker session is being cancelled: {session.tracker_url}")
+            raise
         except Exception as e:
             exception_str = str(e).replace('\n]', ']')
             self._logger.warning(f"Got session error for the tracker: {session.tracker_url}\n{exception_str}")

--- a/src/tribler/core/components/torrent_checker/torrent_checker/torrent_checker.py
+++ b/src/tribler/core/components/torrent_checker/torrent_checker/torrent_checker.py
@@ -374,10 +374,12 @@ class TorrentChecker(TaskManager):
                 self._logger.warning(f"Unknown torrent: {hexlify(health.infohash)}")
                 return False
 
-            torrent_state.seeders = health.seeders
-            torrent_state.leechers = health.leechers
-            torrent_state.last_check = health.last_check
-            torrent_state.self_checked = True
+            if not health.should_update(torrent_state, self_checked=True):
+                self._logger.info("Skip health update, the health in the database is fresher")
+                return False
+
+            torrent_state.set(seeders=health.seeders, leechers=health.leechers, last_check=health.last_check,
+                              self_checked=True)
 
         if health.seeders > 0:
             self.torrents_checked[health.infohash] = health

--- a/src/tribler/core/components/torrent_checker/torrent_checker/torrent_checker.py
+++ b/src/tribler/core/components/torrent_checker/torrent_checker/torrent_checker.py
@@ -17,12 +17,9 @@ from tribler.core.components.libtorrent.download_manager.download_manager import
 from tribler.core.components.metadata_store.db.serialization import REGULAR_TORRENT
 from tribler.core.components.metadata_store.db.store import MetadataStore
 from tribler.core.components.torrent_checker.torrent_checker import DHT
-from tribler.core.components.torrent_checker.torrent_checker.torrentchecker_session import (
-    FakeBep33DHTSession,
-    FakeDHTSession,
-    InfohashHealth, TrackerResponse, TrackerSession, UdpSocketManager,
-    create_tracker_session,
-)
+from tribler.core.components.torrent_checker.torrent_checker.dataclasses import InfohashHealth, TrackerResponse
+from tribler.core.components.torrent_checker.torrent_checker.torrentchecker_session import \
+    FakeBep33DHTSession, FakeDHTSession, TrackerSession, UdpSocketManager, create_tracker_session
 from tribler.core.components.torrent_checker.torrent_checker.tracker_manager import MAX_TRACKER_FAILURES, TrackerManager
 from tribler.core.config.tribler_config import TriblerConfig
 from tribler.core.utilities.notifier import Notifier

--- a/src/tribler/core/components/torrent_checker/torrent_checker/torrent_checker.py
+++ b/src/tribler/core/components/torrent_checker/torrent_checker/torrent_checker.py
@@ -300,8 +300,7 @@ class TorrentChecker(TaskManager):
                 time_diff = time.time() - last_check
                 if time_diff < MIN_TORRENT_CHECK_INTERVAL and not scrape_now:
                     self._logger.info(f"Time interval too short, not doing torrent health check for {infohash_hex}")
-                    return InfohashHealth(infohash, seeders=torrent_state.seeders, leechers=torrent_state.leechers,
-                                          last_check=torrent_state.last_check)
+                    return torrent_state.to_health()
 
                 # get torrent's tracker list from DB
                 tracker_set = self.get_valid_trackers_of_torrent(torrent_state.infohash)

--- a/src/tribler/core/components/torrent_checker/torrent_checker/torrentchecker_session.py
+++ b/src/tribler/core/components/torrent_checker/torrent_checker/torrentchecker_session.py
@@ -8,7 +8,6 @@ import sys
 import time
 from abc import ABCMeta, abstractmethod
 from asyncio import DatagramProtocol, Future, TimeoutError, ensure_future, gather, get_event_loop
-from dataclasses import dataclass, field
 from typing import List, TYPE_CHECKING
 
 import async_timeout
@@ -18,8 +17,8 @@ from ipv8.taskmanager import TaskManager
 from tribler.core.components.socks_servers.socks5.aiohttp_connector import Socks5Connector
 from tribler.core.components.socks_servers.socks5.client import Socks5Client
 from tribler.core.components.torrent_checker.torrent_checker import DHT
+from tribler.core.components.torrent_checker.torrent_checker.dataclasses import InfohashHealth, TrackerResponse
 from tribler.core.utilities.tracker_utils import add_url_params, parse_tracker_url
-from tribler.core.utilities.unicode import hexlify
 from tribler.core.utilities.utilities import bdecode_compat
 
 if TYPE_CHECKING:
@@ -36,24 +35,6 @@ MAX_INT32 = 2 ** 16 - 1
 UDP_TRACKER_INIT_CONNECTION_ID = 0x41727101980
 
 MAX_INFOHASHES_IN_SCRAPE = 60
-
-
-@dataclass
-class TrackerResponse:
-    url: str
-    torrent_health_list: List[InfohashHealth]
-
-
-@dataclass
-class InfohashHealth:
-    infohash: bytes = field(repr=False)
-    infohash_hex: str = field(init=False)
-    seeders: int = 0
-    leechers: int = 0
-    last_check: int = 0
-
-    def __post_init__(self):
-        self.infohash_hex = hexlify(self.infohash)
 
 
 class TrackerSession(TaskManager):

--- a/src/tribler/core/components/torrent_checker/torrent_checker/torrentchecker_session.py
+++ b/src/tribler/core/components/torrent_checker/torrent_checker/torrentchecker_session.py
@@ -17,7 +17,7 @@ from ipv8.taskmanager import TaskManager
 from tribler.core.components.socks_servers.socks5.aiohttp_connector import Socks5Connector
 from tribler.core.components.socks_servers.socks5.client import Socks5Client
 from tribler.core.components.torrent_checker.torrent_checker import DHT
-from tribler.core.components.torrent_checker.torrent_checker.dataclasses import InfohashHealth, TrackerResponse
+from tribler.core.components.torrent_checker.torrent_checker.dataclasses import HealthInfo, TrackerResponse
 from tribler.core.components.torrent_checker.torrent_checker.utils import filter_non_exceptions, gather_coros
 from tribler.core.utilities.tracker_utils import add_url_params, parse_tracker_url
 from tribler.core.utilities.utilities import bdecode_compat
@@ -146,7 +146,7 @@ class HttpTrackerSession(TrackerSession):
         if not response_dict:
             self.failed(msg="no valid response")
 
-        health_list: List[InfohashHealth] = []
+        health_list: List[HealthInfo] = []
         now = int(time.time())
 
         unprocessed_infohashes = set(self.infohash_list)
@@ -161,14 +161,14 @@ class HttpTrackerSession(TrackerSession):
                     leechers = file_info.get(b'incomplete', 0)
 
                 unprocessed_infohashes.discard(infohash)
-                health_list.append(InfohashHealth(infohash, last_check=now, seeders=seeders, leechers=leechers))
+                health_list.append(HealthInfo(infohash, last_check=now, seeders=seeders, leechers=leechers))
 
         elif b'failure reason' in response_dict:
             self._logger.info("%s Failure as reported by tracker [%s]", self, repr(response_dict[b'failure reason']))
             self.failed(msg=repr(response_dict[b'failure reason']))
 
         # handle the infohashes with no result (seeders/leechers = 0/0)
-        health_list.extend(InfohashHealth(infohash=infohash, last_check=now) for infohash in unprocessed_infohashes)
+        health_list.extend(HealthInfo(infohash=infohash, last_check=now) for infohash in unprocessed_infohashes)
 
         self.is_finished = True
         return TrackerResponse(url=self.tracker_url, torrent_health_list=health_list)
@@ -397,7 +397,7 @@ class UdpTrackerSession(TrackerSession):
             # Store the information in the hash dict to be returned.
             # Sow complete as seeders. "complete: number of peers with the entire file, i.e. seeders (integer)"
             #  - https://wiki.theory.org/BitTorrentSpecification#Tracker_.27scrape.27_Convention
-            response_list.append(InfohashHealth(infohash, last_check=now, seeders=complete, leechers=incomplete))
+            response_list.append(HealthInfo(infohash, last_check=now, seeders=complete, leechers=incomplete))
 
         # close this socket and remove its transaction ID from the list
         self.remove_transaction_id()
@@ -422,8 +422,7 @@ class FakeDHTSession(TrackerSession):
         now = int(time.time())
         for infohash in self.infohash_list:
             metainfo = await self.download_manager.get_metainfo(infohash, timeout=self.timeout, raise_errors=True)
-            health = InfohashHealth(infohash, last_check=now,
-                                    seeders=metainfo[b'seeders'], leechers=metainfo[b'leechers'])
+            health = HealthInfo(infohash, last_check=now, seeders=metainfo[b'seeders'], leechers=metainfo[b'leechers'])
             health_list.append(health)
 
         return TrackerResponse(url=DHT, torrent_health_list=health_list)

--- a/src/tribler/core/components/torrent_checker/torrent_checker/utils.py
+++ b/src/tribler/core/components/torrent_checker/torrent_checker/utils.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from asyncio import gather
 from typing import Awaitable, Dict, Iterable, List, TypeVar, Union, cast
 
-from tribler.core.components.torrent_checker.torrent_checker.dataclasses import InfohashHealth, TrackerResponse
+from tribler.core.components.torrent_checker.torrent_checker.dataclasses import HealthInfo, TrackerResponse
 
 
 T = TypeVar("T")
@@ -24,11 +24,11 @@ def filter_non_exceptions(items: List[Union[T, BaseException]]) -> List[T]:
     return [item for item in items if not isinstance(item, BaseException)]
 
 
-def aggregate_responses_for_infohash(infohash: bytes, responses: List[TrackerResponse]) -> InfohashHealth:
+def aggregate_responses_for_infohash(infohash: bytes, responses: List[TrackerResponse]) -> HealthInfo:
     """
     Finds the "best" health info (with the max number of seeders) for a specified infohash
     """
-    result = InfohashHealth(infohash, last_check=0)
+    result = HealthInfo(infohash, last_check=0)
     for response in responses:
         for health in response.torrent_health_list:
             if health.infohash == infohash and health.seeders > result.seeders:
@@ -36,11 +36,11 @@ def aggregate_responses_for_infohash(infohash: bytes, responses: List[TrackerRes
     return result
 
 
-def aggregate_health_by_infohash(health_list: List[InfohashHealth]) -> List[InfohashHealth]:
+def aggregate_health_by_infohash(health_list: List[HealthInfo]) -> List[HealthInfo]:
     """
     For each infohash in the health list, finds the "best" health info (with the max number of seeders)
     """
-    d: Dict[bytes, InfohashHealth] = {}
+    d: Dict[bytes, HealthInfo] = {}
     for health in health_list:
         infohash = health.infohash
         if infohash not in d or health.seeders > d[infohash].seeders:

--- a/src/tribler/core/components/torrent_checker/torrent_checker/utils.py
+++ b/src/tribler/core/components/torrent_checker/torrent_checker/utils.py
@@ -28,7 +28,7 @@ def aggregate_responses_for_infohash(infohash: bytes, responses: List[TrackerRes
     """
     Finds the "best" health info (with the max number of seeders) for a specified infohash
     """
-    result = InfohashHealth(infohash)
+    result = InfohashHealth(infohash, last_check=0)
     for response in responses:
         for health in response.torrent_health_list:
             if health.infohash == infohash and health.seeders > result.seeders:

--- a/src/tribler/core/components/torrent_checker/torrent_checker/utils.py
+++ b/src/tribler/core/components/torrent_checker/torrent_checker/utils.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from asyncio import gather
+from typing import Awaitable, Dict, Iterable, List, TypeVar, Union, cast
+
+from tribler.core.components.torrent_checker.torrent_checker.dataclasses import InfohashHealth, TrackerResponse
+
+
+T = TypeVar("T")
+
+
+async def gather_coros(coros: Iterable[Awaitable[T]]) -> List[Union[T, BaseException]]:
+    """
+    A replacement of asyncio.gather() with a proper typing support for coroutines with the same result type
+    """
+    results = await gather(*coros, return_exceptions=True)
+    return cast(List[Union[T, BaseException]], results)
+
+
+def filter_non_exceptions(items: List[Union[T, BaseException]]) -> List[T]:
+    """
+    Removes exceptions from the result of the `await gather_coro(...)` call
+    """
+    return [item for item in items if not isinstance(item, BaseException)]
+
+
+def aggregate_responses_for_infohash(infohash: bytes, responses: List[TrackerResponse]) -> InfohashHealth:
+    """
+    Finds the "best" health info (with the max number of seeders) for a specified infohash
+    """
+    result = InfohashHealth(infohash)
+    for response in responses:
+        for health in response.torrent_health_list:
+            if health.infohash == infohash and health.seeders > result.seeders:
+                result = health
+    return result
+
+
+def aggregate_health_by_infohash(health_list: List[InfohashHealth]) -> List[InfohashHealth]:
+    """
+    For each infohash in the health list, finds the "best" health info (with the max number of seeders)
+    """
+    d: Dict[bytes, InfohashHealth] = {}
+    for health in health_list:
+        infohash = health.infohash
+        if infohash not in d or health.seeders > d[infohash].seeders:
+            d[infohash] = health
+    return list(d.values())

--- a/src/tribler/core/components/tunnel/tests/test_triblertunnel_community.py
+++ b/src/tribler/core/components/tunnel/tests/test_triblertunnel_community.py
@@ -286,19 +286,19 @@ class TestTriblerTunnelCommunity(TestBase):  # pylint: disable=too-many-public-m
         self.nodes[0].overlay.get_download = lambda _: download
 
         lt_session = Mock()
-        self.nodes[0].overlay.dlmgr = Mock()
-        self.nodes[0].overlay.dlmgr.get_session = lambda _: lt_session
-        self.nodes[0].overlay.dlmgr.update_ip_filter = Mock()
-        self.nodes[0].overlay.dlmgr.get_downloads = lambda: [download]
+        self.nodes[0].overlay.download_manager = Mock()
+        self.nodes[0].overlay.download_manager.get_session = lambda _: lt_session
+        self.nodes[0].overlay.download_manager.update_ip_filter = Mock()
+        self.nodes[0].overlay.download_manager.get_downloads = lambda: [download]
 
         self.nodes[0].overlay.update_ip_filter(0)
         ips = ['1.1.1.1']
-        self.nodes[0].overlay.dlmgr.update_ip_filter.assert_called_with(lt_session, ips)
+        self.nodes[0].overlay.download_manager.update_ip_filter.assert_called_with(lt_session, ips)
 
         circuit.ctype = CIRCUIT_TYPE_RP_SEEDER
         self.nodes[0].overlay.update_ip_filter(0)
         ips = [self.nodes[0].overlay.circuit_id_to_ip(circuit.circuit_id), '1.1.1.1']
-        self.nodes[0].overlay.dlmgr.update_ip_filter.assert_called_with(lt_session, ips)
+        self.nodes[0].overlay.download_manager.update_ip_filter.assert_called_with(lt_session, ips)
 
     def test_update_torrent(self):
         """

--- a/src/tribler/core/logger/logger.yaml
+++ b/src/tribler/core/logger/logger.yaml
@@ -7,9 +7,9 @@ filters:
 # Logging formatter
 formatters:
     standard:
-        format: "[PID:%(process)d] %(asctime)s - %(levelname)s - %(name)s(%(lineno)d) - %(message)s"
+        format: "[%(app_mode)s PID:%(process)d] %(asctime)s - %(levelname)s - %(name)s(%(lineno)d) - %(message)s"
     error:
-        format: "[PID:%(process)d] %(asctime)s - %(levelname)s <%(module)s:%(lineno)d> %(name)s.%(funcName)s(): %(message)s"
+        format: "[%(app_mode)s PID:%(process)d] %(asctime)s - %(levelname)s <%(module)s:%(lineno)d> %(name)s.%(funcName)s(): %(message)s"
 
 # Logging handlers
 handlers:

--- a/src/tribler/core/utilities/dependencies.py
+++ b/src/tribler/core/utilities/dependencies.py
@@ -25,7 +25,6 @@ class Scope(Enum):
 # Exceptional pip packages where the name does not match with actual import.
 package_to_import_mapping = {
     'Faker': 'faker',
-    'sentry-sdk': 'sentry_sdk'
 }
 
 
@@ -52,12 +51,14 @@ def _get_pip_dependencies(path_to_requirements: Path) -> Iterator[str]:
 def _extract_libraries_from_requirements(text: str) -> Iterator[str]:
     logger.debug(f'requirements.txt content: {text}')
     for line in text.split('\n'):
-        library = _extract_library(line)
-        if library:
-            pip_package = re.split(r'[><=~]', library, maxsplit=1)[0]
-            yield package_to_import_mapping.get(pip_package, pip_package)
+        package = _extract_package_from_line(line)
+        if package:
+            yield package
 
 
-def _extract_library(line) -> Optional[str]:
-    library = line.partition('#')[0].strip()
-    return library or None
+def _extract_package_from_line(line) -> Optional[str]:
+    without_comment = line.partition('#')[0].strip()
+    without_version = re.split(r'[><=~]', without_comment, maxsplit=1)[0]
+    with_underscores = without_version.replace('-', '_')
+    package = package_to_import_mapping.get(with_underscores, with_underscores)
+    return package or None

--- a/src/tribler/core/utilities/dependencies.py
+++ b/src/tribler/core/utilities/dependencies.py
@@ -5,16 +5,22 @@ Note that this file should not depend on any external modules itself other than 
 """
 import logging
 import re
-import tribler
 from enum import Enum
+from pathlib import Path
 from typing import Iterator, Optional
-from tribler.core.utilities.path_util import Path
+
+import tribler
+
 
 # fmt: off
 
 logger = logging.getLogger(__name__)
 
-Scope = Enum('Scope', 'core gui')
+
+class Scope(Enum):
+    core = 'core'
+    gui = 'gui'
+
 
 # Exceptional pip packages where the name does not match with actual import.
 package_to_import_mapping = {
@@ -22,27 +28,31 @@ package_to_import_mapping = {
     'sentry-sdk': 'sentry_sdk'
 }
 
-# pylint: disable=import-outside-toplevel
 
 def get_dependencies(scope: Scope) -> Iterator[str]:
-    def _get_path_to_requirements_txt() -> Optional[Path]:
-        root_path = Path(tribler.__file__).parent.parent.parent
-        if scope == Scope.core:
-            return root_path / 'requirements-core.txt'
-        if scope == Scope.gui:
-            return root_path / 'requirements.txt'
-        raise AttributeError(f'Scope is {scope} but should be in {[s for s in Scope]}')  # pylint: disable=unnecessary-comprehension
-
-    return _get_pip_dependencies(_get_path_to_requirements_txt())
+    requirements_path = _get_path_to_requirements_txt(scope)
+    return _get_pip_dependencies(requirements_path)
 
 
-def _extract_libraries_from_requirements(text: str) -> Iterator[str]:
-    logger.debug(f'requirements.txt content: {text}')
-    for library in filter(None, text.split('\n')):
-        pip_package = re.split(r'[><=~]', library, maxsplit=1)[0]
-        yield package_to_import_mapping.get(pip_package, pip_package)
+def _get_path_to_requirements_txt(scope: Scope) -> Path:
+    root_path = Path(tribler.__file__).parent.parent.parent
+    if scope == Scope.core:
+        return root_path / 'requirements-core.txt'
+    if scope == Scope.gui:
+        return root_path / 'requirements.txt'
+    raise AttributeError(f'Scope is {scope} but should be in {list(Scope)}')
 
 
 def _get_pip_dependencies(path_to_requirements: Path) -> Iterator[str]:
     logger.info(f'Getting dependencies from: {path_to_requirements}')
-    return _extract_libraries_from_requirements(path_to_requirements.read_text())
+    requirements_text = path_to_requirements.read_text()
+    return _extract_libraries_from_requirements(requirements_text)
+
+
+def _extract_libraries_from_requirements(text: str) -> Iterator[str]:
+    logger.debug(f'requirements.txt content: {text}')
+    for line in text.split('\n'):
+        library = line.strip()
+        if library:
+            pip_package = re.split(r'[><=~]', library, maxsplit=1)[0]
+            yield package_to_import_mapping.get(pip_package, pip_package)

--- a/src/tribler/core/utilities/dependencies.py
+++ b/src/tribler/core/utilities/dependencies.py
@@ -52,7 +52,12 @@ def _get_pip_dependencies(path_to_requirements: Path) -> Iterator[str]:
 def _extract_libraries_from_requirements(text: str) -> Iterator[str]:
     logger.debug(f'requirements.txt content: {text}')
     for line in text.split('\n'):
-        library = line.strip()
+        library = _extract_library(line)
         if library:
             pip_package = re.split(r'[><=~]', library, maxsplit=1)[0]
             yield package_to_import_mapping.get(pip_package, pip_package)
+
+
+def _extract_library(line) -> Optional[str]:
+    library = line.partition('#')[0].strip()
+    return library or None

--- a/src/tribler/core/utilities/tests/test_dependencies.py
+++ b/src/tribler/core/utilities/tests/test_dependencies.py
@@ -12,17 +12,16 @@ from tribler.core.utilities.path_util import Path
 
 # pylint: disable=protected-access
 
-# fmt: off
-
 def test_extract_libraries_from_requirements():
     # check that libraries extracts from text correctly
-    text = 'PyQt5>=5.14\n' \
-           'psutil\n' \
-           '\n' \
-           'configobj\n'
-
+    text = (
+        'PyQt5>=5.14\n'
+        'psutil  # some comment\n'
+        '\n'
+        '# comment line\n'
+        'configobj\n'
+    )
     assert list(_extract_libraries_from_requirements(text)) == ['PyQt5', 'psutil', 'configobj']
-
 
 def test_pip_dependencies_gen():
     # check that libraries extracts from file correctly

--- a/src/tribler/core/utilities/unicode.py
+++ b/src/tribler/core/utilities/unicode.py
@@ -79,5 +79,5 @@ def recursive_bytes(obj):
     return obj
 
 
-def hexlify(binary):
+def hexlify(binary: bytes) -> str:
     return binascii.hexlify(binary).decode('utf-8')


### PR DESCRIPTION
This PR related to #6131, fixes #7287

Changes:
* logging has been extended
* fixed types inconsistency
* fixed `run_tribler_headless.py` (it was run without components)
* fixed `check_random_tracker` (the result of checks were never saved in DB)
* `app_mode` added to logging
* fixed `FakeDHTSession` logic inconsistency
* fixed  recheck torrent health logic (@kozlovsky)
* a tooltip was added to show the freshness of the seeders/leechers info (@kozlovsky)