### PR TITLE
Bump libsodium version to `1.0.18`

### DIFF
--- a/.github/actions/windows_dependencies/action.yml
+++ b/.github/actions/windows_dependencies/action.yml
@@ -29,12 +29,17 @@ runs:
 
     - name: Download Libsodium
       if: steps.check_libsodium.outputs.files_exists == 'false'
+      env:
+        RELEASE_FOLDER: .\libsodium\x64\Release
       shell: cmd
       run: |
         C:\msys64\usr\bin\wget.exe -q https://download.libsodium.org/libsodium/releases/libsodium-${{inputs.libsodium-version}}-msvc.zip
         7z x libsodium-${{inputs.libsodium-version}}-msvc.zip
+        dir %RELEASE_FOLDER% /ad /b /o-n > latest_release_file
+        set /p latest_release= < latest_release_file
+        echo Latest release: %latest_release%
         if not exist "cached-bin\libsodium-${{inputs.libsodium-version}}" mkdir "cached-bin\libsodium-${{inputs.libsodium-version}}"
-        copy .\x64\Release\v141\dynamic\libsodium.dll .\cached-bin\libsodium-${{inputs.libsodium-version}}\libsodium.dll
+        copy %RELEASE_FOLDER%\%latest_release%\dynamic\libsodium.dll .\cached-bin\libsodium-${{inputs.libsodium-version}}\libsodium.dll
 
     - name: Install Libsodium
       shell: cmd

--- a/.github/actions/windows_dependencies/action.yml
+++ b/.github/actions/windows_dependencies/action.yml
@@ -2,7 +2,7 @@ name: windows_dependencies
 description: Setup windows dependencies for Tribler
 inputs:
   libsodium-version:
-    default: '1.0.17'
+    default: '1.0.18'
     description: 'Libsodium version'
     required: false
 


### PR DESCRIPTION
This PR fixes #7436 by bumping libsodium version to `1.0.18`.

Version `1.0.17` is no longer available https://download.libsodium.org/libsodium/releases/libsodium-1.0.17-msvc.zip

The GUI tests will be fixed following the merger of this PR.