### PR TITLE
Add information about the total runtime of the test suite.

### DIFF
--- a/src/tribler/core/conftest.py
+++ b/src/tribler/core/conftest.py
@@ -14,19 +14,33 @@ from tribler.core.utilities.network_utils import default_network_utils
 # was garbage collected. Without the origin tracking, it may be hard to see the test that created the task.
 sys.set_coroutine_origin_tracking_depth(10)
 
+pytest_start_time = 0  # a time when the test suite started
 
-def pytest_configure(config):  # pylint: disable=unused-argument
+
+# pylint: disable=unused-argument
+
+def pytest_configure(config):
     # Disable logging from faker for all tests
     logging.getLogger('faker.factory').propagate = False
 
 
+@pytest.hookimpl
+def pytest_collection_finish(session):
+    """ Save the start time of the test suite execution"""
+    # Called after collection has been performed and modified.
+    global pytest_start_time  # pylint: disable=global-statement
+    pytest_start_time = time.time()
+
+
 @pytest.hookimpl(hookwrapper=True)
-def pytest_runtest_protocol(item, log=True, nextitem=None):  # pylint: disable=unused-argument
+def pytest_runtest_protocol(item, log=True, nextitem=None):
     """ Modify the pytest output to include the execution duration for all tests """
+    # Perform the runtest protocol for a single test item.
     start_time = time.time()
     yield
     duration = time.time() - start_time
-    print(f' in {duration:.3f}s', end='')
+    total = time.time() - pytest_start_time
+    print(f' in {duration:.3f}s ({total:.1f}s in total)', end='')
 
 
 @pytest.fixture

--- a/src/tribler/gui/tests/conftest.py
+++ b/src/tribler/gui/tests/conftest.py
@@ -3,6 +3,10 @@ import time
 
 import pytest
 
+pytest_start_time = 0  # a time when the test suite started
+
+
+# pylint: disable=unused-argument
 
 def pytest_configure(config):  # pylint: disable=unused-argument
     # Disable logging from faker for all tests
@@ -29,10 +33,20 @@ def pytest_collection_modifyitems(config, items):
             item.add_marker(skip_guitests)
 
 
+@pytest.hookimpl
+def pytest_collection_finish(session):
+    """ Save the start time of the test suite execution"""
+    # Called after collection has been performed and modified.
+    global pytest_start_time  # pylint: disable=global-statement
+    pytest_start_time = time.time()
+
+
 @pytest.hookimpl(hookwrapper=True)
-def pytest_runtest_protocol(item, log=True, nextitem=None):  # pylint: disable=unused-argument
+def pytest_runtest_protocol(item, log=True, nextitem=None):
     """ Modify the pytest output to include the execution duration for all tests """
+    # Perform the runtest protocol for a single test item.
     start_time = time.time()
     yield
     duration = time.time() - start_time
-    print(f' in {duration:.3f}s', end='')
+    total = time.time() - pytest_start_time
+    print(f' in {duration:.3f}s ({total:.1f}s in total)', end='')


### PR DESCRIPTION
This PR adds the total runtime of the test suite to the pytest output.
Related to #7132, #7134

The modified output:
```python
src/tribler/core/components/metadata_store/restapi/tests/test_channels_endpoint.py::test_put_channel_thumbnail PASSED      [  5%] in 0.046s (2.9s in total)
src/tribler/core/components/metadata_store/restapi/tests/test_channels_endpoint.py::test_get_channel_contents PASSED       [  5%] in 0.082s (3.0s in total)
src/tribler/core/components/metadata_store/restapi/tests/test_channels_endpoint.py::test_get_popular_torrents PASSED       [  5%] in 0.090s (3.1s in total)
src/tribler/core/components/metadata_store/restapi/tests/test_channels_endpoint.py::test_get_channels_sort_by_health PASSED [  5%] in 0.087s (3.2s in total)
src/tribler/core/components/metadata_store/restapi/tests/test_channels_endpoint.py::test_add_torrent_invalid_uri PASSED    [  5%] in 0.234s (3.4s in total)
src/tribler/core/components/metadata_store/restapi/tests/test_channels_endpoint.py::test_get_channel_description PASSED    [  5%] in 0.042s (3.5s in total)
src/tribler/core/components/metadata_store/restapi/tests/test_channels_endpoint.py::test_get_channel_contents_remote PASSED [  5%] in 0.086s (3.5s in total)
src/tribler/core/components/metadata_store/restapi/tests/test_channels_endpoint.py::test_get_subscribed_channels PASSED    [  5%] in 0.084s (3.6s in total)
src/tribler/core/components/metadata_store/restapi/tests/test_channels_endpoint.py::test_get_my_channel_tags PASSED        [  5%] in 0.646s (4.3s in total)
```


For reference (The Hierarchy of hooks): 

```
root
└── pytest_cmdline_main
 ├── pytest_plugin_registered
 ├── pytest_configure
 │ └── pytest_plugin_registered
 ├── pytest_sessionstart
 │ ├── pytest_plugin_registered
 │ └── pytest_report_header
 ├── pytest_collection
 │ ├── pytest_collectstart
 │ ├── pytest_make_collect_report
 │ │ ├── pytest_collect_file
 │ │ │ └── pytest_pycollect_makemodule
 │ │ └── pytest_pycollect_makeitem
 │ │ └── pytest_generate_tests
 │ │ └── pytest_make_parametrize_id
 │ ├── pytest_collectreport
 │ ├── pytest_itemcollected
 │ ├── pytest_collection_modifyitems
 │ └── pytest_collection_finish
 │ └── pytest_report_collectionfinish
 ├── pytest_runtestloop
 │ └── pytest_runtest_protocol
 │ ├── pytest_runtest_logstart
 │ ├── pytest_runtest_setup
 │ │ └── pytest_fixture_setup
 │ ├── pytest_runtest_makereport
 │ ├── pytest_runtest_logreport
 │ │ └── pytest_report_teststatus
 │ ├── pytest_runtest_call
 │ │ └── pytest_pyfunc_call
 │ ├── pytest_runtest_teardown
 │ │ └── pytest_fixture_post_finalizer
 │ └── pytest_runtest_logfinish
 ├── pytest_sessionfinish
 │ └── pytest_terminal_summary
 └── pytest_unconfigure
```

Refs:
* https://paragkamble.medium.com/understanding-hooks-in-pytest-892e91edbdb7
* https://docs.pytest.org/en/7.1.x/reference/reference.html