### PR TITLE
Add `local/` to ignored folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,6 @@ _build/
 .Tribler/
 
 .mailmap
+
+# this folder is dedicated to storing local experimental code that don't want to be committed
+local/


### PR DESCRIPTION
This PR adds the `local/` folder to `.gitignore`. 
The developers will benefit from it by using the local folder as a place to store their "experimental/throwaway/dont-want-to-commit" code that is dependent on Tribler.