### PR TITLE
Add a description to the error when tried to download a newer version of channel

### DIFF
--- a/src/tribler/core/components/gigachannel_manager/gigachannel_manager.py
+++ b/src/tribler/core/components/gigachannel_manager/gigachannel_manager.py
@@ -208,10 +208,9 @@ class GigaChannelManager(TaskManager):
                         channel.timestamp,
                     )
                     self.channels_processing_queue[channel.infohash] = (PROCESS_CHANNEL_DIR, channel)
-            except Exception:
-                self._logger.exception(
-                    "Error when tried to download a newer version of channel %s", hexlify(channel.public_key)
-                )
+            except Exception as e:
+                self._logger.exception("Error when tried to download a newer version of channel "
+                                       f"{hexlify(channel.public_key)}: {type(e).__name__}: {e}")
 
     async def remove_channel_download(self, to_remove):
         """


### PR DESCRIPTION
In Sentry logs related to different errors [I sometimes see a log lines](https://sentry.tribler.org/organizations/tribler/issues/1949/events/0d9de1bc65ef4ab0aebb2c5788259b3f/?project=7) like "Error when tried to download a newer version of channel c3f187dbf463172a48a5c6e0cd3b513ce2bd8b0915b1ff4087055ddf6e565c1e017a2986a3d7cf142425a0d9789bd7afbfc6972dfb55792c045e0ff097575e45"

In this PR I add an error details to the log line to be able to see the reason of the error.