### PR TITLE
Detect slow coroutines and freezes in the asyncio loop

### DIFF
--- a/src/run_tribler.py
+++ b/src/run_tribler.py
@@ -11,7 +11,9 @@ import encodings.idna  # pylint: disable=unused-import
 
 from tribler.core.sentry_reporter.sentry_reporter import SentryReporter, SentryStrategy
 from tribler.core.sentry_reporter.sentry_scrubber import SentryScrubber
+from tribler.core.utilities.slow_coro_detection.main_thread_stack_tracking import start_main_thread_stack_tracing
 from tribler.core.utilities.osutils import get_root_state_directory
+from tribler.core.utilities.utilities import is_frozen
 from tribler.core.version import version_id
 
 logger = logging.getLogger(__name__)
@@ -94,6 +96,13 @@ if __name__ == "__main__":
         from tribler.core.components.reporter.exception_handler import default_core_exception_handler
 
         init_sentry_reporter(default_core_exception_handler.sentry_reporter)
+
+        slow_coro_stack_tracking = os.environ.get('SLOW_CORO_STACK_TRACING', '0' if is_frozen() else '1')
+        # By default, the stack tracking of slow coroutines is enabled when running the Tribler from sources
+        # and disabled in the compiled version, as it makes the Python code of Core work slower.
+        if slow_coro_stack_tracking == '1':
+            start_main_thread_stack_tracing()
+
         run_core(api_port, api_key, root_state_dir, parsed_args)
     else:  # GUI
         from tribler.gui.start_gui import run_gui

--- a/src/tribler/core/start_core.py
+++ b/src/tribler/core/start_core.py
@@ -39,6 +39,7 @@ from tribler.core.config.tribler_config import TriblerConfig
 from tribler.core.logger.logger import load_logger_config
 from tribler.core.sentry_reporter.sentry_reporter import SentryReporter, SentryStrategy
 from tribler.core.upgrade.version_manager import VersionHistory
+from tribler.core.utilities import slow_coro_detection
 from tribler.core.utilities.process_manager import ProcessKind, ProcessManager, TriblerProcess, \
     set_global_process_manager
 
@@ -132,6 +133,9 @@ def run_tribler_core_session(api_port: int, api_key: str, state_dir: Path, gui_t
     logger.info(f'Start tribler core. API port: "{api_port}". '
                 f'API key: "{api_key}". State dir: "{state_dir}". '
                 f'Core test mode: "{gui_test_mode}"')
+
+    slow_coro_detection.patch_asyncio()  # Track the current coroutine handled by asyncio
+    slow_coro_detection.start_watching_thread()  # Run a separate thread to watch for the main thread asyncio freezes
 
     config = TriblerConfig.load(state_dir=state_dir, reset_config_on_error=True)
     config.gui_test_mode = gui_test_mode

--- a/src/tribler/core/utilities/slow_coro_detection/__init__.py
+++ b/src/tribler/core/utilities/slow_coro_detection/__init__.py
@@ -1,0 +1,7 @@
+# pylint: disable=wrong-import-position
+
+import logging
+logger = logging.getLogger(__name__)
+
+from .patch import patch_asyncio
+from .watching_thread import start_watching_thread

--- a/src/tribler/core/utilities/slow_coro_detection/main_thread_stack_tracking.py
+++ b/src/tribler/core/utilities/slow_coro_detection/main_thread_stack_tracking.py
@@ -1,0 +1,95 @@
+import linecache
+import sys
+from types import FrameType
+from typing import Callable, List, Optional, Tuple
+
+from tribler.core.utilities.slow_coro_detection import logger
+
+# The default interval Python uses to switch threads is 0.005 seconds. When obtaining the main stack,
+# the _get_main_thread_stack_info() function temporarily switches it to a much bigger value of 0.1 seconds
+# to prevent a thread switch at that moment, so the debug thread can copy the main_thread_stack list content
+# without interruption.
+SWITCH_INTERVAL = 0.1
+
+_main_thread_stack: List[FrameType] = []
+
+
+_main_stack_tracking_activated: bool = False
+
+
+def main_stack_tracking_is_activated() -> bool:
+    return _main_stack_tracking_activated
+
+
+def main_thread_profile(frame: FrameType, event: str, _):
+    """
+    A hook that calls before and after a function call in the main thread if the stack tracking is activated
+    """
+    if event == 'call':
+        _main_thread_stack.append(frame)
+    elif event == 'return' and _main_thread_stack:
+        # Usually, 'call' and 'return' are always paired, so 'return' removes the frame added by the previous 'call'.
+        # But at the very beginning, when the `start_main_thread_stack_tracing` function is called, we are already
+        # inside the function, so we get unpaired `return` when we exit from the function. At that moment, the stack
+        # is empty. By checking that the stack can be empty, we handle this situation by ignoring the unpaired 'return'.
+        _main_thread_stack.pop()
+    return main_thread_profile
+
+
+def start_main_thread_stack_tracing() -> Callable:
+    """
+    Activates the profiler hook in the main thread. Note that it makes Python functions about two times slower.
+    The compiled code is run as fast, so libtorrent calls and database queries should be as efficient as before.
+
+    Returns the profiler function (for testing purpose)
+    """
+    logger.info('Start tracing of coroutine stack to show stack for slow coroutines (makes code execution slower)')
+    global _main_stack_tracking_activated  # pylint: disable=global-statement
+    _main_stack_tracking_activated = True
+    sys.setprofile(main_thread_profile)
+    return main_thread_profile
+
+
+def stop_main_thread_stack_tracing() -> Callable:
+    """
+    Deactivates the profiler hook in the main thread.
+    Returns the previous profiler function (for testing purpose)
+    """
+    previous_profiler = sys.getprofile()
+    sys.setprofile(None)
+    global _main_stack_tracking_activated  # pylint: disable=global-statement
+    _main_stack_tracking_activated = False
+    return previous_profiler
+
+
+def _get_main_thread_stack_info() -> List[Tuple[str, str, Optional[int]]]:
+    """
+    Quickly copies necessary information from the main thread stack, so it is possible later to format a usual
+    traceback in a separate thread.
+
+    The function temporarily changes the interpreter’s thread switch interval to prevent thread switch during
+    the stack copying. It is a lighter analogue of holding the GIL (Global Interpreter Lock).
+    """
+    previous_switch_interval = sys.getswitchinterval()
+    sys.setswitchinterval(SWITCH_INTERVAL)
+    try:
+        stack_info = [(frame.f_code.co_name, frame.f_code.co_filename, frame.f_lineno)
+                      for frame in _main_thread_stack]
+    finally:
+        sys.setswitchinterval(previous_switch_interval)
+    return stack_info
+
+
+def get_main_thread_stack() -> str:
+    """
+    Obtains the main thread stack and format it in a usual way.
+    """
+    lines = ['Traceback (most recent call last):']
+    stack_info = _get_main_thread_stack_info()
+    for func_name, file_name, line_number in stack_info:
+        line = f'  File "{file_name}", line {line_number or "?"}, in {func_name}'
+        lines.append(line)
+        if line_number:
+            source_line = linecache.getline(file_name, line_number)
+            lines.append('    ' + (source_line.strip() or '?'))
+    return '\n'.join(lines) + '\n'

--- a/src/tribler/core/utilities/slow_coro_detection/patch.py
+++ b/src/tribler/core/utilities/slow_coro_detection/patch.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import time
+from asyncio import Handle
+
+from tribler.core.utilities.slow_coro_detection import logger
+from tribler.core.utilities.slow_coro_detection.utils import format_info
+from tribler.core.utilities.slow_coro_detection.watching_thread import SLOW_CORO_DURATION_THRESHOLD, current, lock
+
+# pylint: disable=protected-access
+
+_original_handle_run = Handle._run
+
+
+def patch_asyncio():
+    """
+    Patches the asyncio internal methods to be able to track the current coroutine executed by the loop.
+    You also need to call `start_watching_thread()` to run a separate thread that detects and reports slow coroutines.
+    """
+    with lock:
+        if getattr(Handle._run, 'patched', False):
+            return  # the _run method is already patched
+
+        Handle._run = patched_handle_run
+        Handle._run.patched = True
+
+
+def patched_handle_run(self: Handle):
+    """
+    Remembers the current asyncio handle object and its starting time globally, so it becomes possible
+    to access it from the separate thread and detect slow coroutines.
+    """
+    start_time = time.time()
+    with lock:
+        current.handle, current.start_time = self, start_time
+    try:
+        _original_handle_run(self)
+    finally:
+        with lock:
+            current.handle = current.start_time = None
+
+        duration = time.time() - start_time
+        if duration > SLOW_CORO_DURATION_THRESHOLD:
+            # The coroutine step is finished successfully (without freezing), but the execution time was too long
+            _report_long_duration(self, duration)
+
+        self = None  # Needed to break cycles when an exception occurs (copied from the original Handle._run method)
+
+
+def _report_long_duration(handle: Handle, duration: float):
+    info_str = format_info(handle)
+    logger.error(f'Slow coroutine step execution (duration={duration:.3f} seconds): {info_str}')

--- a/src/tribler/core/utilities/slow_coro_detection/tests/test_main_thread_stack_tracing.py
+++ b/src/tribler/core/utilities/slow_coro_detection/tests/test_main_thread_stack_tracing.py
@@ -1,0 +1,71 @@
+import sys
+from unittest.mock import Mock, patch
+
+import pytest
+
+from tribler.core.utilities.slow_coro_detection.main_thread_stack_tracking import (
+    _get_main_thread_stack_info, get_main_thread_stack, main_stack_tracking_is_activated, main_thread_profile,
+    start_main_thread_stack_tracing,
+    stop_main_thread_stack_tracing
+)
+
+
+def test_main_thread_profile():
+    frame = Mock()
+    arg = Mock()
+    stack = []
+
+    with patch('tribler.core.utilities.slow_coro_detection.main_thread_stack_tracking._main_thread_stack', stack):
+        assert not stack
+
+        result = main_thread_profile(frame, 'call', arg)
+        assert result is main_thread_profile
+        assert stack == [frame]
+
+        result = main_thread_profile(frame, 'return', arg)
+        assert result is main_thread_profile
+        assert not stack
+
+
+def test_main_stack_tracking_is_activated():
+    assert not main_stack_tracking_is_activated()
+    activated_profiler = start_main_thread_stack_tracing()
+    assert main_stack_tracking_is_activated()
+    deactivated_profiler = stop_main_thread_stack_tracing()
+    assert not main_stack_tracking_is_activated()
+    assert activated_profiler is deactivated_profiler
+
+
+def test_get_main_thread_stack_info():
+    frame1 = Mock(f_lineno=111)
+    frame1.f_code.co_name = 'CO_NAME1'
+    frame1.f_code.co_filename = 'CO_FILENAME1'
+    frame2 = Mock(f_lineno=222)
+    frame2.f_code.co_name = 'CO_NAME2'
+    frame2.f_code.co_filename = 'CO_FILENAME2'
+    stack = [frame1, frame2]
+
+    prev_switch_interval = sys.getswitchinterval()
+    test_switch_interval = 10.0
+    assert prev_switch_interval != pytest.approx(test_switch_interval, abs=0.01)
+    sys.setswitchinterval(test_switch_interval)
+
+    with patch('tribler.core.utilities.slow_coro_detection.main_thread_stack_tracking._main_thread_stack', stack):
+        stack_info = _get_main_thread_stack_info()
+
+    assert stack_info == [('CO_NAME1', 'CO_FILENAME1', 111), ('CO_NAME2', 'CO_FILENAME2', 222)]
+    assert sys.getswitchinterval() == pytest.approx(test_switch_interval, abs=0.01)
+    sys.setswitchinterval(prev_switch_interval)
+
+
+def test_get_main_thread_stack():
+    stack_info = [('CO_NAME1', 'CO_FILENAME1', 111), ('CO_NAME2', 'CO_FILENAME2', 222)]
+    with patch('tribler.core.utilities.slow_coro_detection.main_thread_stack_tracking._get_main_thread_stack_info',
+               return_value=stack_info):
+        with patch('linecache.getline', side_effect=['line1', 'line2']):
+            stack = get_main_thread_stack()
+    assert stack == 'Traceback (most recent call last):\n' \
+                    '  File "CO_FILENAME1", line 111, in CO_NAME1\n' \
+                    '    line1\n' \
+                    '  File "CO_FILENAME2", line 222, in CO_NAME2\n' \
+                    '    line2\n'

--- a/src/tribler/core/utilities/slow_coro_detection/tests/test_slow_coro_detection.py
+++ b/src/tribler/core/utilities/slow_coro_detection/tests/test_slow_coro_detection.py
@@ -1,0 +1,98 @@
+from unittest.mock import Mock, patch
+
+from tribler.core.utilities.slow_coro_detection.patch import _report_long_duration, patched_handle_run
+from tribler.core.utilities.slow_coro_detection.watching_thread import SlowCoroWatchingThread, _report_freeze
+
+
+@patch('tribler.core.utilities.slow_coro_detection.watching_thread._report_freeze')
+@patch('tribler.core.utilities.slow_coro_detection.watching_thread.current')
+@patch('time.sleep')
+def test_slow_coro_watching_thread_run_1(_, current: Mock, _report_freeze: Mock):
+    thread = SlowCoroWatchingThread()
+    thread.stop_event = Mock()
+    thread.stop_event.is_set.side_effect = [False, True]
+    current.handle = Mock()
+    current.start_time = start_time = 1000.0
+    with patch('time.time', side_effect=[start_time + 0.01]):
+        thread.run()
+
+    _report_freeze.assert_not_called()
+
+
+@patch('tribler.core.utilities.slow_coro_detection.watching_thread._report_freeze')
+@patch('tribler.core.utilities.slow_coro_detection.watching_thread.current')
+@patch('time.sleep')
+def test_slow_coro_watching_thread_run_2(_, current: Mock, _report_freeze: Mock):
+    thread = SlowCoroWatchingThread()
+    thread.stop_event = Mock()
+    thread.stop_event.is_set.side_effect = [False, False, False, True]
+    current.handle = Mock()
+    current.start_time = start_time = 1000.0
+    with patch('time.time', side_effect=[start_time + 0.01, start_time + 1.5, start_time + 2.5]):
+        thread.run()
+
+    assert _report_freeze.call_count == 2
+    assert _report_freeze.call_args_list[0].kwargs['first_report']
+    assert not _report_freeze.call_args_list[1].kwargs['first_report']
+
+
+def test_slow_coro_watching_thread_stop():
+    thread = SlowCoroWatchingThread()
+    thread.stop_event = Mock()
+    thread.stop()
+    thread.stop_event.set.assert_called()
+
+
+@patch('tribler.core.utilities.slow_coro_detection.patch._report_long_duration')
+@patch('tribler.core.utilities.slow_coro_detection.patch.current')
+@patch('time.sleep')
+def test_patched_handle_run(_, current: Mock, report_long_duration: Mock):
+    handle = Mock()
+    start_time = 1000
+
+    def patched_original_handle_run(self):
+        assert self is handle
+        assert current.handle is handle
+        assert current.start_time is start_time
+
+    with patch('time.time', side_effect=[start_time, start_time + 1.5]):
+        with patch('tribler.core.utilities.slow_coro_detection.patch._original_handle_run',
+                   new=patched_original_handle_run):
+            patched_handle_run(handle)
+
+    assert current.handle is None
+    assert current.start_time is None
+    report_long_duration.assert_called()
+
+
+@patch('tribler.core.utilities.slow_coro_detection.patch.format_info', return_value='<formatted handle>')
+@patch('tribler.core.utilities.slow_coro_detection.patch.logger')
+def test_report_long_duration(logger, format_info: Mock):
+    handle = Mock()
+    duration = 10
+    _report_long_duration(handle, duration)
+    format_info.assert_called_with(handle)
+    logger.error.assert_called_with('Slow coroutine step execution (duration=10.000 seconds): <formatted handle>')
+
+
+@patch('tribler.core.utilities.slow_coro_detection.watching_thread.format_info', return_value='<formatted handle>')
+@patch('tribler.core.utilities.slow_coro_detection.watching_thread.logger')
+def test__report_freeze_first_report(logger, format_info):
+    handle = Mock()
+    duration = 10
+
+    _report_freeze(handle, duration, first_report=True)
+    format_info.assert_called_with(handle, include_stack=True)
+    logger.error.assert_called_with(
+        'Slow coroutine is occupying the loop for 10.000 seconds already: <formatted handle>')
+
+
+@patch('tribler.core.utilities.slow_coro_detection.watching_thread.format_info', return_value='<formatted handle>')
+@patch('tribler.core.utilities.slow_coro_detection.watching_thread.logger')
+def test__report_freeze_not_first_report(logger, format_info):
+    handle = Mock()
+    duration = 10
+
+    _report_freeze(handle, duration, first_report=False)
+    format_info.assert_called_with(handle, include_stack=False)
+    logger.error.assert_called_with('Still executing <formatted handle>')

--- a/src/tribler/core/utilities/slow_coro_detection/utils.py
+++ b/src/tribler/core/utilities/slow_coro_detection/utils.py
@@ -1,0 +1,27 @@
+import io
+from asyncio import Handle, Task
+
+
+# pylint: disable=protected-access
+
+
+from tribler.core.utilities.slow_coro_detection.main_thread_stack_tracking import get_main_thread_stack, \
+    main_stack_tracking_is_activated
+
+
+def format_info(handle: Handle, include_stack: bool = False) -> str:
+    """
+    Returns the representation of a task executed by asyncio, with or without the stack.
+    """
+    func = handle._callback
+    task: Task = getattr(func, '__self__', None)
+    if not isinstance(task, Task) or not include_stack:
+        return repr(func)
+
+    if not main_stack_tracking_is_activated():
+        stream = io.StringIO()
+        task.print_stack(limit=3, file=stream)
+        stack = stream.getvalue()
+    else:
+        stack = get_main_thread_stack()
+    return f"{task}\n{stack}"

--- a/src/tribler/core/utilities/slow_coro_detection/watching_thread.py
+++ b/src/tribler/core/utilities/slow_coro_detection/watching_thread.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import time
+from asyncio import Handle
+from threading import Event, Lock, Thread
+
+from typing import Optional
+
+from tribler.core.utilities.slow_coro_detection import logger
+from tribler.core.utilities.slow_coro_detection.utils import format_info
+
+# How long (in seconds) a coroutine can run before we generate an error.
+# Reduce if you want stricter limits for maximum coroutine step duration.
+SLOW_CORO_DURATION_THRESHOLD = 1.0
+
+# How long (in seconds) the debug thread waits before checks.
+# Reduce if you want a better precision at the expense of a minor performance hit.
+WATCHING_THREAD_INTERVAL = 1.0
+
+
+class DebugInfo:
+    def __init__(self):
+        self.handle: Optional[Handle] = None
+        self.start_time: Optional[float] = None
+
+
+current = DebugInfo()
+lock = Lock()
+_thread: Optional[SlowCoroWatchingThread] = None
+
+
+def start_watching_thread():
+    """
+    Starts separate thread that detects and reports slow coroutines.
+    """
+    global _thread  # pylint: disable=global-statement
+    with lock:
+        if _thread is not None:
+            return  # the thread is already created
+
+        _thread = SlowCoroWatchingThread(daemon=True)
+
+    _thread.start()
+
+
+class SlowCoroWatchingThread(Thread):
+    """
+    A thread that detects and reports slow coroutines.
+    """
+    def __init__(self, group=None, target=None, name=None, args=(), kwargs=None, *, daemon=None):
+        super().__init__(group=group, target=target, name=name, args=args, kwargs=kwargs, daemon=daemon)
+        self.stop_event = Event()
+
+    def run(self):
+        # SlowCoroWatchingThread.run() checks periodically that we are not currently in the coroutine step that already
+        # took too much time but is not finished yet. This way, we can detect a freezer coroutine that never finished
+        # or a coroutine that freezes the loop until the GUI process decides to kill the Core process. In contrast to
+        # patched_handle_run(), it is not guaranteed that SlowCoroWatchingThread.run() is triggered for each coroutine,
+        # a coroutine that was just slightly longer than the limit may be missed by SlowCoroWatchingThread.run().
+        #
+        # Also, SlowCoroWatchingThread.run() displays the current main stack (as we are inside a running coroutine)
+        # while patched_handle_run() does not display the stack (as the coroutine step is already finished).
+
+        prev_reported_handle = None  # to detect in the loop when we have the second report of the same slow coroutine
+        while not self.stop_event.is_set():
+            time.sleep(WATCHING_THREAD_INTERVAL)
+            with lock:
+                handle, start_time = current.handle, current.start_time
+
+            new_reported_handle = None
+            if handle is not None:
+                duration = time.time() - start_time
+                if duration > SLOW_CORO_DURATION_THRESHOLD:
+                    _report_freeze(current.handle, duration, first_report=prev_reported_handle is not handle)
+                    new_reported_handle = handle
+            prev_reported_handle = new_reported_handle
+
+    def stop(self):
+        # We actually do not use it, as the thread is started as daemonic, that is, it runs till the very end
+        # and does not prevent the process exiting
+        self.stop_event.set()
+
+
+def _report_freeze(handle: Handle, duration: float, first_report: bool):
+    if first_report:
+        info_str = format_info(handle, include_stack=True)
+        logger.error(f'Slow coroutine is occupying the loop for {duration:.3f} seconds already: {info_str}')
+        return
+
+    info_str = format_info(handle, include_stack=False)
+    logger.error(f"Still executing {info_str}")


### PR DESCRIPTION
This PR adds functionality to detect slow coroutine step execution in the asyncio loop. If a coroutine step requires too much time (more than 1 second by default), the coroutine is reported to the error log.

A separate thread watches whether the main line is currently inside the coroutine for too long and reports a possible freeze.
 
It is possible to specify an environment variable `SLOW_CORO_STACK_TRACING=1`; in that case, the coroutine stack is also tracked and reported in case of a possible freeze. With stack tracing enabled, the Core works slower, so this option is intended to be run not on user machines (although this is possible).