### PR TITLE
Disable logging in the faker module for pytest.

### DIFF
--- a/src/tribler/core/conftest.py
+++ b/src/tribler/core/conftest.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import os
 import platform
 import sys
@@ -30,6 +31,11 @@ from tribler.core.utilities.unicode import hexlify
 # Note that the error can happen in an unrelated test where the unhandled task from the previous test
 # was garbage collected. Without the origin tracking, it may be hard to see the test that created the task.
 sys.set_coroutine_origin_tracking_depth(10)
+
+
+def pytest_configure(config):  # pylint: disable=unused-argument
+    # Disable logging from faker for all tests
+    logging.getLogger('faker.factory').propagate = False
 
 
 @pytest.fixture(name="tribler_root_dir")


### PR DESCRIPTION
Currently, all failed test output look like this:

```python
============================= test session starts ==============================
collecting ... collected 1 item

test_settings.py::test_get_default_home_download_dir_exists 
-------------------------------- live log setup --------------------------------
21:29:38.116 DEBUG faker.factory(78) Looking for locale `en_US` in provider `faker.providers.address`.
21:29:38.119 DEBUG faker.factory(97) Provider `faker.providers.address` has been localized to `en_US`.
21:29:38.123 DEBUG faker.factory(78) Looking for locale `en_US` in provider `faker.providers.automotive`.
21:29:38.125 DEBUG faker.factory(97) Provider `faker.providers.automotive` has been localized to `en_US`.
21:29:38.127 DEBUG faker.factory(78) Looking for locale `en_US` in provider `faker.providers.bank`.
21:29:38.128 DEBUG faker.factory(88) Specified locale `en_US` is not available for provider `faker.providers.bank`. Locale reset to `en_GB` for this provider.
21:29:38.129 DEBUG faker.factory(78) Looking for locale `en_US` in provider `faker.providers.barcode`.
21:29:38.130 DEBUG faker.factory(97) Provider `faker.providers.barcode` has been localized to `en_US`.
21:29:38.132 DEBUG faker.factory(78) Looking for locale `en_US` in provider `faker.providers.color`.
21:29:38.133 DEBUG faker.factory(97) Provider `faker.providers.color` has been localized to `en_US`.
21:29:38.134 DEBUG faker.factory(78) Looking for locale `en_US` in provider `faker.providers.company`.
21:29:38.136 DEBUG faker.factory(97) Provider `faker.providers.company` has been localized to `en_US`.
21:29:38.137 DEBUG faker.factory(78) Looking for locale `en_US` in provider `faker.providers.credit_card`.
21:29:38.138 DEBUG faker.factory(97) Provider `faker.providers.credit_card` has been localized to `en_US`.
21:29:38.139 DEBUG faker.factory(78) Looking for locale `en_US` in provider `faker.providers.currency`.
21:29:38.141 DEBUG faker.factory(97) Provider `faker.providers.currency` has been localized to `en_US`.
21:29:38.142 DEBUG faker.factory(78) Looking for locale `en_US` in provider `faker.providers.date_time`.
21:29:38.144 DEBUG faker.factory(97) Provider `faker.providers.date_time` has been localized to `en_US`.
21:29:38.145 DEBUG faker.factory(109) Provider `faker.providers.file` does not feature localization. Specified locale `en_US` is not utilized for this provider.
21:29:38.145 DEBUG faker.factory(78) Looking for locale `en_US` in provider `faker.providers.geo`.
21:29:38.145 DEBUG faker.factory(97) Provider `faker.providers.geo` has been localized to `en_US`.
21:29:38.146 DEBUG faker.factory(78) Looking for locale `en_US` in provider `faker.providers.internet`.
21:29:38.148 DEBUG faker.factory(97) Provider `faker.providers.internet` has been localized to `en_US`.
21:29:38.149 DEBUG faker.factory(109) Provider `faker.providers.isbn` does not feature localization. Specified locale `en_US` is not utilized for this provider.
21:29:38.150 DEBUG faker.factory(78) Looking for locale `en_US` in provider `faker.providers.job`.
21:29:38.151 DEBUG faker.factory(97) Provider `faker.providers.job` has been localized to `en_US`.
21:29:38.152 DEBUG faker.factory(78) Looking for locale `en_US` in provider `faker.providers.lorem`.
21:29:38.154 DEBUG faker.factory(97) Provider `faker.providers.lorem` has been localized to `en_US`.
21:29:38.157 DEBUG faker.factory(78) Looking for locale `en_US` in provider `faker.providers.misc`.
21:29:38.158 DEBUG faker.factory(97) Provider `faker.providers.misc` has been localized to `en_US`.
21:29:38.159 DEBUG faker.factory(78) Looking for locale `en_US` in provider `faker.providers.person`.
21:29:38.162 DEBUG faker.factory(97) Provider `faker.providers.person` has been localized to `en_US`.
21:29:38.167 DEBUG faker.factory(78) Looking for locale `en_US` in provider `faker.providers.phone_number`.
21:29:38.170 DEBUG faker.factory(97) Provider `faker.providers.phone_number` has been localized to `en_US`.
21:29:38.172 DEBUG faker.factory(109) Provider `faker.providers.profile` does not feature localization. Specified locale `en_US` is not utilized for this provider.
21:29:38.172 DEBUG faker.factory(109) Provider `faker.providers.python` does not feature localization. Specified locale `en_US` is not utilized for this provider.
21:29:38.172 DEBUG faker.factory(78) Looking for locale `en_US` in provider `faker.providers.ssn`.
21:29:38.175 DEBUG faker.factory(97) Provider `faker.providers.ssn` has been localized to `en_US`.
21:29:38.177 DEBUG faker.factory(109) Provider `faker.providers.user_agent` does not feature localization. Specified locale `en_US` is not utilized for this provider.
FAILED
src/tribler/core/components/libtorrent/tests/test_settings.py:18 (test_get_default_home_download_dir_exists)
Path('/private/var/folders/mg/7124pd9x7q545c5zphg6q2cc0000gn/T/pytest-of-<user>/pytest-43/test_get_default_home_download0/home/Downloads/TriblerDownloads') != Path('home/Downloads')

Expected :Path('home/Downloads')
Actual   :Path('/private/var/folders/mg/7124pd9x7q545c5zphg6q2cc0000gn/T/pytest-of-<user>/pytest-43
```

After this fix:
```python
============================= test session starts ==============================
collecting ... collected 1 item

test_settings.py::test_get_default_home_download_dir_exists 
-------------------------------- live log setup --------------------------------
FAILED
src/tribler/core/components/libtorrent/tests/test_settings.py:18 (test_get_default_home_download_dir_exists)
Path('/private/var/folders/mg/7124pd9x7q545c5zphg6q2cc0000gn/T/pytest-of-<user>/pytest-43/test_get_default_home_download0/home/Downloads/TriblerDownloads') != Path('home/Downloads')

Expected :Path('home/Downloads')
Actual   :Path('/private/var/folders/mg/7124pd9x7q545c5zphg6q2cc0000gn/T/pytest-of-<user>/pytest-43
```