### PR TITLE
Fix mathematical mistake in the progress bar drawing

### DIFF
--- a/src/tribler/gui/widgets/downloadprogressbar.py
+++ b/src/tribler/gui/widgets/downloadprogressbar.py
@@ -24,10 +24,10 @@ class DownloadProgressBar(QWidget):
         if download["status"] in ("DLSTATUS_SEEDING", "DLSTATUS_CIRCUITS"):
             self.set_fraction(download["progress"])
         elif download["status"] in (
-            "DLSTATUS_HASHCHECKING",
-            "DLSTATUS_DOWNLOADING",
-            "DLSTATUS_STOPPED",
-            "DLSTATUS_STOPPED_ON_ERROR",
+                "DLSTATUS_HASHCHECKING",
+                "DLSTATUS_DOWNLOADING",
+                "DLSTATUS_STOPPED",
+                "DLSTATUS_STOPPED_ON_ERROR",
         ):
             self.set_pieces()
         else:
@@ -64,22 +64,23 @@ class DownloadProgressBar(QWidget):
 
             if len(self.pieces) <= self.width():  # We have less pieces than pixels
                 piece_width = self.width() / float(len(self.pieces))
-                for i in range(len(self.pieces)):
-                    if self.pieces[i]:
+                for pixel in range(len(self.pieces)):
+                    if self.pieces[pixel]:
                         painter.fillRect(
-                            QRect(int(float(i) * piece_width), 0, math.ceil(piece_width), self.height()),
+                            QRect(int(float(pixel) * piece_width), 0, math.ceil(piece_width), self.height()),
                             QColor(230, 115, 0),
                         )
             else:  # We have more pieces than pixels, group pieces
                 pieces_per_pixel = len(self.pieces) / float(self.width())
-                for i in range(self.width()):
-                    begin_piece = int(pieces_per_pixel * i)
-                    end_piece = int(begin_piece + pieces_per_pixel)
-                    piece_sum = 0
-                    for j in range(begin_piece, end_piece):
-                        piece_sum += self.pieces[j]
-                    qt_color = QColor()
-                    qt_color.setHsl(26, 255, 128 + int(127 * (1 - piece_sum // pieces_per_pixel)))
-                    painter.fillRect(QRect(i, 0, 10, self.height()), qt_color)
+                for pixel in range(self.width()):
+                    start = int(pieces_per_pixel * pixel)
+                    stop = int(start + pieces_per_pixel)
+
+                    downloaded_pieces = sum(self.pieces[start:stop])
+                    qt_color = QColor(230, 115, 0)
+                    decimal_percentage = 1 - downloaded_pieces / pieces_per_pixel
+                    fill_size = 128 + int(127 * decimal_percentage)
+                    qt_color.setHsl(26, 255, fill_size)
+                    painter.fillRect(QRect(pixel, 0, 10, self.height()), qt_color)
         else:
             painter.fillRect(QRect(0, 0, int(self.width() * self.fraction), self.height()), QColor(230, 115, 0))

--- a/src/tribler/gui/widgets/downloadspage.py
+++ b/src/tribler/gui/widgets/downloadspage.py
@@ -88,7 +88,7 @@ class DownloadsPage(AddBreadcrumbOnShowMixin, QWidget):
         connect(self.window().stop_download_button.clicked, self.on_stop_download_clicked)
         connect(self.window().remove_download_button.clicked, self.on_remove_download_clicked)
 
-        connect(self.window().downloads_list.itemSelectionChanged, self.on_download_item_clicked)
+        connect(self.window().downloads_list.itemSelectionChanged, self.update_downloads)
 
         connect(self.window().downloads_list.customContextMenuRequested, self.on_right_click_item)
 
@@ -226,7 +226,7 @@ class DownloadsPage(AddBreadcrumbOnShowMixin, QWidget):
 
         # Update the top download management button if we have a row selected
         if len(self.window().downloads_list.selectedItems()) > 0:
-            self.on_download_item_clicked()
+            self.update_downloads()
 
         self.received_downloads.emit(downloads)
 
@@ -279,26 +279,25 @@ class DownloadsPage(AddBreadcrumbOnShowMixin, QWidget):
             ]
         )
 
-    def on_download_item_clicked(self):
-        selected_count = len(self.window().downloads_list.selectedItems())
+    def update_downloads(self):
+        selected = self.window().downloads_list.selectedItems()
+        selected_count = len(selected)
         if selected_count == 0:
             self.window().remove_download_button.setEnabled(False)
             self.window().start_download_button.setEnabled(False)
             self.window().stop_download_button.setEnabled(False)
             self.window().download_details_widget.hide()
-        elif selected_count == 1:
-            self.selected_items = self.window().downloads_list.selectedItems()
-            self.window().remove_download_button.setEnabled(True)
-            self.window().start_download_button.setEnabled(DownloadsPage.start_download_enabled(self.selected_items))
-            self.window().stop_download_button.setEnabled(DownloadsPage.stop_download_enabled(self.selected_items))
+            return
 
-            self.window().download_details_widget.update_with_download(self.selected_items[0].download_info)
+        self.selected_items = selected
+        self.window().remove_download_button.setEnabled(True)
+        self.window().start_download_button.setEnabled(DownloadsPage.start_download_enabled(self.selected_items))
+        self.window().stop_download_button.setEnabled(DownloadsPage.stop_download_enabled(self.selected_items))
+
+        if selected_count == 1:
+            self.window().download_details_widget.update_with_download(selected[0].download_info)
             self.window().download_details_widget.show()
         else:
-            self.selected_items = self.window().downloads_list.selectedItems()
-            self.window().remove_download_button.setEnabled(True)
-            self.window().start_download_button.setEnabled(DownloadsPage.start_download_enabled(self.selected_items))
-            self.window().stop_download_button.setEnabled(DownloadsPage.stop_download_enabled(self.selected_items))
             self.window().download_details_widget.hide()
 
     def on_start_download_clicked(self, checked):
@@ -312,7 +311,7 @@ class DownloadsPage(AddBreadcrumbOnShowMixin, QWidget):
                 if selected_item.download_info["infohash"] == json_result["infohash"]:
                     selected_item.download_info['status'] = "DLSTATUS_DOWNLOADING"
                     selected_item.update_item()
-                    self.on_download_item_clicked()
+                    self.update_downloads()
 
     def on_stop_download_clicked(self, checked):
         for selected_item in self.selected_items:
@@ -325,7 +324,7 @@ class DownloadsPage(AddBreadcrumbOnShowMixin, QWidget):
                 if selected_item.download_info["infohash"] == json_result["infohash"]:
                     selected_item.download_info['status'] = "DLSTATUS_STOPPED"
                     selected_item.update_item()
-                    self.on_download_item_clicked()
+                    self.update_downloads()
 
     def on_remove_download_clicked(self, checked):
         self.dialog = ConfirmationDialog(
@@ -374,7 +373,7 @@ class DownloadsPage(AddBreadcrumbOnShowMixin, QWidget):
                 if selected_item.download_info["infohash"] == result["infohash"]:
                     selected_item.download_info['status'] = "DLSTATUS_HASHCHECKING"
                     selected_item.update_item()
-                    self.on_download_item_clicked()
+                    self.update_downloads()
 
     def on_change_anonymity(self, result):
         pass


### PR DESCRIPTION
This PR fixes #7316 
 
The actual fix is the following change (the rest is cosmetic refactoring and could be extracted to a separate PR by request):

from:
```python
qt_color.setHsl(26, 255, 128 + int(127 * (1 - piece_sum // pieces_per_pixel)))
```

to:
```python
qt_color.setHsl(26, 255, 128 + int(127 * (1 - piece_sum / pieces_per_pixel)))
```

<img width="572" alt="image" src="https://user-images.githubusercontent.com/13798583/224719193-31dac1c3-5a20-43d0-b309-9bbf41a57610.png">
