### PR TITLE
Make `KnowledgeRulesProcessor` less aggressive

### DIFF
--- a/src/tribler/core/components/metadata_store/restapi/channels_endpoint.py
+++ b/src/tribler/core/components/metadata_store/restapi/channels_endpoint.py
@@ -193,7 +193,7 @@ class ChannelsEndpoint(MetadataEndpointBase):
                 total = self.mds.get_total_count(**sanitized) if include_total else None
 
         if self.tag_rules_processor:
-            self.tag_rules_processor.process_queue()
+            await self.tag_rules_processor.process_queue()
 
         self.add_download_progress_to_metadata_list(contents_list)
         self.add_statements_to_metadata_list(contents_list, hide_xxx=sanitized["hide_xxx"])
@@ -503,7 +503,7 @@ class ChannelsEndpoint(MetadataEndpointBase):
                 contents_list.append(entry.to_simple_dict())
 
         if self.tag_rules_processor:
-            self.tag_rules_processor.process_queue()
+            await self.tag_rules_processor.process_queue()
 
         self.add_download_progress_to_metadata_list(contents_list)
         self.add_statements_to_metadata_list(contents_list, hide_xxx=sanitized["hide_xxx"])

--- a/src/tribler/core/components/metadata_store/restapi/search_endpoint.py
+++ b/src/tribler/core/components/metadata_store/restapi/search_endpoint.py
@@ -162,7 +162,7 @@ class SearchEndpoint(MetadataEndpointBase):
             return RESTResponse(status=HTTP_BAD_REQUEST)
 
         if self.tag_rules_processor:
-            self.tag_rules_processor.process_queue()
+            await self.tag_rules_processor.process_queue()
 
         self.add_statements_to_metadata_list(search_results, hide_xxx=sanitized["hide_xxx"])
 

--- a/src/tribler/core/utilities/async_force_switch.py
+++ b/src/tribler/core/utilities/async_force_switch.py
@@ -1,0 +1,60 @@
+import asyncio
+import functools
+
+
+def force_switch(func):
+    """Decorator for forced coroutine switch. The switch will occur before calling the function.
+
+    For more information, see the example at the end of this file.
+     Also check this: https://stackoverflow.com/questions/59586879/does-await-in-python-yield-to-the-event-loop
+    """
+
+    @functools.wraps(func)
+    async def wrapper(*args, **kwargs):
+        await asyncio.sleep(0)
+        return await func(*args, **kwargs)
+
+    return wrapper
+
+# the behavior of asyncio without using the force_switch decorator:
+#
+# import asyncio
+#
+#
+# async def a():
+#     async def a_print():
+#         print('a')
+#
+#     while True:
+#         await a_print()
+#
+#
+# async def b():
+#     async def b_print():
+#         print('b')
+#
+#     while True:
+#         await b_print()
+#
+#
+# async def main():
+#     tasks = {
+#         asyncio.create_task(a()),
+#         asyncio.create_task(b())
+#     }
+#
+#     await asyncio.wait(tasks)
+#
+#
+# asyncio.run(main())
+#
+# -------------------
+# the output will be:
+# a
+# a
+# a
+# a
+# a
+# a
+# ...
+# a

--- a/src/tribler/core/utilities/tests/test_async_force_switch.py
+++ b/src/tribler/core/utilities/tests/test_async_force_switch.py
@@ -1,0 +1,50 @@
+import asyncio
+import time
+
+import pytest
+
+from tribler.core.utilities.async_force_switch import force_switch
+
+
+@pytest.mark.looptime(False)
+async def test_without_switch():
+    # In this test, we reproduce the asyncio behavior where there's a possibility
+    # to block the main thread if there's no blocking event in the coroutine.
+    class EndOfTheTest(TimeoutError):
+        """Exception to stop a test after 0.2 seconds."""
+
+    start_time = time.time()
+
+    async def any_non_blocking_coro():
+        duration = time.time() - start_time
+        if duration >= 0.2:
+            # to prevent indefinite block of a thread, raise an exception after 2 seconds.
+            raise EndOfTheTest
+        # With this line ↓
+        # await asyncio.sleep(0)
+        # `asyncio.wait_for()` will work as expected, interrupting the execution of the coroutine after 0.1 sec.
+        # Without this line, the main thread will be blocked indefinitely.
+
+    async def a():
+        while True:
+            await any_non_blocking_coro()
+
+    # We are waiting for the timeout, but coroutine a() will never be cancelled.
+    with pytest.raises(EndOfTheTest):
+        await asyncio.wait_for(a(), timeout=0.1)
+
+
+@pytest.mark.looptime(False)
+async def test_force_switch():
+    # In this test, we show that by using the @force_switch decorator, the function any_non_blocking_coro
+    # doesn't block the main thread and `asyncio.wait_for` works as expected.
+    @force_switch
+    async def any_non_blocking_coro():
+        ...
+
+    async def a():
+        while True:
+            await any_non_blocking_coro()
+
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(a(), timeout=0.1)


### PR DESCRIPTION
This is a continuation of the previous PR #7417 and the final PR from the `KnowledgeRulesProcessor` improvements series.

As demonstrated in #7414 by @kozlovsky, `process_batch` is one of the few "long-running" coroutines. This behavior could lead to a brief freeze of Tribler every 10 seconds. This happens on the core side and should go unnoticed by users. However, it's possible to reduce the time of synchronous `process_batch` execution by making `process_torrent_title` an async function.

I've tried to carefully isolate the use of `db_session` so it won't be affected by the switch to async. @kozlovsky, could you please confirm that I've done everything correctly?