### PR TITLE
Properly stop non-primary process

### DIFF
--- a/src/tribler/core/utilities/process_manager/tests/test_process.py
+++ b/src/tribler/core/utilities/process_manager/tests/test_process.py
@@ -14,7 +14,17 @@ def test_tribler_process():
     assert p.is_current_process()
     assert p.is_running()
 
-    pattern = r"^CoreProcess\(pid=\d+, gui_pid=123, version='[^']+', started='\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}'\)$"
+    pattern = r"^CoreProcess\(running, current process, pid=\d+, gui_pid=123, version='[^']+', " \
+              r"started='\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}'\, duration='0:00:\d{2}'\)$"
+    assert re.match(pattern, str(p))
+
+    p.canceled = True
+    p.api_port = 123
+    p.exit_code = 1
+
+    pattern = r"^CoreProcess\(finished, current process, canceled, pid=\d+, gui_pid=123, version='[^']+', " \
+              r"started='\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}'\, api_port=123, duration='0:00:\d{2}', " \
+              r"exit_code=1\)$"
     assert re.match(pattern, str(p))
 
 
@@ -93,7 +103,8 @@ def test_tribler_process_set_error(current_process):
     assert current_process.error_msg == 'ValueError: exception text'
 
     # The error text is included in ProcessInfo.__str__() output
-    pattern = r"^CoreProcess\(primary, pid=\d+, version='[^']+', started='[^']+', error='ValueError: exception text'\)$"
+    pattern = r"^CoreProcess\(running, current process, primary, pid=\d+, version='[^']+', " \
+              r"started='[^']+', duration='0:00:\d{2}', error='ValueError: exception text'\)$"
     assert re.match(pattern, str(current_process))
 
 

--- a/src/tribler/gui/start_gui.py
+++ b/src/tribler/gui/start_gui.py
@@ -63,16 +63,10 @@ def run_gui(api_port, api_key, root_state_dir, parsed_args):
         translator = get_translator(settings.value('translation', None))
         app.installTranslator(translator)
 
-        if not current_process_is_primary and app.connected_to_previous_instance:
-            # if an application is already running, then send the command line
-            # argument to it and close the current instance
-            logger.info('GUI Application is already running. Passing a torrent file path to it.')
-            for arg in sys.argv[1:]:
-                if os.path.exists(arg) and arg.endswith(".torrent"):
-                    app.send_message(path_to_url(arg))
-                elif arg.startswith('magnet'):
-                    app.send_message(arg)
-            logger.info('Close the current application.')
+        if not current_process_is_primary:
+            logger.info('GUI Application is already running.')
+            app.send_torrent_file_path_to_primary_process()
+            logger.info('Close the current GUI application.')
             process_manager.sys_exit(1, 'Tribler GUI application is already running')
 
         logger.info('Start Tribler Window')


### PR DESCRIPTION
This PR closes #7034 by fixing #7212. Namely, it fixes the following race condition:
1. Due to an unusual OS bug, two Tribler GUI processes sometimes start at the same time
2. With the help of #7212, one process determines itself as a primary process and another as a non-primary process.
3. Now, the non-primary process should check if it has some torrent URL specified as a command line argument and pass it to the primary process.
4. The non-primary process attempts to connect with the primary process through a socket.
5. **Now the bug happens**: if the non-primary process cannot connect to the primary process (for example, because the primary process just started itself and had no time to open a socket), then the non-primary process continues to work as if it was a primary process. Then two GUI processes running in parallel start their core processes, and another weird race condition can happen in Core processes.

The current PR fixes this bug by ensuring that the non-primary process immediately stops, even if it cannot connect to the primary process via a socket.

The torrent URL passing from a non-primary process to a primary process is designed for the situation when the first process has already been working for some time, and the user launches the second process by clicking on the torrent file. In the situation when two processes are started at the same moment (due to an unknown OS bug), I think it is not necessary to pass a torrent URL from one process to another process because both processes likely have the same arguments. So, I think it is not a problem that the second process was not able to send the torrent URL to the first process because the socket wasn't open.
