### PR TITLE
Ignore logging for downloads endpoint

### DIFF
--- a/src/tribler/gui/network/request.py
+++ b/src/tribler/gui/network/request.py
@@ -52,11 +52,13 @@ class Request(QObject):
             data: DATA_TYPE = None,
             method: str = GET,
             capture_errors: bool = True,
+            logger_message_level: int = logging.INFO,
             priority=QNetworkRequest.NormalPriority,
             raw_response: bool = False,
     ):
         super().__init__()
         self.logger = logging.getLogger(self.__class__.__name__)
+        self.logger_message_level = logger_message_level
 
         self.endpoint = endpoint
         self.url_params = url_params
@@ -88,6 +90,7 @@ class Request(QObject):
     def set_manager(self, manager: RequestManager):
         self.manager = manager
         self._set_url(manager.get_base_url())
+        self._log(str(self))
 
     def _set_url(self, base_url: str):
         self.url = base_url + self.endpoint
@@ -109,7 +112,7 @@ class Request(QObject):
         if not self.reply or not self.manager:
             return
 
-        self.logger.info(f'Finished: {self}')
+        self._log(f'Finished: {self}')
         try:
             error_code = self.reply.error()
             if error_code != QNetworkReply.NoError:
@@ -171,6 +174,9 @@ class Request(QObject):
         if self.reply:
             self.reply.deleteLater()
             self.reply = None
+
+    def _log(self, message: str):
+        self.logger.log(level=self.logger_message_level, msg=message)
 
     def __str__(self):
         return f'{self.method} {self.url}'

--- a/src/tribler/gui/network/request_manager.py
+++ b/src/tribler/gui/network/request_manager.py
@@ -27,7 +27,6 @@ class RequestManager(QNetworkAccessManager):
     def __init__(self, limit: int = 50, timeout_interval: int = 15):
         QNetworkAccessManager.__init__(self)
         self.logger = logging.getLogger(self.__class__.__name__)
-
         self.active_requests: Set[Request] = set()
         self.performed_requests: deque[Request] = deque(maxlen=200)
 
@@ -38,78 +37,93 @@ class RequestManager(QNetworkAccessManager):
         self.limit = limit
         self.timeout_interval = timeout_interval
 
-    def get(self,
+    def get(
+            self,
             endpoint: str,
             on_success: Callable = lambda _: None,
             url_params: Optional[Dict] = None,
             data: DATA_TYPE = None,
             capture_errors: bool = True,
             priority: int = QNetworkRequest.NormalPriority,
-            raw_response: bool = False) -> Request:
+            raw_response: bool = False,
+            logger_message_level: int = logging.INFO,
+    ) -> Request:
 
         request = Request(endpoint=endpoint, on_success=on_success, url_params=url_params, data=data,
                           capture_errors=capture_errors, priority=priority, raw_response=raw_response,
-                          method=Request.GET)
+                          method=Request.GET, logger_message_level=logger_message_level)
         self.add(request)
         return request
 
-    def post(self,
-             endpoint: str,
-             on_success: Callable = lambda _: None,
-             url_params: Optional[Dict] = None,
-             data: DATA_TYPE = None,
-             capture_errors: bool = True,
-             priority: int = QNetworkRequest.NormalPriority,
-             raw_response: bool = False) -> Request:
-
-        request = Request(endpoint=endpoint, on_success=on_success, url_params=url_params, data=data,
-                          capture_errors=capture_errors, priority=priority, raw_response=raw_response,
-                          method=Request.POST)
-        self.add(request)
-        return request
-
-    def put(self,
+    def post(
+            self,
             endpoint: str,
             on_success: Callable = lambda _: None,
             url_params: Optional[Dict] = None,
             data: DATA_TYPE = None,
             capture_errors: bool = True,
             priority: int = QNetworkRequest.NormalPriority,
-            raw_response: bool = False) -> Request:
+            raw_response: bool = False,
+            logger_message_level: int = logging.INFO,
+    ) -> Request:
 
         request = Request(endpoint=endpoint, on_success=on_success, url_params=url_params, data=data,
                           capture_errors=capture_errors, priority=priority, raw_response=raw_response,
-                          method=Request.PUT)
+                          method=Request.POST, logger_message_level=logger_message_level)
         self.add(request)
         return request
 
-    def patch(self,
-              endpoint: str,
-              on_success: Callable = lambda _: None,
-              url_params: Optional[Dict] = None,
-              data: DATA_TYPE = None,
-              capture_errors: bool = True,
-              priority: int = QNetworkRequest.NormalPriority,
-              raw_response: bool = False) -> Request:
+    def put(
+            self,
+            endpoint: str,
+            on_success: Callable = lambda _: None,
+            url_params: Optional[Dict] = None,
+            data: DATA_TYPE = None,
+            capture_errors: bool = True,
+            priority: int = QNetworkRequest.NormalPriority,
+            raw_response: bool = False,
+            logger_message_level: int = logging.INFO,
+    ) -> Request:
 
         request = Request(endpoint=endpoint, on_success=on_success, url_params=url_params, data=data,
                           capture_errors=capture_errors, priority=priority, raw_response=raw_response,
-                          method=Request.PATCH)
+                          method=Request.PUT, logger_message_level=logger_message_level)
         self.add(request)
         return request
 
-    def delete(self,
-               endpoint: str,
-               on_success: Callable = lambda _: None,
-               url_params: Optional[Dict] = None,
-               data: DATA_TYPE = None,
-               capture_errors: bool = True,
-               priority: int = QNetworkRequest.NormalPriority,
-               raw_response: bool = False) -> Request:
+    def patch(
+            self,
+            endpoint: str,
+            on_success: Callable = lambda _: None,
+            url_params: Optional[Dict] = None,
+            data: DATA_TYPE = None,
+            capture_errors: bool = True,
+            priority: int = QNetworkRequest.NormalPriority,
+            raw_response: bool = False,
+            logger_message_level: int = logging.INFO,
+    ) -> Request:
 
         request = Request(endpoint=endpoint, on_success=on_success, url_params=url_params, data=data,
                           capture_errors=capture_errors, priority=priority, raw_response=raw_response,
-                          method=Request.DELETE)
+                          method=Request.PATCH, logger_message_level=logger_message_level)
+        self.add(request)
+        return request
+
+    def delete(
+            self,
+            endpoint: str,
+            on_success: Callable = lambda _: None,
+            url_params: Optional[Dict] = None,
+            data: DATA_TYPE = None,
+            capture_errors: bool = True,
+            priority: int = QNetworkRequest.NormalPriority,
+            raw_response: bool = False,
+            logger_level: int = logging.INFO,
+    ) -> Request:
+
+        request = Request(endpoint=endpoint, on_success=on_success, url_params=url_params, data=data,
+                          capture_errors=capture_errors, priority=priority, raw_response=raw_response,
+                          method=Request.DELETE, logger_message_level=logger_level)
         self.add(request)
         return request
 
@@ -120,8 +134,6 @@ class RequestManager(QNetworkAccessManager):
         self.active_requests.add(request)
         self.performed_requests.append(request)
         request.set_manager(self)
-        self.logger.info(f'Request: {request}')
-
         qt_request = QNetworkRequest(QUrl(request.url))
         qt_request.setPriority(request.priority)
         qt_request.setHeader(QNetworkRequest.ContentTypeHeader, 'application/x-www-form-urlencoded')

--- a/src/tribler/gui/widgets/downloadspage.py
+++ b/src/tribler/gui/widgets/downloadspage.py
@@ -125,11 +125,11 @@ class DownloadsPage(AddBreadcrumbOnShowMixin, QWidget):
         self.downloads_timeout_timer.stop()
 
     def load_downloads(self):
-        url = "downloads?get_pieces=1"
+        url_params = {'get_pieces': 1}
         if self.window().download_details_widget.currentIndex() == 3:
-            url += "&get_peers=1"
+            url_params['get_peers'] = 1
         elif self.window().download_details_widget.currentIndex() == 1:
-            url += "&get_files=1"
+            url_params['get_files'] = 1
 
         isactive = not self.isHidden()
 
@@ -139,7 +139,14 @@ class DownloadsPage(AddBreadcrumbOnShowMixin, QWidget):
             priority = QNetworkRequest.LowPriority if not isactive else QNetworkRequest.HighPriority
             if self.rest_request:
                 self.rest_request.cancel()
-            request_manager.get(url, self.on_received_downloads, priority=priority)
+
+            request_manager.get(
+                endpoint="downloads",
+                url_params=url_params,
+                on_success=self.on_received_downloads,
+                priority=priority,
+                logger_message_level=logging.DEBUG
+            )
 
     def on_received_downloads(self, downloads):
         if not downloads or "downloads" not in downloads:


### PR DESCRIPTION
This PR decreases the level of log messages for the downloads endpoint because it overflows the logs and they become useless for investigations:

<img width="597" alt="image" src="https://user-images.githubusercontent.com/13798583/232523470-b01492bc-af7c-4992-9dd0-04ab4cf93a02.png">
