### PR TITLE
Increase the size of log files and the number of log file backups

### DIFF
--- a/src/tribler/core/logger/logger.yaml
+++ b/src/tribler/core/logger/logger.yaml
@@ -18,8 +18,8 @@ handlers:
     level: INFO
     formatter: standard
     filename: TRIBLER_INFO_LOG_FILE
-    maxBytes: 102400 # 100KB
-    backupCount: 1
+    maxBytes: 1048576  # 1 megabyte
+    backupCount: 2
     encoding: utf8
 
   info_memory_handler:
@@ -33,8 +33,8 @@ handlers:
     level: ERROR
     formatter: error
     filename: TRIBLER_ERROR_LOG_FILE
-    maxBytes: 102400 # 100KB
-    backupCount: 1
+    maxBytes: 1048576  # 1 megabyte
+    backupCount: 2
     encoding: utf8
 
   error_memory_handler:


### PR DESCRIPTION
The current size of log files is 100 kilobytes per file, with one backup file for each log file. It is too small if we are trying to find the error details in log files, as the file got deleted quickly.

In this PR, I slightly increase the size of log files: from 100 kilobytes to 1 megabyte and the number of log file backups from 1 to 2.

As a result, we should have 6 log files (`tribler-gui-info.log`, 'tribler-gui-error.log', `tribler-core-info.log`, and `tribler-core-error.log`) of 1 megabyte each and two backups for each file, 12 megabytes in total (still not too much).