### PR TITLE
Update pytest

### DIFF
--- a/.github/workflows/vars/pytest.env
+++ b/.github/workflows/vars/pytest.env
@@ -1,4 +1,4 @@
-PYTEST_COMMON_ARGUMENTS='--randomly-seed=1  --disable-warnings --reruns 1 --reruns-delay 1'
+PYTEST_COMMON_ARGUMENTS='--randomly-seed=1 --disable-warnings --reruns 1 --reruns-delay 1 --verbose --durations=3'
 
 PYTEST_CORE_ARGUMENTS='./src/tribler/core ${PYTEST_COMMON_ARGUMENTS}'
 PYTEST_TUNNELS_ARGUMENTS='./src/tribler/core/components/tunnel/tests/test_full_session --tunneltests ${PYTEST_COMMON_ARGUMENTS}'

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-timeout = 300
+timeout = 60
 ;https://pypi.org/project/pytest-asyncio/
 asyncio_mode = auto
 log_level = INFO

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,14 +1,14 @@
 -r requirements.txt
 
-pytest==7.2.0
+pytest==7.2.2
 pytest-aiohttp==1.0.4
-pytest-asyncio==0.20.2
+pytest-asyncio==0.20.3
 pytest-mock==3.10.0
 pytest-randomly==3.12.0
 pytest-timeout==2.1.0
 pytest-freezegun==0.4.2
-pytest-rerunfailures==10.2
-pytest-sentry==0.1.10
+pytest-rerunfailures==11.1.2
+pytest-sentry==0.1.16
 pytest-profiling==1.7.0 # for pytest profiling
 
 freezegun==1.2.1


### PR DESCRIPTION
We have noticed that our tests have started to timeout again (https://github.com/Tribler/tribler/pull/7322)
Related to #7134

This PR decreases a default pytest timeout to `60s` and updates `pytest` dependencies to the most latest versions.

This PR adds two arguments for `pytest`:
* `--verbose`: https://docs.pytest.org/en/7.1.x/how-to/output.html#verbosity
* `--durations=3`:  show 3 slowest setup/test durations.
https://docs.pytest.org/en/7.1.x/reference/reference.html#ini-options-ref

The example of pytest output with these flags:

```python
================================================ test session starts ================================================
platform darwin -- Python 3.9.6, pytest-7.2.0, pluggy-1.0.0 -- /Users/<user>/Projects/github.com/Tribler/tribler/venv/bin/python
cachedir: .pytest_cache
Using --randomly-seed=2309368522
rootdir: /Users/<user>/Projects/github.com/Tribler/tribler, configfile: pytest.ini
plugins: asyncio-0.20.2, sentry-0.1.10, looptime-0.2, Faker-14.1.0, freezegun-0.4.2, timeout-2.1.0, mock-3.10.0, rerunfailures-10.2, randomly-3.12.0, profiling-1.7.0, anyio-3.6.2, aiohttp-1.0.4
asyncio: mode=auto
timeout: 60.0s
timeout method: signal
timeout func_only: False
collected 64 items

tribler/gui/tests/test_core_manager.py::test_check_core_api_port_already_connected PASSED                     [  1%]
tribler/gui/tests/test_core_manager.py::test_check_core_api_port_not_set PASSED                               [  3%]
tribler/gui/tests/test_core_manager.py::test_on_core_read_ready_os_error_suppressed PASSED                    [  4%]
tribler/gui/tests/test_core_manager.py::test_check_core_api_port_core_process_not_found PASSED                [  6%]
tribler/gui/tests/test_core_manager.py::test_on_core_stdout_read_ready PASSED                                 [  7%]
tribler/gui/tests/test_core_manager.py::test_on_core_finished_calls_quit_application PASSED                   [  9%]
tribler/gui/tests/test_core_manager.py::test_on_core_stderr_read_ready PASSED                                 [ 10%]
tribler/gui/tests/test_core_manager.py::test_on_core_started_calls_check_core_api_port PASSED                 [ 12%]
tribler/gui/tests/test_core_manager.py::test_check_core_api_port_shutting_down PASSED                         [ 14%]
tribler/gui/tests/test_core_manager.py::test_check_core_api_port_not_running PASSED                           [ 15%]
tribler/gui/tests/test_core_manager.py::test_on_core_finished_raises_error PASSED                             [ 17%]
tribler/gui/tests/test_core_manager.py::test_check_core_api_port_timeout PASSED                               [ 18%]
tribler/gui/tests/test_core_manager.py::test_format_error_message PASSED                                      [ 20%]
tribler/gui/tests/test_core_manager.py::test_decode_raw_core_output PASSED                                    [ 21%]
tribler/gui/tests/test_core_manager.py::test_check_core_api_port PASSED                                       [ 23%]
tribler/gui/tests/test_gui.py::test_discovered_page SKIPPED (need --guitests option to run)                   [ 25%]
tribler/gui/tests/test_gui.py::test_popular_page SKIPPED (need --guitests option to run)                      [ 26%]
tribler/gui/tests/test_gui.py::test_download_details SKIPPED (need --guitests option to run)                  [ 28%]
tribler/gui/tests/test_gui.py::test_search_suggestions SKIPPED (need --guitests option to run)                [ 29%]
tribler/gui/tests/test_gui.py::test_search SKIPPED (need --guitests option to run)                            [ 31%]
tribler/gui/tests/test_gui.py::test_debug_pane SKIPPED (need --guitests option to run)                        [ 32%]
tribler/gui/tests/test_gui.py::test_add_download_url SKIPPED (need --guitests option to run)                  [ 34%]
tribler/gui/tests/test_gui.py::test_edit_channel_torrents SKIPPED (need --guitests option to run)             [ 35%]
tribler/gui/tests/test_gui.py::test_settings SKIPPED (need --guitests option to run)                          [ 37%]
tribler/gui/tests/test_gui.py::test_download_start_stop_remove_recheck SKIPPED (need --guitests option to...) [ 39%]
tribler/gui/tests/test_gui.py::test_tags_dialog SKIPPED (need --guitests option to run)                       [ 40%]
tribler/gui/tests/test_gui.py::test_big_negative_token_balance SKIPPED (need --guitests option to run)        [ 42%]
tribler/gui/tests/test_gui.py::test_add_deeptorrent SKIPPED (need --guitests option to run)                   [ 43%]
tribler/gui/tests/test_gui.py::test_close_dialog_with_esc_button SKIPPED (need --guitests option to run)      [ 45%]
tribler/gui/tests/test_gui.py::test_no_tags SKIPPED (need --guitests option to run)                           [ 46%]
tribler/gui/tests/test_gui.py::test_feedback_dialog SKIPPED (need --guitests option to run)                   [ 48%]
tribler/gui/tests/test_gui.py::test_downloads SKIPPED (need --guitests option to run)                         [ 50%]
tribler/gui/tests/test_gui.py::test_feedback_dialog_report_sent SKIPPED (need --guitests option to run)       [ 51%]
tribler/gui/tests/test_gui.py::test_trust_page SKIPPED (need --guitests option to run)                        [ 53%]
tribler/gui/tests/test_error_handler.py::test_gui_is_not_core_exception PASSED                                [ 54%]
tribler/gui/tests/test_error_handler.py::test_core_error PASSED                                               [ 56%]
tribler/gui/tests/test_error_handler.py::test_gui_info_type_in_handled_exceptions PASSED                      [ 57%]
tribler/gui/tests/test_error_handler.py::test_gui_error_tribler_stopped PASSED                                [ 59%]
tribler/gui/tests/test_error_handler.py::test_gui_error_suppressed PASSED                                     [ 60%]
tribler/gui/tests/test_error_handler.py::test_gui_core_crashed_error PASSED                                   [ 62%]
tribler/gui/tests/test_error_handler.py::test_gui_core_connect_timeout_error PASSED                           [ 64%]
tribler/gui/tests/test_error_handler.py::test_core_info_type_in_handled_exceptions PASSED                     [ 65%]
tribler/gui/tests/test_error_handler.py::test_core_should_stop PASSED                                         [ 67%]
tribler/gui/tests/test_util.py::test_quoter_reserved PASSED                                                   [ 68%]
tribler/gui/tests/test_util.py::test_quoter_unichar PASSED                                                    [ 70%]
tribler/gui/tests/test_util.py::test_format_api_key PASSED                                                    [ 71%]
tribler/gui/tests/test_util.py::test_quote_plus_unicode_char PASSED                                           [ 73%]
tribler/gui/tests/test_util.py::test_quote_plus_unicode_unichar PASSED                                        [ 75%]
tribler/gui/tests/test_util.py::test_set_api_key PASSED                                                       [ 76%]
tribler/gui/tests/test_util.py::test_quoter_char PASSED                                                       [ 78%]
tribler/gui/tests/test_util.py::test_is_dict_has PASSED                                                       [ 79%]
tribler/gui/tests/test_util.py::test_create_api_key PASSED                                                    [ 81%]
tribler/gui/tests/test_util.py::test_quote_plus_unicode_reserved PASSED                                       [ 82%]
tribler/gui/tests/test_util.py::test_quote_plus_unicode_compound PASSED                                       [ 84%]
tribler/gui/tests/test_util.py::test_compose_magnetlink PASSED                                                [ 85%]
tribler/gui/network/tests/test_request_manager.py::test_get_base_string PASSED                                [ 87%]
tribler/gui/network/tests/test_request_manager.py::test_get_message_from_error_string PASSED                  [ 89%]
tribler/gui/network/tests/test_request_manager.py::test_get_message_from_error_dict_string PASSED             [ 90%]
tribler/gui/network/tests/test_request_manager.py::test_get_message_from_error_any_dict PASSED                [ 92%]
tribler/gui/network/tests/test_request.py::test_str_data_constructor PASSED                                   [ 93%]
tribler/gui/network/tests/test_request.py::test_on_finished PASSED                                            [ 95%]
tribler/gui/network/tests/test_request.py::test_dict_data_constructor PASSED                                  [ 96%]
tribler/gui/network/tests/test_request.py::test_default_constructor PASSED                                    [ 98%]
tribler/gui/network/tests/test_request.py::test_bytes_data_constructor PASSED                                 [100%]


================================================ slowest 3 durations ================================================
0.18s setup    src/tribler/gui/tests/test_core_manager.py::test_check_core_api_port_already_connected
0.05s setup    src/tribler/gui/tests/test_core_manager.py::test_on_core_finished_calls_quit_application
0.01s setup    src/tribler/gui/tests/test_core_manager.py::test_check_core_api_port_timeout
=================================== 45 passed, 19 skipped, 130 warnings in 1.54s ====================================

```