### PR TITLE
Fix `asyncio.create_task()` calls

### DIFF
--- a/scripts/experiments/tunnel_community/hidden_peer_discovery.py
+++ b/scripts/experiments/tunnel_community/hidden_peer_discovery.py
@@ -29,8 +29,9 @@ class Service(TinyTriblerService, TaskManager):
         self.register_task('_graceful_shutdown', self._graceful_shutdown, delay=EXPERIMENT_RUN_TIME)
 
     def _graceful_shutdown(self):
-        task = asyncio.create_task(self.on_tribler_shutdown())
-        task.add_done_callback(lambda result: TinyTriblerService._graceful_shutdown(self))
+        tasks = self.async_group.add(self.on_tribler_shutdown())
+        shutdown_task = tasks[0]
+        shutdown_task.add_done_callback(lambda result: TinyTriblerService._graceful_shutdown(self))
 
     async def on_tribler_shutdown(self):
         await self.shutdown_task_manager()

--- a/scripts/experiments/tunnel_community/speed_test_exit.py
+++ b/scripts/experiments/tunnel_community/speed_test_exit.py
@@ -29,8 +29,9 @@ class Service(TinyTriblerService, TaskManager):
         self.output_file = 'speed_test_exit.txt'
 
     def _graceful_shutdown(self):
-        task = asyncio.create_task(self.on_tribler_shutdown())
-        task.add_done_callback(lambda result: TinyTriblerService._graceful_shutdown(self))
+        tasks = self.async_group.add(self.on_tribler_shutdown())
+        shutdown_task = tasks[0]
+        shutdown_task.add_done_callback(lambda result: TinyTriblerService._graceful_shutdown(self))
 
     async def on_tribler_shutdown(self):
         await self.shutdown_task_manager()

--- a/src/tribler/core/components/metadata_store/restapi/metadata_endpoint.py
+++ b/src/tribler/core/components/metadata_store/restapi/metadata_endpoint.py
@@ -1,4 +1,3 @@
-from asyncio import create_task
 from binascii import unhexlify
 
 from aiohttp import ContentTypeError, web
@@ -225,5 +224,6 @@ class MetadataEndpoint(MetadataEndpointBase, UpdateEntryMixin):
             return RESTResponse({"error": f"Error processing timeout parameter: {e}"}, status=HTTP_BAD_REQUEST)
 
         infohash = unhexlify(request.match_info['infohash'])
-        create_task(self.torrent_checker.check_torrent_health(infohash, timeout=timeout, scrape_now=True))
+        check_coro = self.torrent_checker.check_torrent_health(infohash, timeout=timeout, scrape_now=True)
+        self.async_group.add(check_coro)
         return RESTResponse({'checking': '1'})

--- a/src/tribler/core/components/restapi/rest/shutdown_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/shutdown_endpoint.py
@@ -18,7 +18,7 @@ class ShutdownEndpoint(RESTEndpoint):
         self.shutdown_callback = shutdown_callback
 
     def setup_routes(self):
-        self.app.add_routes([web.put('', self.shutdown)])
+        self.app.add_routes([web.put('', self.shutdown_request)])
 
     @docs(
         tags=["General"],
@@ -31,7 +31,7 @@ class ShutdownEndpoint(RESTEndpoint):
             }
         }
     )
-    async def shutdown(self, request):
+    async def shutdown_request(self, _):
         self._logger.info('Received a shutdown request from GUI')
         self.shutdown_callback()
         return RESTResponse({"shutdown": True})

--- a/src/tribler/core/components/restapi/rest/tests/test_events_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/tests/test_events_endpoint.py
@@ -150,7 +150,7 @@ async def test_on_tribler_exception_stores_only_first_error(endpoint, reported_e
     assert endpoint.undelivered_error == endpoint.error_message(first_reported_error)
 
 
-@patch.object(EventsEndpoint, 'register_anonymous_task', new=AsyncMock(side_effect=CancelledError))
+@patch('asyncio.sleep', new=AsyncMock(side_effect=CancelledError))
 @patch.object(RESTStreamResponse, 'prepare', new=AsyncMock())
 @patch.object(RESTStreamResponse, 'write', new_callable=AsyncMock)
 @patch.object(EventsEndpoint, 'encode_message')

--- a/src/tribler/core/components/restapi/rest/tests/test_rest_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/tests/test_rest_endpoint.py
@@ -1,0 +1,46 @@
+from unittest.mock import AsyncMock, patch
+
+from tribler.core.components.restapi.rest.rest_endpoint import RESTEndpoint
+from tribler.core.utilities.async_group import AsyncGroup
+
+
+# pylint: disable=protected-access
+
+async def test_shutdown():
+    # In this test we check that all coros related to the Root Endpoint are cancelled
+    # during shutdown
+
+    async def coro():
+        ...
+
+    root_endpoint = RESTEndpoint()
+    root_endpoint.async_group.add(coro())
+
+    # add 2 child endpoints with a single coro in each:
+    child_endpoints = [RESTEndpoint(), RESTEndpoint()]
+    for index, child_endpoint in enumerate(child_endpoints):
+        root_endpoint.add_endpoint(prefix=f'/{index}', endpoint=child_endpoint)
+        child_endpoint.async_group.add(coro())
+
+    def total_coro_count():
+        count = 0
+        for endpoint in child_endpoints + [root_endpoint]:
+            count += len(endpoint.async_group._futures)
+        return count
+
+    assert total_coro_count() == 3
+
+    await root_endpoint.shutdown()
+
+    assert total_coro_count() == 0
+
+
+@patch.object(AsyncGroup, 'cancel', new_callable=AsyncMock)
+async def test_multiple_shutdown_calls(async_group_cancel: AsyncMock):
+    # Test that if shutdown calls twice, only one call is processed
+    endpoint = RESTEndpoint()
+
+    await endpoint.shutdown()
+    await endpoint.shutdown()
+
+    async_group_cancel.assert_called_once()

--- a/src/tribler/core/components/restapi/restapi_component.py
+++ b/src/tribler/core/components/restapi/restapi_component.py
@@ -150,8 +150,8 @@ class RESTComponent(Component):
     async def shutdown(self):
         await super().shutdown()
 
-        if self._events_endpoint:
-            await self._events_endpoint.shutdown()
+        if self.root_endpoint:
+            await self.root_endpoint.shutdown()
 
         if self._core_exception_handler:
             self._core_exception_handler.report_callback = None

--- a/src/tribler/core/utilities/async_group.py
+++ b/src/tribler/core/utilities/async_group.py
@@ -1,5 +1,5 @@
 import asyncio
-from asyncio import CancelledError, Future
+from asyncio import CancelledError, Future, Task
 from contextlib import suppress
 from typing import Iterable, List, Set
 
@@ -24,13 +24,17 @@ class AsyncGroup:
     def __init__(self):
         self._futures: Set[Future] = set()
 
-    def add(self, *coroutines):
+    def add(self, *coroutines) -> List[Task]:
         """Add a coroutine to the group.
         """
+        result = []
         for coroutine in coroutines:
             task = asyncio.create_task(coroutine)
             self._futures.add(task)
             task.add_done_callback(self._done_callback)
+            result.append(task)
+
+        return result
 
     async def wait(self):
         """ Wait for completion of all futures

--- a/src/tribler/core/utilities/tests/test_async_group.py
+++ b/src/tribler/core/utilities/tests/test_async_group.py
@@ -30,21 +30,23 @@ async def raise_exception():
 
 
 async def test_add_single_coro(group: AsyncGroup):
-    group.add(
+    tasks = group.add(
         void()
     )
 
     assert len(group._futures) == 1
+    assert len(tasks) == 1
 
 
 async def test_add_iterable(group: AsyncGroup):
-    group.add(
+    tasks = group.add(
         void(),
         void(),
         void()
     )
 
     assert len(group._futures) == 3
+    assert len(tasks) == 3
 
 
 async def test_cancel(group: AsyncGroup):


### PR DESCRIPTION
This PR fixes #7299

* `shutdown` method has been added to the `RestEndpoint` base class
* `List[Task]` has been added as a result value of the `AsyncGroup.add()` call
* Calls of `asyncio.create_task` have been fixed