### PR TITLE
Fix invalid handle when there is no torrent metadata

### DIFF
--- a/src/tribler/core/components/libtorrent/tests/test_download.py
+++ b/src/tribler/core/components/libtorrent/tests/test_download.py
@@ -410,7 +410,7 @@ def test_on_state_changed(mock_handle, test_download):
     test_download.apply_ip_filter.assert_called_with(False)
 
 
-async def test_apply_ip_filter(test_download, mock_handle):
+async def test_apply_ip_filter(test_download, mock_handle):  # pylint: disable=unused-argument
     test_download.handle.status = lambda: Mock(error=None)
     test_download.tdef.get_infohash = lambda: b'a' * 20
     test_download.config.set_hops(1)

--- a/src/tribler/core/components/libtorrent/torrentdef.py
+++ b/src/tribler/core/components/libtorrent/torrentdef.py
@@ -7,7 +7,7 @@ from hashlib import sha1
 import aiohttp
 
 from tribler.core.components.libtorrent.utils.libtorrent_helper import libtorrent as lt
-from tribler.core.components.libtorrent.utils.torrent_utils import create_torrent_file
+from tribler.core.components.libtorrent.utils import torrent_utils
 from tribler.core.utilities import maketorrent, path_util
 from tribler.core.utilities.path_util import Path
 from tribler.core.utilities.simpledefs import INFOHASH_LENGTH
@@ -317,7 +317,8 @@ class TorrentDef:
         Generate the metainfo and save the torrent file.
         :param torrent_filepath: An optional absolute path to where to save the generated .torrent file.
         """
-        torrent_dict = create_torrent_file(self.files_list, self.torrent_parameters, torrent_filepath=torrent_filepath)
+        torrent_dict = torrent_utils.create_torrent_file(self.files_list, self.torrent_parameters,
+                                                         torrent_filepath=torrent_filepath)
         self.metainfo = bdecode_compat(torrent_dict['metainfo'])
         self.copy_metainfo_to_torrent_parameters()
         self.infohash = torrent_dict['infohash']

--- a/src/tribler/core/components/libtorrent/utils/torrent_utils.py
+++ b/src/tribler/core/components/libtorrent/utils/torrent_utils.py
@@ -4,6 +4,7 @@ from contextlib import suppress
 from hashlib import sha1
 from typing import Any, Dict, Iterable, List, Optional
 
+from tribler.core.components.libtorrent import torrentdef
 from tribler.core.components.libtorrent.utils.libtorrent_helper import libtorrent as lt
 from tribler.core.utilities.path_util import Path
 
@@ -33,14 +34,18 @@ def require_handle(func):
     Invoke the function once the handle is available. Returns a future that will fire once the function has completed.
     Author(s): Egbert Bouman
     """
-
     def invoke_func(*args, **kwargs):
         result_future = Future()
 
         def done_cb(fut):
             with suppress(CancelledError):
                 handle = fut.result()
-            if not fut.cancelled() and not result_future.done() and handle == download.handle and handle.is_valid():
+
+            if not fut.cancelled() \
+                    and not result_future.done() \
+                    and handle == download.handle \
+                    and handle.is_valid() \
+                    and not isinstance(download.tdef, torrentdef.TorrentDefNoMetainfo):
                 result_future.set_result(func(*args, **kwargs))
 
         download = args[0]


### PR DESCRIPTION
The PR updates the `require_handle` decorator to execute the function if TorrentDef has metadata.
- Fixes https://github.com/Tribler/tribler/issues/7412
- Fixes https://github.com/Tribler/tribler/issues/6915