### PR TITLE
Fixes #7406 UnicodeDecodeError in on_tracker_error_alert

### DIFF
--- a/src/tribler/core/components/libtorrent/download_manager/download.py
+++ b/src/tribler/core/components/libtorrent/download_manager/download.py
@@ -312,12 +312,12 @@ class Download(TaskManager):
         self.tracker_status[alert.url] = [alert.num_peers, 'Working']
 
     def on_tracker_error_alert(self, alert: lt.tracker_error_alert):
-        self._logger.error(f'On tracker error alert: {alert}')
-
-        # try-except block here is a workaround and has been added to solve
-        # the issue: "UnicodeDecodeError: invalid continuation byte"
+        # The try-except block is added as a workaround to suppress UnicodeDecodeError in `repr(alert)`,
+        # `alert.url` and `alert.msg`. See https://github.com/arvidn/libtorrent/issues/143
         try:
+            self._logger.error(f'On tracker error alert: {alert}')
             url = alert.url
+
             peers = self.tracker_status[url][0] if url in self.tracker_status else 0
             if alert.msg:
                 status = 'Error: ' + alert.msg
@@ -330,8 +330,7 @@ class Download(TaskManager):
 
             self.tracker_status[url] = [peers, status]
         except UnicodeDecodeError as e:
-            self._logger.exception(e)
-            return
+            self._logger.warning(f'UnicodeDecodeError in on_tracker_error_alert: {e}')
 
     def on_tracker_warning_alert(self, alert: lt.tracker_warning_alert):
         self._logger.warning(f'On tracker warning alert: {alert}')


### PR DESCRIPTION
This PR fixes #7406 by moving the `self._logger.error` call into the try/except block. It also replaces `self._logger.exception` with `self._logger.warning` in case of an error, as the error's origin is known and handled adequately by the workaround.

Initially, in the discussion of #7410, I suggested adding a `safe_repr` function to wrap `alert` with it, but according to https://github.com/arvidn/libtorrent/issues/143, `on_tracker_error_alert` is the only place where the error can happen, so it is not necessary to implement a reusable function for `safe_alert`, as other `on_xyz_alert` handlers do not require a fix.