### PR TITLE
Refactoring `conftest.py`

### DIFF
--- a/src/tribler/core/components/conftest.py
+++ b/src/tribler/core/components/conftest.py
@@ -1,16 +1,27 @@
 from unittest.mock import MagicMock
 
 import pytest
+from ipv8.keyvault.private.libnaclkey import LibNaCLSK
 from ipv8.util import succeed
 
+from tribler.core.components.knowledge.db.knowledge_db import KnowledgeDatabase
+from tribler.core.components.libtorrent.download_manager.download_config import DownloadConfig
+from tribler.core.components.libtorrent.download_manager.download_manager import DownloadManager
 from tribler.core.components.libtorrent.settings import LibtorrentSettings
 from tribler.core.components.libtorrent.torrentdef import TorrentDef
+from tribler.core.components.metadata_store.db.store import MetadataStore
 from tribler.core.config.tribler_config import TriblerConfig
 from tribler.core.tests.tools.common import TESTS_DATA_DIR
 from tribler.core.utilities.path_util import Path
-
+from tribler.core.utilities.simpledefs import DownloadStatus
 
 # pylint: disable=redefined-outer-name
+
+TEST_PERSONAL_KEY = LibNaCLSK(
+    b'4c69624e61434c534b3af56022aa5d556c07aeed704ee98df7dca580f'
+    b'522e1405663f0d36508d2189cb8991af2dd27b34bc18b4d24869e2c4f2cfdb164a78ea6e687daf7a21640d62b1b'[10:]
+)
+
 
 @pytest.fixture
 def tribler_config(tmp_path) -> TriblerConfig:
@@ -60,3 +71,43 @@ def mock_dlmgr(state_dir):
 @pytest.fixture
 def video_tdef():
     return TorrentDef.load(TESTS_DATA_DIR / 'video.avi.torrent')
+
+
+@pytest.fixture
+async def video_seeder(tmp_path_factory, video_tdef):
+    config = LibtorrentSettings()
+    config.dht = False
+    config.upnp = False
+    config.natpmp = False
+    config.lsd = False
+    seeder_state_dir = tmp_path_factory.mktemp('video_seeder_state_dir')
+    dlmgr = DownloadManager(
+        config=config,
+        state_dir=seeder_state_dir,
+        notifier=MagicMock(),
+        peer_mid=b"0000")
+    dlmgr.metadata_tmpdir = tmp_path_factory.mktemp('metadata_tmpdir')
+    dlmgr.initialize()
+    dscfg_seed = DownloadConfig()
+    dscfg_seed.set_dest_dir(TESTS_DATA_DIR)
+    upload = dlmgr.start_download(tdef=video_tdef, config=dscfg_seed)
+    await upload.wait_for_status(DownloadStatus.SEEDING)
+    yield dlmgr
+    await dlmgr.shutdown()
+
+
+@pytest.fixture
+def metadata_store(tmp_path):
+    mds = MetadataStore(db_filename=tmp_path / 'test.db',
+                        channels_dir=tmp_path / 'channels',
+                        my_key=TEST_PERSONAL_KEY,
+                        disable_sync=True)
+    yield mds
+    mds.shutdown()
+
+
+@pytest.fixture
+def knowledge_db():
+    db = KnowledgeDatabase()
+    yield db
+    db.shutdown()

--- a/src/tribler/core/components/conftest.py
+++ b/src/tribler/core/components/conftest.py
@@ -1,5 +1,9 @@
-import pytest
+from unittest.mock import MagicMock
 
+import pytest
+from ipv8.util import succeed
+
+from tribler.core.components.libtorrent.settings import LibtorrentSettings
 from tribler.core.config.tribler_config import TriblerConfig
 from tribler.core.utilities.path_util import Path
 
@@ -26,3 +30,26 @@ def tribler_config(tmp_path) -> TriblerConfig:
     config.resource_monitor.enabled = False
     config.bootstrap.enabled = False
     return config
+
+
+@pytest.fixture
+def state_dir(tmp_path):
+    state_dir = tmp_path / 'state_dir'
+    state_dir.mkdir()
+    return state_dir
+
+
+@pytest.fixture
+def mock_dlmgr(state_dir):
+    download_manager = MagicMock()
+    download_manager.config = LibtorrentSettings()
+    download_manager.shutdown = lambda: succeed(None)
+    checkpoints_dir = state_dir / 'dlcheckpoints'
+    checkpoints_dir.mkdir()
+    download_manager.get_checkpoint_dir = lambda: checkpoints_dir
+    download_manager.state_dir = state_dir
+    download_manager.get_downloads = lambda: []
+    download_manager.checkpoints_count = 1
+    download_manager.checkpoints_loaded = 1
+    download_manager.all_checkpoints_are_loaded = True
+    return download_manager

--- a/src/tribler/core/components/conftest.py
+++ b/src/tribler/core/components/conftest.py
@@ -1,0 +1,28 @@
+import pytest
+
+from tribler.core.config.tribler_config import TriblerConfig
+from tribler.core.utilities.path_util import Path
+
+
+# pylint: disable=redefined-outer-name
+
+@pytest.fixture
+def tribler_config(tmp_path) -> TriblerConfig:
+    state_dir = Path(tmp_path) / "dot.Tribler"
+    download_dir = Path(tmp_path) / "TriblerDownloads"
+    config = TriblerConfig(state_dir=state_dir)
+    config.download_defaults.put_path_as_relative('saveas', download_dir, state_dir=str(state_dir))
+    config.torrent_checking.enabled = False
+    config.ipv8.enabled = False
+    config.ipv8.walk_scaling_enabled = False
+    config.discovery_community.enabled = False
+    config.libtorrent.enabled = False
+    config.libtorrent.dht_readiness_timeout = 0
+    config.tunnel_community.enabled = False
+    config.popularity_community.enabled = False
+    config.dht.enabled = False
+    config.libtorrent.dht = False
+    config.chant.enabled = False
+    config.resource_monitor.enabled = False
+    config.bootstrap.enabled = False
+    return config

--- a/src/tribler/core/components/conftest.py
+++ b/src/tribler/core/components/conftest.py
@@ -4,7 +4,9 @@ import pytest
 from ipv8.util import succeed
 
 from tribler.core.components.libtorrent.settings import LibtorrentSettings
+from tribler.core.components.libtorrent.torrentdef import TorrentDef
 from tribler.core.config.tribler_config import TriblerConfig
+from tribler.core.tests.tools.common import TESTS_DATA_DIR
 from tribler.core.utilities.path_util import Path
 
 
@@ -53,3 +55,8 @@ def mock_dlmgr(state_dir):
     download_manager.checkpoints_loaded = 1
     download_manager.all_checkpoints_are_loaded = True
     return download_manager
+
+
+@pytest.fixture
+def video_tdef():
+    return TorrentDef.load(TESTS_DATA_DIR / 'video.avi.torrent')

--- a/src/tribler/core/components/conftest.py
+++ b/src/tribler/core/components/conftest.py
@@ -111,3 +111,22 @@ def knowledge_db():
     db = KnowledgeDatabase()
     yield db
     db.shutdown()
+
+
+@pytest.fixture
+async def download_manager(tmp_path_factory):
+    config = LibtorrentSettings()
+    config.dht = False
+    config.upnp = False
+    config.natpmp = False
+    config.lsd = False
+    download_manager = DownloadManager(
+        config=config,
+        state_dir=tmp_path_factory.mktemp('state_dir'),
+        notifier=MagicMock(),
+        peer_mid=b"0000")
+    download_manager.metadata_tmpdir = tmp_path_factory.mktemp('metadata_tmpdir')
+    download_manager.initialize()
+    yield download_manager
+
+    await download_manager.shutdown()

--- a/src/tribler/core/components/knowledge/restapi/tests/test_knowledge_endpoint.py
+++ b/src/tribler/core/components/knowledge/restapi/tests/test_knowledge_endpoint.py
@@ -7,11 +7,11 @@ from freezegun import freeze_time
 from ipv8.keyvault.crypto import default_eccrypto
 from pony.orm import db_session
 
+from tribler.core.components.conftest import TEST_PERSONAL_KEY
 from tribler.core.components.knowledge.community.knowledge_payload import StatementOperation
 from tribler.core.components.knowledge.db.knowledge_db import Operation, ResourceType
 from tribler.core.components.knowledge.restapi.knowledge_endpoint import KnowledgeEndpoint
 from tribler.core.components.restapi.rest.base_api_test import do_request
-from tribler.core.conftest import TEST_PERSONAL_KEY
 from tribler.core.utilities.unicode import hexlify
 
 

--- a/src/tribler/core/components/libtorrent/conftest.py
+++ b/src/tribler/core/components/libtorrent/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+from aiohttp import web
 
 from tribler.core.components.libtorrent.download_manager.download_config import DownloadConfig
 from tribler.core.components.libtorrent.torrentdef import TorrentDef
@@ -22,3 +23,21 @@ def test_tdef(state_dir):
     torrentfn = state_dir / "gen.torrent"
     tdef.save(torrentfn)
     return tdef
+
+
+@pytest.fixture
+async def file_server(tmp_path, free_port):
+    """
+    Returns a file server that listens in a free port, and serves from the "serve" directory in the tmp_path
+    """
+    app = web.Application()
+    app.add_routes([web.static('/', tmp_path)])
+    runner = web.AppRunner(app, access_log=None)
+    await runner.setup()
+    site = web.TCPSite(runner, 'localhost', free_port)
+    await site.start()
+    yield free_port
+
+    await app.shutdown()
+    await runner.shutdown()
+    await site.stop()

--- a/src/tribler/core/components/libtorrent/conftest.py
+++ b/src/tribler/core/components/libtorrent/conftest.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock
+
 import pytest
 from aiohttp import web
 
@@ -58,3 +60,26 @@ async def test_download(mock_dlmgr, test_tdef):
 @pytest.fixture
 def mock_handle(mocker, test_download):
     return mocker.patch.object(test_download, 'handle')
+
+
+@pytest.fixture
+def mock_lt_status():
+    lt_status = MagicMock()
+    lt_status.upload_rate = 123
+    lt_status.download_rate = 43
+    lt_status.total_upload = 100
+    lt_status.total_download = 200
+    lt_status.all_time_upload = 100
+    lt_status.total_done = 200
+    lt_status.list_peers = 10
+    lt_status.download_payload_rate = 10
+    lt_status.upload_payload_rate = 30
+    lt_status.list_seeds = 5
+    lt_status.progress = 0.75
+    lt_status.error = False
+    lt_status.paused = False
+    lt_status.state = 3
+    lt_status.num_pieces = 0
+    lt_status.pieces = []
+    lt_status.finished_time = 10
+    return lt_status

--- a/src/tribler/core/components/libtorrent/conftest.py
+++ b/src/tribler/core/components/libtorrent/conftest.py
@@ -1,9 +1,11 @@
 import pytest
 from aiohttp import web
 
+from tribler.core.components.libtorrent.download_manager.download import Download
 from tribler.core.components.libtorrent.download_manager.download_config import DownloadConfig
 from tribler.core.components.libtorrent.torrentdef import TorrentDef
 from tribler.core.tests.tools.common import TESTS_DATA_DIR
+from tribler.core.utilities.unicode import hexlify
 
 
 # pylint: disable=redefined-outer-name
@@ -41,3 +43,18 @@ async def file_server(tmp_path, free_port):
     await app.shutdown()
     await runner.shutdown()
     await site.stop()
+
+
+@pytest.fixture
+async def test_download(mock_dlmgr, test_tdef):
+    config = DownloadConfig(state_dir=mock_dlmgr.state_dir)
+    download = Download(test_tdef, download_manager=mock_dlmgr, config=config)
+    download.infohash = hexlify(test_tdef.get_infohash())
+    yield download
+
+    await download.shutdown()
+
+
+@pytest.fixture
+def mock_handle(mocker, test_download):
+    return mocker.patch.object(test_download, 'handle')

--- a/src/tribler/core/components/libtorrent/conftest.py
+++ b/src/tribler/core/components/libtorrent/conftest.py
@@ -1,6 +1,8 @@
 import pytest
 
 from tribler.core.components.libtorrent.download_manager.download_config import DownloadConfig
+from tribler.core.components.libtorrent.torrentdef import TorrentDef
+from tribler.core.tests.tools.common import TESTS_DATA_DIR
 
 
 # pylint: disable=redefined-outer-name
@@ -9,3 +11,14 @@ from tribler.core.components.libtorrent.download_manager.download_config import 
 @pytest.fixture
 def download_config():
     return DownloadConfig()
+
+
+@pytest.fixture
+def test_tdef(state_dir):
+    tdef = TorrentDef()
+    sourcefn = TESTS_DATA_DIR / 'video.avi'
+    tdef.add_content(sourcefn)
+    tdef.set_tracker("http://localhost/announce")
+    torrentfn = state_dir / "gen.torrent"
+    tdef.save(torrentfn)
+    return tdef

--- a/src/tribler/core/components/libtorrent/conftest.py
+++ b/src/tribler/core/components/libtorrent/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+
+from tribler.core.components.libtorrent.download_manager.download_config import DownloadConfig
+
+
+# pylint: disable=redefined-outer-name
+
+
+@pytest.fixture
+def download_config():
+    return DownloadConfig()

--- a/src/tribler/core/components/metadata_store/conftest.py
+++ b/src/tribler/core/components/metadata_store/conftest.py
@@ -1,8 +1,17 @@
 import pytest
 
+from tribler.core.tests.tools.tracker.udp_tracker import UDPTracker
+
 
 # pylint: disable=redefined-outer-name
 
 @pytest.fixture
 def mock_dlmgr_get_download(mock_dlmgr):  # pylint: disable=unused-argument
     mock_dlmgr.get_download = lambda _: None
+
+
+@pytest.fixture
+async def udp_tracker(free_port):
+    udp_tracker = UDPTracker(free_port)
+    yield udp_tracker
+    await udp_tracker.stop()

--- a/src/tribler/core/components/metadata_store/conftest.py
+++ b/src/tribler/core/components/metadata_store/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+
+
+# pylint: disable=redefined-outer-name
+
+@pytest.fixture
+def mock_dlmgr_get_download(mock_dlmgr):  # pylint: disable=unused-argument
+    mock_dlmgr.get_download = lambda _: None

--- a/src/tribler/core/components/metadata_store/db/tests/test_torrent_metadata.py
+++ b/src/tribler/core/components/metadata_store/db/tests/test_torrent_metadata.py
@@ -7,12 +7,12 @@ from ipv8.keyvault.crypto import default_eccrypto
 from pony import orm
 from pony.orm import db_session
 
+from tribler.core.components.conftest import TEST_PERSONAL_KEY
 from tribler.core.components.libtorrent.torrentdef import TorrentDef
 from tribler.core.components.metadata_store.db.orm_bindings.channel_node import TODELETE
 from tribler.core.components.metadata_store.db.orm_bindings.discrete_clock import clock
 from tribler.core.components.metadata_store.db.orm_bindings.torrent_metadata import tdef_to_metadata_dict
 from tribler.core.components.metadata_store.db.serialization import CHANNEL_TORRENT, REGULAR_TORRENT
-from tribler.core.conftest import TEST_PERSONAL_KEY
 from tribler.core.tests.tools.common import TORRENT_UBUNTU_FILE
 from tribler.core.utilities.utilities import random_infohash
 

--- a/src/tribler/core/conftest.py
+++ b/src/tribler/core/conftest.py
@@ -48,16 +48,12 @@ def pytest_runtest_protocol(item, log=True, nextitem=None):  # pylint: disable=u
     print(f' in {duration:.3f}s', end='')
 
 
-@pytest.fixture(name="tribler_download_dir")
-def _tribler_download_dir(tmp_path):
-    return Path(tmp_path) / "TriblerDownloads"
-
-
 @pytest.fixture(name="tribler_config")
-def _tribler_config(tmp_path, tribler_download_dir) -> TriblerConfig:
+def _tribler_config(tmp_path) -> TriblerConfig:
     state_dir = Path(tmp_path) / "dot.Tribler"
+    download_dir = Path(tmp_path) / "TriblerDownloads"
     config = TriblerConfig(state_dir=state_dir)
-    config.download_defaults.put_path_as_relative('saveas', tribler_download_dir, state_dir=str(state_dir))
+    config.download_defaults.put_path_as_relative('saveas', download_dir, state_dir=str(state_dir))
     config.torrent_checking.enabled = False
     config.ipv8.enabled = False
     config.ipv8.walk_scaling_enabled = False

--- a/src/tribler/core/conftest.py
+++ b/src/tribler/core/conftest.py
@@ -9,7 +9,6 @@ import pytest
 from aiohttp import web
 from ipv8.keyvault.crypto import default_eccrypto
 from ipv8.keyvault.private.libnaclkey import LibNaCLSK
-from ipv8.util import succeed
 
 from tribler.core.components.knowledge.db.knowledge_db import KnowledgeDatabase
 from tribler.core.components.libtorrent.download_manager.download import Download
@@ -43,34 +42,6 @@ def pytest_runtest_protocol(item, log=True, nextitem=None):  # pylint: disable=u
     yield
     duration = time.time() - start_time
     print(f' in {duration:.3f}s', end='')
-
-
-@pytest.fixture
-def state_dir(tmp_path):
-    state_dir = tmp_path / 'state_dir'
-    state_dir.mkdir()
-    return state_dir
-
-
-@pytest.fixture
-def mock_dlmgr(state_dir):
-    dlmgr = MagicMock()
-    dlmgr.config = LibtorrentSettings()
-    dlmgr.shutdown = lambda: succeed(None)
-    checkpoints_dir = state_dir / 'dlcheckpoints'
-    checkpoints_dir.mkdir()
-    dlmgr.get_checkpoint_dir = lambda: checkpoints_dir
-    dlmgr.state_dir = state_dir
-    dlmgr.get_downloads = lambda: []
-    dlmgr.checkpoints_count = 1
-    dlmgr.checkpoints_loaded = 1
-    dlmgr.all_checkpoints_are_loaded = True
-    return dlmgr
-
-
-@pytest.fixture
-def mock_dlmgr_get_download(mock_dlmgr):  # pylint: disable=unused-argument, redefined-outer-name
-    mock_dlmgr.get_download = lambda _: None
 
 
 @pytest.fixture
@@ -175,17 +146,6 @@ async def udp_tracker(free_port):
     udp_tracker = UDPTracker(free_port)
     yield udp_tracker
     await udp_tracker.stop()
-
-
-@pytest.fixture
-def test_tdef(state_dir):
-    tdef = TorrentDef()
-    sourcefn = TESTS_DATA_DIR / 'video.avi'
-    tdef.add_content(sourcefn)
-    tdef.set_tracker("http://localhost/announce")
-    torrentfn = state_dir / "gen.torrent"
-    tdef.save(torrentfn)
-    return tdef
 
 
 @pytest.fixture

--- a/src/tribler/core/conftest.py
+++ b/src/tribler/core/conftest.py
@@ -6,7 +6,6 @@ import time
 from unittest.mock import MagicMock
 
 import pytest
-from ipv8.keyvault.crypto import default_eccrypto
 
 from tribler.core.components.libtorrent.download_manager.download_manager import DownloadManager
 from tribler.core.components.libtorrent.settings import LibtorrentSettings
@@ -48,11 +47,6 @@ def event_loop():
     loop = policy.new_event_loop()
     yield loop
     loop.close()
-
-
-@pytest.fixture
-def peer_key():
-    return default_eccrypto.generate_key("curve25519")
 
 
 @pytest.fixture

--- a/src/tribler/core/conftest.py
+++ b/src/tribler/core/conftest.py
@@ -51,29 +51,6 @@ def event_loop():
 
 
 @pytest.fixture
-def mock_lt_status():
-    lt_status = MagicMock()
-    lt_status.upload_rate = 123
-    lt_status.download_rate = 43
-    lt_status.total_upload = 100
-    lt_status.total_download = 200
-    lt_status.all_time_upload = 100
-    lt_status.total_done = 200
-    lt_status.list_peers = 10
-    lt_status.download_payload_rate = 10
-    lt_status.upload_payload_rate = 30
-    lt_status.list_seeds = 5
-    lt_status.progress = 0.75
-    lt_status.error = False
-    lt_status.paused = False
-    lt_status.state = 3
-    lt_status.num_pieces = 0
-    lt_status.pieces = []
-    lt_status.finished_time = 10
-    return lt_status
-
-
-@pytest.fixture
 def peer_key():
     return default_eccrypto.generate_key("curve25519")
 

--- a/src/tribler/core/conftest.py
+++ b/src/tribler/core/conftest.py
@@ -48,19 +48,14 @@ def pytest_runtest_protocol(item, log=True, nextitem=None):  # pylint: disable=u
     print(f' in {duration:.3f}s', end='')
 
 
-@pytest.fixture(name="tribler_root_dir")
-def _tribler_root_dir(tmp_path):
-    return Path(tmp_path)
-
-
 @pytest.fixture(name="tribler_state_dir")
-def _tribler_state_dir(tribler_root_dir):
-    return tribler_root_dir / "dot.Tribler"
+def _tribler_state_dir(tmp_path):
+    return Path(tmp_path) / "dot.Tribler"
 
 
 @pytest.fixture(name="tribler_download_dir")
-def _tribler_download_dir(tribler_root_dir):
-    return tribler_root_dir / "TriblerDownloads"
+def _tribler_download_dir(tmp_path):
+    return Path(tmp_path) / "TriblerDownloads"
 
 
 @pytest.fixture(name="tribler_config")

--- a/src/tribler/core/conftest.py
+++ b/src/tribler/core/conftest.py
@@ -1,10 +1,8 @@
 import asyncio
 import logging
-import os
 import platform
 import sys
 import time
-from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -20,8 +18,7 @@ from tribler.core.components.libtorrent.download_manager.download_manager import
 from tribler.core.components.libtorrent.settings import LibtorrentSettings
 from tribler.core.components.libtorrent.torrentdef import TorrentDef
 from tribler.core.components.metadata_store.db.store import MetadataStore
-from tribler.core.config.tribler_config import TriblerConfig
-from tribler.core.tests.tools.common import TESTS_DATA_DIR, TESTS_DIR
+from tribler.core.tests.tools.common import TESTS_DATA_DIR
 from tribler.core.tests.tools.tracker.udp_tracker import UDPTracker
 from tribler.core.utilities.network_utils import default_network_utils
 from tribler.core.utilities.simpledefs import DownloadStatus
@@ -48,28 +45,6 @@ def pytest_runtest_protocol(item, log=True, nextitem=None):  # pylint: disable=u
     print(f' in {duration:.3f}s', end='')
 
 
-@pytest.fixture(name="tribler_config")
-def _tribler_config(tmp_path) -> TriblerConfig:
-    state_dir = Path(tmp_path) / "dot.Tribler"
-    download_dir = Path(tmp_path) / "TriblerDownloads"
-    config = TriblerConfig(state_dir=state_dir)
-    config.download_defaults.put_path_as_relative('saveas', download_dir, state_dir=str(state_dir))
-    config.torrent_checking.enabled = False
-    config.ipv8.enabled = False
-    config.ipv8.walk_scaling_enabled = False
-    config.discovery_community.enabled = False
-    config.libtorrent.enabled = False
-    config.libtorrent.dht_readiness_timeout = 0
-    config.tunnel_community.enabled = False
-    config.popularity_community.enabled = False
-    config.dht.enabled = False
-    config.libtorrent.dht = False
-    config.chant.enabled = False
-    config.resource_monitor.enabled = False
-    config.bootstrap.enabled = False
-    return config
-
-
 @pytest.fixture
 def download_config():
     return DownloadConfig()
@@ -80,11 +55,6 @@ def state_dir(tmp_path):
     state_dir = tmp_path / 'state_dir'
     state_dir.mkdir()
     return state_dir
-
-
-@pytest.fixture
-def enable_ipv8(tribler_config):
-    tribler_config.ipv8.enabled = True
 
 
 @pytest.fixture
@@ -203,22 +173,6 @@ def knowledge_db():
     db = KnowledgeDatabase()
     yield db
     db.shutdown()
-
-
-@pytest.fixture
-def enable_https(tribler_config, free_port):
-    tribler_config.api.put_path_as_relative('https_certfile', TESTS_DIR / 'data' / 'certfile.pem',
-                                            tribler_config.state_dir)
-    tribler_config.api.https_enabled = True
-    tribler_config.api.https_port = free_port
-
-
-@pytest.fixture
-def enable_watch_folder(tmp_path, tribler_config):
-    state_dir = Path(tmp_path) / "dot.Tribler"
-    tribler_config.watch_folder.put_path_as_relative('directory', state_dir / "watch", state_dir)
-    os.makedirs(state_dir / "watch")
-    tribler_config.watch_folder.enabled = True
 
 
 @pytest.fixture

--- a/src/tribler/core/conftest.py
+++ b/src/tribler/core/conftest.py
@@ -8,12 +8,9 @@ from unittest.mock import MagicMock
 import pytest
 from ipv8.keyvault.crypto import default_eccrypto
 
-from tribler.core.components.libtorrent.download_manager.download import Download
-from tribler.core.components.libtorrent.download_manager.download_config import DownloadConfig
 from tribler.core.components.libtorrent.download_manager.download_manager import DownloadManager
 from tribler.core.components.libtorrent.settings import LibtorrentSettings
 from tribler.core.utilities.network_utils import default_network_utils
-from tribler.core.utilities.unicode import hexlify
 
 # Enable origin tracking for coroutine objects in the current thread, so when a test does not handle
 # some coroutine properly, we can see a traceback with the name of the test which created the coroutine.
@@ -54,16 +51,6 @@ def event_loop():
 
 
 @pytest.fixture
-async def test_download(mock_dlmgr, test_tdef):
-    config = DownloadConfig(state_dir=mock_dlmgr.state_dir)
-    download = Download(test_tdef, download_manager=mock_dlmgr, config=config)
-    download.infohash = hexlify(test_tdef.get_infohash())
-    yield download
-
-    await download.shutdown()
-
-
-@pytest.fixture
 def mock_lt_status():
     lt_status = MagicMock()
     lt_status.upload_rate = 123
@@ -84,11 +71,6 @@ def mock_lt_status():
     lt_status.pieces = []
     lt_status.finished_time = 10
     return lt_status
-
-
-@pytest.fixture
-def mock_handle(mocker, test_download):
-    return mocker.patch.object(test_download, 'handle')
 
 
 @pytest.fixture

--- a/src/tribler/core/conftest.py
+++ b/src/tribler/core/conftest.py
@@ -15,7 +15,6 @@ from tribler.core.components.libtorrent.download_manager.download import Downloa
 from tribler.core.components.libtorrent.download_manager.download_config import DownloadConfig
 from tribler.core.components.libtorrent.download_manager.download_manager import DownloadManager
 from tribler.core.components.libtorrent.settings import LibtorrentSettings
-from tribler.core.components.libtorrent.torrentdef import TorrentDef
 from tribler.core.components.metadata_store.db.store import MetadataStore
 from tribler.core.tests.tools.common import TESTS_DATA_DIR
 from tribler.core.tests.tools.tracker.udp_tracker import UDPTracker
@@ -45,11 +44,6 @@ def pytest_runtest_protocol(item, log=True, nextitem=None):  # pylint: disable=u
 
 
 @pytest.fixture
-def video_tdef():
-    return TorrentDef.load(TESTS_DATA_DIR / 'video.avi.torrent')
-
-
-@pytest.fixture
 async def video_seeder(tmp_path_factory, video_tdef):
     config = LibtorrentSettings()
     config.dht = False
@@ -70,9 +64,6 @@ async def video_seeder(tmp_path_factory, video_tdef):
     await upload.wait_for_status(DownloadStatus.SEEDING)
     yield dlmgr
     await dlmgr.shutdown()
-
-
-selected_ports = set()
 
 
 @pytest.fixture(name="free_port")

--- a/src/tribler/core/conftest.py
+++ b/src/tribler/core/conftest.py
@@ -46,11 +46,6 @@ def pytest_runtest_protocol(item, log=True, nextitem=None):  # pylint: disable=u
 
 
 @pytest.fixture
-def download_config():
-    return DownloadConfig()
-
-
-@pytest.fixture
 def state_dir(tmp_path):
     state_dir = tmp_path / 'state_dir'
     state_dir.mkdir()

--- a/src/tribler/core/conftest.py
+++ b/src/tribler/core/conftest.py
@@ -48,20 +48,16 @@ def pytest_runtest_protocol(item, log=True, nextitem=None):  # pylint: disable=u
     print(f' in {duration:.3f}s', end='')
 
 
-@pytest.fixture(name="tribler_state_dir")
-def _tribler_state_dir(tmp_path):
-    return Path(tmp_path) / "dot.Tribler"
-
-
 @pytest.fixture(name="tribler_download_dir")
 def _tribler_download_dir(tmp_path):
     return Path(tmp_path) / "TriblerDownloads"
 
 
 @pytest.fixture(name="tribler_config")
-def _tribler_config(tribler_state_dir, tribler_download_dir) -> TriblerConfig:
-    config = TriblerConfig(state_dir=tribler_state_dir)
-    config.download_defaults.put_path_as_relative('saveas', tribler_download_dir, state_dir=tribler_state_dir)
+def _tribler_config(tmp_path, tribler_download_dir) -> TriblerConfig:
+    state_dir = Path(tmp_path) / "dot.Tribler"
+    config = TriblerConfig(state_dir=state_dir)
+    config.download_defaults.put_path_as_relative('saveas', tribler_download_dir, state_dir=str(state_dir))
     config.torrent_checking.enabled = False
     config.ipv8.enabled = False
     config.ipv8.walk_scaling_enabled = False
@@ -222,9 +218,10 @@ def enable_https(tribler_config, free_port):
 
 
 @pytest.fixture
-def enable_watch_folder(tribler_state_dir, tribler_config):
-    tribler_config.watch_folder.put_path_as_relative('directory', tribler_state_dir / "watch", tribler_state_dir)
-    os.makedirs(tribler_state_dir / "watch")
+def enable_watch_folder(tmp_path, tribler_config):
+    state_dir = Path(tmp_path) / "dot.Tribler"
+    tribler_config.watch_folder.put_path_as_relative('directory', state_dir / "watch", state_dir)
+    os.makedirs(state_dir / "watch")
     tribler_config.watch_folder.enabled = True
 
 

--- a/src/tribler/core/conftest.py
+++ b/src/tribler/core/conftest.py
@@ -3,12 +3,9 @@ import logging
 import platform
 import sys
 import time
-from unittest.mock import MagicMock
 
 import pytest
 
-from tribler.core.components.libtorrent.download_manager.download_manager import DownloadManager
-from tribler.core.components.libtorrent.settings import LibtorrentSettings
 from tribler.core.utilities.network_utils import default_network_utils
 
 # Enable origin tracking for coroutine objects in the current thread, so when a test does not handle
@@ -47,22 +44,3 @@ def event_loop():
     loop = policy.new_event_loop()
     yield loop
     loop.close()
-
-
-@pytest.fixture
-async def download_manager(tmp_path_factory):
-    config = LibtorrentSettings()
-    config.dht = False
-    config.upnp = False
-    config.natpmp = False
-    config.lsd = False
-    download_manager = DownloadManager(
-        config=config,
-        state_dir=tmp_path_factory.mktemp('state_dir'),
-        notifier=MagicMock(),
-        peer_mid=b"0000")
-    download_manager.metadata_tmpdir = tmp_path_factory.mktemp('metadata_tmpdir')
-    download_manager.initialize()
-    yield download_manager
-
-    await download_manager.shutdown()


### PR DESCRIPTION
This PR splits big `core/conftest.py` into multiple small ones. It should slightly increase performance and simplify the maintenance of test fixtures.

Refs:
* https://docs.pytest.org/en/latest/reference/fixtures.html#conftest-py-sharing-fixtures-across-multiple-files