### PR TITLE
Sentry: add the field `additional_information`

### DIFF
--- a/src/tribler/core/components/exceptions.py
+++ b/src/tribler/core/components/exceptions.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import Set, TYPE_CHECKING, Type
+
+if TYPE_CHECKING:
+    from tribler.core.components.component import Component
+
+
+class ComponentError(Exception):
+    pass
+
+
+class ComponentStartupException(ComponentError):
+    def __init__(self, component: Component, cause: Exception):
+        super().__init__(component.__class__.__name__)
+        self.component = component
+        self.__cause__ = cause
+
+
+class MissedDependency(ComponentError):
+    def __init__(self, component: Component, dependency: Type[Component]):
+        msg = f'Missed dependency: {component.__class__.__name__} requires {dependency.__name__} to be active'
+        super().__init__(msg)
+        self.component = component
+        self.dependency = dependency
+
+
+class MultipleComponentsFound(ComponentError):
+    def __init__(self, comp_cls: Type[Component], candidates: Set[Component]):
+        msg = f'Found multiple subclasses for the class {comp_cls}. Candidates are: {candidates}.'
+        super().__init__(msg)
+
+
+class NoneComponent:
+    def __getattr__(self, item):
+        return NoneComponent()

--- a/src/tribler/core/components/reporter/exception_handler.py
+++ b/src/tribler/core/components/reporter/exception_handler.py
@@ -7,7 +7,7 @@ from socket import gaierror
 from traceback import print_exception
 from typing import Callable, Optional
 
-from tribler.core.components.component import ComponentStartupException
+from tribler.core.components.exceptions import ComponentStartupException
 from tribler.core.components.reporter.reported_error import ReportedError
 from tribler.core.sentry_reporter.sentry_reporter import SentryReporter
 from tribler.core.utilities.process_manager import get_global_process_manager
@@ -110,7 +110,10 @@ class CoreExceptionHandler:
                 long_text=long_text,
                 context=str(context),
                 event=self.sentry_reporter.event_from_exception(exception) or {},
-                should_stop=should_stop
+                should_stop=should_stop,
+                # `additional_information` should be converted to dict
+                # see: https://github.com/python/cpython/pull/32056
+                additional_information=dict(self.sentry_reporter.additional_information)
             )
             self.logger.error(f"Unhandled exception occurred! {reported_error}\n{reported_error.long_text}")
             if process_manager:

--- a/src/tribler/core/components/reporter/reported_error.py
+++ b/src/tribler/core/components/reporter/reported_error.py
@@ -7,6 +7,7 @@ class ReportedError:
     type: str
     text: str
     event: dict = field(repr=False)
+    additional_information: dict = field(default_factory=lambda: {}, repr=False)
 
     long_text: str = field(default='', repr=False)
     context: str = field(default='', repr=False)

--- a/src/tribler/core/components/restapi/restapi_component.py
+++ b/src/tribler/core/components/restapi/restapi_component.py
@@ -5,7 +5,8 @@ from ipv8.REST.root_endpoint import RootEndpoint as IPV8RootEndpoint
 
 from tribler.core.components.bandwidth_accounting.bandwidth_accounting_component import BandwidthAccountingComponent
 from tribler.core.components.bandwidth_accounting.restapi.bandwidth_endpoint import BandwidthEndpoint
-from tribler.core.components.component import Component, NoneComponent
+from tribler.core.components.component import Component
+from tribler.core.components.exceptions import NoneComponent
 from tribler.core.components.gigachannel.gigachannel_component import GigaChannelComponent
 from tribler.core.components.gigachannel_manager.gigachannel_manager_component import GigachannelManagerComponent
 from tribler.core.components.ipv8.ipv8_component import Ipv8Component

--- a/src/tribler/core/components/restapi/tests/test_restapi_component.py
+++ b/src/tribler/core/components/restapi/tests/test_restapi_component.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from tribler.core.components.bandwidth_accounting.bandwidth_accounting_component import BandwidthAccountingComponent
-from tribler.core.components.component import NoneComponent
+from tribler.core.components.exceptions import NoneComponent
 from tribler.core.components.gigachannel.gigachannel_component import GigaChannelComponent
 from tribler.core.components.ipv8.ipv8_component import Ipv8Component
 from tribler.core.components.key.key_component import KeyComponent

--- a/src/tribler/core/components/tests/test_base_component.py
+++ b/src/tribler/core/components/tests/test_base_component.py
@@ -1,6 +1,7 @@
 import pytest
 
-from tribler.core.components.component import Component, MissedDependency, MultipleComponentsFound, NoneComponent
+from tribler.core.components.component import Component
+from tribler.core.components.exceptions import MissedDependency, MultipleComponentsFound, NoneComponent
 from tribler.core.components.session import Session
 from tribler.core.config.tribler_config import TriblerConfig
 

--- a/src/tribler/core/sentry_reporter/sentry_reporter.py
+++ b/src/tribler/core/sentry_reporter/sentry_reporter.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import sys
+from collections import defaultdict
 from contextlib import contextmanager
 from contextvars import ContextVar
 from enum import Enum, auto
@@ -15,17 +16,28 @@ from sentry_sdk.integrations.threading import ThreadingIntegration
 from tribler.core import version
 from tribler.core.sentry_reporter.sentry_tools import (
     delete_item,
-    extract_dict,
     get_first_item,
     get_last_item, get_value,
     parse_last_core_output, parse_os_environ,
     parse_stacktrace,
 )
 
-# fmt: off
-
+VALUE = 'value'
+TYPE = 'type'
+LAST_CORE_OUTPUT = 'last_core_output'
+LAST_PROCESSES = 'last_processes'
+PLATFORM = 'platform'
+OS = 'os'
+MACHINE = 'machine'
+COMMENTS = 'comments'
+TRIBLER = 'Tribler'
+NAME = 'name'
+VERSION = 'version'
+BROWSER = 'browser'
 PLATFORM_DETAILS = 'platform.details'
 STACKTRACE = '_stacktrace'
+STACKTRACE_EXTRA = f'{STACKTRACE}_extra'
+STACKTRACE_CONTEXT = f'{STACKTRACE}_context'
 SYSINFO = 'sysinfo'
 OS_ENVIRON = 'os.environ'
 SYS_ARGV = 'sys.argv'
@@ -38,6 +50,7 @@ REPORTER = 'reporter'
 VALUES = 'values'
 RELEASE = 'release'
 EXCEPTION = 'exception'
+ADDITIONAL_INFORMATION = 'additional_information'
 
 
 class SentryStrategy(Enum):
@@ -77,6 +90,7 @@ class SentryReporter:
         # SentryReporter.get_actual_strategy()
         self.global_strategy = SentryStrategy.SEND_ALLOWED_WITH_CONFIRMATION
         self.thread_strategy = ContextVar('context_strategy', default=None)
+        self.additional_information = defaultdict(dict)  # dict that will be added to a Sentry event
 
         self._sentry_logger_name = 'SentryReporter'
         self._logger = logging.getLogger(self._sentry_logger_name)
@@ -193,45 +207,47 @@ class SentryReporter:
 
         # tags
         tags = event[TAGS]
-        tags['version'] = get_value(post_data, 'version')
-        tags['machine'] = get_value(post_data, 'machine')
-        tags['os'] = get_value(post_data, 'os')
-        tags['platform'] = get_first_item(get_value(sys_info, 'platform'))
-        tags[f'{PLATFORM_DETAILS}'] = get_first_item(get_value(sys_info, PLATFORM_DETAILS))
+        tags[VERSION] = get_value(post_data, VERSION)
+        tags[MACHINE] = get_value(post_data, MACHINE)
+        tags[OS] = get_value(post_data, OS)
+        tags[PLATFORM] = get_first_item(get_value(sys_info, PLATFORM))
+        tags[PLATFORM_DETAILS] = get_first_item(get_value(sys_info, PLATFORM_DETAILS))
         tags.update(additional_tags)
 
         # context
         context = event[CONTEXTS]
         reporter = context[REPORTER]
-        version = get_value(post_data, 'version')
+        version = get_value(post_data, VERSION)
 
-        context['browser'] = {'version': version, 'name': 'Tribler'}
+        context[BROWSER] = {VERSION: version, NAME: TRIBLER}
 
         stacktrace_parts = parse_stacktrace(get_value(post_data, 'stack'))
         reporter[STACKTRACE] = next(stacktrace_parts, [])
         stacktrace_extra = next(stacktrace_parts, [])
-        reporter[f'{STACKTRACE}_extra'] = stacktrace_extra
-        reporter[f'{STACKTRACE}_context'] = next(stacktrace_parts, [])
+        reporter[STACKTRACE_EXTRA] = stacktrace_extra
+        reporter[STACKTRACE_CONTEXT] = next(stacktrace_parts, [])
 
-        reporter['comments'] = get_value(post_data, 'comments')
+        reporter[COMMENTS] = get_value(post_data, COMMENTS)
 
         reporter[OS_ENVIRON] = parse_os_environ(get_value(sys_info, OS_ENVIRON))
         delete_item(sys_info, OS_ENVIRON)
 
         reporter[SYSINFO] = sys_info
         if last_processes:
-            reporter['last_processes'] = last_processes
+            reporter[LAST_PROCESSES] = last_processes
+
+        reporter[ADDITIONAL_INFORMATION] = self.additional_information
 
         # try to retrieve an error from the last_core_output
         if last_core_output:
             # split for better representation in the web view
-            reporter['last_core_output'] = last_core_output.split('\n')
+            reporter[LAST_CORE_OUTPUT] = last_core_output.split('\n')
             if last_core_exception := parse_last_core_output(last_core_output):
                 exceptions = event.get(EXCEPTION, {})
                 gui_exception = get_last_item(exceptions.get(VALUES, []), {})
 
                 # create a core exception extracted from the last core output
-                core_exception = {'type': last_core_exception.type, 'value': last_core_exception.message}
+                core_exception = {TYPE: last_core_exception.type, VALUE: last_core_exception.message}
 
                 # remove the stacktrace field as it doesn't give any useful information for the further investigation
                 delete_item(gui_exception, 'stacktrace')

--- a/src/tribler/core/sentry_reporter/sentry_reporter.py
+++ b/src/tribler/core/sentry_reporter/sentry_reporter.py
@@ -217,9 +217,9 @@ class SentryReporter:
         # context
         context = event[CONTEXTS]
         reporter = context[REPORTER]
-        version = get_value(post_data, VERSION)
+        tribler_version = get_value(post_data, VERSION)
 
-        context[BROWSER] = {VERSION: version, NAME: TRIBLER}
+        context[BROWSER] = {VERSION: tribler_version, NAME: TRIBLER}
 
         stacktrace_parts = parse_stacktrace(get_value(post_data, 'stack'))
         reporter[STACKTRACE] = next(stacktrace_parts, [])

--- a/src/tribler/gui/error_handler.py
+++ b/src/tribler/gui/error_handler.py
@@ -103,6 +103,7 @@ class ErrorHandler:
             self._stop_tribler(error_text)
 
         SentryScrubber.remove_breadcrumbs(reported_error.event)
+        gui_sentry_reporter.additional_information.update(reported_error.additional_information)
 
         additional_tags = {
             'source': 'core',


### PR DESCRIPTION
This PR adds a dict field to Sentry, which is accessible from any part of the Tribler code and will be included in a Sentry event.

An example of using:

```python
from tribler.core.components.reporter.exception_handler import default_core_exception_handler

reporter = default_core_exception_handler.sentry_reporter
reporter.additional_information['components'] = {
    'KnowledgeComponent':
        {
            'db_size': 1024,
            'load_time': 100
        }
}
```

As a real example, the component's statuses have been added:

<img width="800" alt="image" src="https://user-images.githubusercontent.com/13798583/234631275-f27aeff3-55f5-43b5-9b2f-7aee92ae1d4e.png">

https://sentry.tribler.org/organizations/tribler/issues/2087/?project=3

Also, tests for SentryReporter have been refactored.