### PR TITLE
Ignore old responses for the DownloadsPage

### DIFF
--- a/src/tribler/gui/network/request.py
+++ b/src/tribler/gui/network/request.py
@@ -11,6 +11,8 @@ from PyQt5.QtNetwork import QNetworkReply, QNetworkRequest
 
 from tribler.gui.utilities import connect
 
+REQUEST_ID = '_request_id'
+
 if TYPE_CHECKING:
     from tribler.gui.network.request_manager import RequestManager
 
@@ -84,6 +86,7 @@ class Request(QObject):
         self.status_code = 0
         self.status_text = "unknown"
         self.cancellable = True
+        self.id = 0
 
     def set_manager(self, manager: RequestManager):
         self.manager = manager
@@ -134,6 +137,8 @@ class Request(QObject):
 
             self.logger.debug('Create a json response')
             result = json.loads(data)
+            if isinstance(result, dict):
+                result[REQUEST_ID] = self.id
             is_error = 'error' in result
             if is_error and self.capture_errors:
                 text = self.manager.show_error(self, result)

--- a/src/tribler/gui/network/request_manager.py
+++ b/src/tribler/gui/network/request_manager.py
@@ -34,9 +34,10 @@ class RequestManager(QNetworkAccessManager):
         self.protocol = DEFAULT_API_PROTOCOL
         self.host = DEFAULT_API_HOST
         self.port = DEFAULT_API_PORT
-        self.key = b""
+        self.key = ''
         self.limit = limit
         self.timeout_interval = timeout_interval
+        self.last_request_id = 0
 
     def get(self,
             endpoint: str,
@@ -114,6 +115,10 @@ class RequestManager(QNetworkAccessManager):
         return request
 
     def add(self, request: Request):
+        # Set last request id
+        self.last_request_id += 1
+        request.id = self.last_request_id
+
         if len(self.active_requests) > self.limit:
             self._drop_timed_out_requests()
 

--- a/src/tribler/gui/network/tests/test_request_manager.py
+++ b/src/tribler/gui/network/tests/test_request_manager.py
@@ -1,3 +1,5 @@
+from unittest.mock import Mock, patch
+
 import pytest
 
 from tribler.gui.network.request_manager import RequestManager
@@ -42,3 +44,13 @@ def test_get_message_from_error_any_dict(request_manager: RequestManager):
         }
     )
     assert message == '{"key": "value"}'
+
+
+@patch('tribler.gui.network.request_manager.QBuffer', Mock())
+@patch.object(RequestManager, 'sendCustomRequest', Mock())
+def test_request_id(request_manager: RequestManager):
+    request = request_manager.get('endpoint')
+    assert request.id == 1
+
+    request = request_manager.delete('endpoint')
+    assert request.id == 2

--- a/src/tribler/gui/tests/test_downloadspage.py
+++ b/src/tribler/gui/tests/test_downloadspage.py
@@ -1,0 +1,50 @@
+from unittest.mock import MagicMock, Mock, patch
+
+from PyQt5.QtWidgets import QWidget
+
+from tribler.gui.network.request import REQUEST_ID
+from tribler.gui.widgets.downloadspage import DownloadsPage
+
+
+def downloads_page() -> DownloadsPage:
+    window = MagicMock()
+    window.downloads_list.indexOfTopLevelItem = Mock(return_value=-1)
+
+    page = DownloadsPage()
+    page.window = Mock(return_value=window)
+    page.received_downloads = Mock()
+    return page
+
+
+@patch.object(QWidget, '__init__', Mock())
+def test_accept_requests():
+    # Test that the page accepts requests with the greater request id
+    page = downloads_page()
+
+    page.on_received_downloads(result={REQUEST_ID: 1, 'downloads': MagicMock()})
+    assert page.received_downloads.emit.called
+
+    page.received_downloads.emit.reset_mock()
+    page.on_received_downloads(result={REQUEST_ID: 2, 'downloads': MagicMock()})
+    assert page.received_downloads.emit.called
+
+    page.received_downloads.emit.reset_mock()
+    page.on_received_downloads(result={REQUEST_ID: 10, 'downloads': MagicMock()})
+    assert page.received_downloads.emit.called
+
+
+@patch.object(QWidget, '__init__', Mock())
+def test_ignore_request():
+    # Test that the page ignores requests with a lower or equal request id
+    page = downloads_page()
+
+    page.on_received_downloads(result={REQUEST_ID: 10, 'downloads': MagicMock()})
+    assert page.received_downloads.emit.called
+
+    page.received_downloads.emit.reset_mock()
+    page.on_received_downloads(result={REQUEST_ID: 10, 'downloads': MagicMock()})
+    assert not page.received_downloads.emit.called
+
+    page.received_downloads.emit.reset_mock()
+    page.on_received_downloads(result={REQUEST_ID: 9, 'downloads': MagicMock()})
+    assert not page.received_downloads.emit.called


### PR DESCRIPTION
This PR is related to #7360 and continues the work done in #7378.

It adds an id for each Request on the GUI side. This new functionality is utilized in the DownloadsPage to ignore outdated requests.
