### PR TITLE
On GUI side, handle Core REST API responses without data

### DIFF
--- a/src/tribler/gui/debug_window.py
+++ b/src/tribler/gui/debug_window.py
@@ -905,7 +905,7 @@ class DebugWindow(QMainWindow):
 
     def load_libtorrent_settings_tab(self, hop, export=False):
         request_manager.get(endpoint=f"libtorrent/settings?hop={hop}",
-                            on_finish=lambda data: self.on_libtorrent_settings_received(data, export=export))
+                            on_success=lambda data: self.on_libtorrent_settings_received(data, export=export))
         self.window().libtorrent_settings_tree_widget.clear()
 
     def on_libtorrent_settings_received(self, data, export=False):
@@ -921,7 +921,7 @@ class DebugWindow(QMainWindow):
 
     def load_libtorrent_sessions_tab(self, hop, export=False):
         request_manager.get(endpoint=f"libtorrent/session?hop={hop}",
-                            on_finish=lambda data: self.on_libtorrent_session_received(data, export=export))
+                            on_success=lambda data: self.on_libtorrent_session_received(data, export=export))
         self.window().libtorrent_session_tree_widget.clear()
 
     def on_libtorrent_session_received(self, data, export=False):

--- a/src/tribler/gui/debug_window.py
+++ b/src/tribler/gui/debug_window.py
@@ -324,11 +324,10 @@ class DebugWindow(QMainWindow):
             method = request.method
             data = request.data
             timestamp = request.time
-            status_code = request.status_code
 
             item = QTreeWidgetItem(self.window().requests_tree_widget)
             item.setText(0, f"{method} {repr(endpoint)} {repr(data)}")
-            item.setText(1, str(status_code or "unknown"))
+            item.setText(1, request.status_text)
             item.setText(2, f"{strftime('%H:%M:%S', localtime(timestamp))}")
             self.window().requests_tree_widget.addTopLevelItem(item)
 

--- a/src/tribler/gui/dialogs/addtopersonalchanneldialog.py
+++ b/src/tribler/gui/dialogs/addtopersonalchanneldialog.py
@@ -92,7 +92,7 @@ class AddToChannelDialog(DialogContainer):
 
     def load_channel(self, channel_id):
         request = request_manager.get(f"channels/mychannel/{channel_id}",
-                                      on_finish=lambda result: self.on_channel_contents(result, channel_id),
+                                      on_success=lambda result: self.on_channel_contents(result, channel_id),
                                       url_params={
                                           "metadata_type": [CHANNEL_TORRENT, COLLECTION_NODE],
                                           "first": 1,

--- a/src/tribler/gui/dialogs/createtorrentdialog.py
+++ b/src/tribler/gui/dialogs/createtorrentdialog.py
@@ -115,7 +115,7 @@ class CreateTorrentDialog(DialogContainer):
         is_seed = self.dialog_widget.seed_after_adding_checkbox.isChecked()
         self.rest_request1 = request_manager.post(
             endpoint='createtorrent',
-            on_finish=self.on_torrent_created,
+            on_success=self.on_torrent_created,
             url_params={'download': 1} if is_seed else None,
             data={"name": self.name, "description": description, "files": files_list, "export_dir": export_dir},
         )

--- a/src/tribler/gui/dialogs/editmetadatadialog.py
+++ b/src/tribler/gui/dialogs/editmetadatadialog.py
@@ -70,7 +70,7 @@ class EditMetadataDialog(DialogContainer):
         self.dialog_widget.content_name_label.setText(self.data_item["name"])
 
         # Fetch suggestions
-        request_manager.get(f"knowledge/{self.infohash}/tag_suggestions", on_finish=self.on_received_tag_suggestions)
+        request_manager.get(f"knowledge/{self.infohash}/tag_suggestions", on_success=self.on_received_tag_suggestions)
 
         self.update_window()
 

--- a/src/tribler/gui/dialogs/startdownloaddialog.py
+++ b/src/tribler/gui/dialogs/startdownloaddialog.py
@@ -144,7 +144,7 @@ class StartDownloadDialog(DialogContainer):
         params = {'uri': self.download_uri}
         if direct:
             params['hops'] = 0
-        self.rest_request = request_manager.get('torrentinfo', on_finish=self.on_received_metainfo,
+        self.rest_request = request_manager.get('torrentinfo', on_success=self.on_received_metainfo,
                                                 url_params=params, capture_errors=False)
 
         if self.metainfo_retries <= METAINFO_MAX_RETRIES:

--- a/src/tribler/gui/network/request.py
+++ b/src/tribler/gui/network/request.py
@@ -34,7 +34,7 @@ class Request(QObject):
     def __init__(
             self,
             endpoint: str,
-            on_finish: Callable = lambda _: None,
+            on_success: Callable = lambda _: None,
             url_params: Optional[Dict] = None,
             data: DATA_TYPE = None,
             method: str = GET,
@@ -61,7 +61,7 @@ class Request(QObject):
             raw_data = data
         self.raw_data: Optional[bytes] = raw_data
 
-        connect(self.on_finished_signal, on_finish)
+        connect(self.on_finished_signal, on_success)
 
         self.reply: Optional[QNetworkReply] = None  # to hold the associated QNetworkReply object
         self.manager: Optional[RequestManager] = None

--- a/src/tribler/gui/network/request.py
+++ b/src/tribler/gui/network/request.py
@@ -104,7 +104,7 @@ class Request(QObject):
                 return
 
             if not data:
-                self.on_finished_signal.emit({})
+                self.logger.error(f'No data received in the reply for {self}')
                 return
 
             self.logger.debug('Create a json response')

--- a/src/tribler/gui/network/request_manager.py
+++ b/src/tribler/gui/network/request_manager.py
@@ -40,14 +40,14 @@ class RequestManager(QNetworkAccessManager):
 
     def get(self,
             endpoint: str,
-            on_finish: Callable = lambda _: None,
+            on_success: Callable = lambda _: None,
             url_params: Optional[Dict] = None,
             data: DATA_TYPE = None,
             capture_errors: bool = True,
             priority: int = QNetworkRequest.NormalPriority,
             raw_response: bool = False) -> Request:
 
-        request = Request(endpoint=endpoint, on_finish=on_finish, url_params=url_params, data=data,
+        request = Request(endpoint=endpoint, on_success=on_success, url_params=url_params, data=data,
                           capture_errors=capture_errors, priority=priority, raw_response=raw_response,
                           method=Request.GET)
         self.add(request)
@@ -55,14 +55,14 @@ class RequestManager(QNetworkAccessManager):
 
     def post(self,
              endpoint: str,
-             on_finish: Callable = lambda _: None,
+             on_success: Callable = lambda _: None,
              url_params: Optional[Dict] = None,
              data: DATA_TYPE = None,
              capture_errors: bool = True,
              priority: int = QNetworkRequest.NormalPriority,
              raw_response: bool = False) -> Request:
 
-        request = Request(endpoint=endpoint, on_finish=on_finish, url_params=url_params, data=data,
+        request = Request(endpoint=endpoint, on_success=on_success, url_params=url_params, data=data,
                           capture_errors=capture_errors, priority=priority, raw_response=raw_response,
                           method=Request.POST)
         self.add(request)
@@ -70,14 +70,14 @@ class RequestManager(QNetworkAccessManager):
 
     def put(self,
             endpoint: str,
-            on_finish: Callable = lambda _: None,
+            on_success: Callable = lambda _: None,
             url_params: Optional[Dict] = None,
             data: DATA_TYPE = None,
             capture_errors: bool = True,
             priority: int = QNetworkRequest.NormalPriority,
             raw_response: bool = False) -> Request:
 
-        request = Request(endpoint=endpoint, on_finish=on_finish, url_params=url_params, data=data,
+        request = Request(endpoint=endpoint, on_success=on_success, url_params=url_params, data=data,
                           capture_errors=capture_errors, priority=priority, raw_response=raw_response,
                           method=Request.PUT)
         self.add(request)
@@ -85,14 +85,14 @@ class RequestManager(QNetworkAccessManager):
 
     def patch(self,
               endpoint: str,
-              on_finish: Callable = lambda _: None,
+              on_success: Callable = lambda _: None,
               url_params: Optional[Dict] = None,
               data: DATA_TYPE = None,
               capture_errors: bool = True,
               priority: int = QNetworkRequest.NormalPriority,
               raw_response: bool = False) -> Request:
 
-        request = Request(endpoint=endpoint, on_finish=on_finish, url_params=url_params, data=data,
+        request = Request(endpoint=endpoint, on_success=on_success, url_params=url_params, data=data,
                           capture_errors=capture_errors, priority=priority, raw_response=raw_response,
                           method=Request.PATCH)
         self.add(request)
@@ -100,14 +100,14 @@ class RequestManager(QNetworkAccessManager):
 
     def delete(self,
                endpoint: str,
-               on_finish: Callable = lambda _: None,
+               on_success: Callable = lambda _: None,
                url_params: Optional[Dict] = None,
                data: DATA_TYPE = None,
                capture_errors: bool = True,
                priority: int = QNetworkRequest.NormalPriority,
                raw_response: bool = False) -> Request:
 
-        request = Request(endpoint=endpoint, on_finish=on_finish, url_params=url_params, data=data,
+        request = Request(endpoint=endpoint, on_success=on_success, url_params=url_params, data=data,
                           capture_errors=capture_errors, priority=priority, raw_response=raw_response,
                           method=Request.DELETE)
         self.add(request)

--- a/src/tribler/gui/network/tests/test_request.py
+++ b/src/tribler/gui/network/tests/test_request.py
@@ -41,11 +41,11 @@ def test_str_data_constructor():
 def test_on_finished():
     # Test that if 'request.reply' is empty, the `on_finish` method is called with an empty dict.
     # see: https://github.com/Tribler/tribler/issues/7297
-    on_finish = MagicMock()
-    request = Request(endpoint='endpoint', on_finish=on_finish)
+    on_success = MagicMock()
+    request = Request(endpoint='endpoint', on_success=on_success)
     request.manager = MagicMock()
     request.reply = MagicMock(readAll=MagicMock(return_value=b''))
 
     request.on_finished()
 
-    on_finish.assert_called_once_with({})
+    on_success.assert_called_once_with({})

--- a/src/tribler/gui/network/tests/test_request.py
+++ b/src/tribler/gui/network/tests/test_request.py
@@ -39,8 +39,8 @@ def test_str_data_constructor():
 
 
 def test_on_finished():
-    # Test that if 'request.reply' is empty, the `on_finish` method is called with an empty dict.
-    # see: https://github.com/Tribler/tribler/issues/7297
+    # Test that if 'request.reply' is empty, the `on_success` callback is not called
+    # see: https://github.com/Tribler/tribler/issues/7333
     on_success = MagicMock()
     request = Request(endpoint='endpoint', on_success=on_success)
     request.manager = MagicMock()
@@ -48,4 +48,4 @@ def test_on_finished():
 
     request.on_finished()
 
-    on_success.assert_called_once_with({})
+    on_success.assert_not_called()

--- a/src/tribler/gui/tribler_window.py
+++ b/src/tribler/gui/tribler_window.py
@@ -675,7 +675,7 @@ class TriblerWindow(QMainWindow):
         anon_hops = int(self.tribler_settings['download_defaults']['number_hops']) if anon_download else 0
         safe_seeding = 1 if safe_seeding else 0
         request_manager.put("downloads",
-                            on_finish=callback if callback else self.on_download_added,
+                            on_success=callback if callback else self.on_download_added,
                             data={
                                 "uri": uri,
                                 "anon_hops": anon_hops,
@@ -702,8 +702,8 @@ class TriblerWindow(QMainWindow):
 
             if post_data:
                 request_manager.put(f"channels/mychannel/{channel_id}/torrents",
-                                    on_finish=lambda _: self.tray_show_message(tr("Channel update"),
-                                                                               tr("Torrent(s) added to your channel")),
+                                    on_success=lambda _: self.tray_show_message(tr("Channel update"),
+                                                                                tr("Torrent(s) added to your channel")),
                                     data=post_data)
 
         self.window().add_to_channel_dialog.show_dialog(on_add_button_pressed, confirm_button_text="Add torrent")
@@ -714,8 +714,8 @@ class TriblerWindow(QMainWindow):
 
             if post_data:
                 request_manager.put(f"channels/mychannel/{channel_id}/torrents",
-                                    on_finish=lambda _: self.tray_show_message(tr("Channel update"),
-                                                                               tr("Torrent(s) added to your channel")),
+                                    on_success=lambda _: self.tray_show_message(tr("Channel update"),
+                                                                                tr("Torrent(s) added to your channel")),
                                     data=post_data)
 
         self.window().add_to_channel_dialog.show_dialog(on_add_button_pressed, confirm_button_text="Add torrent")
@@ -979,7 +979,7 @@ class TriblerWindow(QMainWindow):
 
                     request_manager.put(
                         endpoint=f"collections/mychannel/{channel_id}/torrents",
-                        on_finish=lambda _: self.tray_show_message(
+                        on_success=lambda _: self.tray_show_message(
                             tr("Channels update"), tr("%s added to your channel") % self.chosen_dir
                         ),
                         data={"torrents_dir": self.chosen_dir}

--- a/src/tribler/gui/widgets/channelcontentswidget.py
+++ b/src/tribler/gui/widgets/channelcontentswidget.py
@@ -130,7 +130,7 @@ class ChannelContentsWidget(AddBreadcrumbOnShowMixin, widget_form, widget_class)
             self.update_labels()
 
     def commit_channels(self, checked=False):  # pylint: disable=W0613
-        request_manager.post("channels/mychannel/0/commit", on_finish=self.on_channel_committed)
+        request_manager.post("channels/mychannel/0/commit", on_success=self.on_channel_committed)
 
     def initialize_content_page(
             self,
@@ -574,8 +574,8 @@ class ChannelContentsWidget(AddBreadcrumbOnShowMixin, widget_form, widget_class)
 
     def _add_torrent_request(self, data):
         channel_id = self.model.channel_info["id"]
-        request_manager.put(f'collections/mychannel/{channel_id}/torrents', on_finish=self._on_torrent_to_channel_added,
-                            data=data)
+        request_manager.put(f'collections/mychannel/{channel_id}/torrents',
+                            on_success=self._on_torrent_to_channel_added, data=data)
 
     def add_torrent_to_channel(self, filename):
         with open(filename, "rb") as torrent_file:

--- a/src/tribler/gui/widgets/channeldescriptionwidget.py
+++ b/src/tribler/gui/widgets/channeldescriptionwidget.py
@@ -144,7 +144,7 @@ class ChannelDescriptionWidget(AddBreadcrumbOnShowMixin, widget_form, widget_cla
         if self.description_text is not None:
             descr_changed = True
             request_manager.put(f'channels/{self.channel_pk}/{self.channel_id}/description',
-                                on_finish=self._on_description_received,
+                                on_success=self._on_description_received,
                                 data={"description_text": self.description_text})
 
         if self.channel_thumbnail_bytes is not None:
@@ -154,7 +154,7 @@ class ChannelDescriptionWidget(AddBreadcrumbOnShowMixin, widget_form, widget_cla
                 pass
 
             request_manager.put(f'channels/{self.channel_pk}/{self.channel_id}/thumbnail',
-                                on_finish=_on_thumbnail_updated,
+                                on_success=_on_thumbnail_updated,
                                 data=self.channel_thumbnail_bytes,
                                 raw_response=True)
 
@@ -232,7 +232,7 @@ class ChannelDescriptionWidget(AddBreadcrumbOnShowMixin, widget_form, widget_cla
             self.description_text_preview.setMarkdown("")
 
         request_manager.get(f'channels/{self.channel_pk}/{self.channel_id}/thumbnail',
-                            on_finish=self._on_thumbnail_received,
+                            on_success=self._on_thumbnail_received,
                             raw_response=True)
 
     def set_widget_visible(self, show):

--- a/src/tribler/gui/widgets/downloadspage.py
+++ b/src/tribler/gui/widgets/downloadspage.py
@@ -398,7 +398,7 @@ class DownloadsPage(AddBreadcrumbOnShowMixin, QWidget):
         _name = self.selected_items[0].download_info["name"]
 
         request_manager.patch(f"downloads/{_infohash}",
-                              on_finish=lambda res: self.on_files_moved(res, _name, dest_dir),
+                              on_success=lambda res: self.on_files_moved(res, _name, dest_dir),
                               data={"state": "move_storage", "dest_dir": dest_dir})
 
     def on_files_moved(self, response, name, dest_dir):
@@ -428,7 +428,7 @@ class DownloadsPage(AddBreadcrumbOnShowMixin, QWidget):
             self.dialog.show()
 
     def on_export_download_dialog_done(self, action):
-        def on_finish(result: Tuple):
+        def on_success(result: Tuple):
             data, _ = result
             self.on_export_download_request_done(filename, data)
 
@@ -436,7 +436,7 @@ class DownloadsPage(AddBreadcrumbOnShowMixin, QWidget):
         if action == 0 and selected_item:
             filename = self.dialog.dialog_widget.dialog_input.text()
             request_manager.get(f"downloads/{selected_item[0].download_info['infohash']}/torrent",
-                                on_finish, priority=QNetworkRequest.LowPriority, raw_response=True)
+                                on_success=on_success, priority=QNetworkRequest.LowPriority, raw_response=True)
 
         self.dialog.close_dialog()
         self.dialog = None
@@ -464,7 +464,7 @@ class DownloadsPage(AddBreadcrumbOnShowMixin, QWidget):
                 infohash = selected_item.download_info["infohash"]
                 name = selected_item.download_info["name"]
                 request_manager.put(f"channels/mychannel/{channel_id}/torrents",
-                                    on_finish=lambda _: self.window().tray_show_message(
+                                    on_success=lambda _: self.window().tray_show_message(
                                         tr("Channel update"), tr("Torrent(s) added to your channel")
                                     ),
                                     data={"uri": compose_magnetlink(infohash, name=name)})

--- a/src/tribler/gui/widgets/lazytableview.py
+++ b/src/tribler/gui/widgets/lazytableview.py
@@ -279,7 +279,9 @@ class TriblerContentTableView(QTableView):
         self.edited_metadata.emit(data_item)
 
     def save_edited_metadata(self, index: QModelIndex, statements: List[Dict]):
+        def on_success(_):
+            self.on_metadata_edited(index, statements)
+
         data_item = self.model().data_items[index.row()]
-        request_manager.patch(f"knowledge/{data_item['infohash']}",
-                              on_finish=lambda _, ind=index, stmts=statements: self.on_metadata_edited(ind, statements),
+        request_manager.patch(f"knowledge/{data_item['infohash']}", on_success=on_success,
                               data=json.dumps({"statements": statements}))

--- a/src/tribler/gui/widgets/triblertablecontrollers.py
+++ b/src/tribler/gui/widgets/triblertablecontrollers.py
@@ -241,7 +241,7 @@ class ContextMenuMixin:
         def on_add_to_channel(_):
             def on_confirm_clicked(channel_id):
                 request_manager.post(f"collections/mychannel/{channel_id}/copy",
-                                     on_finish=lambda _: self.table_view.window().tray_show_message(
+                                     on_success=lambda _: self.table_view.window().tray_show_message(
                                          tr("Channel update"), tr("Torrent(s) added to your channel")
                                      ),
                                      data=json.dumps(entries))


### PR DESCRIPTION
This PR fixes #7333:
1. It adds the handling of `QNeworkReply` errors mentioned in #7335 by checking the QNetworkReply error code before reading the response data;
2. If there is an error or if the response data is empty, now Request does not call the `on_success` callback (renamed from `on_finish`);
3. In case of an error, it displays QNetworkReply errors in debug window as a request status code.