### PR TITLE
Fix/unminimizing when clicking on file

### DIFF
--- a/src/tribler/gui/single_application.py
+++ b/src/tribler/gui/single_application.py
@@ -89,7 +89,7 @@ class QtSingleApplication(QApplication):
         self._incoming_stream.setCodec('UTF-8')
         connect(self._incoming_connection.readyRead, self._on_ready_read)
         if self.tribler_window:
-            self.tribler_window.restore_from_minimised()
+            self.tribler_window.raise_window()
 
     def _on_ready_read(self):
         while True:

--- a/src/tribler/gui/tribler_window.py
+++ b/src/tribler/gui/tribler_window.py
@@ -1250,10 +1250,6 @@ class TriblerWindow(QMainWindow):
         if event.key() == Qt.Key_Escape:
             self.escape_pressed.emit()
 
-    def restore_from_minimised(self):
-        self.setWindowState(self.windowState() & ~Qt.WindowMinimized)
-        self.raise_()
-
     def handle_uri(self, uri):
         self.pending_uri_requests.append(uri)
         if self.tribler_started and not self.start_download_dialog_active:


### PR DESCRIPTION
This PR fixes #7462 by using the same method, `TriblerWindow.raise_window()` in both cases: when a user clicks on the Tribler icon in the taskbar notification area and when the user double-clicks the torrent file.