### PR TITLE
Fixes #7386

### DIFF
--- a/src/tribler/core/components/gigachannel_manager/gigachannel_manager.py
+++ b/src/tribler/core/components/gigachannel_manager/gigachannel_manager.py
@@ -201,8 +201,8 @@ class GigaChannelManager(TaskManager):
                     self.download_channel(channel)
                     continue
 
-                status = self.download_manager.get_download(infohash).get_state().get_status()
-                if status == DownloadStatus.SEEDING:
+                channel_download = self.download_manager.get_download(infohash)
+                if channel_download and channel_download.get_state().get_status() == DownloadStatus.SEEDING:
                     self._logger.info(
                         "Processing previously downloaded, but unprocessed channel torrent %s ver %i->%i",
                         channel.dirname,

--- a/src/tribler/core/components/gigachannel_manager/gigachannel_manager.py
+++ b/src/tribler/core/components/gigachannel_manager/gigachannel_manager.py
@@ -191,7 +191,6 @@ class GigaChannelManager(TaskManager):
                 infohash = bytes(channel.infohash)
                 if self.download_manager.metainfo_requests.get(infohash):
                     continue
-                status = self.download_manager.get_download(infohash).get_state().get_status()
                 if not self.download_manager.download_exists(infohash):
                     self._logger.info(
                         "Downloading new channel version %s ver %i->%i",
@@ -200,7 +199,10 @@ class GigaChannelManager(TaskManager):
                         channel.timestamp,
                     )
                     self.download_channel(channel)
-                elif status == DownloadStatus.SEEDING:
+                    continue
+
+                status = self.download_manager.get_download(infohash).get_state().get_status()
+                if status == DownloadStatus.SEEDING:
                     self._logger.info(
                         "Processing previously downloaded, but unprocessed channel torrent %s ver %i->%i",
                         channel.dirname,

--- a/src/tribler/core/components/gigachannel_manager/tests/test_gigachannel_manager.py
+++ b/src/tribler/core/components/gigachannel_manager/tests/test_gigachannel_manager.py
@@ -247,8 +247,7 @@ async def test_check_channel_updates_for_different_states(gigachannel_manager, m
         def mock_get_metainfo(infohash):
             return MagicMock() if infohash == channel_with_metainfo.infohash else None
 
-        gigachannel_manager.download_manager.metainfo_requests = MagicMock()
-        gigachannel_manager.download_manager.metainfo_requests.get = mock_get_metainfo
+        gigachannel_manager.download_manager.metainfo_requests = MagicMock(get=mock_get_metainfo)
 
         # Setup 2: Only one specific channel torrent is already downloaded.
         def mock_download_exists(infohash):
@@ -265,12 +264,8 @@ async def test_check_channel_updates_for_different_states(gigachannel_manager, m
             if infohash != already_downloaded_channel.infohash:
                 return None
 
-            seeding_state = MagicMock()
-            seeding_state.get_status = lambda: DownloadStatus.SEEDING
-
-            mock_download = MagicMock()
-            mock_download.get_state = lambda: seeding_state
-            return mock_download
+            seeding_state = MagicMock(get_status=lambda: DownloadStatus.SEEDING)
+            return MagicMock(get_state=lambda: seeding_state)
 
         gigachannel_manager.download_manager.get_download = mock_get_download
 

--- a/src/tribler/core/components/gigachannel_manager/tests/test_gigachannel_manager.py
+++ b/src/tribler/core/components/gigachannel_manager/tests/test_gigachannel_manager.py
@@ -1,4 +1,6 @@
 import asyncio
+import os
+import random
 from asyncio import Future
 from datetime import datetime
 from pathlib import Path
@@ -35,8 +37,8 @@ def personal_channel(metadata_store):
         return chan
 
 
-@pytest.fixture
-async def gigachannel_manager(metadata_store):
+@pytest.fixture(name="gigachannel_manager")
+async def gigachannel_manager_fixture(metadata_store):
     chanman = GigaChannelManager(
         state_dir=metadata_store.channels_dir.parent,
         metadata_store=metadata_store,
@@ -220,6 +222,65 @@ async def test_check_channels_updates(personal_channel, gigachannel_manager, met
 
     # The queue should be empty afterwards
     assert not gigachannel_manager.channels_processing_queue
+
+
+async def test_check_channel_updates_for_different_states(gigachannel_manager, metadata_store):
+    with db_session:
+        def random_subscribed_channel():
+            return metadata_store.ChannelMetadata(
+                title=f"Channel {random.randint(0, 100)}",
+                public_key=os.urandom(32),
+                signature=os.urandom(32),
+                skip_key_check=True,
+                timestamp=123,
+                local_version=122,
+                subscribed=True,
+                infohash=random_infohash(),
+            )
+
+        # Three channels in different states based on the setup
+        channel_with_metainfo = random_subscribed_channel()
+        already_downloaded_channel = random_subscribed_channel()
+        non_downloaded_channel = random_subscribed_channel()
+
+        # Setup 1: metainfo is already available for channel torrent.
+        def mock_get_metainfo(infohash):
+            return MagicMock() if infohash == channel_with_metainfo.infohash else None
+
+        gigachannel_manager.download_manager.metainfo_requests = MagicMock()
+        gigachannel_manager.download_manager.metainfo_requests.get = mock_get_metainfo
+
+        # Setup 2: Only one specific channel torrent is already downloaded.
+        def mock_download_exists(infohash):
+            return infohash == already_downloaded_channel.infohash
+
+        gigachannel_manager.download_manager.download_exists = mock_download_exists
+
+        # Setup 2 (contd): We expect non-downloaded channel to be downloaded
+        # so mocking download_channel() method.
+        gigachannel_manager.download_channel = MagicMock()
+
+        # Setup 3: Downloaded channel torrent is set on Seeding state.
+        def mock_get_download(infohash):
+            if infohash != already_downloaded_channel.infohash:
+                return None
+
+            seeding_state = MagicMock()
+            seeding_state.get_status = lambda: DownloadStatus.SEEDING
+
+            mock_download = MagicMock()
+            mock_download.get_state = lambda: seeding_state
+            return mock_download
+
+        gigachannel_manager.download_manager.get_download = mock_get_download
+
+        # Act
+        gigachannel_manager.check_channels_updates()
+
+        # Assert
+        gigachannel_manager.download_channel.assert_called_once_with(non_downloaded_channel)
+        assert len(gigachannel_manager.channels_processing_queue) == 1
+        assert already_downloaded_channel.infohash in gigachannel_manager.channels_processing_queue
 
 
 async def test_remove_cruft_channels(torrent_template, personal_channel, gigachannel_manager, metadata_store):

--- a/src/tribler/core/components/gigachannel_manager/tests/test_gigachannel_manager.py
+++ b/src/tribler/core/components/gigachannel_manager/tests/test_gigachannel_manager.py
@@ -224,58 +224,58 @@ async def test_check_channels_updates(personal_channel, gigachannel_manager, met
     assert not gigachannel_manager.channels_processing_queue
 
 
-async def test_check_channel_updates_for_different_states(gigachannel_manager, metadata_store):
-    with db_session:
-        def random_subscribed_channel():
-            return metadata_store.ChannelMetadata(
-                title=f"Channel {random.randint(0, 100)}",
-                public_key=os.urandom(32),
-                signature=os.urandom(32),
-                skip_key_check=True,
-                timestamp=123,
-                local_version=122,
-                subscribed=True,
-                infohash=random_infohash(),
-            )
+@db_session
+def test_check_channel_updates_for_different_states(gigachannel_manager, metadata_store):
+    def random_subscribed_channel():
+        return metadata_store.ChannelMetadata(
+            title=f"Channel {random.randint(0, 100)}",
+            public_key=os.urandom(32),
+            signature=os.urandom(32),
+            skip_key_check=True,
+            timestamp=123,
+            local_version=122,
+            subscribed=True,
+            infohash=random_infohash(),
+        )
 
-        # Three channels in different states based on the setup
-        channel_with_metainfo = random_subscribed_channel()
-        already_downloaded_channel = random_subscribed_channel()
-        non_downloaded_channel = random_subscribed_channel()
+    # Three channels in different states based on the setup
+    channel_with_metainfo = random_subscribed_channel()
+    already_downloaded_channel = random_subscribed_channel()
+    non_downloaded_channel = random_subscribed_channel()
 
-        # Setup 1: metainfo is already available for channel torrent.
-        def mock_get_metainfo(infohash):
-            return MagicMock() if infohash == channel_with_metainfo.infohash else None
+    # Setup 1: metainfo is already available for channel torrent.
+    def mock_get_metainfo(infohash):
+        return MagicMock() if infohash == channel_with_metainfo.infohash else None
 
-        gigachannel_manager.download_manager.metainfo_requests = MagicMock(get=mock_get_metainfo)
+    gigachannel_manager.download_manager.metainfo_requests = MagicMock(get=mock_get_metainfo)
 
-        # Setup 2: Only one specific channel torrent is already downloaded.
-        def mock_download_exists(infohash):
-            return infohash == already_downloaded_channel.infohash
+    # Setup 2: Only one specific channel torrent is already downloaded.
+    def mock_download_exists(infohash):
+        return infohash == already_downloaded_channel.infohash
 
-        gigachannel_manager.download_manager.download_exists = mock_download_exists
+    gigachannel_manager.download_manager.download_exists = mock_download_exists
 
-        # Setup 2 (contd): We expect non-downloaded channel to be downloaded
-        # so mocking download_channel() method.
-        gigachannel_manager.download_channel = MagicMock()
+    # Setup 2 (contd): We expect non-downloaded channel to be downloaded
+    # so mocking download_channel() method.
+    gigachannel_manager.download_channel = MagicMock()
 
-        # Setup 3: Downloaded channel torrent is set on Seeding state.
-        def mock_get_download(infohash):
-            if infohash != already_downloaded_channel.infohash:
-                return None
+    # Setup 3: Downloaded channel torrent is set on Seeding state.
+    def mock_get_download(infohash):
+        if infohash != already_downloaded_channel.infohash:
+            return None
 
-            seeding_state = MagicMock(get_status=lambda: DownloadStatus.SEEDING)
-            return MagicMock(get_state=lambda: seeding_state)
+        seeding_state = MagicMock(get_status=lambda: DownloadStatus.SEEDING)
+        return MagicMock(get_state=lambda: seeding_state)
 
-        gigachannel_manager.download_manager.get_download = mock_get_download
+    gigachannel_manager.download_manager.get_download = mock_get_download
 
-        # Act
-        gigachannel_manager.check_channels_updates()
+    # Act
+    gigachannel_manager.check_channels_updates()
 
-        # Assert
-        gigachannel_manager.download_channel.assert_called_once_with(non_downloaded_channel)
-        assert len(gigachannel_manager.channels_processing_queue) == 1
-        assert already_downloaded_channel.infohash in gigachannel_manager.channels_processing_queue
+    # Assert
+    gigachannel_manager.download_channel.assert_called_once_with(non_downloaded_channel)
+    assert len(gigachannel_manager.channels_processing_queue) == 1
+    assert already_downloaded_channel.infohash in gigachannel_manager.channels_processing_queue
 
 
 async def test_remove_cruft_channels(torrent_template, personal_channel, gigachannel_manager, metadata_store):


### PR DESCRIPTION
Fixes the bug on checking channel updates where the existence of the channel should be checked first before trying to get the state of download.