### PR TITLE
Profiling of slow coroutines

### DIFF
--- a/src/tribler/core/utilities/slow_coro_detection/main_thread_stack_tracking.py
+++ b/src/tribler/core/utilities/slow_coro_detection/main_thread_stack_tracking.py
@@ -11,14 +11,17 @@ from tribler.core.utilities.slow_coro_detection import logger
 # without interruption.
 SWITCH_INTERVAL = 0.1
 
+
+_main_thread_stack_tracking_is_enabled: bool = False
+
+
+# If the main thread stack tracing is enabled, the list contains frames for stack of the main thread.
+# The second element of a tuple is a frame's start time. We use tuple and not dataclass here for performance reasons.
 _main_thread_stack: List[FrameType] = []
 
 
-_main_stack_tracking_activated: bool = False
-
-
-def main_stack_tracking_is_activated() -> bool:
-    return _main_stack_tracking_activated
+def main_stack_tracking_is_enabled() -> bool:
+    return _main_thread_stack_tracking_is_enabled
 
 
 def main_thread_profile(frame: FrameType, event: str, _):
@@ -44,8 +47,8 @@ def start_main_thread_stack_tracing() -> Callable:
     Returns the profiler function (for testing purpose)
     """
     logger.info('Start tracing of coroutine stack to show stack for slow coroutines (makes code execution slower)')
-    global _main_stack_tracking_activated  # pylint: disable=global-statement
-    _main_stack_tracking_activated = True
+    global _main_thread_stack_tracking_is_enabled  # pylint: disable=global-statement
+    _main_thread_stack_tracking_is_enabled = True
     sys.setprofile(main_thread_profile)
     return main_thread_profile
 
@@ -57,8 +60,8 @@ def stop_main_thread_stack_tracing() -> Callable:
     """
     previous_profiler = sys.getprofile()
     sys.setprofile(None)
-    global _main_stack_tracking_activated  # pylint: disable=global-statement
-    _main_stack_tracking_activated = False
+    global _main_thread_stack_tracking_is_enabled  # pylint: disable=global-statement
+    _main_thread_stack_tracking_is_enabled = False
     return previous_profiler
 
 

--- a/src/tribler/core/utilities/slow_coro_detection/profiler.py
+++ b/src/tribler/core/utilities/slow_coro_detection/profiler.py
@@ -1,0 +1,111 @@
+import cProfile
+import logging
+import pstats
+import io
+import sys
+import time
+from functools import wraps
+from types import FunctionType
+from typing import List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+def profile(func: Optional[FunctionType] = None, /, *,
+            sort_order: pstats.SortKey = pstats.SortKey.TIME, threshold_duration: float = 0.1):
+    """
+    Enables profiling for the wrapped function.
+
+    Example 1:
+        >>> @profile:
+        ... def my_function():
+                ...
+
+    Example 2:
+        >>> @profile(threshold_duration=1.0):
+        ... def my_function():
+                ...
+
+    Args:
+        func: positional-only argument for a function, used when the decorator is specified without parentheses;
+        sort_order: how to sort the output, by default it's the time inside the function itself without nested calls;
+        threshold_duration: do not print statistics if the function executed faster than the threshold duration.
+    """
+    def profile_decorator(func: FunctionType):
+        @wraps(func)
+        def profile_wrapper(*args, **kwargs):
+            profiler = cProfile.Profile()
+
+            prev_profiler = sys.getprofile()
+            sys.setprofile(None)
+            try:
+                t = time.time()
+
+                profiler.enable()
+                try:
+                    result = func(*args, **kwargs)
+                finally:
+                    profiler.disable()
+
+                duration = time.time() - t
+            finally:
+                # To be able to combine the @profile decorator with the main thread stack tracing
+                sys.setprofile(prev_profiler)
+
+            if duration < threshold_duration:
+                logger.info(f'Profiled function `{func.__name__}` executed in {duration:.3f} seconds')
+            else:
+                stats = _get_statistics(profiler, sort_order)
+                logger.info(f'Profiled results for `{func.__name__}`:\n{stats}')
+
+            return result
+
+        return profile_wrapper
+
+    if func is not None:
+        return profile_decorator(func)
+
+    return profile_decorator
+
+
+def _get_statistics(profiler: cProfile.Profile, sort_order: pstats.SortKey) -> str:
+    stream = io.StringIO()
+    ps = pstats.Stats(profiler, stream=stream).sort_stats(sort_order.value)
+    _fix_fcn_list(ps)
+    ps.print_stats()
+    return stream.getvalue()
+
+
+def _fix_fcn_list(stats: pstats.Stats):
+    # The function fixes two problems with the default statistics output:
+    # 1. The default list of the function is very long, and most functions have an execution time of 0.000.
+    #    Let's remove fast functions to make statistics easier to read and make an accent on slow functions
+    # 2. Some dynamically generated functions have a weird multi-line name that includes the function source code;
+    #    these function names make the resulting table hard to read and understand. Let's simplify them a bit.
+    prev_func_list: List[Tuple[str, int, str]] = getattr(stats, 'fcn_list', [])
+    if not prev_func_list:
+        return  # pragma: no cover  # should not happen, added for extra safety
+
+    new_func_list: List[Tuple[str, int, str]] = []
+
+    stats_dict: dict = getattr(stats, 'stats', {})
+    for func_tuple in prev_func_list:
+        stat = stats_dict.get(func_tuple)
+        if stat is None:
+            continue  # pragma: no cover  # Should not happen, added for extra safety
+
+        cumulative_time = stat[3]
+        if cumulative_time < 0.0005:
+            continue  # The function is fast and its time will be displayed as 0.000, remove it to simplify statistics
+
+        func_file_name = func_tuple[0]
+        if '\n' in func_file_name:  # pragma: no cover  # tested manually
+            # The function is dynamically generated and have a weird multi-line name that makes statistics looks weird.
+            # Replace it with a shorter single-line name. Add a hash to the name to distinct theoretical duplicates.
+            fixed_file_name = func_file_name.strip().partition('\n')[0][:20] + f'... (name hash {id(func_file_name)})'
+            fixed_func_tuple = (fixed_file_name,) + func_tuple[1:]
+            stats_dict[fixed_func_tuple] = stats_dict[func_tuple]  # copy statistics from the old name to the new name
+            func_tuple = fixed_func_tuple
+
+        new_func_list.append(func_tuple)
+    stats.fcn_list = new_func_list

--- a/src/tribler/core/utilities/slow_coro_detection/tests/test_main_thread_stack_tracing.py
+++ b/src/tribler/core/utilities/slow_coro_detection/tests/test_main_thread_stack_tracing.py
@@ -54,8 +54,8 @@ def test_get_main_thread_stack_info():
     with patch('tribler.core.utilities.slow_coro_detection.main_thread_stack_tracking._main_thread_stack', stack):
         stack_info = _get_main_thread_stack_info()
 
-    assert stack_info == [('CO_NAME1', 'CO_FILENAME1', 111, start_time_1),
-                          ('CO_NAME2', 'CO_FILENAME2', 222, start_time_2)]
+    assert stack_info == [('CO_NAME1', 'CO_FILENAME1', 111, start_time_1, False),
+                          ('CO_NAME2', 'CO_FILENAME2', 222, start_time_2, False)]
     assert sys.getswitchinterval() == pytest.approx(test_switch_interval, abs=0.01)
     sys.setswitchinterval(prev_switch_interval)
 
@@ -63,13 +63,14 @@ def test_get_main_thread_stack_info():
 def test_get_main_thread_stack():
     t = time.time()
     stack_info = [
-        ('CO_NAME1', 'CO_FILENAME1', 111, t-4),  # This line is cut from the output because of limit=2
-        ('CO_NAME2', 'CO_FILENAME2', 222, t-3),
-        ('CO_NAME3', 'CO_FILENAME3', 333, t-2),
-        ('CO_NAME4', 'CO_FILENAME4', 444, t-1),  # This line is cut because we want to see the line where the last
-                                                 # slow function is called, not the line inside the last slow function
-        ('CO_NAME5', 'CO_FILENAME5', 555, t-0.02),  # This function is fast and not added to the stack
-        ('CO_NAME6', 'CO_FILENAME6', 666, t-0.01)   # This function is fast and not added to the stack
+        ('CO_NAME1', 'CO_FILENAME1', 111, t-4, False),  # This line is cut from the output because of limit=2
+        ('CO_NAME2', 'CO_FILENAME2', 222, t-3, False),
+        ('CO_NAME3', 'CO_FILENAME3', 333, t-2, False),
+        ('CO_NAME4', 'CO_FILENAME4', 444, t-1, False),  # This line is cut from the traceback because we want to see
+                                                        # the line where the last slow function is called, not the line
+                                                        # inside the last slow function
+        ('CO_NAME5', 'CO_FILENAME5', 555, t-0.02, False),  # This function is fast and not added to the stack
+        ('CO_NAME6', 'CO_FILENAME6', 666, t-0.01, False)   # This function is fast and not added to the stack
     ]
     with patch('tribler.core.utilities.slow_coro_detection.main_thread_stack_tracking._get_main_thread_stack_info',
                return_value=stack_info):

--- a/src/tribler/core/utilities/slow_coro_detection/tests/test_main_thread_stack_tracing.py
+++ b/src/tribler/core/utilities/slow_coro_detection/tests/test_main_thread_stack_tracing.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from tribler.core.utilities.slow_coro_detection.main_thread_stack_tracking import (
-    _get_main_thread_stack_info, get_main_thread_stack, main_stack_tracking_is_activated, main_thread_profile,
+    _get_main_thread_stack_info, get_main_thread_stack, main_stack_tracking_is_enabled, main_thread_profile,
     start_main_thread_stack_tracing,
     stop_main_thread_stack_tracing
 )
@@ -28,11 +28,11 @@ def test_main_thread_profile():
 
 
 def test_main_stack_tracking_is_activated():
-    assert not main_stack_tracking_is_activated()
+    assert not main_stack_tracking_is_enabled()
     activated_profiler = start_main_thread_stack_tracing()
-    assert main_stack_tracking_is_activated()
+    assert main_stack_tracking_is_enabled()
     deactivated_profiler = stop_main_thread_stack_tracing()
-    assert not main_stack_tracking_is_activated()
+    assert not main_stack_tracking_is_enabled()
     assert activated_profiler is deactivated_profiler
 
 

--- a/src/tribler/core/utilities/slow_coro_detection/tests/test_main_thread_stack_tracing.py
+++ b/src/tribler/core/utilities/slow_coro_detection/tests/test_main_thread_stack_tracing.py
@@ -1,4 +1,6 @@
+import re
 import sys
+import time
 from unittest.mock import Mock, patch
 
 import pytest
@@ -18,9 +20,9 @@ def test_main_thread_profile():
     with patch('tribler.core.utilities.slow_coro_detection.main_thread_stack_tracking._main_thread_stack', stack):
         assert not stack
 
-        result = main_thread_profile(frame, 'call', arg)
+        result = main_thread_profile(frame, 'call', arg, now=lambda: 123)
         assert result is main_thread_profile
-        assert stack == [frame]
+        assert stack == [(frame, 123)]
 
         result = main_thread_profile(frame, 'return', arg)
         assert result is main_thread_profile
@@ -37,13 +39,12 @@ def test_main_stack_tracking_is_activated():
 
 
 def test_get_main_thread_stack_info():
-    frame1 = Mock(f_lineno=111)
-    frame1.f_code.co_name = 'CO_NAME1'
-    frame1.f_code.co_filename = 'CO_FILENAME1'
-    frame2 = Mock(f_lineno=222)
-    frame2.f_code.co_name = 'CO_NAME2'
-    frame2.f_code.co_filename = 'CO_FILENAME2'
-    stack = [frame1, frame2]
+    frame1 = Mock(f_lineno=111, f_code=Mock(co_name='CO_NAME1', co_filename='CO_FILENAME1'))
+    frame2 = Mock(f_lineno=222, f_code=Mock(co_name='CO_NAME2', co_filename='CO_FILENAME2'))
+    start_time_1 = time.time() - 2
+    start_time_2 = time.time() - 1
+
+    stack = [(frame1, start_time_1), (frame2, start_time_2)]
 
     prev_switch_interval = sys.getswitchinterval()
     test_switch_interval = 10.0
@@ -53,19 +54,23 @@ def test_get_main_thread_stack_info():
     with patch('tribler.core.utilities.slow_coro_detection.main_thread_stack_tracking._main_thread_stack', stack):
         stack_info = _get_main_thread_stack_info()
 
-    assert stack_info == [('CO_NAME1', 'CO_FILENAME1', 111), ('CO_NAME2', 'CO_FILENAME2', 222)]
+    assert stack_info == [('CO_NAME1', 'CO_FILENAME1', 111, start_time_1),
+                          ('CO_NAME2', 'CO_FILENAME2', 222, start_time_2)]
     assert sys.getswitchinterval() == pytest.approx(test_switch_interval, abs=0.01)
     sys.setswitchinterval(prev_switch_interval)
 
 
 def test_get_main_thread_stack():
-    stack_info = [('CO_NAME1', 'CO_FILENAME1', 111), ('CO_NAME2', 'CO_FILENAME2', 222)]
+    t = time.time()
+    stack_info = [('CO_NAME1', 'CO_FILENAME1', 111, t-2), ('CO_NAME2', 'CO_FILENAME2', 222, t-1)]
     with patch('tribler.core.utilities.slow_coro_detection.main_thread_stack_tracking._get_main_thread_stack_info',
                return_value=stack_info):
         with patch('linecache.getline', side_effect=['line1', 'line2']):
-            stack = get_main_thread_stack()
-    assert stack == 'Traceback (most recent call last):\n' \
-                    '  File "CO_FILENAME1", line 111, in CO_NAME1\n' \
-                    '    line1\n' \
-                    '  File "CO_FILENAME2", line 222, in CO_NAME2\n' \
-                    '    line2\n'
+            stack_str = get_main_thread_stack()
+
+    traceback_re = re.compile(r'Traceback \(most recent call last\):\n'
+                              r'  File "CO_FILENAME1", line 111, in CO_NAME1 \(function started [0-9.]* seconds ago\)\n'
+                              r'    line1\n'
+                              r'  File "CO_FILENAME2", line 222, in CO_NAME2 \(function started [0-9.]* seconds ago\)\n'
+                              r'    line2\n')
+    assert traceback_re.match(stack_str)

--- a/src/tribler/core/utilities/slow_coro_detection/tests/test_profile.py
+++ b/src/tribler/core/utilities/slow_coro_detection/tests/test_profile.py
@@ -1,0 +1,48 @@
+import time
+
+from _pytest.logging import LogCaptureFixture
+
+from tribler.core.utilities.slow_coro_detection.profiler import profile
+
+
+def profiled_function():
+    function1()
+    function2()
+    function3()
+
+
+def function1():
+    pass
+
+
+def function2():
+    time.sleep(0.02)
+
+
+def function3():
+    time.sleep(0.01)
+
+
+def test_profile(caplog: LogCaptureFixture):
+    f = profile(threshold_duration=0.0)(profiled_function)
+    f()
+
+    log_text = caplog.text
+    assert 'Profiled results for `profiled_function`:' in log_text
+    assert '{built-in method time.sleep}' in log_text
+    assert '(profiled_function)' in log_text
+    assert '(function1)' not in log_text
+    assert '(function2)' in log_text
+    assert '(function3)' in log_text
+    assert log_text.index('{built-in method time.sleep}') < log_text.index('(profiled_function)')
+    assert log_text.index('{built-in method time.sleep}') < log_text.index('(function2)')
+    assert log_text.index('{built-in method time.sleep}') < log_text.index('(function3)')
+
+
+def test_fast_profile_no_stats(caplog: LogCaptureFixture):
+    f = profile(threshold_duration=1.0)(profiled_function)
+    f()
+
+    log_text = caplog.text
+    assert 'Profiled function `profiled_function` executed in' in log_text
+    assert 'Profiled results for `profiled_function`:' not in log_text

--- a/src/tribler/core/utilities/slow_coro_detection/tests/test_slow_coro_detection.py
+++ b/src/tribler/core/utilities/slow_coro_detection/tests/test_slow_coro_detection.py
@@ -1,5 +1,7 @@
 from unittest.mock import Mock, patch
 
+import pytest
+
 from tribler.core.utilities.slow_coro_detection.patch import _report_long_duration, patched_handle_run
 from tribler.core.utilities.slow_coro_detection.watching_thread import SlowCoroWatchingThread, _report_freeze
 
@@ -82,7 +84,7 @@ def test__report_freeze_first_report(logger, format_info):
     duration = 10
 
     _report_freeze(handle, duration, first_report=True)
-    format_info.assert_called_with(handle, include_stack=True)
+    format_info.assert_called_with(handle, include_stack=True, stack_cut_duration=pytest.approx(8.0))
     logger.error.assert_called_with(
         'Slow coroutine is occupying the loop for 10.000 seconds already: <formatted handle>')
 
@@ -94,5 +96,5 @@ def test__report_freeze_not_first_report(logger, format_info):
     duration = 10
 
     _report_freeze(handle, duration, first_report=False)
-    format_info.assert_called_with(handle, include_stack=False)
+    format_info.assert_called_with(handle, include_stack=True, stack_cut_duration=pytest.approx(8.0), limit=2)
     logger.error.assert_called_with('Still executing <formatted handle>')

--- a/src/tribler/core/utilities/slow_coro_detection/tests/test_slow_coro_detection.py
+++ b/src/tribler/core/utilities/slow_coro_detection/tests/test_slow_coro_detection.py
@@ -96,5 +96,6 @@ def test__report_freeze_not_first_report(logger, format_info):
     duration = 10
 
     _report_freeze(handle, duration, first_report=False)
-    format_info.assert_called_with(handle, include_stack=True, stack_cut_duration=pytest.approx(8.0), limit=2)
+    format_info.assert_called_with(handle, include_stack=True, stack_cut_duration=pytest.approx(8.0),
+                                   limit=2, enable_profiling_tip=False)
     logger.error.assert_called_with('Still executing <formatted handle>')

--- a/src/tribler/core/utilities/slow_coro_detection/utils.py
+++ b/src/tribler/core/utilities/slow_coro_detection/utils.py
@@ -10,7 +10,7 @@ from tribler.core.utilities.slow_coro_detection.main_thread_stack_tracking impor
 
 
 def format_info(handle: Handle, include_stack: bool = False, stack_cut_duration: Optional[float] = None,
-                limit: Optional[int] = None) -> str:
+                limit: Optional[int] = None, enable_profiling_tip: bool = True) -> str:
     """
     Returns the representation of a task executed by asyncio, with or without the stack.
     """
@@ -27,5 +27,5 @@ def format_info(handle: Handle, include_stack: bool = False, stack_cut_duration:
         task.print_stack(limit=limit, file=stream)
         stack = stream.getvalue()
     else:
-        stack = get_main_thread_stack(stack_cut_duration, limit)
+        stack = get_main_thread_stack(stack_cut_duration, limit, enable_profiling_tip)
     return f"{task}\n{stack}"

--- a/src/tribler/core/utilities/slow_coro_detection/utils.py
+++ b/src/tribler/core/utilities/slow_coro_detection/utils.py
@@ -15,8 +15,11 @@ def format_info(handle: Handle, include_stack: bool = False) -> str:
     """
     func = handle._callback
     task: Task = getattr(func, '__self__', None)
-    if not isinstance(task, Task) or not include_stack:
+    if not isinstance(task, Task):
         return repr(func)
+
+    if not include_stack:
+        return repr(task)
 
     if not main_stack_tracking_is_activated():
         stream = io.StringIO()

--- a/src/tribler/core/utilities/slow_coro_detection/utils.py
+++ b/src/tribler/core/utilities/slow_coro_detection/utils.py
@@ -6,7 +6,7 @@ from asyncio import Handle, Task
 
 
 from tribler.core.utilities.slow_coro_detection.main_thread_stack_tracking import get_main_thread_stack, \
-    main_stack_tracking_is_activated
+    main_stack_tracking_is_enabled
 
 
 def format_info(handle: Handle, include_stack: bool = False) -> str:
@@ -21,7 +21,7 @@ def format_info(handle: Handle, include_stack: bool = False) -> str:
     if not include_stack:
         return repr(task)
 
-    if not main_stack_tracking_is_activated():
+    if not main_stack_tracking_is_enabled():
         stream = io.StringIO()
         task.print_stack(limit=3, file=stream)
         stack = stream.getvalue()

--- a/src/tribler/core/utilities/slow_coro_detection/utils.py
+++ b/src/tribler/core/utilities/slow_coro_detection/utils.py
@@ -1,6 +1,6 @@
 import io
 from asyncio import Handle, Task
-
+from typing import Optional
 
 # pylint: disable=protected-access
 
@@ -9,7 +9,8 @@ from tribler.core.utilities.slow_coro_detection.main_thread_stack_tracking impor
     main_stack_tracking_is_enabled
 
 
-def format_info(handle: Handle, include_stack: bool = False) -> str:
+def format_info(handle: Handle, include_stack: bool = False, stack_cut_duration: Optional[float] = None,
+                limit: Optional[int] = None) -> str:
     """
     Returns the representation of a task executed by asyncio, with or without the stack.
     """
@@ -23,8 +24,8 @@ def format_info(handle: Handle, include_stack: bool = False) -> str:
 
     if not main_stack_tracking_is_enabled():
         stream = io.StringIO()
-        task.print_stack(limit=3, file=stream)
+        task.print_stack(limit=limit, file=stream)
         stack = stream.getvalue()
     else:
-        stack = get_main_thread_stack()
+        stack = get_main_thread_stack(stack_cut_duration, limit)
     return f"{task}\n{stack}"

--- a/src/tribler/core/utilities/slow_coro_detection/watching_thread.py
+++ b/src/tribler/core/utilities/slow_coro_detection/watching_thread.py
@@ -91,5 +91,6 @@ def _report_freeze(handle: Handle, duration: float, first_report: bool):
         logger.error(f'Slow coroutine is occupying the loop for {duration:.3f} seconds already: {info_str}')
         return
 
-    info_str = format_info(handle, include_stack=True, stack_cut_duration=stack_cut_duration, limit=2)
+    info_str = format_info(handle, include_stack=True, stack_cut_duration=stack_cut_duration, limit=2,
+                           enable_profiling_tip=False)
     logger.error(f"Still executing {info_str}")

--- a/src/tribler/core/utilities/slow_coro_detection/watching_thread.py
+++ b/src/tribler/core/utilities/slow_coro_detection/watching_thread.py
@@ -82,10 +82,14 @@ class SlowCoroWatchingThread(Thread):
 
 
 def _report_freeze(handle: Handle, duration: float, first_report: bool):
+    # When printing the stack, we only want to show the stack frames executing long enough,
+    # as displaying the entire stack can confuse the reader and mislead him regarding what function should be optimized
+    stack_cut_duration = duration * 0.8
+
     if first_report:
-        info_str = format_info(handle, include_stack=True)
+        info_str = format_info(handle, include_stack=True, stack_cut_duration=stack_cut_duration)
         logger.error(f'Slow coroutine is occupying the loop for {duration:.3f} seconds already: {info_str}')
         return
 
-    info_str = format_info(handle, include_stack=False)
+    info_str = format_info(handle, include_stack=True, stack_cut_duration=stack_cut_duration, limit=2)
     logger.error(f"Still executing {info_str}")


### PR DESCRIPTION
This PR does a bunch of changes to slow the coroutine detection mechanism:
1. It adds a duration for each line of the main stack trace so it becomes possible to see how long we are already into this function call, like `function started 1.268 seconds ago`.
2. It limits the number of displayed stack frames to show only the relevant function calls, so, at the last line of the traceback, you can see the actual function that causes the slowness (and not some arbitrary nested functions that happen to be executed at the moment of the periodic snapshot).
3. It adds a `@profile` decorator that logs statistics for the function and allows a developer to find the reason for its slowness and adds to the traceback a tip to use this decorator, which includes mentioning the function it should be applied to.

This is how the current traceback looks after the PR changes:
```
[tribler-core PID:23024] 2023-05-30 17:16:41,890 - ERROR <watching_thread:91> tribler.core.utilities.slow_coro_detection._report_freeze(): Slow coroutine is occupying the loop for 0.618 seconds already: <Task pending name='GigaChannelCommunity:take step' coro=<interval_runner() running at C:\dev\py-ipv8\ipv8\taskmanager.py:18> cb=[TaskManager.register_task.<locals>.done_cb() at C:\dev\py-ipv8\ipv8\taskmanager.py:128]>
Traceback (most recent call last):
  File "C:\dev\tribler\src\tribler\core\start_core.py", line 205, in run_core (function started 27.965 seconds ago)
    exit_code = run_tribler_core_session(api_port, api_key, state_dir, gui_test_mode=parsed_args.gui_test_mode)
  File "C:\dev\tribler\src\tribler\core\start_core.py", line 170, in run_tribler_core_session (function started 27.924 seconds ago)
    exit_code = loop.run_until_complete(core_session(config, components=list(components_gen(config))))
  File "C:\Python39\lib\asyncio\base_events.py", line 629, in run_until_complete (function started 27.912 seconds ago)
    self.run_forever()
  File "C:\Python39\lib\asyncio\base_events.py", line 596, in run_forever (function started 27.912 seconds ago)
    self._run_once()
  File "C:\Python39\lib\asyncio\base_events.py", line 1890, in _run_once (function started 0.618 seconds ago)
    handle._run()
  File "C:\dev\tribler\src\tribler\core\utilities\slow_coro_detection\patch.py", line 37, in patched_handle_run (function started 0.618 seconds ago)
    _original_handle_run(self)
  File "C:\Python39\lib\asyncio\events.py", line 80, in _run (function started 0.618 seconds ago)
    self._context.run(self._callback, *self._args)
  File "C:\dev\py-ipv8\ipv8\taskmanager.py", line 18, in interval_runner (function started 0.618 seconds ago)
    await task(*args)
  File "C:\dev\py-ipv8\ipv8\util.py", line 35, in call_async (function started 0.618 seconds ago)
    return func(*args, **kwargs)
  File "C:\dev\tribler\src\tribler\core\components\ipv8\discovery_booster.py", line 84, in take_step (function started 0.618 seconds ago)
    self.walker.take_step()

Tip: by applying the `@profile()` decorator to the `take_step` function, you can obtain statistics for its internal calls and see the reason for slowness
```
You can see the duration in each line, a much shorter stack, and a tip at the end.

4. If function execution continues for too long, the periodic logging of the current freeze now includes a limited stack (2 frames only)
```
[tribler-core PID:23024] 2023-05-30 17:16:42,540 - ERROR <watching_thread:96> tribler.core.utilities.slow_coro_detection._report_freeze(): Still executing <Task pending name='GigaChannelCommunity:take step' coro=<interval_runner() running at C:\dev\py-ipv8\ipv8\taskmanager.py:18> cb=[TaskManager.register_task.<locals>.done_cb() at C:\dev\py-ipv8\ipv8\taskmanager.py:128]>
Traceback (most recent call last):
  File "C:\dev\py-ipv8\ipv8\util.py", line 35, in call_async (function started 1.268 seconds ago)
    return func(*args, **kwargs)
  File "C:\dev\tribler\src\tribler\core\components\ipv8\discovery_booster.py", line 84, in take_step (function started 1.268 seconds ago)
    self.walker.take_step()

[tribler-core PID:23024] 2023-05-30 17:16:43,070 - ERROR <watching_thread:96> tribler.core.utilities.slow_coro_detection._report_freeze(): Still executing <Task pending name='GigaChannelCommunity:take step' coro=<interval_runner() running at C:\dev\py-ipv8\ipv8\taskmanager.py:18> cb=[TaskManager.register_task.<locals>.done_cb() at C:\dev\py-ipv8\ipv8\taskmanager.py:128]>
Traceback (most recent call last):
  File "C:\dev\py-ipv8\ipv8\util.py", line 35, in call_async (function started 1.798 seconds ago)
    return func(*args, **kwargs)
  File "C:\dev\tribler\src\tribler\core\components\ipv8\discovery_booster.py", line 84, in take_step (function started 1.798 seconds ago)
    self.walker.take_step()
```

Internally, both main thread stack tracing and function profiler use the same mechanism for tracking the execution, so they are written in a compatible way. When the profiler decorator starts profiling the specific function, it temporarily turns off the main thread stack tracing and turns it on again after the profiling is done.

The statistics generated by the profiler go through important cosmetic updates before it is printed to the logs. First, some functions in Tribler are auto-generated, and their filenames actually contain the entire source code of the function, which destroys the profiler output. The cleanup fixes the names for such functions so they can be displayed in a table alongside other functions. Second, internal calls that a very fast are removed from the resulting statistics, so only functions that affect the execution time are shown in the statistics output; the function that makes the most slowdown is shown first.

