### PR TITLE
Fix crash on Ubuntu while selecting File Chooser

### DIFF
--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -59,6 +59,13 @@ jobs:
           fetch-depth: 0
           ref: ${{inputs.ref || github.ref}}
 
+      - name: Install Ubuntu dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install debhelper devscripts
+          # for qt:
+          sudo apt-get -y install libxcb-xinerama0-dev libqt5x11extras5 libgirepository1.0-dev
+
       - name: Create python environment
         id: pyenv
         uses: ./.github/actions/pyenv
@@ -68,13 +75,6 @@ jobs:
           custom_cache_key_element: ${{inputs.ref || github.ref_name}}
 
       - uses: ./.github/actions/save_git_info
-
-      - name: Install Ubuntu dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get -y install debhelper devscripts
-          # for qt:
-          sudo apt-get -y install libxcb-xinerama0-dev libqt5x11extras5 libgirepository1.0-dev
 
       - name: Run build script
         timeout-minutes: 10

--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -74,7 +74,7 @@ jobs:
           sudo apt-get update
           sudo apt-get -y install debhelper devscripts
           # for qt:
-          sudo apt-get -y install libxcb-xinerama0-dev libqt5x11extras5
+          sudo apt-get -y install libxcb-xinerama0-dev libqt5x11extras5 libgirepository1.0-dev
 
       - name: Run build script
         timeout-minutes: 10

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,11 +1,12 @@
 -r requirements.txt
 
-PyInstaller==5.1; sys_platform != 'darwin'
+PyInstaller==5.11.0; sys_platform != 'darwin'
 
 setuptools==65.5.1; sys_platform == 'darwin'
 text-unidecode==1.3; sys_platform == 'darwin'
 
 defusedxml==0.7.1; sys_platform == 'linux2' or sys_platform == 'linux'
 markupsafe==2.0.1; sys_platform == 'linux2' or sys_platform == 'linux'
+PyGObject==3.44.1; sys_platform == 'linux2' or sys_platform == 'linux'
 
 requests==2.25.1

--- a/tribler.spec
+++ b/tribler.spec
@@ -104,6 +104,12 @@ hiddenimports = [
                     'typing_extensions',
                 ] + widget_files + pony_deps + get_sentry_hooks()
 
+# Fix for issue: Could not load a pixbuf from icon theme.
+# Unrecognized image file format (gdk-pixbuf-error-quark, 3).
+# See: https://github.com/Tribler/tribler/issues/7457
+if sys.platform.startswith('linux'):
+    hiddenimports += ['gi', 'gi.repository.GdkPixbuf']
+
 # https://github.com/pyinstaller/pyinstaller/issues/5359
 hiddenimports += collect_submodules('pydantic')
 


### PR DESCRIPTION
Summary of the issue:
1. The binary built on Ubuntu 20.04 works on 20.04 but not Ubuntu 22.04 (and higher likely, not tested)
2. The binary built on Ubuntu 22.04 works on 22.04 but not lower.

The issue was related to `GdkPixbuf` internally required by PyQt5 File chooser on Linux. Turns out PyInstaller did not import required internal gtk libs within the build bundle. For the binaries built on the same distribution, the executable was able to find the required libs from the system but not on different distros.

A solution is presented on this PR. Here I add `PyGObject` as a build dependency for Linux which provides GTK libs for python, then add `gi` and `gi.repository` as hidden imports. These hidden imports make sure that `GdkPixbuf` is accessible and that PyQt Filechooser can work without a crash. 

I have tested the build with these fixes on Ubuntu 20.04 and 22.04 and can confirm to work. 

Here is a build to test.
https://jenkins-ci.tribler.org/job/Build-Tribler_release/job/Build-Ubuntu64/653/