### PR TITLE
Fix empty `saveas` issue

### DIFF
--- a/src/tribler/core/components/libtorrent/download_manager/download_config.py
+++ b/src/tribler/core/components/libtorrent/download_manager/download_config.py
@@ -4,11 +4,10 @@ from typing import Dict, Optional
 from configobj import ConfigObj
 from validate import Validator
 
-from tribler.core.components.libtorrent.settings import DownloadDefaultsSettings
+from tribler.core.components.libtorrent.settings import DownloadDefaultsSettings, get_default_download_dir
 from tribler.core.components.libtorrent.utils.libtorrent_helper import libtorrent as lt
 from tribler.core.exceptions import InvalidConfigException
 from tribler.core.utilities.install_dir import get_lib_path
-from tribler.core.utilities.osutils import get_home_dir
 from tribler.core.utilities.path_util import Path
 from tribler.core.utilities.utilities import bdecode_compat
 
@@ -61,12 +60,7 @@ class DownloadConfig:
 
         config.set_hops(settings.number_hops)
         config.set_safe_seeding(settings.safeseeding_enabled)
-
-        destination_directory = settings.saveas
-        if destination_directory is None:
-            destination_directory = get_default_dest_dir()
-
-        config.set_dest_dir(destination_directory)
+        config.set_dest_dir(settings.saveas)
 
         return config
 
@@ -91,7 +85,7 @@ class DownloadConfig:
         """
         dest_dir = self.config['download_defaults']['saveas']
         if not dest_dir:
-            dest_dir = get_default_dest_dir()
+            dest_dir = get_default_download_dir()
             self.set_dest_dir(dest_dir)
 
         # This is required to support relative paths
@@ -176,19 +170,3 @@ class DownloadConfig:
 
     def get_engineresumedata(self) -> Optional[Dict]:
         return _to_dict(self.config['state']['engineresumedata'])
-
-
-def get_default_dest_dir():
-    """
-    Returns the default dir to save content to.
-    """
-    tribler_downloads = Path("TriblerDownloads")
-    if tribler_downloads.is_dir():
-        return tribler_downloads.resolve()
-
-    home = get_home_dir()
-    downloads = home / "Downloads"
-    if downloads.is_dir():
-        return (downloads / tribler_downloads).resolve()
-
-    return (home / tribler_downloads).resolve()

--- a/src/tribler/core/components/libtorrent/settings.py
+++ b/src/tribler/core/components/libtorrent/settings.py
@@ -5,6 +5,10 @@ from pydantic import validator
 
 from tribler.core.config.tribler_config_section import TriblerConfigSection
 from tribler.core.utilities.network_utils import NetworkUtils
+from tribler.core.utilities.osutils import get_home_dir
+from tribler.core.utilities.path_util import Path
+
+TRIBLER_DOWNLOADS_DEFAULT = "TriblerDownloads"
 
 
 # pylint: disable=no-self-argument
@@ -47,11 +51,31 @@ class SeedingMode(str, Enum):
     time = 'time'
 
 
+def get_default_download_dir(home: Optional[Path] = None, tribler_downloads_name=TRIBLER_DOWNLOADS_DEFAULT) -> Path:
+    """
+    Returns the default dir to save content to.
+    Could be one of:
+        - TriblerDownloads
+        - $HOME/Downloads/TriblerDownloads
+        - $HOME/TriblerDownloads
+    """
+    path = Path(tribler_downloads_name)
+    if path.is_dir():
+        return path.resolve()
+
+    home = home or get_home_dir()
+    downloads = home / "Downloads"
+    if downloads.is_dir():
+        return downloads.resolve() / tribler_downloads_name
+
+    return home.resolve() / tribler_downloads_name
+
+
 class DownloadDefaultsSettings(TriblerConfigSection):
     anonymity_enabled: bool = True
     number_hops: int = 1
     safeseeding_enabled: bool = True
-    saveas: Optional[str] = None
+    saveas: str = str(get_default_download_dir())
     seeding_mode: SeedingMode = SeedingMode.forever
     seeding_ratio: float = 2.0
     seeding_time: float = 60

--- a/src/tribler/core/components/libtorrent/tests/test_download_config.py
+++ b/src/tribler/core/components/libtorrent/tests/test_download_config.py
@@ -3,8 +3,7 @@ from pathlib import Path
 import pytest
 from configobj import ConfigObjError
 
-from tribler.core.components.libtorrent.download_manager.download_config import DownloadConfig, _from_dict, _to_dict, \
-    get_default_dest_dir
+from tribler.core.components.libtorrent.download_manager.download_config import DownloadConfig, _from_dict, _to_dict
 from tribler.core.tests.tools.common import TESTS_DATA_DIR
 
 CONFIG_FILES_DIR = TESTS_DATA_DIR / "config_files"
@@ -50,10 +49,6 @@ def test_download_save_load(download_config, tmpdir):
 def test_download_load_corrupt(download_config):
     with pytest.raises(ConfigObjError):
         download_config.load(CONFIG_FILES_DIR / "corrupt_download_config.conf")
-
-
-def test_get_default_dest_dir():
-    assert isinstance(get_default_dest_dir(), Path)
 
 
 def test_default_download_config_load(tmpdir):

--- a/src/tribler/core/components/libtorrent/tests/test_settings.py
+++ b/src/tribler/core/components/libtorrent/tests/test_settings.py
@@ -1,0 +1,38 @@
+from tribler.core.components.libtorrent.settings import TRIBLER_DOWNLOADS_DEFAULT, get_default_download_dir
+from tribler.core.utilities.path_util import Path
+
+
+def test_get_default_download_dir_exists(tmp_path, monkeypatch):
+    # Test the case when the default download dir exists. Then it should be returned as is.
+    # Historically, the default download dir was 'TriblerDownloads'
+    monkeypatch.chdir(tmp_path)
+
+    downloads = Path(TRIBLER_DOWNLOADS_DEFAULT)
+    downloads.mkdir()
+
+    actual = get_default_download_dir(home=Path("home"))
+    assert actual == downloads.resolve()
+
+
+def test_get_default_home_download_dir_exists(tmp_path, monkeypatch):
+    # Test the case when the `$HOME/Downloads` dir exists. Then it should return default dir
+    # as `$HOME/Downloads/TriblerDownloads`
+    monkeypatch.chdir(tmp_path)
+
+    home = Path("home")
+    downloads = home / "Downloads"
+    downloads.mkdir(parents=True)
+
+    download_dir = get_default_download_dir(home)
+    assert download_dir == (downloads / TRIBLER_DOWNLOADS_DEFAULT).resolve()
+
+
+def test_get_default_home_nothing_exists(tmp_path, monkeypatch):
+    # Test the case when neither `$HOME/Downloads` nor `TriblerDownloads` dir exists.
+    # Then it should return default dir as `$HOME/TriblerDownloads`
+    monkeypatch.chdir(tmp_path)
+
+    home = Path("home")
+
+    download_dir = get_default_download_dir(home)
+    assert download_dir == (home / TRIBLER_DOWNLOADS_DEFAULT).resolve()

--- a/src/tribler/core/config/tests/test_tribler_config.py
+++ b/src/tribler/core/config/tests/test_tribler_config.py
@@ -75,6 +75,11 @@ def test_load_write_nonascii(tmpdir):
     assert config.file == tmpdir / filename
 
 
+def test_load_default_saveas(tmpdir):
+    config = TriblerConfig(state_dir=tmpdir)
+    assert config.download_defaults.saveas
+
+
 def test_copy(tmpdir):
     config = TriblerConfig(state_dir=tmpdir, file=tmpdir / '1.txt')
     config.api.http_port = 42

--- a/src/tribler/gui/tribler_window.py
+++ b/src/tribler/gui/tribler_window.py
@@ -546,19 +546,23 @@ class TriblerWindow(QMainWindow):
             return
 
         self._logger.info("Core connected")
-
         self.tribler_started = True
         self.tribler_version = version
 
+        request_manager.get("settings", self.on_receive_settings, capture_errors=False)
+
+    def on_receive_settings(self, settings):
+        self.tribler_settings = settings['settings']
+        self.start_ui()
+
+    def start_ui(self):
         self.top_menu_button.setHidden(False)
         self.left_menu.setHidden(False)
         # self.token_balance_widget.setHidden(False)  # restore it after the token balance calculation is fixed
         self.settings_button.setHidden(False)
         self.add_torrent_button.setHidden(False)
         self.top_search_bar.setHidden(False)
-
-        self.fetch_settings()
-
+        self.process_uri_request()
         self.downloads_page.start_loading_downloads()
 
         self.setAcceptDrops(True)
@@ -739,33 +743,6 @@ class TriblerWindow(QMainWindow):
         if completions_list:
             self.search_completion_model.setStringList(completions_list)
 
-    def fetch_settings(self):
-        request_manager.get("settings", self.received_settings, capture_errors=False)
-
-    def received_settings(self, settings):
-        if not settings:
-            return
-        # If we cannot receive the settings, stop Tribler with an option to send the crash report.
-        if 'error' in settings:
-            raise RuntimeError(RequestManager.get_message_from_error(settings))
-
-        # If there is any pending dialog (likely download dialog or error dialog of setting not available),
-        # close the dialog
-        if self.dialog:
-            self.dialog.close_dialog()
-            self.dialog = None
-
-        self.tribler_settings = settings['settings']
-
-        self.downloads_all_button.click()
-
-        # process pending file requests (i.e. someone clicked a torrent file when Tribler was closed)
-        # We do this after receiving the settings so we have the default download location.
-        self.process_uri_request()
-
-        if self.token_balance_widget.isVisible():
-            self.enable_token_balance_refresh()
-
     def on_settings_button_click(self):
         self.deselect_all_menu_buttons()
         self.stackedWidget.setCurrentIndex(PAGE_SETTINGS)
@@ -879,20 +856,8 @@ class TriblerWindow(QMainWindow):
     def start_download_from_uri(self, uri):
         uri = uri.decode('utf-8') if isinstance(uri, bytes) else uri
 
-        if get_gui_setting(self.gui_settings, "ask_download_settings", True, is_bool=True):
-            # FIXME: instead of using this workaround, make sure the settings are _available_ by this moment
-            # If tribler settings is not available, fetch the settings and inform the user to try again.
-            if not self.tribler_settings:
-                self.fetch_settings()
-                self.dialog = ConfirmationDialog.show_error(
-                    self,
-                    tr("Download Error"),
-                    tr("Tribler settings is not available yet. Fetching it now. Please try again later."),
-                )
-                # By re-adding the download uri to the pending list, the request is re-processed
-                # when the settings is received
-                self.pending_uri_requests.append(uri)
-                return
+        ask_download_settings = get_gui_setting(self.gui_settings, "ask_download_settings", True, is_bool=True)
+        if ask_download_settings:
             # Clear any previous dialog if exists
             if self.dialog:
                 self.dialog.close_dialog()
@@ -903,15 +868,6 @@ class TriblerWindow(QMainWindow):
             self.dialog.show()
             self.start_download_dialog_active = True
         else:
-            # FIXME: instead of using this workaround, make sure the settings are _available_ by this moment
-            # In the unlikely scenario that tribler settings are not available yet, try to fetch settings again and
-            # add the download uri back to self.pending_uri_requests to process again.
-            if not self.tribler_settings:
-                self.fetch_settings()
-                if uri not in self.pending_uri_requests:
-                    self.pending_uri_requests.append(uri)
-                return
-
             self.window().perform_start_download_request(
                 uri,
                 self.window().tribler_settings['download_defaults']['anonymity_enabled'],
@@ -1114,7 +1070,7 @@ class TriblerWindow(QMainWindow):
         self.stackedWidget.setCurrentIndex(PAGE_DOWNLOADS)
 
     def clicked_debug_panel_button(self, *_):
-        if not self.tribler_settings or not self.gui_settings:
+        if not self.gui_settings:
             self._logger.info("Tribler settings (Core and/or GUI) is not available yet.")
             return
         if not self.debug_window:

--- a/src/tribler/gui/widgets/settingspage.py
+++ b/src/tribler/gui/widgets/settingspage.py
@@ -558,6 +558,9 @@ class SettingsPage(AddBreadcrumbOnShowMixin, QWidget):
         self.save_language_selection()
         self.window().tray_show_message(tr("Tribler settings"), tr("Settings saved"))
 
-        self.window().fetch_settings()
+        def on_receive_settings(response):
+            self.window().tribler_settings = response['settings']
+
+        request_manager.get("settings", on_receive_settings, capture_errors=False)
 
         self.settings_edited.emit()


### PR DESCRIPTION
This PR fixes #7342

The actual fix is on the core side. The fix forbids `saveas` to be `None`. Now the default value is one of the:
- `TriblerDownloads`
- `$HOME/Downloads/TriblerDownloads`
- `$HOME/TriblerDownloads`

This value comes from the function `get_default_download_dir`. 

Note that doesn't relate to the original bug. This function was not covered by tests and consisted of a bug. In this PR tests were added and the bug was fixed.

---

On the GUI side, there is a refactoring that was needed to make it possible to understand and investigate the bug.

The refactoring changes GUI startup logic.

Instead of requesting Tribler settings in parallel:


```mermaid
graph LR;
    A[core connected]-->B[receive settings];
    A-->C[start UI];

```


 it does this sequentially now:

```mermaid
graph LR;
    A[core connected]-->B[receive settings];
    B-->C[start UI];
```