### PR TITLE
Replace list comprehensions with generator expressions and similar functions

### DIFF
--- a/src/tribler/core/components/libtorrent/download_manager/download_manager.py
+++ b/src/tribler/core/components/libtorrent/download_manager/download_manager.py
@@ -586,8 +586,7 @@ class DownloadManager(TaskManager):
         download = self.get_download(infohash)
 
         if download and infohash not in self.metainfo_requests:
-            new_trackers = list(set(tdef.get_trackers_as_single_tuple()) -
-                                set(download.get_def().get_trackers_as_single_tuple()))
+            new_trackers = list(tdef.get_trackers() - download.get_def().get_trackers())
             if new_trackers:
                 self.update_trackers(tdef.get_infohash(), new_trackers)
             return download
@@ -779,8 +778,8 @@ class DownloadManager(TaskManager):
         download = self.get_download(infohash)
         if download:
             old_def = download.get_def()
-            old_trackers = old_def.get_trackers_as_single_tuple()
-            new_trackers = list(set(trackers) - set(old_trackers))
+            old_trackers = old_def.get_trackers()
+            new_trackers = list(set(trackers) - old_trackers)
             all_trackers = list(old_trackers) + new_trackers
 
             if new_trackers:

--- a/src/tribler/core/components/libtorrent/restapi/downloads_endpoint.py
+++ b/src/tribler/core/components/libtorrent/restapi/downloads_endpoint.py
@@ -50,7 +50,7 @@ def _safe_extended_peer_info(ext_peer_info):
         return ensure_unicode(ext_peer_info, "utf8")
     except UnicodeDecodeError:
         # We might have some special unicode characters in here
-        return ''.join([chr(c) for c in ext_peer_info])
+        return ''.join(map(chr, ext_peer_info))
 
 
 def get_extended_status(tunnel_community, download) -> DownloadStatus:

--- a/src/tribler/core/components/libtorrent/restapi/downloads_endpoint.py
+++ b/src/tribler/core/components/libtorrent/restapi/downloads_endpoint.py
@@ -44,13 +44,13 @@ def _safe_extended_peer_info(ext_peer_info):
     """
     # First see if we can use this as-is
     if not ext_peer_info:
-        return ''
+        return ""
 
     try:
         return ensure_unicode(ext_peer_info, "utf8")
     except UnicodeDecodeError:
         # We might have some special unicode characters in here
-        return ''.join(map(chr, ext_peer_info))
+        return "".join(map(chr, ext_peer_info))
 
 
 def get_extended_status(tunnel_community, download) -> DownloadStatus:

--- a/src/tribler/core/components/libtorrent/restapi/tests/test_downloads_endpoint.py
+++ b/src/tribler/core/components/libtorrent/restapi/tests/test_downloads_endpoint.py
@@ -9,7 +9,7 @@ from ipv8.util import fail, succeed
 
 import tribler.core.components.libtorrent.restapi.downloads_endpoint as download_endpoint
 from tribler.core.components.libtorrent.download_manager.download_state import DownloadState
-from tribler.core.components.libtorrent.restapi.downloads_endpoint import DownloadsEndpoint, get_extended_status, _safe_extended_peer_info
+from tribler.core.components.libtorrent.restapi.downloads_endpoint import DownloadsEndpoint, get_extended_status
 from tribler.core.components.restapi.rest.base_api_test import do_request
 from tribler.core.components.restapi.rest.rest_manager import error_middleware
 from tribler.core.tests.tools.common import TESTS_DATA_DIR
@@ -150,8 +150,10 @@ def test_get_extended_status_circuits(mock_extended_status):
 @unittest.mock.patch("tribler.core.components.libtorrent.restapi.downloads_endpoint.ensure_unicode",
        Mock(side_effect=UnicodeDecodeError("", b"", 0, 0, "")))
 def test_safe_extended_peer_info():
-    # Test that we return the string mapped by `chr` in the case of `UnicodeDecodeError`
-    extended_peer_info = download_endpoint._safe_extended_peer_info(b"abcd")
+    """
+    Test that we return the string mapped by `chr` in the case of `UnicodeDecodeError`
+    """
+    extended_peer_info = download_endpoint._safe_extended_peer_info(b"abcd") # pylint: disable=protected-access
     assert extended_peer_info == "abcd"
 
 

--- a/src/tribler/core/components/libtorrent/restapi/tests/test_downloads_endpoint.py
+++ b/src/tribler/core/components/libtorrent/restapi/tests/test_downloads_endpoint.py
@@ -145,6 +145,14 @@ def test_get_extended_status_circuits(mock_extended_status):
     assert mock_extended_status == DownloadStatus.CIRCUITS
 
 
+@pytest.patch('tribler.core.components.libtorrent.restapi.downloads_endpoint.ensure_unicode',
+       Mock(side_effect=UnicodeDecodeError('', b'', 0, 0, '')))
+def test_safe_extended_peer_info():
+    # Test that we return the string mapped by `chr` in the case of `UnicodeDecodeError`
+    extended_peer_info = _safe_extended_peer_info(b'abcd')
+    assert extended_peer_info == 'abcd'
+
+
 async def test_get_downloads_if_checkpoints_are_not_loaded(mock_dlmgr, rest_api):
     mock_dlmgr.checkpoints_count = 10
     mock_dlmgr.checkpoints_loaded = 5

--- a/src/tribler/core/components/libtorrent/restapi/tests/test_downloads_endpoint.py
+++ b/src/tribler/core/components/libtorrent/restapi/tests/test_downloads_endpoint.py
@@ -1,13 +1,15 @@
 import collections
 import os
+import unittest.mock
 from unittest.mock import Mock
 
 import pytest
 from aiohttp.web_app import Application
 from ipv8.util import fail, succeed
 
+import tribler.core.components.libtorrent.restapi.downloads_endpoint as download_endpoint
 from tribler.core.components.libtorrent.download_manager.download_state import DownloadState
-from tribler.core.components.libtorrent.restapi.downloads_endpoint import DownloadsEndpoint, get_extended_status
+from tribler.core.components.libtorrent.restapi.downloads_endpoint import DownloadsEndpoint, get_extended_status, _safe_extended_peer_info
 from tribler.core.components.restapi.rest.base_api_test import do_request
 from tribler.core.components.restapi.rest.rest_manager import error_middleware
 from tribler.core.tests.tools.common import TESTS_DATA_DIR
@@ -145,12 +147,12 @@ def test_get_extended_status_circuits(mock_extended_status):
     assert mock_extended_status == DownloadStatus.CIRCUITS
 
 
-@pytest.patch('tribler.core.components.libtorrent.restapi.downloads_endpoint.ensure_unicode',
-       Mock(side_effect=UnicodeDecodeError('', b'', 0, 0, '')))
+@unittest.mock.patch("tribler.core.components.libtorrent.restapi.downloads_endpoint.ensure_unicode",
+       Mock(side_effect=UnicodeDecodeError("", b"", 0, 0, "")))
 def test_safe_extended_peer_info():
     # Test that we return the string mapped by `chr` in the case of `UnicodeDecodeError`
-    extended_peer_info = _safe_extended_peer_info(b'abcd')
-    assert extended_peer_info == 'abcd'
+    extended_peer_info = download_endpoint._safe_extended_peer_info(b"abcd")
+    assert extended_peer_info == "abcd"
 
 
 async def test_get_downloads_if_checkpoints_are_not_loaded(mock_dlmgr, rest_api):

--- a/src/tribler/core/components/libtorrent/tests/test_download_manager.py
+++ b/src/tribler/core/components/libtorrent/tests/test_download_manager.py
@@ -263,7 +263,7 @@ def test_start_download_existing_download(fake_dlmgr):
     infohash = b'a' * 20
 
     mock_download = MagicMock()
-    mock_download.get_def = lambda: MagicMock(get_trackers_as_single_tuple=lambda: ())
+    mock_download.get_def = lambda: MagicMock(get_trackers=set)
 
     mock_ltsession = MagicMock()
 

--- a/src/tribler/core/components/libtorrent/tests/test_torrent_def.py
+++ b/src/tribler/core/components/libtorrent/tests/test_torrent_def.py
@@ -154,9 +154,9 @@ def test_set_tracker_strip_slash(tdef):
 
 
 def test_set_tracker(tdef):
-    assert not tdef.get_trackers_as_single_tuple()
+    assert len(tdef.get_trackers()) == 0
     tdef.set_tracker("http://tracker.org")
-    assert tdef.get_trackers_as_single_tuple() == ('http://tracker.org',)
+    assert tdef.get_trackers() == {'http://tracker.org'}
 
 
 def test_get_nr_pieces(tdef):
@@ -207,13 +207,13 @@ def test_torrent_no_metainfo():
     assert tdef.get_name_as_unicode() == VIDEO_FILE_NAME
     assert not tdef.get_files()
     assert tdef.get_files_with_length() == []
-    assert not tdef.get_trackers_as_single_tuple()
+    assert len(tdef.get_trackers()) == 0
     assert not tdef.is_private()
     assert tdef.get_name_utf8() == "video.avi"
     assert tdef.get_nr_pieces() == 0
 
     torrent2 = TorrentDefNoMetainfo(b"12345678901234567890", VIDEO_FILE_NAME, "magnet:")
-    assert not torrent2.get_trackers_as_single_tuple()
+    assert len(torrent2.get_trackers()) == 0
 
 
 def test_get_length(tdef):

--- a/src/tribler/core/components/libtorrent/tests/test_torrent_def.py
+++ b/src/tribler/core/components/libtorrent/tests/test_torrent_def.py
@@ -1,4 +1,5 @@
 import shutil
+from unittest.mock import Mock
 
 import pytest
 from aiohttp import ClientResponseError
@@ -158,6 +159,19 @@ def test_set_tracker(tdef):
     tdef.set_tracker("http://tracker.org")
     assert tdef.get_trackers() == {'http://tracker.org'}
 
+
+def test_get_trackers(tdef):
+    """
+    Test that `get_trackers` returns flat set of trackers
+    """
+    tdef.get_tracker_hierarchy = Mock(return_value=[["t1", "t2"], ["t3"], ["t4"]])
+    trackers = tdef.get_trackers()
+    assert trackers == {"t1", "t2", "t3", "t4"}
+
+def test_filter_characters(tdef):
+    """
+    Test `_filter_characters` sanitizes its input
+    """
 
 def test_get_nr_pieces(tdef):
     """

--- a/src/tribler/core/components/libtorrent/tests/test_torrent_def.py
+++ b/src/tribler/core/components/libtorrent/tests/test_torrent_def.py
@@ -168,11 +168,6 @@ def test_get_trackers(tdef):
     trackers = tdef.get_trackers()
     assert trackers == {"t1", "t2", "t3", "t4"}
 
-def test_filter_characters(tdef):
-    """
-    Test `_filter_characters` sanitizes its input
-    """
-
 def test_get_nr_pieces(tdef):
     """
     Test getting the number of pieces from a TorrentDef
@@ -264,7 +259,20 @@ def test_get_name_as_unicode(tdef):
     tdef.metainfo = {b'info': {b'name': name_bytes}}
     assert tdef.get_name_as_unicode() == name_unicode
     tdef.metainfo = {b'info': {b'name': b'test\xff' + name_bytes}}
-    assert tdef.get_name_as_unicode() == 'test?????????????'
+    assert tdef.get_name_as_unicode() == 'test' + '?' * len(b'\xff' + name_bytes)
+
+
+def test_filter_characters(tdef):
+    """
+    Test `_filter_characters` sanitizes its input
+    """
+    name_bytes = b"\xe8\xaf\xad\xe8\xa8\x80\xe5\xa4\x84\xe7\x90\x86"
+    name = name_bytes
+    name_sanitized = "?" * len(name)
+    assert tdef._filter_characters(name) == name_sanitized # pylint: disable=protected-access
+    name = b"test\xff" + name_bytes
+    name_sanitized = "test" + "?" * len(b"\xff" + name_bytes)
+    assert tdef._filter_characters(name) == name_sanitized # pylint: disable=protected-access
 
 
 def test_get_files_with_length(tdef):

--- a/src/tribler/core/components/libtorrent/torrentdef.py
+++ b/src/tribler/core/components/libtorrent/torrentdef.py
@@ -15,6 +15,25 @@ from tribler.core.utilities.unicode import ensure_unicode
 from tribler.core.utilities.utilities import bdecode_compat, is_valid_url, parse_magnetlink
 
 
+def _filter_characters(name: str) -> str:
+    """Sanitize the names in path to unicode by replacing out all
+    characters that may -even remotely- cause problems with the '?'
+    character.
+
+    :param name: the name to sanitize
+    :type name: str
+    :return: the sanitized string
+    :rtype: str
+    """
+    def filter_character(char: str) -> str:
+        if 0 < char < 128:
+            return chr(char)
+        self._logger.debug("Bad character 0x%X", char)
+        return "?"
+
+    return "".join(map(filter_character, name))
+
+
 def escape_as_utf8(string, encoding='utf8'):
     """
     Make a string UTF-8 compliant, destroying characters if necessary.
@@ -296,16 +315,7 @@ class TorrentDef:
             # all characters that may -even remotely- cause problems
             # with the '?' character
             try:
-                def filter_characters(name):
-                    def filter_character(char):
-                        if 0 < char < 128:
-                            return chr(char)
-                        self._logger.debug("Bad character 0x%X", char)
-                        return "?"
-
-                    return "".join([filter_character(char) for char in name])
-
-                return filter_characters(self.metainfo[b"info"][b"name"])
+                return _filter_characters(self.metainfo[b"info"][b"name"])
             except UnicodeError:
                 pass
 
@@ -376,16 +386,7 @@ class TorrentDef:
                     # replacing out all characters that may -even
                     # remotely- cause problems with the '?' character
                     try:
-                        def filter_characters(name):
-                            def filter_character(char):
-                                if 0 < char < 128:
-                                    return chr(char)
-                                self._logger.debug("Bad character 0x%X", char)
-                                return "?"
-
-                            return "".join([filter_character(char) for char in name])
-
-                        yield (Path(*[filter_characters(element) for element in file_dict[b"path"]]),
+                        yield (Path(*[_filter_characters(element) for element in file_dict[b"path"]]),
                                file_dict[b"length"])
                         continue
                     except UnicodeError:

--- a/src/tribler/core/components/libtorrent/torrentdef.py
+++ b/src/tribler/core/components/libtorrent/torrentdef.py
@@ -198,17 +198,20 @@ class TorrentDef:
         """
         return self.torrent_parameters.get(b'announce-list', [])
 
-    def get_trackers_as_single_tuple(self):
+    def get_trackers(self) -> set:
         """
-        Returns a flat tuple of all known trackers.
+        Returns a flat set of all known trackers.
+
+        :return: all known trackers
+        :rtype: set
         """
         if self.get_tracker_hierarchy():
             trackers = itertools.chain.from_iterable(self.get_tracker_hierarchy())
-            return tuple(set(filter(None, trackers)))
+            return set(filter(None, trackers))
         tracker = self.get_tracker()
         if tracker:
-            return tracker,
-        return ()
+            return {tracker}
+        return set()
 
     def set_piece_length(self, piece_length):
         """
@@ -513,11 +516,17 @@ class TorrentDefNoMetainfo:
     def get_files_with_length(self, exts=None):
         return []
 
-    def get_trackers_as_single_tuple(self):
+    def get_trackers(self) -> set:
+        """
+        Returns a flat set of all known trackers.
+
+        :return: all known trackers
+        :rtype: set
+        """
         if self.url and self.url.startswith('magnet:'):
-            _, _, trs = parse_magnetlink(self.url)
-            return tuple(trs)
-        return ()
+            trackers = parse_magnetlink(self.url)[2]
+            return set(trackers)
+        return set()
 
     def is_private(self):
         return False

--- a/src/tribler/core/components/libtorrent/torrentdef.py
+++ b/src/tribler/core/components/libtorrent/torrentdef.py
@@ -1,6 +1,7 @@
 """
 Author(s): Arno Bakker
 """
+import itertools
 import logging
 from hashlib import sha1
 
@@ -202,12 +203,8 @@ class TorrentDef:
         Returns a flat tuple of all known trackers.
         """
         if self.get_tracker_hierarchy():
-            trackers = []
-            for level in self.get_tracker_hierarchy():
-                for tracker in level:
-                    if tracker and tracker not in trackers:
-                        trackers.append(tracker)
-            return tuple(trackers)
+            trackers = itertools.chain.from_iterable(self.get_tracker_hierarchy())
+            return tuple(set(filter(None, trackers)))
         tracker = self.get_tracker()
         if tracker:
             return tracker,

--- a/src/tribler/core/components/libtorrent/torrentdef.py
+++ b/src/tribler/core/components/libtorrent/torrentdef.py
@@ -137,7 +137,8 @@ class TorrentDef:
         return TorrentDef.load_from_memory(body)
 
     def _filter_characters(self, name: bytes) -> str:
-        """Sanitize the names in path to unicode by replacing out all
+        """
+        Sanitize the names in path to unicode by replacing out all
         characters that may -even remotely- cause problems with the '?'
         character.
 

--- a/src/tribler/core/components/metadata_store/remote_query_community/payload_checker.py
+++ b/src/tribler/core/components/metadata_store/remote_query_community/payload_checker.py
@@ -102,7 +102,7 @@ class PayloadChecker:
         """
         if is_forbidden(
                 " ".join(
-                    [getattr(self.payload, attr) for attr in ("title", "tags", "text") if hasattr(self.payload, attr)])
+                    getattr(self.payload, attr) for attr in ("title", "tags", "text") if hasattr(self.payload, attr))
         ):
             return []
         return CONTINUE


### PR DESCRIPTION
Replaced generator expressions with similar functions, such as `map` and `filter`. In addition, replaced an indented pair of `for` loops and `if` statement with a creation of `set`. It uses a generator expression and a call to `filter` to create it in one go. This way it avoids repeatedly appending to a list. Fixes #7433 .