### PR TITLE
Consider HealthInfo with negative seeders and leechers as invalid

### DIFF
--- a/src/tribler/core/components/popularity/community/popularity_community.py
+++ b/src/tribler/core/components/popularity/community/popularity_community.py
@@ -62,7 +62,8 @@ class PopularityCommunity(RemoteQueryCommunity, VersionCommunityMixin):
             return []
 
         # Filter torrents that have seeders
-        return [health for health in self.torrent_checker.torrents_checked.values() if health.seeders > 0]
+        return [health for health in self.torrent_checker.torrents_checked.values() if
+                health.seeders > 0 and health.leechers >= 0]
 
     def gossip_random_torrents_health(self):
         """

--- a/src/tribler/core/components/torrent_checker/torrent_checker/dataclasses.py
+++ b/src/tribler/core/components/torrent_checker/torrent_checker/dataclasses.py
@@ -53,7 +53,7 @@ class HealthInfo:
         return hexlify(self.infohash)
 
     def is_valid(self) -> bool:
-        return self.last_check < int(time.time()) + TOLERABLE_TIME_DRIFT
+        return self.seeders >= 0 and self.leechers >= 0 and self.last_check < int(time.time()) + TOLERABLE_TIME_DRIFT
 
     def old(self) -> bool:
         now = int(time.time())

--- a/src/tribler/core/components/torrent_checker/torrent_checker/tests/test_health_info_should_update.py
+++ b/src/tribler/core/components/torrent_checker/torrent_checker/tests/test_health_info_should_update.py
@@ -27,6 +27,12 @@ def test_invalid_health():
     assert not health.should_replace(prev_health)
 
 
+def test_health_negative_seeders_or_leechers():
+    """ Test that health with negative seeders or leechers is considered invalid"""
+    assert not HealthInfo(INFOHASH, seeders=-1).is_valid()
+    assert not HealthInfo(INFOHASH, leechers=-1).is_valid()
+
+
 def test_self_checked_health_update_remote_health():
     prev_health = HealthInfo(INFOHASH)
     health = HealthInfo(INFOHASH, self_checked=True)


### PR DESCRIPTION
This PR fixes #7430 by suppressing all errors in `PopularityCommunity.gossip_random_torrents_health()`.

In #7430 the root cause of the error is a packing error in the attempt to pack the signed number -2 into an unsigned 32-bit integer.

We have several strategies for addressing this bug:

1. Inspect all instances where the leecher count is created/modified to ensure it consistently remains positive.
1. Guarantee that num_leechers is positive before invoking Community.ez_send().
1. Suppress all errors within the community.

I've opted for the third approach, in line with the existing ipv8 policy of error suppression within communities to prevent Tribler from crashing due to, for instance, a packet of death.

This bug uncovers the inconsistency in ipv8 error handling methods: some suppress exceptions, while others do not. Ideally, ipv8 error handling would be made more consistent, but due to strict contribution rules, this isn't easily achievable (it's nearly impossible for Tribler developers to introduce changes to ipv8). Hence, we should address this issue on Tribler's end.

<del>
I've implemented an annotation 
This annotation can be appended to any method (synchronous or asynchronous), and it will suppress all exceptions that arise within the method. However, it's important to note that this isn't a comprehensive solution. The complete solution would involve incorporating the same logic into all fragile community methods. Implementing this fully is a significant change for Tribler, so it would be more prudent to reserve such a comprehensive overhaul for the next release.
</del>