### PR TITLE
Use separate `misc` table for the KnowledgeDB

### DIFF
--- a/src/tribler/core/components/knowledge/db/knowledge_db.py
+++ b/src/tribler/core/components/knowledge/db/knowledge_db.py
@@ -139,7 +139,7 @@ class KnowledgeDatabase:
 
             orm.composite_key(statement, peer)
 
-        class Misc(db.Entity):
+        class Misc(db.Entity):  # pylint: disable=unused-variable
             name = orm.PrimaryKey(str)
             value = orm.Optional(str)
 

--- a/src/tribler/core/components/knowledge/db/knowledge_db.py
+++ b/src/tribler/core/components/knowledge/db/knowledge_db.py
@@ -2,7 +2,7 @@ import datetime
 import logging
 from dataclasses import dataclass
 from enum import IntEnum
-from typing import Callable, Iterator, List, Optional, Set
+from typing import Any, Callable, Iterator, List, Optional, Set
 
 from pony import orm
 from pony.orm import raw_sql
@@ -138,6 +138,10 @@ class KnowledgeDatabase:
             auto_generated = orm.Required(bool, default=False)
 
             orm.composite_key(statement, peer)
+
+        class Misc(db.Entity):
+            name = orm.PrimaryKey(str)
+            value = orm.Optional(str)
 
     def add_operation(self, operation: StatementOperation, signature: bytes, is_local_peer: bool = False,
                       is_auto_generated: bool = False, counter_increment: int = 1) -> bool:
@@ -441,3 +445,11 @@ class KnowledgeDatabase:
                     operations.add(operation)
 
         return operations
+
+    def get_misc(self, key: str, default: Optional[str] = None) -> Optional[str]:
+        data = self.instance.Misc.get(name=key)
+        return data.value if data else default
+
+    def set_misc(self, key: str, value: Any):
+        key_value = get_or_create(self.instance.Misc, name=key)
+        key_value.value = str(value)

--- a/src/tribler/core/components/knowledge/db/tests/test_knowledge_db.py
+++ b/src/tribler/core/components/knowledge/db/tests/test_knowledge_db.py
@@ -633,3 +633,18 @@ class TestTagDB(TestTagDBBase):
         assert _subjects(obj='linux') == {'infohash1', 'infohash2', 'infohash3'}
         assert _subjects(predicate=ResourceType.TAG, obj='linux') == {'infohash3'}
         assert _subjects(predicate=ResourceType.TITLE) == {'infohash1', 'infohash2'}
+
+    @db_session
+    def test_non_existent_misc(self):
+        """Test that get_misc returns proper values"""
+        # None if the key does not exist
+        assert not self.db.get_misc(key='non existent')
+
+        # A value if the key does exist
+        assert self.db.get_misc(key='non existent', default=42) == 42
+
+    @db_session
+    def test_set_misc(self):
+        """Test that set_misc works as expected"""
+        self.db.set_misc(key='key', value='value')
+        assert self.db.get_misc(key='key') == 'value'

--- a/src/tribler/core/components/knowledge/rules/knowledge_rules_processor.py
+++ b/src/tribler/core/components/knowledge/rules/knowledge_rules_processor.py
@@ -115,13 +115,13 @@ class KnowledgeRulesProcessor(TaskManager):
             self.db.add_auto_generated(subject_type=subject_type, subject=subject, predicate=predicate, obj=obj)
 
     def get_last_processed_torrent_id(self) -> int:
-        return int(self.mds.get_value(LAST_PROCESSED_TORRENT_ID, default='0'))
+        return int(self.db.get_misc(LAST_PROCESSED_TORRENT_ID, default='0'))
 
     def set_last_processed_torrent_id(self, value: int):
-        self.mds.set_value(LAST_PROCESSED_TORRENT_ID, str(value))
+        self.db.set_misc(LAST_PROCESSED_TORRENT_ID, str(value))
 
     def get_rules_processor_version(self) -> int:
-        return int(self.mds.get_value(RULES_PROCESSOR_VERSION, default='0'))
+        return int(self.db.get_misc(RULES_PROCESSOR_VERSION, default='0'))
 
     def set_rules_processor_version(self, version: int):
-        self.mds.set_value(RULES_PROCESSOR_VERSION, str(version))
+        self.db.set_misc(RULES_PROCESSOR_VERSION, str(version))


### PR DESCRIPTION
This PR fixes deadlocks that happen with mutual updates from:
1. `KnowledgeRulesProcessor` (write attempt to `KnowledgeDB` and `MetadataDB` in the `process_batch` function)
2. `MDS` (write attempt to `KnowledgeDB` and `MetadataDB` in the constructor of `TorrentMetadata`)



```mermaid
graph TD;
    P-->|write: process_batch|K(KnowledgeDB);
    P[KnowledgeRulesProcessor]-->|write: process_batch|M(MetadataDB);


    T[TorrentMetadata]-->|write: __init__|M;
    T-->|write: __init__|K;
```

This situation arises when two factors coincide:

1. Access to DBs occur simultaneously (this is true because the `Metadata Store` uses a different thread to perform operations with the DB).
2. These accesses lock the same entity (this is true because we use SQLite and it locks the entire database, as mentioned below).


> 3.0 Locking
From the point of view of a single process, a database file can be in one of five locking states:
> * UNLOCKED	No locks are held on the database. The database may be neither read nor written. Any internally cached data is considered suspect and subject to verification against the database file before being used. Other processes can read or write the database as their own locking states permit. This is the default state.
> * SHARED	The database may be read but not written. Any number of processes can hold SHARED locks at the same time, hence there can be many simultaneous readers. But no other thread or process is allowed to write to the database file while one or more SHARED locks are active.
> * RESERVED	A RESERVED lock means that the process is planning on writing to the database file at some point in the future but that it is currently just reading from the file. Only a single RESERVED lock may be active at one time, though multiple SHARED locks can coexist with a single RESERVED lock. RESERVED differs from PENDING in that new SHARED locks can be acquired while there is a RESERVED lock.
> * PENDING	A PENDING lock means that the process holding the lock wants to write to the database as soon as possible and is just waiting on all current SHARED locks to clear so that it can get an EXCLUSIVE lock. No new SHARED locks are permitted against the database if a PENDING lock is active, though existing SHARED locks are allowed to continue.
> * EXCLUSIVE	An EXCLUSIVE lock is needed in order to write to the database file. Only one EXCLUSIVE lock is allowed on the file and no other locks of any kind are allowed to coexist with an EXCLUSIVE lock. In order to maximize concurrency, SQLite works to minimize the amount of time that EXCLUSIVE locks are held.

This PR eliminates the write attempts from `KnowledgeRulesProcessor` to `MetadataDB` by beginning to utilize a separate `misc` table.

```mermaid
graph TD;
    
    P[KnowledgeRulesProcessor]-->|write: process_batch|K(KnowledgeDB);

    T[TorrentMetadata]-->|write: __init__|M(MetadataDB);
    T-->|write: __init__|K;
```


Please note that this PR does not entirely solve the deadlock problem. A comprehensive solution will involve one of the following:
1. Merging `KnowledgeDB` and `MetadataDB` into a single database.
2. Creating a single namespace that houses two different databases.
3. Eliminating the `notifications.new_torrent_metadata_created` event.

Refs:
* https://www.sqlite.org/lockingv3.html