### PR TITLE
Add reprocess feature for `KnowledgeRulesProcessor`

### DIFF
--- a/src/tribler/core/components/knowledge/knowledge_component.py
+++ b/src/tribler/core/components/knowledge/knowledge_component.py
@@ -4,7 +4,7 @@ from tribler.core.components.ipv8.ipv8_component import Ipv8Component
 from tribler.core.components.key.key_component import KeyComponent
 from tribler.core.components.knowledge.community.knowledge_community import KnowledgeCommunity
 from tribler.core.components.knowledge.db.knowledge_db import KnowledgeDatabase
-from tribler.core.components.knowledge.rules.tag_rules_processor import KnowledgeRulesProcessor
+from tribler.core.components.knowledge.rules.knowledge_rules_processor import KnowledgeRulesProcessor
 from tribler.core.components.metadata_store.utils import generate_test_channels
 from tribler.core.utilities.simpledefs import STATEDIR_DB_DIR
 

--- a/src/tribler/core/components/knowledge/rules/tests/test_knowledge_rules_processor.py
+++ b/src/tribler/core/components/knowledge/rules/tests/test_knowledge_rules_processor.py
@@ -5,7 +5,7 @@ import pytest
 
 from tribler.core import notifications
 from tribler.core.components.knowledge.db.knowledge_db import ResourceType
-from tribler.core.components.knowledge.rules.tag_rules_processor import KnowledgeRulesProcessor, \
+from tribler.core.components.knowledge.rules.knowledge_rules_processor import KnowledgeRulesProcessor, \
     LAST_PROCESSED_TORRENT_ID
 
 TEST_BATCH_SIZE = 100

--- a/src/tribler/core/components/metadata_store/metadata_store_component.py
+++ b/src/tribler/core/components/metadata_store/metadata_store_component.py
@@ -1,7 +1,7 @@
 from tribler.core import notifications
 from tribler.core.components.component import Component
 from tribler.core.components.key.key_component import KeyComponent
-from tribler.core.components.knowledge.rules.tag_rules_processor import KnowledgeRulesProcessor
+from tribler.core.components.knowledge.rules.knowledge_rules_processor import KnowledgeRulesProcessor
 from tribler.core.components.metadata_store.db.store import MetadataStore
 from tribler.core.utilities.simpledefs import STATEDIR_DB_DIR
 

--- a/src/tribler/core/components/metadata_store/restapi/metadata_endpoint_base.py
+++ b/src/tribler/core/components/metadata_store/restapi/metadata_endpoint_base.py
@@ -4,7 +4,7 @@ from typing import Optional
 from pony.orm import db_session
 
 from tribler.core.components.knowledge.db.knowledge_db import KnowledgeDatabase, ResourceType
-from tribler.core.components.knowledge.rules.tag_rules_processor import KnowledgeRulesProcessor
+from tribler.core.components.knowledge.rules.knowledge_rules_processor import KnowledgeRulesProcessor
 from tribler.core.components.metadata_store.category_filter.family_filter import default_xxx_filter
 from tribler.core.components.metadata_store.db.serialization import CHANNEL_TORRENT, COLLECTION_NODE, REGULAR_TORRENT
 from tribler.core.components.metadata_store.db.store import MetadataStore


### PR DESCRIPTION
During the migration from the TagsDB to the KnowledgeDB all old autogenerated entries were removed (https://github.com/Tribler/tribler/pull/7070). Therefore it is necessary to restart the automatic knowledge rule extraction for the whole Metadata DB.