### PR TITLE
Use TestError instead of AssertionError in test to avoid confusion

### DIFF
--- a/src/tribler/gui/tests/test_error_handler.py
+++ b/src/tribler/gui/tests/test_error_handler.py
@@ -22,11 +22,15 @@ def reported_error():
     return ReportedError(type='Exception', text='text', event={})
 
 
+class TestError(Exception):
+    pass
+
+
 @patch('tribler.gui.error_handler.FeedbackDialog')
 def test_gui_error_tribler_stopped(mocked_feedback_dialog: MagicMock, error_handler: ErrorHandler):
     # test that while tribler_stopped is True FeedbackDialog is not called
     error_handler._tribler_stopped = True
-    error_handler.gui_error(AssertionError, AssertionError("error text"), None)
+    error_handler.gui_error(TestError, TestError("error text"), None)
     mocked_feedback_dialog.assert_not_called()
 
 
@@ -34,7 +38,7 @@ def test_gui_error_tribler_stopped(mocked_feedback_dialog: MagicMock, error_hand
 @patch.object(SentryReporter, 'global_strategy', create=True,
               new=PropertyMock(return_value=SentryStrategy.SEND_SUPPRESSED))
 def test_gui_error_suppressed(mocked_feedback_dialog: MagicMock, error_handler: ErrorHandler):
-    error_handler.gui_error(AssertionError, AssertionError('error_text'), None)
+    error_handler.gui_error(TestError, TestError('error_text'), None)
     mocked_feedback_dialog.assert_not_called()
     assert not error_handler._handled_exceptions
 
@@ -42,8 +46,8 @@ def test_gui_error_suppressed(mocked_feedback_dialog: MagicMock, error_handler: 
 @patch('tribler.gui.error_handler.FeedbackDialog')
 def test_gui_info_type_in_handled_exceptions(mocked_feedback_dialog: MagicMock, error_handler: ErrorHandler):
     # test that if exception type in _handled_exceptions then FeedbackDialog is not called
-    error_handler._handled_exceptions = {AssertionError}
-    error_handler.gui_error(AssertionError, AssertionError("error text"), None)
+    error_handler._handled_exceptions = {TestError}
+    error_handler.gui_error(TestError, TestError("error text"), None)
     mocked_feedback_dialog.assert_not_called()
     assert len(error_handler._handled_exceptions) == 1
 


### PR DESCRIPTION
Some tests (of the Core test suite) deliberately raise an AssertionError and expect it to be in `error_handler._handled_exceptions`. It is better to raise a specific `TestError` instead of a generic `AsserionError` not to be confused about whether the error was planned or unexpected. In this PR, I change `AssertionError` to `TestError` to avoid possible confusion.

The reason I want to fix it is that I had observed seen some strange cases when the string `"AssertionError"` was in `error_handler._handled_exceptions` while it was expected to be empty (unfortunately can't provide an example right now), and I want to eliminate possible cases of it.