### PR TITLE
Fix calling `await app.shutdown()` in REST API tests

### DIFF
--- a/src/tribler/core/components/conftest.py
+++ b/src/tribler/core/components/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+from aiohttp.web_app import Application
+
+from tribler.core.components.restapi.rest.rest_manager import error_middleware
+
+
+@pytest.fixture(name='web_app')
+async def web_app_fixture():
+    app = Application(middlewares=[error_middleware])
+    yield app
+    await app.shutdown()

--- a/src/tribler/core/components/knowledge/restapi/tests/test_knowledge_endpoint.py
+++ b/src/tribler/core/components/knowledge/restapi/tests/test_knowledge_endpoint.py
@@ -27,11 +27,9 @@ def knowledge_endpoint(knowledge_db):
 
 
 @pytest.fixture
-def rest_api(event_loop, aiohttp_client, knowledge_endpoint):
-    app = Application()
-    app.add_subapp('/knowledge', knowledge_endpoint.app)
-    yield event_loop.run_until_complete(aiohttp_client(app))
-    app.shutdown()
+def rest_api(web_app, event_loop, aiohttp_client, knowledge_endpoint):
+    web_app.add_subapp('/knowledge', knowledge_endpoint.app)
+    yield event_loop.run_until_complete(aiohttp_client(web_app))
 
 
 def tag_to_statement(tag: str) -> Dict:

--- a/src/tribler/core/components/libtorrent/restapi/tests/test_downloads_endpoint.py
+++ b/src/tribler/core/components/libtorrent/restapi/tests/test_downloads_endpoint.py
@@ -17,14 +17,10 @@ from tribler.core.utilities.unicode import hexlify
 
 
 @pytest.fixture
-def rest_api(event_loop, aiohttp_client, mock_dlmgr, metadata_store):  # pylint: disable=unused-argument
-
+def rest_api(web_app, event_loop, aiohttp_client, mock_dlmgr, metadata_store):
     endpoint = DownloadsEndpoint(mock_dlmgr, metadata_store=metadata_store)
-
-    app = Application(middlewares=[error_middleware])
-    app.add_subapp('/downloads', endpoint.app)
-    yield event_loop.run_until_complete(aiohttp_client(app))
-    app.shutdown()
+    web_app.add_subapp('/downloads', endpoint.app)
+    yield event_loop.run_until_complete(aiohttp_client(web_app))
 
 
 def get_hex_infohash(tdef):

--- a/src/tribler/core/components/libtorrent/restapi/tests/test_libtorrent_endpoint.py
+++ b/src/tribler/core/components/libtorrent/restapi/tests/test_libtorrent_endpoint.py
@@ -15,11 +15,9 @@ def endpoint(mock_dlmgr, mock_lt_session):
 
 
 @pytest.fixture
-def rest_api(event_loop, aiohttp_client, endpoint):  # pylint: disable=unused-argument
-    app = Application(middlewares=[error_middleware])
-    app.add_subapp('/libtorrent', endpoint.app)
-    yield event_loop.run_until_complete(aiohttp_client(app))
-    app.shutdown()
+def rest_api(web_app, event_loop, aiohttp_client, endpoint):
+    web_app.add_subapp('/libtorrent', endpoint.app)
+    yield event_loop.run_until_complete(aiohttp_client(web_app))
 
 
 @pytest.fixture

--- a/src/tribler/core/components/libtorrent/restapi/tests/test_torrentinfo_endpoint.py
+++ b/src/tribler/core/components/libtorrent/restapi/tests/test_torrentinfo_endpoint.py
@@ -51,11 +51,9 @@ def endpoint(download_manager):
 
 
 @pytest.fixture
-def rest_api(event_loop, aiohttp_client, endpoint):  # pylint: disable=unused-argument
-    app = Application(middlewares=[error_middleware])
-    app.add_subapp('/torrentinfo', endpoint.app)
-    yield event_loop.run_until_complete(aiohttp_client(app))
-    app.shutdown()
+def rest_api(web_app, event_loop, aiohttp_client, endpoint):
+    web_app.add_subapp('/torrentinfo', endpoint.app)
+    yield event_loop.run_until_complete(aiohttp_client(web_app))
 
 
 async def test_get_torrentinfo_escaped_characters(tmp_path, rest_api):

--- a/src/tribler/core/components/metadata_store/restapi/tests/test_channels_endpoint.py
+++ b/src/tribler/core/components/metadata_store/restapi/tests/test_channels_endpoint.py
@@ -36,7 +36,7 @@ PNG_DATA = unhexlify(
 
 
 @pytest.fixture
-def rest_api(event_loop, aiohttp_client, mock_dlmgr, metadata_store, knowledge_db):  # pylint: disable=unused-argument
+def rest_api(web_app, event_loop, aiohttp_client, mock_dlmgr, metadata_store, knowledge_db):
     mock_gigachannel_manager = Mock()
     mock_gigachannel_community = Mock()
 
@@ -51,11 +51,9 @@ def rest_api(event_loop, aiohttp_client, mock_dlmgr, metadata_store, knowledge_d
     collections_endpoint = ChannelsEndpoint(*ep_args, **ep_kwargs)
     channels_endpoint = ChannelsEndpoint(*ep_args, **ep_kwargs)
 
-    app = Application(middlewares=[error_middleware])
-    app.add_subapp('/channels', channels_endpoint.app)
-    app.add_subapp('/collections', collections_endpoint.app)
-    yield event_loop.run_until_complete(aiohttp_client(app))
-    app.shutdown()
+    web_app.add_subapp('/channels', channels_endpoint.app)
+    web_app.add_subapp('/collections', collections_endpoint.app)
+    yield event_loop.run_until_complete(aiohttp_client(web_app))
 
 
 async def test_get_channels(rest_api, add_fake_torrents_channels, add_subscribed_and_not_downloaded_channel, mock_dlmgr,

--- a/src/tribler/core/components/metadata_store/restapi/tests/test_metadata_endpoint.py
+++ b/src/tribler/core/components/metadata_store/restapi/tests/test_metadata_endpoint.py
@@ -40,13 +40,11 @@ async def torrent_checker(mock_dlmgr, metadata_store):
 
 
 @pytest.fixture
-def rest_api(event_loop, aiohttp_client, torrent_checker, metadata_store):  # pylint: disable=unused-argument
+def rest_api(web_app, event_loop, aiohttp_client, torrent_checker, metadata_store):
     endpoint = MetadataEndpoint(torrent_checker, metadata_store)
 
-    app = Application(middlewares=[error_middleware])
-    app.add_subapp('/metadata', endpoint.app)
-    yield event_loop.run_until_complete(aiohttp_client(app))
-    app.shutdown()
+    web_app.add_subapp('/metadata', endpoint.app)
+    yield event_loop.run_until_complete(aiohttp_client(web_app))
 
 
 async def test_update_multiple_metadata_entries(metadata_store, add_fake_torrents_channels, rest_api):

--- a/src/tribler/core/components/metadata_store/restapi/tests/test_search_endpoint.py
+++ b/src/tribler/core/components/metadata_store/restapi/tests/test_search_endpoint.py
@@ -31,12 +31,10 @@ def needle_in_haystack_mds(metadata_store):
 
 
 @pytest.fixture
-def rest_api(event_loop, needle_in_haystack_mds, aiohttp_client, knowledge_db):
+def rest_api(web_app, event_loop, needle_in_haystack_mds, aiohttp_client, knowledge_db):
     channels_endpoint = SearchEndpoint(needle_in_haystack_mds, knowledge_db=knowledge_db)
-    app = Application()
-    app.add_subapp('/search', channels_endpoint.app)
-    yield event_loop.run_until_complete(aiohttp_client(app))
-    app.shutdown()
+    web_app.add_subapp('/search', channels_endpoint.app)
+    yield event_loop.run_until_complete(aiohttp_client(web_app))
 
 
 async def test_search_wrong_mdtype(rest_api):

--- a/src/tribler/core/components/restapi/rest/tests/test_create_torrent_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/tests/test_create_torrent_endpoint.py
@@ -17,11 +17,9 @@ def endpoint():
 
 
 @pytest.fixture
-def rest_api(event_loop, aiohttp_client, endpoint):  # pylint: disable=unused-argument
-    app = Application(middlewares=[error_middleware])
-    app.add_subapp('/createtorrent', endpoint.app)
-    yield event_loop.run_until_complete(aiohttp_client(app))
-    app.shutdown()
+def rest_api(web_app, event_loop, aiohttp_client, endpoint):
+    web_app.add_subapp('/createtorrent', endpoint.app)
+    yield event_loop.run_until_complete(aiohttp_client(web_app))
 
 
 async def test_create_torrent(rest_api, tmp_path, endpoint):

--- a/src/tribler/core/components/restapi/rest/tests/test_debug_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/tests/test_debug_endpoint.py
@@ -36,13 +36,10 @@ async def core_resource_monitor(tmp_path):
 
 
 @pytest.fixture
-def rest_api(event_loop, aiohttp_client, mock_tunnel_community, endpoint):  # pylint: disable=unused-argument
+def rest_api(web_app, event_loop, aiohttp_client, mock_tunnel_community, endpoint):
     endpoint.tunnel_community = mock_tunnel_community
-
-    app = Application(middlewares=[error_middleware])
-    app.add_subapp('/debug', endpoint.app)
-    yield event_loop.run_until_complete(aiohttp_client(app))
-    app.shutdown()
+    web_app.add_subapp('/debug', endpoint.app)
+    yield event_loop.run_until_complete(aiohttp_client(web_app))
 
 
 async def test_get_slots(rest_api, mock_tunnel_community):

--- a/src/tribler/core/components/restapi/rest/tests/test_settings_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/tests/test_settings_endpoint.py
@@ -21,11 +21,9 @@ def endpoint(tribler_config):
 
 
 @pytest.fixture
-def rest_api(event_loop, aiohttp_client, endpoint):  # pylint: disable=unused-argument
-    app = Application(middlewares=[error_middleware])
-    app.add_subapp('/settings', endpoint.app)
-    yield event_loop.run_until_complete(aiohttp_client(app))
-    app.shutdown()
+def rest_api(web_app, event_loop, aiohttp_client, endpoint):
+    web_app.add_subapp('/settings', endpoint.app)
+    yield event_loop.run_until_complete(aiohttp_client(web_app))
 
 
 def verify_settings(settings_dict):

--- a/src/tribler/core/components/restapi/rest/tests/test_shutdown_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/tests/test_shutdown_endpoint.py
@@ -14,11 +14,9 @@ def endpoint():
 
 
 @pytest.fixture
-def rest_api(event_loop, aiohttp_client, endpoint):  # pylint: disable=unused-argument
-    app = Application(middlewares=[error_middleware])
-    app.add_subapp('/shutdown', endpoint.app)
-    yield event_loop.run_until_complete(aiohttp_client(app))
-    app.shutdown()
+def rest_api(web_app, event_loop, aiohttp_client, endpoint):
+    web_app.add_subapp('/shutdown', endpoint.app)
+    yield event_loop.run_until_complete(aiohttp_client(web_app))
 
 
 async def test_shutdown(rest_api, endpoint):

--- a/src/tribler/core/components/restapi/rest/tests/test_statistics_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/tests/test_statistics_endpoint.py
@@ -30,11 +30,9 @@ def endpoint():
 
 
 @pytest.fixture
-def rest_api(event_loop, aiohttp_client, endpoint):  # pylint: disable=unused-argument
-    app = Application(middlewares=[error_middleware])
-    app.add_subapp('/statistics', endpoint.app)
-    yield event_loop.run_until_complete(aiohttp_client(app))
-    app.shutdown()
+def rest_api(web_app, event_loop, aiohttp_client, endpoint):
+    web_app.add_subapp('/statistics', endpoint.app)
+    yield event_loop.run_until_complete(aiohttp_client(web_app))
 
 
 async def test_get_tribler_statistics(rest_api, endpoint, metadata_store):

--- a/src/tribler/core/components/restapi/rest/tests/test_trustview_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/tests/test_trustview_endpoint.py
@@ -22,11 +22,9 @@ def endpoint(bandwidth_db):  # pylint: disable=W0621
 
 
 @pytest.fixture
-def rest_api(event_loop, aiohttp_client, endpoint):  # pylint: disable=unused-argument
-    app = Application(middlewares=[error_middleware])
-    app.add_subapp('/trustview', endpoint.app)
-    yield event_loop.run_until_complete(aiohttp_client(app))
-    app.shutdown()
+def rest_api(web_app, event_loop, aiohttp_client, endpoint):
+    web_app.add_subapp('/trustview', endpoint.app)
+    yield event_loop.run_until_complete(aiohttp_client(web_app))
 
 
 @pytest.fixture


### PR DESCRIPTION
As it turns out, many REST API-related test fixtures have an `app.shutdown()` call at the end instead of `await app.shutdown()`, and it can be the reason for many problems with test stability.

In this PR, I add a `web_app` fixture that provides an instance of `aiohttp.web_app.Application` and correctly calls `await app.shutdown()` at the end.

The fixture is named `web_app` and not `app` to avoid PyCharm confusion with the `sphinx.testing.fixtures.app` fixture it tries to use when the new fixture is named `app`.