### PR TITLE
Add extended logging to RESTManager.site.start() call

### DIFF
--- a/src/tribler/core/components/restapi/rest/rest_manager.py
+++ b/src/tribler/core/components/restapi/rest/rest_manager.py
@@ -143,7 +143,9 @@ class RESTManager:
                         port = api_port + bind_attempts
                         self.site = web.TCPSite(self.runner, self.http_host, port,
                                                 shutdown_timeout=self.shutdown_timeout)
+                        self._logger.info(f"Starting HTTP REST API server on port {port}...")
                         await self.site.start()
+                        self._logger.info(f"HTTP REST API server started on port {port}")
                         self.set_api_port(port)
                         break
                     except OSError:

--- a/src/tribler/core/components/restapi/rest/rest_manager.py
+++ b/src/tribler/core/components/restapi/rest/rest_manager.py
@@ -148,8 +148,14 @@ class RESTManager:
                         self._logger.info(f"HTTP REST API server started on port {port}")
                         self.set_api_port(port)
                         break
-                    except OSError:
+
+                    except OSError as e:
+                        self._logger.warning(f"{e.__class__.__name__}: {e}")
                         bind_attempts += 1
+
+                    except BaseException as e:
+                        self._logger.error(f"{e.__class__.__name__}: {e}")
+                        raise  # an unexpected exception; propagate it
 
             self._logger.info("Started HTTP REST API: %s", self.site.name)
 


### PR DESCRIPTION
The  `await RESTManager.site.start()` call should be fast, but it looks like it hangs sometimes. In this PR, I added extended logging when calling `site.start()` and a timeout. It should allow understanding of what is going on in some rare cases when the site.start() appears to hang.