### PR TITLE
Remove events and requests from Sentry report

### DIFF
--- a/src/tribler/core/sentry_reporter/sentry_reporter.py
+++ b/src/tribler/core/sentry_reporter/sentry_reporter.py
@@ -218,9 +218,7 @@ class SentryReporter:
         reporter[OS_ENVIRON] = parse_os_environ(get_value(sys_info, OS_ENVIRON))
         delete_item(sys_info, OS_ENVIRON)
 
-        reporter['events'] = extract_dict(sys_info, r'^(event|request)')
-        reporter[SYSINFO] = {key: sys_info[key] for key in sys_info if key not in reporter['events']}
-
+        reporter[SYSINFO] = sys_info
         if last_processes:
             reporter['last_processes'] = last_processes
 

--- a/src/tribler/core/sentry_reporter/tests/test_sentry_reporter.py
+++ b/src/tribler/core/sentry_reporter/tests/test_sentry_reporter.py
@@ -208,7 +208,6 @@ def test_send_defaults(sentry_reporter):
                 'comments': None,
                 OS_ENVIRON: {},
                 'sysinfo': {},
-                'events': {},
             },
         },
         'tags': {'machine': None, 'os': None, 'platform': None, PLATFORM_DETAILS: None, 'version': None},
@@ -231,7 +230,6 @@ def test_send_post_data(sentry_reporter):
                 'comments': 'comment',
                 'os.environ': {},
                 'sysinfo': {},
-                'events': {},
             },
         },
         'tags': {'machine': 'x86_64', 'os': 'posix', 'platform': None, PLATFORM_DETAILS: None,
@@ -241,10 +239,11 @@ def test_send_post_data(sentry_reporter):
 
 
 def test_send_sys_info(sentry_reporter):
-    actual = sentry_reporter.send_event(event={}, sys_info={'platform': ['darwin'], PLATFORM_DETAILS: ['details'],
-                                                            OS_ENVIRON: ['KEY:VALUE', 'KEY1:VALUE1'],
-                                                            'event_1': [{'type': ''}], 'request_1': [{}], 'event_2': [],
-                                                            'request_2': [], }, )
+    sys_info = {
+        'platform': ['darwin'],
+        PLATFORM_DETAILS: ['details'],
+        OS_ENVIRON: ['KEY:VALUE', 'KEY1:VALUE1'],
+    }
     expected = {
         'contexts': {
             'browser': {'name': 'Tribler', 'version': None},
@@ -255,12 +254,12 @@ def test_send_sys_info(sentry_reporter):
                 'comments': None,
                 OS_ENVIRON: {'KEY': 'VALUE', 'KEY1': 'VALUE1'},
                 'sysinfo': {'platform': ['darwin'], PLATFORM_DETAILS: ['details']},
-                'events': {'event_1': [{'type': ''}], 'request_1': [{}], 'event_2': [], 'request_2': []},
             },
         },
         'tags': {'machine': None, 'os': None, 'platform': 'darwin', 'platform.details': 'details',
                  'version': None},
     }
+    actual = sentry_reporter.send_event(event={}, sys_info=sys_info)
     assert actual == expected
 
 
@@ -276,7 +275,6 @@ def test_send_additional_tags(sentry_reporter):
                 'comments': None,
                 OS_ENVIRON: {},
                 'sysinfo': {},
-                'events': {},
             },
         },
         'tags': {
@@ -407,7 +405,6 @@ Press Ctrl-C to quit
                 'comments': None,
                 OS_ENVIRON: {},
                 'sysinfo': {},
-                'events': {},
             },
         },
         'tags': {'machine': None, 'os': None, 'platform': None, PLATFORM_DETAILS: None, 'version': None},

--- a/src/tribler/gui/dialogs/feedbackdialog.py
+++ b/src/tribler/gui/dialogs/feedbackdialog.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import os
 import platform
 import sys
@@ -15,8 +14,6 @@ from tribler.core.components.reporter.reported_error import ReportedError
 from tribler.core.sentry_reporter.sentry_reporter import SentryReporter
 from tribler.core.sentry_reporter.sentry_scrubber import SentryScrubber
 from tribler.core.sentry_reporter.sentry_tools import CONTEXT_DELIMITER, LONG_TEXT_DELIMITER
-from tribler.gui.event_request_manager import received_events
-from tribler.gui.network.request_manager import request_manager
 from tribler.gui.sentry_mixin import AddBreadcrumbOnShowMixin
 from tribler.gui.tribler_action_menu import TriblerActionMenu
 from tribler.gui.utilities import connect, get_ui_file_path, tr
@@ -98,23 +95,6 @@ class FeedbackDialog(AddBreadcrumbOnShowMixin, QDialog):
 
         for key in os.environ.keys():
             add_item_to_info_widget('os.environ', f'{key}: {os.environ[key]}')
-
-        # Add recent requests to feedback dialog
-        request_ind = 1
-
-        for request in request_manager.performed_requests:
-            add_item_to_info_widget(
-                'request_%d' % request_ind,
-                '%s %s %s (time: %s, code: %s)'
-                % (request.endpoint, request.method, request.data, request.time, request.status_code),
-            )
-            request_ind += 1
-
-        # Add recent events to feedback dialog
-        events_ind = 1
-        for event, event_time in received_events[:30][::-1]:
-            add_item_to_info_widget('event_%d' % events_ind, f'{json.dumps(event)} (time: {event_time})')
-            events_ind += 1
 
         # Users can remove specific lines in the report
         connect(self.env_variables_list.customContextMenuRequested, self.on_right_click_item)


### PR DESCRIPTION
This PR removes "events" and "requests" fields from a Sentry report.

See an example: https://sentry.tribler.org/organizations/tribler/issues/2065