### PR TITLE
Fix and speed up health checks

### DIFF
--- a/src/tribler/core/components/libtorrent/download_manager/dht_health_manager.py
+++ b/src/tribler/core/components/libtorrent/download_manager/dht_health_manager.py
@@ -65,7 +65,7 @@ class DHTHealthManager(TaskManager):
         seeders = DHTHealthManager.get_size_from_bloomfilter(bf_seeders)
         peers = DHTHealthManager.get_size_from_bloomfilter(bf_peers)
         if not self.lookup_futures[infohash].done():
-            health = HealthInfo(infohash, last_check=int(time.time()), seeders=seeders, leechers=peers)
+            health = HealthInfo(infohash, seeders=seeders, leechers=peers)
             self.lookup_futures[infohash].set_result(health)
 
         self.lookup_futures.pop(infohash, None)

--- a/src/tribler/core/components/metadata_store/db/orm_bindings/torrent_state.py
+++ b/src/tribler/core/components/metadata_store/db/orm_bindings/torrent_state.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Tuple
+
 from pony import orm
 from tribler.core.components.torrent_checker.torrent_checker.dataclasses import HealthInfo
 
@@ -28,5 +30,9 @@ def define_binding(db):
         def to_health(self) -> HealthInfo:
             return HealthInfo(infohash=self.infohash, last_check=self.last_check,
                               seeders=self.seeders, leechers=self.leechers)
+
+        @property
+        def seeders_leechers_last_check(self) -> Tuple[int, int, int]:
+            return self.seeders, self.leechers, self.last_check
 
     return TorrentState

--- a/src/tribler/core/components/metadata_store/db/orm_bindings/torrent_state.py
+++ b/src/tribler/core/components/metadata_store/db/orm_bindings/torrent_state.py
@@ -23,10 +23,9 @@ def define_binding(db):
         @classmethod
         def from_health(cls, health: HealthInfo):
             return cls(infohash=health.infohash, seeders=health.seeders, leechers=health.leechers,
-                       last_check=health.last_check)
+                       last_check=health.last_check, self_checked=health.self_checked)
 
         def to_health(self) -> HealthInfo:
-            return HealthInfo(infohash=self.infohash, last_check=self.last_check,
-                              seeders=self.seeders, leechers=self.leechers)
+            return HealthInfo(self.infohash, self.seeders, self.leechers, self.last_check, self.self_checked)
 
     return TorrentState

--- a/src/tribler/core/components/metadata_store/db/orm_bindings/torrent_state.py
+++ b/src/tribler/core/components/metadata_store/db/orm_bindings/torrent_state.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Tuple
-
 from pony import orm
 from tribler.core.components.torrent_checker.torrent_checker.dataclasses import HealthInfo
 
@@ -30,9 +28,5 @@ def define_binding(db):
         def to_health(self) -> HealthInfo:
             return HealthInfo(infohash=self.infohash, last_check=self.last_check,
                               seeders=self.seeders, leechers=self.leechers)
-
-        @property
-        def seeders_leechers_last_check(self) -> Tuple[int, int, int]:
-            return self.seeders, self.leechers, self.last_check
 
     return TorrentState

--- a/src/tribler/core/components/metadata_store/db/store.py
+++ b/src/tribler/core/components/metadata_store/db/store.py
@@ -484,7 +484,7 @@ class MetadataStore:
 
         torrent_state = self.TorrentState.get_for_update(infohash=health.infohash)
 
-        if torrent_state and health.should_update(torrent_state):
+        if torrent_state and health.should_replace(torrent_state.to_health()):
             self._logger.debug(f"Update health info {health}")
             torrent_state.set(seeders=health.seeders, leechers=health.leechers, last_check=health.last_check,
                               self_checked=False)

--- a/src/tribler/core/components/metadata_store/remote_query_community/remote_query_community.py
+++ b/src/tribler/core/components/metadata_store/remote_query_community/remote_query_community.py
@@ -23,8 +23,6 @@ from tribler.core.components.metadata_store.db.store import MetadataStore
 from tribler.core.components.metadata_store.remote_query_community.payload_checker import ObjState
 from tribler.core.components.metadata_store.remote_query_community.settings import RemoteQueryCommunitySettings
 from tribler.core.components.metadata_store.utils import RequestTimeoutException
-from tribler.core.components.knowledge.community.knowledge_validator import is_valid_resource
-from tribler.core.components.knowledge.db.knowledge_db import ResourceType
 from tribler.core.utilities.pony_utils import run_threaded
 from tribler.core.utilities.unicode import hexlify
 

--- a/src/tribler/core/components/popularity/community/tests/test_popularity_community.py
+++ b/src/tribler/core/components/popularity/community/tests/test_popularity_community.py
@@ -32,8 +32,7 @@ def _generate_single_checked_torrent(status: str = None) -> HealthInfo:
             return randint(101, 1000)
         return randint(1, 100)
 
-    return HealthInfo(random_infohash(), last_check=int(time.time()),
-                      seeders=get_peers_for(status), leechers=get_peers_for(status))
+    return HealthInfo(random_infohash(), seeders=get_peers_for(status), leechers=get_peers_for(status))
 
 
 def _generate_checked_torrents(count: int, status: str = None) -> List[HealthInfo]:
@@ -89,7 +88,7 @@ class TestPopularityCommunity(TestBase):
         """
         Test whether torrent health information is correctly gossiped around
         """
-        checked_torrent_info = HealthInfo(b'a' * 20, seeders=200, leechers=0, last_check=int(time.time()))
+        checked_torrent_info = HealthInfo(b'a' * 20, seeders=200, leechers=0)
         node0_db = self.nodes[0].overlay.mds.TorrentState
         node1_db2 = self.nodes[1].overlay.mds.TorrentState
 
@@ -180,7 +179,7 @@ class TestPopularityCommunity(TestBase):
         """
         self.fill_database(self.nodes[1].overlay.mds)
 
-        checked_torrent_info = HealthInfo(b'0' * 20, seeders=200, leechers=0, last_check=int(time.time()))
+        checked_torrent_info = HealthInfo(b'0' * 20, seeders=200, leechers=0)
         await self.init_first_node_and_gossip(checked_torrent_info, deliver_timeout=0.5)
 
         # Check whether node 1 has new torrent health information
@@ -197,7 +196,7 @@ class TestPopularityCommunity(TestBase):
         with db_session:
             self.nodes[0].overlay.mds.TorrentMetadata(infohash=infohash)
         await self.init_first_node_and_gossip(
-            HealthInfo(infohash, seeders=200, leechers=0, last_check=int(time.time())))
+            HealthInfo(infohash, seeders=200, leechers=0))
         with db_session:
             assert self.nodes[1].overlay.mds.TorrentMetadata.get()
 
@@ -209,5 +208,5 @@ class TestPopularityCommunity(TestBase):
             self.nodes[1].overlay.mds.TorrentMetadata(infohash=infohash)
         self.nodes[1].overlay.send_remote_select = Mock()
         await self.init_first_node_and_gossip(
-            HealthInfo(infohash, seeders=200, leechers=0, last_check=int(time.time())))
+            HealthInfo(infohash, seeders=200, leechers=0))
         self.nodes[1].overlay.send_remote_select.assert_not_called()

--- a/src/tribler/core/components/socks_servers/socks5/connection.py
+++ b/src/tribler/core/components/socks_servers/socks5/connection.py
@@ -41,6 +41,7 @@ class Socks5Connection(Protocol):
     def __init__(self, socksserver):
         super().__init__()
         self._logger = logging.getLogger(self.__class__.__name__)
+        self._logger.setLevel(logging.WARNING)
         self.socksserver = socksserver
         self.transport = None
         self.connect_to = None

--- a/src/tribler/core/components/torrent_checker/torrent_checker/dataclasses.py
+++ b/src/tribler/core/components/torrent_checker/torrent_checker/dataclasses.py
@@ -1,6 +1,6 @@
 import time
 from dataclasses import dataclass, field
-from typing import List
+from typing import List, Tuple
 
 import human_readable
 
@@ -45,6 +45,10 @@ class HealthInfo:
 
     def is_valid(self) -> bool:
         return self.last_check < int(time.time()) + TOLERABLE_TIME_DRIFT
+
+    @property
+    def seeders_leechers_last_check(self) -> Tuple[int, int, int]:
+        return self.seeders, self.leechers, self.last_check
 
     def should_update(self, torrent_state, self_checked=False):
         if self.last_check <= torrent_state.last_check:

--- a/src/tribler/core/components/torrent_checker/torrent_checker/dataclasses.py
+++ b/src/tribler/core/components/torrent_checker/torrent_checker/dataclasses.py
@@ -17,9 +17,9 @@ HEALTH_FRESHNESS_SECONDS = 4 * HOUR  # Number of seconds before a torrent health
 @dataclass
 class HealthInfo:
     infohash: bytes = field(repr=False)
-    last_check: int
     seeders: int = 0
     leechers: int = 0
+    last_check: int = field(default_factory=lambda: int(time.time()))
 
     def __repr__(self):
         infohash_repr = hexlify(self.infohash[:4])

--- a/src/tribler/core/components/torrent_checker/torrent_checker/tests/test_health_info_should_update.py
+++ b/src/tribler/core/components/torrent_checker/torrent_checker/tests/test_health_info_should_update.py
@@ -20,7 +20,7 @@ def torrent_state_fixture():
 
 
 def test_different_infohashes(torrent_state: Mock):
-    health = HealthInfo(infohash=b'infohash_2', last_check=now())
+    health = HealthInfo(infohash=b'infohash_2')
     with pytest.raises(ValueError, match='^An attempt to compare health for different infohashes$'):
         health.should_update(torrent_state)
 
@@ -33,14 +33,14 @@ def test_invalid_health(torrent_state: Mock):
 
 def test_self_checked_health_remote_torrent_state(torrent_state: Mock):
     torrent_state.self_checked = False
-    health = HealthInfo(INFOHASH, last_check=now())
+    health = HealthInfo(INFOHASH)
     assert health.should_update(torrent_state, self_checked=True)
 
 
 def test_self_checked_health_torrent_state_outside_window(torrent_state: Mock):
     torrent_state.self_checked = True
     torrent_state.last_check = now() - TORRENT_CHECK_WINDOW - 1
-    health = HealthInfo(INFOHASH, last_check=now())
+    health = HealthInfo(INFOHASH)
     assert health.should_update(torrent_state, self_checked=True)
 
 

--- a/src/tribler/core/components/torrent_checker/torrent_checker/tests/test_health_info_should_update.py
+++ b/src/tribler/core/components/torrent_checker/torrent_checker/tests/test_health_info_should_update.py
@@ -14,70 +14,67 @@ def now() -> int:
     return int(time.time())
 
 
-@pytest.fixture(name='torrent_state')
-def torrent_state_fixture():
-    return Mock(infohash=INFOHASH)
+def mock_torrent_state(self_checked=False, seeders=0, leechers=0, last_check=None) -> Mock:
+    result = Mock(infohash=INFOHASH, self_checked=self_checked, seeders=seeders, leechers=leechers,
+                  last_check=now() if last_check is None else last_check)
+    result.to_health.return_value = HealthInfo(INFOHASH, seeders, leechers, last_check)
+    return result
 
 
-def test_different_infohashes(torrent_state: Mock):
+def test_different_infohashes():
+    torrent_state = mock_torrent_state()
     health = HealthInfo(infohash=b'infohash_2')
     with pytest.raises(ValueError, match='^An attempt to compare health for different infohashes$'):
         health.should_update(torrent_state)
 
 
-def test_invalid_health(torrent_state: Mock):
+def test_invalid_health():
+    torrent_state = mock_torrent_state()
     health = HealthInfo(INFOHASH, last_check=now() + TOLERABLE_TIME_DRIFT + 2)
     assert not health.is_valid()
     assert not health.should_update(torrent_state)
 
 
-def test_self_checked_health_remote_torrent_state(torrent_state: Mock):
-    torrent_state.self_checked = False
+def test_self_checked_health_remote_torrent_state():
+    torrent_state = mock_torrent_state(self_checked=False)
     health = HealthInfo(INFOHASH)
     assert health.should_update(torrent_state, self_checked=True)
 
 
-def test_self_checked_health_torrent_state_outside_window(torrent_state: Mock):
-    torrent_state.self_checked = True
-    torrent_state.last_check = now() - TORRENT_CHECK_WINDOW - 1
+def test_self_checked_health_torrent_state_outside_window():
+    torrent_state = mock_torrent_state(self_checked=True, last_check=now() - TORRENT_CHECK_WINDOW - 1)
     health = HealthInfo(INFOHASH)
     assert health.should_update(torrent_state, self_checked=True)
 
 
-def test_self_checked_health_inside_window_more_seeders(torrent_state: Mock):
+def test_self_checked_health_inside_window_more_seeders():
     now_ = now()
-    torrent_state.self_checked = True
-    torrent_state.last_check = now_ - TORRENT_CHECK_WINDOW + 2
-    torrent_state.to_health.return_value = HealthInfo(INFOHASH, seeders=1, leechers=2,
-                                                      last_check=torrent_state.last_check)
+    torrent_state = mock_torrent_state(self_checked=True, seeders=1, leechers=2,
+                                       last_check=now_ - TORRENT_CHECK_WINDOW + 2)
     health = HealthInfo(INFOHASH, last_check=now_, seeders=2, leechers=1)
     assert health > torrent_state.to_health()
     assert health.should_update(torrent_state, self_checked=True)
 
 
-def test_self_checked_health_inside_window_fewer_seeders(torrent_state: Mock):
+def test_self_checked_health_inside_window_fewer_seeders():
     now_ = now()
-    torrent_state.self_checked = True
-    torrent_state.last_check = now_ - TORRENT_CHECK_WINDOW + 2
-    torrent_state.to_health.return_value = HealthInfo(INFOHASH, seeders=2, leechers=1,
-                                                      last_check=torrent_state.last_check)
+    torrent_state = mock_torrent_state(self_checked=True, seeders=2, leechers=1,
+                                       last_check=now_ - TORRENT_CHECK_WINDOW + 2)
     health = HealthInfo(INFOHASH, last_check=now_, seeders=1, leechers=2)
     assert health < torrent_state.to_health()
     assert not health.should_update(torrent_state, self_checked=True)
 
 
-def test_self_checked_torrent_state_fresh_enough(torrent_state: Mock):
+def test_self_checked_torrent_state_fresh_enough():
     now_ = now()
-    torrent_state.self_checked = True
-    torrent_state.last_check = now_ - HEALTH_FRESHNESS_SECONDS + 2  # self-checked, fresh enough
+    torrent_state = mock_torrent_state(self_checked=True, last_check=now_ - HEALTH_FRESHNESS_SECONDS + 2)
     health = HealthInfo(INFOHASH, last_check=now_)
     assert not health.should_update(torrent_state)
 
 
-def test_torrent_state_self_checked_long_ago(torrent_state: Mock):
+def test_torrent_state_self_checked_long_ago():
     now_ = now()
-    torrent_state.self_checked = True
-    torrent_state.last_check = now_ - HEALTH_FRESHNESS_SECONDS - 2
+    torrent_state = mock_torrent_state(self_checked=True, last_check=now_ - HEALTH_FRESHNESS_SECONDS - 2)
     health = HealthInfo(INFOHASH, last_check=now_)
     assert health.should_update(torrent_state)
 
@@ -88,11 +85,9 @@ def test_torrent_state_self_checked_long_ago(torrent_state: Mock):
     assert health.should_update(torrent_state)
 
 
-def test_more_recent_more_seeders(torrent_state: Mock):
+def test_more_recent_more_seeders():
     t = now() - 100
-    torrent_state.self_checked = False
-    torrent_state.last_check = t
-    torrent_state.to_health.return_value = HealthInfo(INFOHASH, seeders=1, leechers=2, last_check=t)
+    torrent_state = mock_torrent_state(self_checked=False, seeders=1, leechers=2, last_check=t)
 
     health = HealthInfo(INFOHASH, last_check=t-1, seeders=2, leechers=1)
     assert abs(torrent_state.last_check - health.last_check) <= TOLERABLE_TIME_DRIFT
@@ -103,11 +98,9 @@ def test_more_recent_more_seeders(torrent_state: Mock):
     assert health.should_update(torrent_state)
 
 
-def test_more_recent_fewer_seeders(torrent_state: Mock):
+def test_more_recent_fewer_seeders():
     t = now() - 100
-    torrent_state.self_checked = False
-    torrent_state.last_check = t
-    torrent_state.to_health.return_value = HealthInfo(INFOHASH, seeders=2, leechers=1, last_check=t)
+    torrent_state = mock_torrent_state(self_checked=False, seeders=2, leechers=1, last_check=t)
 
     health = HealthInfo(INFOHASH, last_check=t-1, seeders=1, leechers=2)
     assert abs(torrent_state.last_check - health.last_check) <= TOLERABLE_TIME_DRIFT
@@ -118,10 +111,8 @@ def test_more_recent_fewer_seeders(torrent_state: Mock):
     assert not health.should_update(torrent_state)
 
 
-def test_less_recent_more_seeders(torrent_state: Mock):
+def test_less_recent_more_seeders():
     t = now() - 100
-    torrent_state.self_checked = False
-    torrent_state.last_check = t
-
+    torrent_state = mock_torrent_state(self_checked=False, last_check=t)
     health = HealthInfo(INFOHASH, last_check=t - TOLERABLE_TIME_DRIFT - 1, seeders=100)
     assert not health.should_update(torrent_state)

--- a/src/tribler/core/components/torrent_checker/torrent_checker/tests/test_health_info_should_update.py
+++ b/src/tribler/core/components/torrent_checker/torrent_checker/tests/test_health_info_should_update.py
@@ -1,0 +1,127 @@
+import time
+from unittest.mock import Mock
+
+import pytest
+
+from tribler.core.components.torrent_checker.torrent_checker.dataclasses import HEALTH_FRESHNESS_SECONDS, HealthInfo, \
+    TOLERABLE_TIME_DRIFT, \
+    TORRENT_CHECK_WINDOW
+
+INFOHASH = b'infohash_1'
+
+
+def now() -> int:
+    return int(time.time())
+
+
+@pytest.fixture(name='torrent_state')
+def torrent_state_fixture():
+    return Mock(infohash=INFOHASH)
+
+
+def test_different_infohashes(torrent_state: Mock):
+    health = HealthInfo(infohash=b'infohash_2', last_check=now())
+    with pytest.raises(ValueError, match='^An attempt to compare health for different infohashes$'):
+        health.should_update(torrent_state)
+
+
+def test_invalid_health(torrent_state: Mock):
+    health = HealthInfo(INFOHASH, last_check=now() + TOLERABLE_TIME_DRIFT + 2)
+    assert not health.is_valid()
+    assert not health.should_update(torrent_state)
+
+
+def test_self_checked_health_remote_torrent_state(torrent_state: Mock):
+    torrent_state.self_checked = False
+    health = HealthInfo(INFOHASH, last_check=now())
+    assert health.should_update(torrent_state, self_checked=True)
+
+
+def test_self_checked_health_torrent_state_outside_window(torrent_state: Mock):
+    torrent_state.self_checked = True
+    torrent_state.last_check = now() - TORRENT_CHECK_WINDOW - 1
+    health = HealthInfo(INFOHASH, last_check=now())
+    assert health.should_update(torrent_state, self_checked=True)
+
+
+def test_self_checked_health_inside_window_more_seeders(torrent_state: Mock):
+    now_ = now()
+    torrent_state.self_checked = True
+    torrent_state.last_check = now_ - TORRENT_CHECK_WINDOW + 2
+    torrent_state.seeders_leechers_last_check = (1, 2, torrent_state.last_check)
+    health = HealthInfo(INFOHASH, last_check=now_, seeders=2, leechers=1)
+    assert health.seeders_leechers_last_check == (2, 1, now_)
+    assert health.seeders_leechers_last_check > torrent_state.seeders_leechers_last_check
+    assert health.should_update(torrent_state, self_checked=True)
+
+
+def test_self_checked_health_inside_window_fewer_seeders(torrent_state: Mock):
+    now_ = now()
+    torrent_state.self_checked = True
+    torrent_state.last_check = now_ - TORRENT_CHECK_WINDOW + 2
+    torrent_state.seeders_leechers_last_check = (2, 1, torrent_state.last_check)
+    health = HealthInfo(INFOHASH, last_check=now_, seeders=1, leechers=2)
+    assert health.seeders_leechers_last_check == (1, 2, now_)
+    assert health.seeders_leechers_last_check < torrent_state.seeders_leechers_last_check
+    assert not health.should_update(torrent_state, self_checked=True)
+
+
+def test_self_checked_torrent_state_fresh_enough(torrent_state: Mock):
+    now_ = now()
+    torrent_state.self_checked = True
+    torrent_state.last_check = now_ - HEALTH_FRESHNESS_SECONDS + 2  # self-checked, fresh enough
+    health = HealthInfo(INFOHASH, last_check=now_)
+    assert not health.should_update(torrent_state)
+
+
+def test_torrent_state_self_checked_long_ago(torrent_state: Mock):
+    now_ = now()
+    torrent_state.self_checked = True
+    torrent_state.last_check = now_ - HEALTH_FRESHNESS_SECONDS - 2
+    health = HealthInfo(INFOHASH, last_check=now_)
+    assert health.should_update(torrent_state)
+
+    # should work the same way if time is not recent
+    big_time_offset = 1000000
+    torrent_state.last_check -= big_time_offset
+    health.last_check -= big_time_offset
+    assert health.should_update(torrent_state)
+
+
+def test_more_recent_more_seeders(torrent_state: Mock):
+    t = now() - 100
+    torrent_state.self_checked = False
+    torrent_state.last_check = t
+    torrent_state.seeders_leechers_last_check = (1, 2, t)
+
+    health = HealthInfo(INFOHASH, last_check=t-1, seeders=2, leechers=1)
+    assert abs(torrent_state.last_check - health.last_check) <= TOLERABLE_TIME_DRIFT
+    assert health.should_update(torrent_state)
+
+    health.last_check = t+1
+    assert abs(torrent_state.last_check - health.last_check) <= TOLERABLE_TIME_DRIFT
+    assert health.should_update(torrent_state)
+
+
+def test_more_recent_fewer_seeders(torrent_state: Mock):
+    t = now() - 100
+    torrent_state.self_checked = False
+    torrent_state.last_check = t
+    torrent_state.seeders_leechers_last_check = (2, 1, t)
+
+    health = HealthInfo(INFOHASH, last_check=t-1, seeders=1, leechers=2)
+    assert abs(torrent_state.last_check - health.last_check) <= TOLERABLE_TIME_DRIFT
+    assert not health.should_update(torrent_state)
+
+    health.last_check = t+1
+    assert abs(torrent_state.last_check - health.last_check) <= TOLERABLE_TIME_DRIFT
+    assert not health.should_update(torrent_state)
+
+
+def test_less_recent_more_seeders(torrent_state: Mock):
+    t = now() - 100
+    torrent_state.self_checked = False
+    torrent_state.last_check = t
+
+    health = HealthInfo(INFOHASH, last_check=t - TOLERABLE_TIME_DRIFT - 1, seeders=100)
+    assert not health.should_update(torrent_state)

--- a/src/tribler/core/components/torrent_checker/torrent_checker/tests/test_health_info_should_update.py
+++ b/src/tribler/core/components/torrent_checker/torrent_checker/tests/test_health_info_should_update.py
@@ -1,5 +1,4 @@
 import time
-from unittest.mock import Mock
 
 import pytest
 
@@ -14,105 +13,92 @@ def now() -> int:
     return int(time.time())
 
 
-def mock_torrent_state(self_checked=False, seeders=0, leechers=0, last_check=None) -> Mock:
-    result = Mock(infohash=INFOHASH, self_checked=self_checked, seeders=seeders, leechers=leechers,
-                  last_check=now() if last_check is None else last_check)
-    result.to_health.return_value = HealthInfo(INFOHASH, seeders, leechers, last_check)
-    return result
-
-
 def test_different_infohashes():
-    torrent_state = mock_torrent_state()
+    prev_health = HealthInfo(INFOHASH)
     health = HealthInfo(infohash=b'infohash_2')
     with pytest.raises(ValueError, match='^An attempt to compare health for different infohashes$'):
-        health.should_update(torrent_state)
+        health.should_replace(prev_health)
 
 
 def test_invalid_health():
-    torrent_state = mock_torrent_state()
+    prev_health = HealthInfo(INFOHASH)
     health = HealthInfo(INFOHASH, last_check=now() + TOLERABLE_TIME_DRIFT + 2)
     assert not health.is_valid()
-    assert not health.should_update(torrent_state)
+    assert not health.should_replace(prev_health)
 
 
-def test_self_checked_health_remote_torrent_state():
-    torrent_state = mock_torrent_state(self_checked=False)
-    health = HealthInfo(INFOHASH)
-    assert health.should_update(torrent_state, self_checked=True)
+def test_self_checked_health_update_remote_health():
+    prev_health = HealthInfo(INFOHASH)
+    health = HealthInfo(INFOHASH, self_checked=True)
+    assert health.should_replace(prev_health)
 
 
 def test_self_checked_health_torrent_state_outside_window():
-    torrent_state = mock_torrent_state(self_checked=True, last_check=now() - TORRENT_CHECK_WINDOW - 1)
-    health = HealthInfo(INFOHASH)
-    assert health.should_update(torrent_state, self_checked=True)
+    prev_health = HealthInfo(INFOHASH, last_check=now() - TORRENT_CHECK_WINDOW - 1, self_checked=True)
+    health = HealthInfo(INFOHASH, self_checked=True)
+    assert health.should_replace(prev_health)
 
 
 def test_self_checked_health_inside_window_more_seeders():
-    now_ = now()
-    torrent_state = mock_torrent_state(self_checked=True, seeders=1, leechers=2,
-                                       last_check=now_ - TORRENT_CHECK_WINDOW + 2)
-    health = HealthInfo(INFOHASH, last_check=now_, seeders=2, leechers=1)
-    assert health > torrent_state.to_health()
-    assert health.should_update(torrent_state, self_checked=True)
+    prev_health = HealthInfo(INFOHASH, 1, 2, last_check=now() - TORRENT_CHECK_WINDOW + 2, self_checked=True)
+    health = HealthInfo(INFOHASH, 2, 1, self_checked=True)
+    assert health > prev_health
+    assert health.should_replace(prev_health)
 
 
 def test_self_checked_health_inside_window_fewer_seeders():
-    now_ = now()
-    torrent_state = mock_torrent_state(self_checked=True, seeders=2, leechers=1,
-                                       last_check=now_ - TORRENT_CHECK_WINDOW + 2)
-    health = HealthInfo(INFOHASH, last_check=now_, seeders=1, leechers=2)
-    assert health < torrent_state.to_health()
-    assert not health.should_update(torrent_state, self_checked=True)
+    prev_health = HealthInfo(INFOHASH, 2, 1, last_check=now() - TORRENT_CHECK_WINDOW + 2, self_checked=True)
+    health = HealthInfo(INFOHASH, 1, 2, self_checked=True)
+    assert health < prev_health
+    assert not health.should_replace(prev_health)
 
 
 def test_self_checked_torrent_state_fresh_enough():
-    now_ = now()
-    torrent_state = mock_torrent_state(self_checked=True, last_check=now_ - HEALTH_FRESHNESS_SECONDS + 2)
-    health = HealthInfo(INFOHASH, last_check=now_)
-    assert not health.should_update(torrent_state)
+    prev_health = HealthInfo(INFOHASH, last_check=now() - HEALTH_FRESHNESS_SECONDS + 2, self_checked=True)
+    health = HealthInfo(INFOHASH)
+    assert not health.should_replace(prev_health)
 
 
 def test_torrent_state_self_checked_long_ago():
-    now_ = now()
-    torrent_state = mock_torrent_state(self_checked=True, last_check=now_ - HEALTH_FRESHNESS_SECONDS - 2)
-    health = HealthInfo(INFOHASH, last_check=now_)
-    assert health.should_update(torrent_state)
+    prev_health = HealthInfo(INFOHASH, last_check=now() - HEALTH_FRESHNESS_SECONDS - 2, self_checked=True)
+    health = HealthInfo(INFOHASH)
+    assert health.should_replace(prev_health)
 
     # should work the same way if time is not recent
     big_time_offset = 1000000
-    torrent_state.last_check -= big_time_offset
+    prev_health.last_check -= big_time_offset
     health.last_check -= big_time_offset
-    assert health.should_update(torrent_state)
+    assert health.should_replace(prev_health)
 
 
 def test_more_recent_more_seeders():
     t = now() - 100
-    torrent_state = mock_torrent_state(self_checked=False, seeders=1, leechers=2, last_check=t)
+    prev_health = HealthInfo(INFOHASH, 1, 2, last_check=t)
 
-    health = HealthInfo(INFOHASH, last_check=t-1, seeders=2, leechers=1)
-    assert abs(torrent_state.last_check - health.last_check) <= TOLERABLE_TIME_DRIFT
-    assert health.should_update(torrent_state)
+    health = HealthInfo(INFOHASH, 2, 1, last_check=t-1)
+    assert abs(prev_health.last_check - health.last_check) <= TOLERABLE_TIME_DRIFT
+    assert health.should_replace(prev_health)
 
     health.last_check = t+1
-    assert abs(torrent_state.last_check - health.last_check) <= TOLERABLE_TIME_DRIFT
-    assert health.should_update(torrent_state)
+    assert abs(prev_health.last_check - health.last_check) <= TOLERABLE_TIME_DRIFT
+    assert health.should_replace(prev_health)
 
 
 def test_more_recent_fewer_seeders():
     t = now() - 100
-    torrent_state = mock_torrent_state(self_checked=False, seeders=2, leechers=1, last_check=t)
+    prev_health = HealthInfo(INFOHASH, 2, 1, last_check=t)
 
     health = HealthInfo(INFOHASH, last_check=t-1, seeders=1, leechers=2)
-    assert abs(torrent_state.last_check - health.last_check) <= TOLERABLE_TIME_DRIFT
-    assert not health.should_update(torrent_state)
+    assert abs(prev_health.last_check - health.last_check) <= TOLERABLE_TIME_DRIFT
+    assert not health.should_replace(prev_health)
 
     health.last_check = t+1
-    assert abs(torrent_state.last_check - health.last_check) <= TOLERABLE_TIME_DRIFT
-    assert not health.should_update(torrent_state)
+    assert abs(prev_health.last_check - health.last_check) <= TOLERABLE_TIME_DRIFT
+    assert not health.should_replace(prev_health)
 
 
 def test_less_recent_more_seeders():
     t = now() - 100
-    torrent_state = mock_torrent_state(self_checked=False, last_check=t)
-    health = HealthInfo(INFOHASH, last_check=t - TOLERABLE_TIME_DRIFT - 1, seeders=100)
-    assert not health.should_update(torrent_state)
+    prev_health = HealthInfo(INFOHASH, last_check=t)
+    health = HealthInfo(INFOHASH, 100, last_check=t - TOLERABLE_TIME_DRIFT - 1)
+    assert not health.should_replace(prev_health)

--- a/src/tribler/core/components/torrent_checker/torrent_checker/tests/test_torrentchecker.py
+++ b/src/tribler/core/components/torrent_checker/torrent_checker/tests/test_torrentchecker.py
@@ -258,6 +258,7 @@ def test_update_health(torrent_checker: TorrentChecker):
     ]
 
     health = aggregate_responses_for_infohash(infohash, responses)
+    health.self_checked = True
 
     # Check that everything works fine even if the database contains no proper infohash
     updated = torrent_checker.update_torrent_health(health)

--- a/src/tribler/core/components/torrent_checker/torrent_checker/tests/test_torrentchecker.py
+++ b/src/tribler/core/components/torrent_checker/torrent_checker/tests/test_torrentchecker.py
@@ -1,15 +1,19 @@
+import logging
 import os
 import random
 import secrets
 import time
-from unittest.mock import AsyncMock, MagicMock
+from asyncio import CancelledError
+from binascii import unhexlify
+from unittest.mock import AsyncMock, MagicMock, Mock
 
 import pytest
 from ipv8.util import succeed
 from pony.orm import db_session
 
 import tribler.core.components.torrent_checker.torrent_checker.torrent_checker as torrent_checker_module
-from tribler.core.components.torrent_checker.torrent_checker.dataclasses import HealthInfo, TrackerResponse
+from tribler.core.components.torrent_checker.torrent_checker.dataclasses import HealthInfo, TOLERABLE_TIME_DRIFT, \
+    TrackerResponse
 from tribler.core.components.torrent_checker.torrent_checker.utils import aggregate_responses_for_infohash, \
     filter_non_exceptions
 from tribler.core.components.torrent_checker.torrent_checker.torrent_checker import TorrentChecker
@@ -20,13 +24,13 @@ from tribler.core.components.torrent_checker.torrent_checker.tracker_manager imp
 
 # pylint: disable=protected-access
 
-@pytest.fixture
-def tracker_manager(tmp_path, metadata_store):
+@pytest.fixture(name="tracker_manager")
+def tracker_manager_fixture(tmp_path, metadata_store):
     return TrackerManager(state_dir=tmp_path, metadata_store=metadata_store)
 
 
 @pytest.fixture(name="torrent_checker")
-async def fixture_torrent_checker(tribler_config, tracker_manager, metadata_store):
+async def torrent_checker_fixture(tribler_config, tracker_manager, metadata_store):
     torrent_checker = TorrentChecker(config=tribler_config,
                                      download_manager=MagicMock(),
                                      notifier=MagicMock(),
@@ -378,3 +382,121 @@ async def test_check_channel_torrents(torrent_checker: TorrentChecker):
     # Health check requests are sent for all selected torrents
     result = await torrent_checker.check_torrents_in_user_channel()
     assert len(result) == len(selected_torrents)
+
+
+async def test_get_tracker_response_cancelled_error(torrent_checker: TorrentChecker, caplog):
+    """
+    Tests that CancelledError from session.connect_to_tracker() is handled correctly
+    """
+    torrent_checker.clean_session = AsyncMock()
+    torrent_checker.update_torrent_health = Mock()
+    torrent_checker.tracker_manager.update_tracker_info = Mock()
+
+    tracker_url = '<tracker_url>'
+    session = Mock(tracker_url=tracker_url)
+    session.connect_to_tracker = AsyncMock(side_effect=CancelledError())
+
+    with pytest.raises(CancelledError):
+        await torrent_checker.get_tracker_response(session)
+
+    torrent_checker.clean_session.assert_called_once()
+    torrent_checker.update_torrent_health.assert_not_called()
+    torrent_checker.tracker_manager.update_tracker_info.assert_not_called()
+
+    assert caplog.record_tuples == [
+        ('TorrentChecker', logging.INFO, 'Tracker session is being cancelled: <tracker_url>')
+    ]
+
+
+async def test_get_tracker_response_other_error(torrent_checker: TorrentChecker, caplog):
+    """
+    Tests that arbitrary exception from session.connect_to_tracker() is handled correctly
+    """
+    torrent_checker.clean_session = AsyncMock()
+    torrent_checker.update_torrent_health = Mock()
+    torrent_checker.tracker_manager.update_tracker_info = Mock()
+
+    tracker_url = '<tracker_url>'
+    session = Mock(tracker_url=tracker_url)
+    session.connect_to_tracker = AsyncMock(side_effect=ValueError('error text'))
+
+    with pytest.raises(ValueError, match='^error text$'):
+        await torrent_checker.get_tracker_response(session)
+
+    torrent_checker.clean_session.assert_called_once()
+    torrent_checker.update_torrent_health.assert_not_called()
+    torrent_checker.tracker_manager.update_tracker_info.assert_called_once_with(tracker_url, False)
+
+    assert caplog.record_tuples == [
+        ('TorrentChecker', logging.WARNING, "Got session error for the tracker: <tracker_url>\nerror text")
+    ]
+
+
+async def test_get_tracker_response(torrent_checker: TorrentChecker, caplog):
+    """
+    Tests that the result from session.connect_to_tracker() is handled correctly and passed to update_torrent_health()
+    """
+    health = HealthInfo(unhexlify('abcd0123'))
+    tracker_url = '<tracker_url>'
+    tracker_response = TrackerResponse(url=tracker_url, torrent_health_list=[health])
+
+    session = Mock(tracker_url=tracker_url)
+    session.connect_to_tracker = AsyncMock(return_value=tracker_response)
+
+    torrent_checker.clean_session = AsyncMock()
+    torrent_checker.update_torrent_health = Mock()
+    results = await torrent_checker.get_tracker_response(session)
+
+    assert results is tracker_response
+    torrent_checker.update_torrent_health.assert_called_once_with(health)
+
+    assert "Got response from Mock" in caplog.text
+
+
+def test_update_torrent_health_invalid_health(torrent_checker: TorrentChecker, caplog):
+    """
+    Tests that invalid health is ignored in TorrentChecker.update_torrent_health()
+    """
+    caplog.set_level(logging.WARNING)
+    now = int(time.time())
+    health = HealthInfo(unhexlify('abcd0123'), last_check=now + TOLERABLE_TIME_DRIFT + 2)
+    assert not torrent_checker.update_torrent_health(health)
+    assert "Invalid health info ignored: " in caplog.text
+
+
+def test_update_torrent_health_not_self_checked(torrent_checker: TorrentChecker, caplog):
+    """
+    Tests that non-self-checked health is ignored in TorrentChecker.update_torrent_health()
+    """
+    caplog.set_level(logging.ERROR)
+    health = HealthInfo(unhexlify('abcd0123'))
+    assert not torrent_checker.update_torrent_health(health)
+    assert "Self-checked torrent health expected" in caplog.text
+
+
+def test_update_torrent_health_unknown_torrent(torrent_checker: TorrentChecker, caplog):
+    """
+    Tests that unknown torrent's health is ignored in TorrentChecker.update_torrent_health()
+    """
+    caplog.set_level(logging.WARNING)
+    health = HealthInfo(unhexlify('abcd0123'), 1, 2, self_checked=True)
+    assert not torrent_checker.update_torrent_health(health)
+    assert "Unknown torrent: abcd0123" in caplog.text
+
+
+async def test_update_torrent_health_no_replace(torrent_checker, caplog):
+    """
+    Tests that the TorrentChecker.notify() method is called even if the new health does not replace the old health
+    """
+    now = int(time.time())
+    torrent_checker.notify = Mock()
+
+    with db_session:
+        torrent_state = torrent_checker.mds.TorrentState(infohash=unhexlify('abcd0123'), seeders=2, leechers=1,
+                                                         last_check=now, self_checked=True)
+        prev_health = torrent_state.to_health()
+
+    health = HealthInfo(unhexlify('abcd0123'), 1, 2, self_checked=True, last_check=now)
+    assert not torrent_checker.update_torrent_health(health)
+    assert "Skip health update, the health in the database is fresher or have more seeders" in caplog.text
+    torrent_checker.notify.assert_called_with(prev_health)

--- a/src/tribler/core/components/torrent_checker/torrent_checker/tests/test_torrentchecker_session.py
+++ b/src/tribler/core/components/torrent_checker/torrent_checker/tests/test_torrentchecker_session.py
@@ -362,7 +362,7 @@ async def test_connect_to_tracker_bep33(bep33_session, mock_dlmgr):
     Test the metainfo lookup of the BEP33 DHT session
     """
     infohash = b'a' * 20
-    infohash_health = HealthInfo(infohash, last_check=int(time.time()), seeders=1, leechers=2)
+    infohash_health = HealthInfo(infohash, seeders=1, leechers=2)
 
     mock_dlmgr.dht_health_manager = Mock()
     mock_dlmgr.dht_health_manager.get_health = lambda *_, **__: succeed(infohash_health)

--- a/src/tribler/core/components/torrent_checker/torrent_checker/torrent_checker.py
+++ b/src/tribler/core/components/torrent_checker/torrent_checker/torrent_checker.py
@@ -396,6 +396,10 @@ class TorrentChecker(TaskManager):
         else:
             self.torrents_checked.pop(health.infohash, None)
 
+        self.notify(health)
+        return True
+
+    def notify(self, health: HealthInfo):
         self.notifier[notifications.channel_entity_updated]({
             'infohash': health.infohash_hex,
             'num_seeders': health.seeders,
@@ -403,4 +407,3 @@ class TorrentChecker(TaskManager):
             'last_tracker_check': health.last_check,
             'health': 'updated'
         })
-        return True

--- a/src/tribler/core/components/torrent_checker/torrent_checker/torrent_checker.py
+++ b/src/tribler/core/components/torrent_checker/torrent_checker/torrent_checker.py
@@ -386,6 +386,7 @@ class TorrentChecker(TaskManager):
 
             if not health.should_update(torrent_state, self_checked=True):
                 self._logger.info("Skip health update, the health in the database is fresher")
+                self.notify(torrent_state.to_health())  # to update UI state from "Checking..."
                 return False
 
             torrent_state.set(seeders=health.seeders, leechers=health.leechers, last_check=health.last_check,

--- a/src/tribler/core/components/torrent_checker/torrent_checker/torrent_checker.py
+++ b/src/tribler/core/components/torrent_checker/torrent_checker/torrent_checker.py
@@ -162,8 +162,9 @@ class TorrentChecker(TaskManager):
                 self.update_torrent_health(health)
 
     async def get_tracker_response(self, session: TrackerSession) -> TrackerResponse:
+        t1 = time.time()
         try:
-            return await session.connect_to_tracker()
+            result = await session.connect_to_tracker()
         except CancelledError:
             self._logger.info(f"Tracker session is being cancelled: {session.tracker_url}")
             raise
@@ -174,6 +175,11 @@ class TorrentChecker(TaskManager):
             raise e
         finally:
             await self.clean_session(session)
+
+        t2 = time.time()
+        self._logger.info(f"Got response from {session.__class__.__name__} in {t2-t1:.3f}seconds: {result}")
+
+        return result
 
     @property
     def torrents_checked(self) -> Dict[bytes, HealthInfo]:

--- a/src/tribler/core/components/torrent_checker/torrent_checker/torrent_checker.py
+++ b/src/tribler/core/components/torrent_checker/torrent_checker/torrent_checker.py
@@ -387,7 +387,7 @@ class TorrentChecker(TaskManager):
             torrent_state.set(seeders=health.seeders, leechers=health.leechers, last_check=health.last_check,
                               self_checked=True)
 
-        if health.seeders > 0:
+        if health.seeders > 0 or health.leechers > 0:
             self.torrents_checked[health.infohash] = health
         else:
             self.torrents_checked.pop(health.infohash, None)

--- a/src/tribler/core/components/torrent_checker/torrent_checker/torrent_checker.py
+++ b/src/tribler/core/components/torrent_checker/torrent_checker/torrent_checker.py
@@ -15,7 +15,8 @@ from tribler.core.components.libtorrent.download_manager.download_manager import
 from tribler.core.components.metadata_store.db.serialization import REGULAR_TORRENT
 from tribler.core.components.metadata_store.db.store import MetadataStore
 from tribler.core.components.torrent_checker.torrent_checker import DHT
-from tribler.core.components.torrent_checker.torrent_checker.dataclasses import HealthInfo, TrackerResponse
+from tribler.core.components.torrent_checker.torrent_checker.dataclasses import HEALTH_FRESHNESS_SECONDS, HealthInfo, \
+    TrackerResponse
 from tribler.core.components.torrent_checker.torrent_checker.utils import aggregate_responses_for_infohash, \
     filter_non_exceptions, gather_coros, aggregate_health_by_infohash
 from tribler.core.components.torrent_checker.torrent_checker.torrentchecker_session import \
@@ -36,7 +37,6 @@ MAX_TORRENTS_CHECKED_PER_SESSION = 50
 
 TORRENT_SELECTION_POOL_SIZE = 2  # How many torrents to check (popular or random) during periodic check
 USER_CHANNEL_TORRENT_SELECTION_POOL_SIZE = 5  # How many torrents to check from user's channel during periodic check
-HEALTH_FRESHNESS_SECONDS = 4 * 3600  # Number of seconds before a torrent health is considered stale. Default: 4 hours
 TORRENTS_CHECKED_RETURN_SIZE = 240  # Estimated torrents checked on default 4 hours idle run
 
 

--- a/src/tribler/core/components/torrent_checker/torrent_checker/torrent_checker.py
+++ b/src/tribler/core/components/torrent_checker/torrent_checker/torrent_checker.py
@@ -175,7 +175,7 @@ class TorrentChecker(TaskManager):
             await self.clean_session(session)
 
         t2 = time.time()
-        self._logger.info(f"Got response from {session.__class__.__name__} in {t2-t1:.3f}seconds: {result}")
+        self._logger.info(f"Got response from {session.__class__.__name__} in {t2-t1:.3f} seconds: {result}")
 
         with db_session:
             for health in result.torrent_health_list:
@@ -391,7 +391,7 @@ class TorrentChecker(TaskManager):
 
             prev_health = torrent_state.to_health()
             if not health.should_replace(prev_health):
-                self._logger.info("Skip health update, the health in the database is fresher")
+                self._logger.info("Skip health update, the health in the database is fresher or have more seeders")
                 self.notify(prev_health)  # to update UI state from "Checking..."
                 return False
 

--- a/src/tribler/core/components/torrent_checker/torrent_checker/torrentchecker_session.py
+++ b/src/tribler/core/components/torrent_checker/torrent_checker/torrentchecker_session.py
@@ -161,7 +161,7 @@ class HttpTrackerSession(TrackerSession):
                     leechers = file_info.get(b'incomplete', 0)
 
                 unprocessed_infohashes.discard(infohash)
-                health_list.append(HealthInfo(infohash, last_check=now, seeders=seeders, leechers=leechers))
+                health_list.append(HealthInfo(infohash, seeders=seeders, leechers=leechers, last_check=now))
 
         elif b'failure reason' in response_dict:
             self._logger.info("%s Failure as reported by tracker [%s]", self, repr(response_dict[b'failure reason']))
@@ -397,7 +397,7 @@ class UdpTrackerSession(TrackerSession):
             # Store the information in the hash dict to be returned.
             # Sow complete as seeders. "complete: number of peers with the entire file, i.e. seeders (integer)"
             #  - https://wiki.theory.org/BitTorrentSpecification#Tracker_.27scrape.27_Convention
-            response_list.append(HealthInfo(infohash, last_check=now, seeders=complete, leechers=incomplete))
+            response_list.append(HealthInfo(infohash, seeders=complete, leechers=incomplete, last_check=now))
 
         # close this socket and remove its transaction ID from the list
         self.remove_transaction_id()
@@ -422,7 +422,7 @@ class FakeDHTSession(TrackerSession):
         now = int(time.time())
         for infohash in self.infohash_list:
             metainfo = await self.download_manager.get_metainfo(infohash, timeout=self.timeout, raise_errors=True)
-            health = HealthInfo(infohash, last_check=now, seeders=metainfo[b'seeders'], leechers=metainfo[b'leechers'])
+            health = HealthInfo(infohash, seeders=metainfo[b'seeders'], leechers=metainfo[b'leechers'], last_check=now)
             health_list.append(health)
 
         return TrackerResponse(url=DHT, torrent_health_list=health_list)

--- a/src/tribler/core/components/torrent_checker/torrent_checker/torrentchecker_session.py
+++ b/src/tribler/core/components/torrent_checker/torrent_checker/torrentchecker_session.py
@@ -161,14 +161,15 @@ class HttpTrackerSession(TrackerSession):
                     leechers = file_info.get(b'incomplete', 0)
 
                 unprocessed_infohashes.discard(infohash)
-                health_list.append(HealthInfo(infohash, seeders=seeders, leechers=leechers, last_check=now))
+                health_list.append(HealthInfo(infohash, seeders, leechers, last_check=now, self_checked=True))
 
         elif b'failure reason' in response_dict:
             self._logger.info("%s Failure as reported by tracker [%s]", self, repr(response_dict[b'failure reason']))
             self.failed(msg=repr(response_dict[b'failure reason']))
 
         # handle the infohashes with no result (seeders/leechers = 0/0)
-        health_list.extend(HealthInfo(infohash=infohash, last_check=now) for infohash in unprocessed_infohashes)
+        health_list.extend(HealthInfo(infohash=infohash, last_check=now, self_checked=True)
+                           for infohash in unprocessed_infohashes)
 
         self.is_finished = True
         return TrackerResponse(url=self.tracker_url, torrent_health_list=health_list)
@@ -397,7 +398,8 @@ class UdpTrackerSession(TrackerSession):
             # Store the information in the hash dict to be returned.
             # Sow complete as seeders. "complete: number of peers with the entire file, i.e. seeders (integer)"
             #  - https://wiki.theory.org/BitTorrentSpecification#Tracker_.27scrape.27_Convention
-            response_list.append(HealthInfo(infohash, seeders=complete, leechers=incomplete, last_check=now))
+            response_list.append(HealthInfo(infohash, seeders=complete, leechers=incomplete,
+                                            last_check=now, self_checked=True))
 
         # close this socket and remove its transaction ID from the list
         self.remove_transaction_id()
@@ -422,7 +424,8 @@ class FakeDHTSession(TrackerSession):
         now = int(time.time())
         for infohash in self.infohash_list:
             metainfo = await self.download_manager.get_metainfo(infohash, timeout=self.timeout, raise_errors=True)
-            health = HealthInfo(infohash, seeders=metainfo[b'seeders'], leechers=metainfo[b'leechers'], last_check=now)
+            health = HealthInfo(infohash, seeders=metainfo[b'seeders'], leechers=metainfo[b'leechers'],
+                                last_check=now, self_checked=True)
             health_list.append(health)
 
         return TrackerResponse(url=DHT, torrent_health_list=health_list)

--- a/src/tribler/core/components/torrent_checker/torrent_checker/utils.py
+++ b/src/tribler/core/components/torrent_checker/torrent_checker/utils.py
@@ -34,15 +34,3 @@ def aggregate_responses_for_infohash(infohash: bytes, responses: List[TrackerRes
             if health.infohash == infohash and health.seeders > result.seeders:
                 result = health
     return result
-
-
-def aggregate_health_by_infohash(health_list: List[HealthInfo]) -> List[HealthInfo]:
-    """
-    For each infohash in the health list, finds the "best" health info (with the max number of seeders)
-    """
-    d: Dict[bytes, HealthInfo] = {}
-    for health in health_list:
-        infohash = health.infohash
-        if infohash not in d or health.seeders > d[infohash].seeders:
-            d[infohash] = health
-    return list(d.values())

--- a/src/tribler/core/components/torrent_checker/torrent_checker/utils.py
+++ b/src/tribler/core/components/torrent_checker/torrent_checker/utils.py
@@ -31,6 +31,6 @@ def aggregate_responses_for_infohash(infohash: bytes, responses: List[TrackerRes
     result = HealthInfo(infohash, last_check=0)
     for response in responses:
         for health in response.torrent_health_list:
-            if health.infohash == infohash and health.seeders_leechers_last_check > result.seeders_leechers_last_check:
+            if health.infohash == infohash and health > result:
                 result = health
     return result

--- a/src/tribler/core/components/torrent_checker/torrent_checker/utils.py
+++ b/src/tribler/core/components/torrent_checker/torrent_checker/utils.py
@@ -31,6 +31,6 @@ def aggregate_responses_for_infohash(infohash: bytes, responses: List[TrackerRes
     result = HealthInfo(infohash, last_check=0)
     for response in responses:
         for health in response.torrent_health_list:
-            if health.infohash == infohash and health.seeders > result.seeders:
+            if health.infohash == infohash and health.seeders_leechers_last_check > result.seeders_leechers_last_check:
                 result = health
     return result

--- a/src/tribler/core/utilities/notifier.py
+++ b/src/tribler/core/utilities/notifier.py
@@ -107,6 +107,7 @@ class Notifier:
         self.logger = logging.getLogger(self.__class__.__name__)
 
         self.topics_by_name: Dict[str, Callable] = {}
+        self.unknown_topic_names = set()
         # We use the dict type for `self.observers` and `set.generic_observers` instead of the set type to provide
         # the deterministic ordering of callbacks. In Python, dictionaries are ordered while sets aren't.
         # Therefore, `value: bool` here is unnecessary and is never used.
@@ -204,7 +205,9 @@ class Notifier:
         with self.lock:
             topic = self.topics_by_name.get(topic_name)
         if topic is None:
-            self.logger.warning(f'Topic with name `{topic_name}` not found')
+            if topic_name not in self.unknown_topic_names:
+                self.unknown_topic_names.add(topic_name)
+                self.logger.warning(f'Topic with name `{topic_name}` not found')
         else:
             self.notify(topic, *args, **kwargs)
 

--- a/src/tribler/gui/widgets/tablecontentmodel.py
+++ b/src/tribler/gui/widgets/tablecontentmodel.py
@@ -534,6 +534,9 @@ class ChannelContentModel(RemoteTableModel):
             time_without_microseconds = str(td).partition('.')[0]
             return f'Checked: {time_without_microseconds} ago'
 
+        if role == Qt.ToolTipRole and column_type == Column.NAME:
+            return f'{item["infohash"][:8]}'
+
         # The 'name' column is special in a sense that we want to draw the title and tags ourselves.
         # At the same time, we want to name this column to not break the renaming of torrent files, hence this check.
         if column_type == Column.NAME and not is_editing:


### PR DESCRIPTION
This PR fixes #7287. There were several reasons for the bug:
1. When no trackers for a specific infohash were able to provide health info, the resulting health record with zero seeders and zero leechers had an incorrect `last_check` timestamp value of 0.
2. The checks in `HealthInfo.should_update()` were also incorrect, and the logic sometimes decided to keep the previous health info and not replace it with the new health info.
3. In such situations, due to the third bug, the notification was not sent to the GUI; as a result, the GUI status for the torrent was stuck in the "Checking..." state indefinitely.

Also, this PR fixes the long checking time by updating the torrent health immediately. Previously, TorrentChecker aggregated all results from all possible trackers before providing the new health info. Some trackers return result almost immediately, while other wait for up to 20 seconds. Because of this, all health checks previously took around 20 seconds, and now in many cases, they are updated almost immediately and then corrected with results from additional trackers if necessary.