### PR TITLE
Make pytest extended logging logic dependent on `--verbose` flag

### DIFF
--- a/src/tribler/core/conftest.py
+++ b/src/tribler/core/conftest.py
@@ -5,6 +5,7 @@ import sys
 import time
 
 import pytest
+from _pytest.config import Config
 
 from tribler.core.utilities.network_utils import default_network_utils
 
@@ -14,6 +15,7 @@ from tribler.core.utilities.network_utils import default_network_utils
 # was garbage collected. Without the origin tracking, it may be hard to see the test that created the task.
 sys.set_coroutine_origin_tracking_depth(10)
 
+enable_extended_logging = False
 pytest_start_time = 0  # a time when the test suite started
 
 
@@ -22,6 +24,14 @@ pytest_start_time = 0  # a time when the test suite started
 def pytest_configure(config):
     # Disable logging from faker for all tests
     logging.getLogger('faker.factory').propagate = False
+
+
+@pytest.hookimpl
+def pytest_cmdline_main(config: Config):
+    """ Enable extended logging if the verbose option is used """
+    # Called for performing the main command line action.
+    global enable_extended_logging  # pylint: disable=global-statement
+    enable_extended_logging = config.option.verbose > 0
 
 
 @pytest.hookimpl
@@ -40,7 +50,8 @@ def pytest_runtest_protocol(item, log=True, nextitem=None):
     yield
     duration = time.time() - start_time
     total = time.time() - pytest_start_time
-    print(f' in {duration:.3f}s ({total:.1f}s in total)', end='')
+    if enable_extended_logging:
+        print(f' in {duration:.3f}s ({total:.1f}s in total)', end='')
 
 
 @pytest.fixture

--- a/src/tribler/gui/tests/conftest.py
+++ b/src/tribler/gui/tests/conftest.py
@@ -2,7 +2,9 @@ import logging
 import time
 
 import pytest
+from _pytest.config import Config
 
+enable_extended_logging = False
 pytest_start_time = 0  # a time when the test suite started
 
 
@@ -13,6 +15,14 @@ def pytest_configure(config):  # pylint: disable=unused-argument
     logging.getLogger('faker.factory').propagate = False
     # Disable logging from PyQt5.uic for all tests
     logging.getLogger('PyQt5.uic').propagate = False
+
+
+@pytest.hookimpl
+def pytest_cmdline_main(config: Config):
+    """ Enable extended logging if the verbose option is used """
+    # Called for performing the main command line action.
+    global enable_extended_logging  # pylint: disable=global-statement
+    enable_extended_logging = config.option.verbose > 0
 
 
 def pytest_addoption(parser):
@@ -49,4 +59,5 @@ def pytest_runtest_protocol(item, log=True, nextitem=None):
     yield
     duration = time.time() - start_time
     total = time.time() - pytest_start_time
-    print(f' in {duration:.3f}s ({total:.1f}s in total)', end='')
+    if enable_extended_logging:
+        print(f' in {duration:.3f}s ({total:.1f}s in total)', end='')


### PR DESCRIPTION
This PR makes extended logging (introduced in #7482 and #7485) dependent on `--verbose` flag.
Related to #7132, #7134

Without this PR, the output logic operates as expected when the `--verbose` flag is utilized. However, when running the test suite without this flag, we encounter an output that could be seen as inconvenient:
```
src/tribler/core/components/gigachannel/community/tests/test_gigachannel_community.py . in 1.158s (1.2s in total). in 0.230s (1.4s in total). in 0.198s (1.6s in total). in 0.131s (1.8s in total). in 0.089s (1.9s in total). in 0.084s (1.9s in total). in 0.239s (2.2s in total). in 0.584s (2.8s in total). in 0.236s (3.0s in total). in 0.433s (3.4s in total). in 0.135s (3.6s in total)^C^C in 0.009s (3.6s in total)
```

instead of 

```
src/tribler/core/components/gigachannel/community/tests/test_gigachannel_community.py ................
```
This PR addresses the issue by enhancing logging, but only if the `--verbose` flag is explicitly activated. 

---

For reference (The Hierarchy of hooks): 

```
root
└── pytest_cmdline_main
 ├── pytest_plugin_registered
 ├── pytest_configure
 │ └── pytest_plugin_registered
 ├── pytest_sessionstart
 │ ├── pytest_plugin_registered
 │ └── pytest_report_header
 ├── pytest_collection
 │ ├── pytest_collectstart
 │ ├── pytest_make_collect_report
 │ │ ├── pytest_collect_file
 │ │ │ └── pytest_pycollect_makemodule
 │ │ └── pytest_pycollect_makeitem
 │ │ └── pytest_generate_tests
 │ │ └── pytest_make_parametrize_id
 │ ├── pytest_collectreport
 │ ├── pytest_itemcollected
 │ ├── pytest_collection_modifyitems
 │ └── pytest_collection_finish
 │ └── pytest_report_collectionfinish
 ├── pytest_runtestloop
 │ └── pytest_runtest_protocol
 │ ├── pytest_runtest_logstart
 │ ├── pytest_runtest_setup
 │ │ └── pytest_fixture_setup
 │ ├── pytest_runtest_makereport
 │ ├── pytest_runtest_logreport
 │ │ └── pytest_report_teststatus
 │ ├── pytest_runtest_call
 │ │ └── pytest_pyfunc_call
 │ ├── pytest_runtest_teardown
 │ │ └── pytest_fixture_post_finalizer
 │ └── pytest_runtest_logfinish
 ├── pytest_sessionfinish
 │ └── pytest_terminal_summary
 └── pytest_unconfigure
```

Refs:
* https://docs.pytest.org/en/7.1.x/reference/reference.html