### PR TITLE
Fix item_rank(), torrent_rank(), freshness_rank() functions

### DIFF
--- a/src/tribler/core/tests/test_search_utils.py
+++ b/src/tribler/core/tests/test_search_utils.py
@@ -1,3 +1,4 @@
+import time
 from collections import deque
 
 import pytest
@@ -33,10 +34,10 @@ def test_title_rank_range():
 
 
 def test_freshness_rank_range():
-    assert freshness_rank(-1) == 0
-    assert freshness_rank(0) == 0
-    assert freshness_rank(0.001) == pytest.approx(1.0)
-    assert freshness_rank(1000000000) == pytest.approx(0.0025852989)
+    assert freshness_rank(-1) == freshness_rank(None) == 0  # Invalid or unknown freshness has the lowest rank
+    assert freshness_rank(0) == 1  # Maximum freshness has the highest rank
+    assert freshness_rank(0.001) == pytest.approx(1.0)  # Very fresh torrent
+    assert freshness_rank(1000000000) == pytest.approx(0.0025852989)  # Very old torrent
 
 
 def test_seeders_rank_range():
@@ -147,8 +148,14 @@ def test_title_rank():
 
 
 def test_item_rank():
+    item = dict(name="abc", num_seeders=10, num_leechers=20, updated=time.time() - 10 * DAY)
+    assert item_rank("abc", item) == pytest.approx(0.88794642)  # Torrent created ten days ago
+
+    item = dict(name="abc", num_seeders=10, num_leechers=20, updated=0)
+    assert item_rank("abc", item) == pytest.approx(0.81964285)  # Torrent creation date is unknown
+
     item = dict(name="abc", num_seeders=10, num_leechers=20)
-    assert item_rank("abc", item) == pytest.approx(0.819784)
+    assert item_rank("abc", item) == pytest.approx(0.81964285)  # Torrent creation date is unknown
 
 
 def test_find_word():


### PR DESCRIPTION
As it turns out there is a minor issue in the logic of the `item_rank()`, `torrent_rank()`, and `freshness_rank()` functions.

The crux of the problem lies in how torrents with an unspecified creation date were handled. These torrents were treated as if they were created at the Unix epoch, `1970-01-01 00:00:00`. Consequently, their freshness rank was marginally above zero and gradually decreased as their assumed "creation date" grew more distant. This led to unstable results in the `test_item_rank`, as the rank values were not constant but slowly diminishing.

To resolve this issue, this PR implements a fix that ensures the freshness rank, as well as the freshness component of the composite torrent rank, is strictly zero for all torrents with unknown or invalid creation dates. This adjustment has stabilized the tests and provided more accurate results.