### PR TITLE
Fixes #7467 ConnectionResetError

### DIFF
--- a/src/tribler/core/components/restapi/rest/rest_manager.py
+++ b/src/tribler/core/components/restapi/rest/rest_manager.py
@@ -53,6 +53,11 @@ class ApiKeyMiddleware:
 async def error_middleware(request, handler):
     try:
         response = await handler(request)
+    except ConnectionResetError:
+        # A client closes the connection. It is not the Core error, nothing to handle or report this.
+        # We cannot return response, as the connection is already closed, so we just propagate the exception
+        # without reporting it to Sentry. The exception will be printed to the log by aiohttp.server.log_exception()
+        raise
     except HTTPNotFound:
         return RESTResponse({'error': {
             'handled': True,


### PR DESCRIPTION
This PR fixes #7467 by re-raising the error without sending it to Sentry. The error will be printed to the log by `aiohttp.server.log_exception()` and will look like this:

```
[tribler-core PID:5432] 2023-06-09 15:00:49,051 - ERROR <web_protocol:406> aiohttp.server.log_exception(): Error handling request
Traceback (most recent call last):
  File "C:\dev\tribler\venv\lib\site-packages\aiohttp\web_protocol.py", line 436, in _handle_request
    resp = await request_handler(request)
  File "C:\dev\tribler\venv\lib\site-packages\sentry_sdk\integrations\aiohttp.py", line 121, in sentry_app_handle
    reraise(*_capture_exception(hub))
  File "C:\dev\tribler\venv\lib\site-packages\sentry_sdk\_compat.py", line 54, in reraise
    raise value
  File "C:\dev\tribler\venv\lib\site-packages\sentry_sdk\integrations\aiohttp.py", line 111, in sentry_app_handle
    response = await old_handle(self, request)
  File "C:\dev\tribler\venv\lib\site-packages\aiohttp\web_app.py", line 504, in _handle
    resp = await handler(request)
  File "C:\dev\tribler\venv\lib\site-packages\aiohttp\web_middlewares.py", line 117, in impl
    return await handler(request)
  File "C:\dev\tribler\src\tribler\core\components\restapi\rest\rest_manager.py", line 39, in __call__
    return await handler(request)
  File "C:\dev\tribler\src\tribler\core\components\restapi\rest\rest_manager.py", line 55, in error_middleware
    response = await handler(request)
  File "C:\dev\tribler\venv\lib\site-packages\aiohttp\web_middlewares.py", line 117, in impl
    return await handler(request)
  File "C:\dev\tribler\src\tribler\core\components\libtorrent\restapi\downloads_endpoint.py", line 493, in update_download
    raise ConnectionResetError('Connection lost')
ConnectionResetError: Connection lost
```

It may be worthwhile to suppress the traceback for this type of error to avoid spamming the log with unnecessary tracebacks, but apparently, AIOHTTP does not allow it.