### PR TITLE
Fixes #7395 "Labels on Discovered channels are missing"

### DIFF
--- a/src/tribler/gui/widgets/tablecontentmodel.py
+++ b/src/tribler/gui/widgets/tablecontentmodel.py
@@ -460,7 +460,8 @@ class ChannelContentModel(RemoteTableModel):
 
     def headerData(self, num, orientation, role=None):
         if orientation == Qt.Horizontal and role == Qt.DisplayRole:
-            return self.columns[num].header
+            header_text = self.columns[num].header
+            return str(header_text)  # convert TranslatedString to str as Qt can't handle str subclasses here
         if role == Qt.InitialSortOrderRole and num != self.column_position.get(Column.NAME):
             return Qt.DescendingOrder
         if role == Qt.TextAlignmentRole:


### PR DESCRIPTION
This PR fixes #7395. As it turns out, the result of the `QAbstractTableModel.headerData` method is expected to be a pure `str` instance and not some `str` subclass (like `TranslatedString`).

It looks like in other places, Qt has no prejudice to str subclasses and renders them correctly.

But there is a slight chance we overlooked another place where the string is not rendered properly. For that reason, we can consider removing the `TranslatedString` subclass. On the other side, it looks like it is currently handled correctly in all other places, and it gives protection against incorrectly translated stings, so we can continue to use it.