### PR TITLE
Add queue for multithread processing

### DIFF
--- a/src/tribler/core/components/knowledge/rules/knowledge_rules_processor.py
+++ b/src/tribler/core/components/knowledge/rules/knowledge_rules_processor.py
@@ -119,7 +119,6 @@ class KnowledgeRulesProcessor(TaskManager):
         added = 0
         for torrent in batch:
             added += self.process_torrent_title(torrent.infohash, torrent.title)
-            torrent.tag_processor_version = self.version
             processed += 1
 
         self.set_last_processed_torrent_id(end)
@@ -134,14 +133,15 @@ class KnowledgeRulesProcessor(TaskManager):
     @db_session(serializable=True)
     def process_queue(self) -> int:
         processed = 0
+        added = 0
         try:
             while title := self.queue.get_nowait():
-                self.process_torrent_title(title.infohash, title.title)
+                added += self.process_torrent_title(title.infohash, title.title)
                 processed += 1
         except queue.Empty:
             pass
         if processed:
-            self.logger.info(f'Processed {processed} titles from the queue')
+            self.logger.info(f'Processed: {processed} titles from the queue. Added {added} tags.')
         return processed
 
     def put_entity_to_the_queue(self, infohash: Optional[bytes] = None, title: Optional[str] = None):

--- a/src/tribler/core/components/knowledge/rules/tests/test_knowledge_rules_processor.py
+++ b/src/tribler/core/components/knowledge/rules/tests/test_knowledge_rules_processor.py
@@ -156,6 +156,13 @@ def test_add_to_queue(tag_rules_processor: KnowledgeRulesProcessor):
     assert title.title == 'title'
 
 
+def test_add_empty_to_queue(tag_rules_processor: KnowledgeRulesProcessor):
+    """Test that add_to_queue does not add the empty title to the queue"""
+    tag_rules_processor.put_entity_to_the_queue(b'infohash', None)
+
+    assert tag_rules_processor.queue.qsize() == 0
+
+
 def test_process_queue(tag_rules_processor: KnowledgeRulesProcessor):
     """Test that process_queue processes the queue"""
     tag_rules_processor.put_entity_to_the_queue(b'infohash', 'title')

--- a/src/tribler/core/components/metadata_store/restapi/channels_endpoint.py
+++ b/src/tribler/core/components/metadata_store/restapi/channels_endpoint.py
@@ -189,9 +189,12 @@ class ChannelsEndpoint(MetadataEndpointBase):
                 contents = self.mds.get_entries(**sanitized)
                 contents_list = []
                 for entry in contents:
-                    self.extract_tags(entry)
                     contents_list.append(entry.to_simple_dict())
                 total = self.mds.get_total_count(**sanitized) if include_total else None
+
+        if self.tag_rules_processor:
+            self.tag_rules_processor.process_queue()
+
         self.add_download_progress_to_metadata_list(contents_list)
         self.add_statements_to_metadata_list(contents_list, hide_xxx=sanitized["hide_xxx"])
         response_dict = {
@@ -497,8 +500,10 @@ class ChannelsEndpoint(MetadataEndpointBase):
             contents = self.mds.get_entries(**sanitized)
             contents_list = []
             for entry in contents:
-                self.extract_tags(entry)
                 contents_list.append(entry.to_simple_dict())
+
+        if self.tag_rules_processor:
+            self.tag_rules_processor.process_queue()
 
         self.add_download_progress_to_metadata_list(contents_list)
         self.add_statements_to_metadata_list(contents_list, hide_xxx=sanitized["hide_xxx"])

--- a/src/tribler/core/components/metadata_store/restapi/metadata_endpoint_base.py
+++ b/src/tribler/core/components/metadata_store/restapi/metadata_endpoint_base.py
@@ -9,9 +9,9 @@ from tribler.core.components.metadata_store.category_filter.family_filter import
 from tribler.core.components.metadata_store.db.serialization import CHANNEL_TORRENT, COLLECTION_NODE, REGULAR_TORRENT
 from tribler.core.components.metadata_store.db.store import MetadataStore
 from tribler.core.components.restapi.rest.rest_endpoint import RESTEndpoint
+
 # This dict is used to translate JSON fields into the columns used in Pony for _sorting_.
 # id_ is not in the list because there is not index on it, so we never really want to sort on it.
-from tribler.core.utilities.unicode import hexlify
 
 json2pony_columns = {
     'category': "tags",
@@ -71,18 +71,6 @@ class MetadataEndpointBase(RESTEndpoint):
                 mtypes.extend(metadata_type_to_search_scope[arg])
             sanitized['metadata_type'] = frozenset(mtypes)
         return sanitized
-
-    def extract_tags(self, entry):
-        is_torrent = entry.get_type() == REGULAR_TORRENT
-        if not is_torrent or not self.tag_rules_processor:
-            return
-
-        is_auto_generated_tags_not_created = entry.tag_processor_version is None or \
-                                             entry.tag_processor_version < self.tag_rules_processor.version
-        if is_auto_generated_tags_not_created:
-            generated = self.tag_rules_processor.process_torrent_title(infohash=entry.infohash, title=entry.title)
-            entry.tag_processor_version = self.tag_rules_processor.version
-            self._logger.info(f'Generated {generated} tags for {hexlify(entry.infohash)}')
 
     @db_session
     def add_statements_to_metadata_list(self, contents_list, hide_xxx=False):

--- a/src/tribler/core/components/metadata_store/restapi/search_endpoint.py
+++ b/src/tribler/core/components/metadata_store/restapi/search_endpoint.py
@@ -161,6 +161,9 @@ class SearchEndpoint(MetadataEndpointBase):
             self._logger.exception("Error while performing DB search: %s: %s", type(e).__name__, e)
             return RESTResponse(status=HTTP_BAD_REQUEST)
 
+        if self.tag_rules_processor:
+            self.tag_rules_processor.process_queue()
+
         self.add_statements_to_metadata_list(search_results, hide_xxx=sanitized["hide_xxx"])
 
         if sanitized["first"] == 1:  # Only show a snippet on top

--- a/src/tribler/core/components/metadata_store/restapi/tests/test_metadata_endpoint.py
+++ b/src/tribler/core/components/metadata_store/restapi/tests/test_metadata_endpoint.py
@@ -1,14 +1,12 @@
 import json
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock
 
 import pytest
 from aiohttp.web_app import Application
 from pony.orm import db_session
 
 from tribler.core.components.metadata_store.db.orm_bindings.channel_node import COMMITTED, TODELETE, UPDATED
-from tribler.core.components.metadata_store.db.serialization import REGULAR_TORRENT
 from tribler.core.components.metadata_store.restapi.metadata_endpoint import MetadataEndpoint, TORRENT_CHECK_TIMEOUT
-from tribler.core.components.metadata_store.restapi.metadata_endpoint_base import MetadataEndpointBase
 from tribler.core.components.restapi.rest.base_api_test import do_request
 from tribler.core.components.restapi.rest.rest_manager import error_middleware
 from tribler.core.components.torrent_checker.torrent_checker.torrent_checker import TorrentChecker
@@ -220,22 +218,3 @@ async def test_check_torrent_query(rest_api, udp_tracker, metadata_store):
     """
     infohash = b'a' * 20
     await do_request(rest_api, f"metadata/torrents/{infohash}/health?timeout=wrong_value&refresh=1", expected_code=400)
-
-
-@patch('tribler.core.components.metadata_store.restapi.metadata_endpoint_base.hexlify', new=Mock())
-def test_extract_tags():
-    # Test that in the case of empty `tag_processor_version` no NPE raise
-    # see: https://github.com/Tribler/tribler/issues/6986
-    mds_endpoint = MetadataEndpointBase(
-        MagicMock(),
-        knowledge_db=MagicMock(),
-        tag_rules_processor=MagicMock(
-            version=1
-        )
-    )
-    entry = MagicMock(
-        get_type=Mock(return_value=REGULAR_TORRENT),
-        tag_processor_version=None
-    )
-    mds_endpoint.extract_tags(entry)
-    assert entry.tag_processor_version == 1


### PR DESCRIPTION
This is a continuation of the previous PR #7413 and the final fix for the deadlock problem.

It adds a thread-safe queue that is used for processing incoming MDS entities, which are created in a different thread.
Additionally, it removes unnecessary logic from Endpoints that perform writes to both databases (`KnowledgeDB` and `MetadataDB`).

As a drawback, this PR reduces the speed of tag extraction, as they are now not performed immediately upon entity addition to the `MetadataDB`. Given that tags aren't directly used in the current release and we plan to remove MDS in upcoming releases, this drawback is acceptable.