### PR TITLE
Fix the step interval of DiscoveryBooster

### DIFF
--- a/src/tribler/core/components/gigachannel/community/gigachannel_community.py
+++ b/src/tribler/core/components/gigachannel/community/gigachannel_community.py
@@ -105,7 +105,7 @@ class GigaChannelCommunity(RemoteQueryCommunity):
         # peer twice. If we do, this should happen really rarely
         self.queried_peers = set()
 
-        self.discovery_booster = DiscoveryBooster(timeout_in_sec=60)
+        self.discovery_booster = DiscoveryBooster()
         self.discovery_booster.apply(self)
 
         self.channels_peers = ChannelsPeersMapping()

--- a/src/tribler/core/components/ipv8/discovery_booster.py
+++ b/src/tribler/core/components/ipv8/discovery_booster.py
@@ -14,7 +14,7 @@ class DiscoveryBooster:
 
     # fmt: off
 
-    def __init__(self, timeout_in_sec: float = 10.0, take_step_interval_in_sec: float = 0.05,
+    def __init__(self, timeout_in_sec: float = 120.0, take_step_interval_in_sec: float = 0.5,
                  walker: DiscoveryStrategy = None):
         """
 


### PR DESCRIPTION
According to @qstokkink, the previously specified step interval of 0.05 seconds is too small, as the time between steps may not be enough to receive responses from other peers after the previous walk step. In this PR, I increase the time between steps and proportionally increase the timeout to be sure that the total number of steps is similar to the previous value (it was: 200 steps, now: 240 steps, a bit more)