### PR TITLE
Skip `on_tribler_exception` if EventsEndpoint is shutting down.

### DIFF
--- a/src/tribler/core/components/restapi/rest/events_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/events_endpoint.py
@@ -119,6 +119,10 @@ class EventsEndpoint(RESTEndpoint):
     # An exception has occurred in Tribler. The event includes a readable
     # string of the error and a Sentry event.
     def on_tribler_exception(self, reported_error: ReportedError):
+        if self._shutdown:
+            self._logger.warning('Ignoring tribler exception, because the endpoint is shutting down.')
+            return
+
         message = self.error_message(reported_error)
         if self.has_connection_to_gui():
             self.async_group.add_task(self.write_data(message))

--- a/src/tribler/core/components/restapi/rest/tests/test_events_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/tests/test_events_endpoint.py
@@ -1,7 +1,7 @@
 import json
 from asyncio import CancelledError, Event, create_task
 from contextlib import suppress
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 from aiohttp import ClientSession
@@ -163,3 +163,15 @@ async def test_get_events_has_undelivered_error(mocked_encode_message, mocked_wr
     mocked_write.assert_called()
     mocked_encode_message.assert_called_with({'undelivered': 'error'})
     assert not endpoint.undelivered_error
+
+
+async def test_on_tribler_exception_shutdown():
+    # test that `on_tribler_exception` will not send any error message if endpoint is shutting down
+    endpoint = EventsEndpoint(Mock())
+    endpoint.error_message = Mock()
+
+    await endpoint.shutdown()
+
+    endpoint.on_tribler_exception(ReportedError('', '', {}))
+
+    assert not endpoint.error_message.called


### PR DESCRIPTION
This PR fixes #7354