### PR TITLE
Fix empty reply decoding issue

### DIFF
--- a/src/tribler/gui/network/request.py
+++ b/src/tribler/gui/network/request.py
@@ -87,7 +87,7 @@ class Request(QObject):
         self.logger.debug(f'Update {self}: {status_code}')
         self.status_code = status_code
 
-    def _on_finished(self):
+    def on_finished(self):
         if not self.reply or not self.manager:
             return
 
@@ -101,6 +101,10 @@ class Request(QObject):
                 self.logger.debug('Create a raw response')
                 header = self.reply.header(QNetworkRequest.ContentTypeHeader)
                 self.on_finished_signal.emit((data, header))
+                return
+
+            if not data:
+                self.on_finished_signal.emit({})
                 return
 
             self.logger.debug('Create a json response')

--- a/src/tribler/gui/network/request_manager.py
+++ b/src/tribler/gui/network/request_manager.py
@@ -138,7 +138,7 @@ class RequestManager(QNetworkAccessManager):
         request.reply = self.sendCustomRequest(qt_request, request.method.encode("utf8"), buf)
         buf.setParent(request.reply)
 
-        connect(request.reply.finished, request._on_finished)  # pylint: disable=protected-access
+        connect(request.reply.finished, request.on_finished)
 
     def remove(self, request: Request):
         self.active_requests.discard(request)

--- a/src/tribler/gui/network/tests/test_request.py
+++ b/src/tribler/gui/network/tests/test_request.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock
+
 from tribler.gui.network.request import Request
 
 
@@ -34,3 +36,16 @@ def test_str_data_constructor():
         data='str'
     )
     assert request.raw_data == b'str'
+
+
+def test_on_finished():
+    # Test that if 'request.reply' is empty, the `on_finish` method is called with an empty dict.
+    # see: https://github.com/Tribler/tribler/issues/7297
+    on_finish = MagicMock()
+    request = Request(endpoint='endpoint', on_finish=on_finish)
+    request.manager = MagicMock()
+    request.reply = MagicMock(readAll=MagicMock(return_value=b''))
+
+    request.on_finished()
+
+    on_finish.assert_called_once_with({})


### PR DESCRIPTION
This PR fixes #7297

The root cause of the issue is the fact that `Request.reply.readAll()` could return a value equal to `b''` which couldn't be decoded correctly by `json.loads(data)`.