### PR TITLE
Modify the pytest output to include the execution duration for all tests

### DIFF
--- a/src/tribler/core/conftest.py
+++ b/src/tribler/core/conftest.py
@@ -3,6 +3,7 @@ import logging
 import os
 import platform
 import sys
+import time
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -36,6 +37,15 @@ sys.set_coroutine_origin_tracking_depth(10)
 def pytest_configure(config):  # pylint: disable=unused-argument
     # Disable logging from faker for all tests
     logging.getLogger('faker.factory').propagate = False
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_protocol(item, log=True, nextitem=None):  # pylint: disable=unused-argument
+    """ Modify the pytest output to include the execution duration for all tests """
+    start_time = time.time()
+    yield
+    duration = time.time() - start_time
+    print(f' in {duration:.3f}s', end='')
 
 
 @pytest.fixture(name="tribler_root_dir")

--- a/src/tribler/gui/tests/conftest.py
+++ b/src/tribler/gui/tests/conftest.py
@@ -1,4 +1,5 @@
 import logging
+import time
 
 import pytest
 
@@ -26,3 +27,12 @@ def pytest_collection_modifyitems(config, items):
     for item in items:
         if "guitest" in item.keywords:
             item.add_marker(skip_guitests)
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_protocol(item, log=True, nextitem=None):  # pylint: disable=unused-argument
+    """ Modify the pytest output to include the execution duration for all tests """
+    start_time = time.time()
+    yield
+    duration = time.time() - start_time
+    print(f' in {duration:.3f}s', end='')


### PR DESCRIPTION
This PR helps to reveal the root cause of #7132 by adding the execution duration of each test to the pytest output.

The modified output looks like this:

```python
src/tribler/core/utilities/async_group/tests/test_async_group.py::test_del_error PASSED [ 11%] in 0.005s
src/tribler/core/utilities/async_group/tests/test_async_group.py::test_del_no_error PASSED [ 11%] in 0.005s
src/tribler/core/utilities/async_group/tests/test_async_group.py::test_add_task_when_cancelled PASSED [ 11%] in 0.005s
src/tribler/core/components/gigachannel/community/tests/test_gigachannel_community.py::TestGigaChannelUnits::test_remote_select_channel_timeout PASSED [ 11%] in 0.259s
src/tribler/core/components/gigachannel/community/tests/test_gigachannel_community.py::TestGigaChannelUnits::test_remote_search_mapped_peers PASSED [ 11%] in 0.339s
src/tribler/core/components/gigachannel/community/tests/test_gigachannel_community.py::TestGigaChannelUnits::test_drop_silent_peer_empty_response_packet PASSED [ 11%] in 0.227s
src/tribler/core/components/gigachannel/community/tests/test_gigachannel_community.py::TestGigaChannelUnits::test_gigachannel_search PASSED [ 12%] in 0.965s
src/tribler/core/components/gigachannel/community/tests/test_gigachannel_community.py::TestGigaChannelUnits::test_get_known_subscribed_peers_for_node PASSED [ 12%] in 0.089s
src/tribler/core/components/gigachannel/community/tests/test_gigachannel_community.py::TestGigaChannelUnits::test_channels_peers_mapping_drop_excess_peers PASSED [ 12%] in 0.100s
src/tribler/core/components/gigachannel/community/tests/test_gigachannel_community.py::TestGigaChannelUnits::test_remote_select_channel_contents_empty PASSED [ 12%] in 0.225s
src/tribler/core/components/gigachannel/community/tests/test_gigachannel_community.py::TestGigaChannelUnits::test_remote_select_channel_contents PASSED [ 12%] in 0.231s
src/tribler/core/components/gigachannel/community/tests/test_gigachannel_community.py::TestGigaChannelUnits::test_query_on_introduction PASSED [ 12%] in 0.077s
```

Refs:
* https://github.com/pytest-dev/pytest/discussions/8268
* https://docs.pytest.org/en/7.1.x/reference/reference.html#pytest.hookspec.pytest_runtest_protocol
* https://py.watch/pytest-save-full-error-output-to-file-ee37d6ccbd32

See the real examples:
* https://github.com/Tribler/tribler/actions/runs/5243130977/jobs/9467421280
* https://github.com/Tribler/tribler/actions/runs/5243130977/jobs/9467421162