### PR TITLE
Fix test check core api port timeout

### DIFF
--- a/src/tribler/gui/tests/test_core_manager.py
+++ b/src/tribler/gui/tests/test_core_manager.py
@@ -81,9 +81,9 @@ def test_check_core_api_port(request_manager: MagicMock, core_manager):
 def test_check_core_api_port_timeout(core_manager):
     core_manager.core_running = True
     # The timeout should be 30 seconds so let's pretend the core started 31 seconds before now
-    core_manager.core_started_at = time.time() - 31
+    core_manager.core_started_at = time.time() - 121
     core_manager.process_manager.current_process.get_core_process.return_value = None
-    with pytest.raises(CoreConnectTimeoutError, match="^Can't get Core API port value within 30 seconds$"):
+    with pytest.raises(CoreConnectTimeoutError, match="^Can't get Core API port value within 120 seconds$"):
         core_manager.check_core_api_port()
 
 


### PR DESCRIPTION
This PR fixes the `test_check_core_api_port_timeout` test that was broken by #7419 