### PR TITLE
Add `tribler_stopped` tag to the Sentry

### DIFF
--- a/src/tribler/core/sentry_reporter/sentry_reporter.py
+++ b/src/tribler/core/sentry_reporter/sentry_reporter.py
@@ -5,7 +5,7 @@ from contextlib import contextmanager
 from contextvars import ContextVar
 from enum import Enum, auto
 from hashlib import md5
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 import sentry_sdk
 from faker import Faker
@@ -147,7 +147,7 @@ class SentryReporter:
         return sentry_sdk.add_breadcrumb(crumb, **kwargs)
 
     def send_event(self, event: Dict = None, post_data: Dict = None, sys_info: Dict = None,
-                   additional_tags: List[str] = None, last_core_output: Optional[str] = None,
+                   additional_tags: Dict[str, Any] = None, last_core_output: Optional[str] = None,
                    last_processes: List[str] = None):
         """Send the event to the Sentry server
 

--- a/src/tribler/core/sentry_reporter/tests/test_sentry_reporter.py
+++ b/src/tribler/core/sentry_reporter/tests/test_sentry_reporter.py
@@ -265,7 +265,7 @@ def test_send_sys_info(sentry_reporter):
 
 
 def test_send_additional_tags(sentry_reporter):
-    actual = sentry_reporter.send_event(event={}, additional_tags={'tag_key': 'tag_value'})
+    actual = sentry_reporter.send_event(event={}, additional_tags={'tag_key': 'tag_value', 'numeric_tag_key': 1})
     expected = {
         'contexts': {
             'browser': {'name': 'Tribler', 'version': None},
@@ -286,6 +286,7 @@ def test_send_additional_tags(sentry_reporter):
             'platform.details': None,
             'version': None,
             'tag_key': 'tag_value',
+            'numeric_tag_key': 1,
         },
     }
     assert actual == expected

--- a/src/tribler/gui/error_handler.py
+++ b/src/tribler/gui/error_handler.py
@@ -72,6 +72,11 @@ class ErrorHandler:
         if self.app_manager.quitting_app:
             return
 
+        additional_tags = {
+            'source': 'gui',
+            'tribler_stopped': self._tribler_stopped
+        }
+
         FeedbackDialog(
             parent=self.tribler_window,
             sentry_reporter=gui_sentry_reporter,
@@ -79,7 +84,7 @@ class ErrorHandler:
             tribler_version=self.tribler_window.tribler_version,
             start_time=self.tribler_window.start_time,
             stop_application_on_close=self._tribler_stopped,
-            additional_tags={'source': 'gui'},
+            additional_tags=additional_tags,
         ).show()
 
     def core_error(self, reported_error: ReportedError):
@@ -99,6 +104,11 @@ class ErrorHandler:
 
         SentryScrubber.remove_breadcrumbs(reported_error.event)
 
+        additional_tags = {
+            'source': 'core',
+            'tribler_stopped': self._tribler_stopped
+        }
+
         FeedbackDialog(
             parent=self.tribler_window,
             sentry_reporter=gui_sentry_reporter,
@@ -106,7 +116,7 @@ class ErrorHandler:
             tribler_version=self.tribler_window.tribler_version,
             start_time=self.tribler_window.start_time,
             stop_application_on_close=self._tribler_stopped,
-            additional_tags={'source': 'core'}
+            additional_tags=additional_tags,
         ).show()
 
     def _stop_tribler(self, text):


### PR DESCRIPTION
While investigating issues from release `7.13,` I realized having a `tribler_stopped` tag in the Sentry would be nice. That helps better understand the bug itself and distinguish the severity of the bug. 

If `tribler_stopped` is set to `True`, then it is a more severe bug than a bug with `tribler_stopped` set to `False`.

As a bonus, this PR adds correct typings for the field `additional_tags`.