### PR TITLE
Fix GUI Test non-zero exit code

### DIFF
--- a/src/tribler/gui/tests/test_gui.py
+++ b/src/tribler/gui/tests/test_gui.py
@@ -76,6 +76,11 @@ def fixture_window(tmp_path_factory):
 
     window.close_tribler()
     screenshot(window, name="tribler_closing")
+
+    # Before quitting the application, wait for max 10 seconds until the core process has successfully finished
+    # Otherwise, process exits with non-zero exit code.
+    # See: https://github.com/Tribler/tribler/issues/7500
+    wait_for_signal(window.core_manager.core_process.finished, timeout=10)
     app_manager.quit_application()
 
 


### PR DESCRIPTION
The reason for the non-zero exit code is the core process not being terminated correctly.
With this PR, we wait a max 10 seconds to let the core process terminate properly.

- Fixes https://github.com/Tribler/tribler/issues/7500