### PR TITLE
[WIP] Python 3.11 Support

### DIFF
--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -20,10 +20,10 @@ pyyaml==6.0
 sentry-sdk==1.14.0
 service-identity==21.1.0
 yappi==1.4.0
-yarl==1.7.2 # keep this dependency higher than 1.6.3. See: https://github.com/aio-libs/yarl/issues/517
+yarl==1.8.2 # keep this dependency higher than 1.6.3. See: https://github.com/aio-libs/yarl/issues/517
 bitarray==2.5.1
 pyipv8==2.10.0
-libtorrent==1.2.15
+libtorrent==1.2.19
 file-read-backwards==2.0.0
 Brotli==1.0.9 # to prevent AttributeError on macOs: module 'brotli' has no attribute 'error' (in urllib3.response)
 human-readable==1.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@
 
 Pillow==9.3.0
 PyQt5==5.15.1
-PyQt5-sip==12.8.1
+PyQt5-sip==12.11.1
 pyqtgraph==0.12.3
 PyQtWebEngine==5.15.2


### PR DESCRIPTION
This PR updates dependencies for Python 3.11 support (#7282). This PR depends on unmerged changes and, as such, is not ready to be merged. In summary, I applied the following dependency changes for 3.11 to function (on Apple Silicon):

- Libtorrent: https://github.com/InvictusRMC/libtorrent/commit/3e2ffa77803e717c682fa99b6fec8558113a850a
  - This requires building from source 
- Pony: https://github.com/ponyorm/pony/pull/671
- Python packages: Yarl, PyQt5.