### PR TITLE
Fix the download torrent dialog behavior after closing it by clicking somewhere outside the dialog area

### DIFF
--- a/src/tribler/gui/dialogs/dialogcontainer.py
+++ b/src/tribler/gui/dialogs/dialogcontainer.py
@@ -29,6 +29,9 @@ class DialogContainer(AddBreadcrumbOnShowMixin, QWidget):
         self.style().drawPrimitive(QStyle.PE_Widget, opt, painter, self)
 
     def close_dialog(self, checked=False):
+        if self.closed:
+            return
+
         try:
             self.close_event.emit()
             self.setParent(None)

--- a/src/tribler/gui/dialogs/startdownloaddialog.py
+++ b/src/tribler/gui/dialogs/startdownloaddialog.py
@@ -120,6 +120,9 @@ class StartDownloadDialog(DialogContainer):
         self.rest_request = None
 
     def close_dialog(self, checked=False):
+        if self.closed:
+            return
+
         if self.rest_request:
             self.rest_request.cancel()
 
@@ -134,6 +137,7 @@ class StartDownloadDialog(DialogContainer):
             except RuntimeError:
                 logging.debug("Deleting loading files widget in the dialog widget failed.")
 
+        self.window().start_download_dialog_active = False
         super().close_dialog()
 
     def perform_files_request(self):


### PR DESCRIPTION
This PR fixes #7464

First, it resets the `TriblerWindow.start_download_dialog_active` flag to False when the dialog is closed.
Before this fix, Tribler assumed that the dialog was already opened and did not open it again in some situations.

Second, it fixes the Tribler crash when Tribler attempts to close and destroy the same dialog twice due to a contrived internal UI logic.

The reason for the crash: clicking on the area outside of the dialog triggers the `DialogContainer.mouseReleaseEvent` method:
```python
    def mouseReleaseEvent(self, qevent):
        # Close the dialog window if user clicks outside it
        if not self.dialog_widget.geometry().contains(qevent.localPos().toPoint()):
            self.close_dialog()
```
that closes the dialog without resetting the `self.dialog` attribute of `TriblerWindow` to `None`. On the next attempt to open the dialog, `TriblerWindow` performs
```python
        if self.dialog:
            self.dialog.close_dialog()
```
That tries to destroy the same dialog the second time, and that leads to RuntimeError.

So, in this PR, I check that the dialog was already closed and, in that case, do not perform the `close_dialog` code again.

Another way to fix the problem may be to set `self.dialog` of `TriblerWindow` to `None`, but it may be harder to do, as:
* This attribute is reused by several dialog windows;
* The `mouseReleaseEvent`, where we should reset `self.dialog` to `None`, is used by multiple classes of dialog windows;
* Not all dialog windows use `self.dialog` attribute of `TriblerWindow`.

Later we can refactor the code of Tribler dialog windows to streamline the logic.