### PR TITLE
The `get_circuit_slots` method of `DebugEndpoint` should handle the case when `tunnel_community` is `None`

### DIFF
--- a/src/tribler/core/components/restapi/rest/debug_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/debug_endpoint.py
@@ -2,18 +2,19 @@ import datetime
 import logging
 import sys
 from io import StringIO
+from typing import Optional
 
 import psutil
 from aiohttp import web
 from aiohttp.abc import BaseRequest
 from aiohttp_apispec import docs
 from ipv8.REST.schema import schema
-from ipv8.messaging.anonymization.community import TunnelCommunity
 from marshmallow.fields import Boolean, Float, Integer, String
 
 from tribler.core.components.reporter.exception_handler import CoreExceptionHandler
 from tribler.core.components.resource_monitor.implementation.base import ResourceMonitor
 from tribler.core.components.restapi.rest.rest_endpoint import RESTEndpoint, RESTResponse
+from tribler.core.components.tunnel.community.tunnel_community import TriblerTunnelCommunity
 from tribler.core.exceptions import TriblerCoreTestException
 from tribler.core.utilities.instrumentation import WatchDog
 from tribler.core.utilities.osutils import get_root_state_directory
@@ -46,9 +47,9 @@ class DebugEndpoint(RESTEndpoint):
     def __init__(self,
                  state_dir: Path,
                  log_dir: Path,
-                 tunnel_community: TunnelCommunity = None,
-                 resource_monitor: ResourceMonitor = None,
-                 core_exception_handler: CoreExceptionHandler = None):
+                 tunnel_community: Optional[TriblerTunnelCommunity] = None,
+                 resource_monitor: Optional[ResourceMonitor] = None,
+                 core_exception_handler: Optional[CoreExceptionHandler] = None):
         super().__init__()
         self.logger = logging.getLogger(self.__class__.__name__)
         self.state_dir = state_dir
@@ -88,10 +89,12 @@ class DebugEndpoint(RESTEndpoint):
         }
     )
     async def get_circuit_slots(self, request):
+        random_slots = self.tunnel_community.random_slots if self.tunnel_community else []
+        competing_slots = self.tunnel_community.competing_slots if self.tunnel_community else []
         return RESTResponse({
             "slots": {
-                "random": self.tunnel_community.random_slots,
-                "competing": self.tunnel_community.competing_slots
+                "random": random_slots,
+                "competing": competing_slots
             }
         })
 


### PR DESCRIPTION
The `run` method of `RESTComponent` has [the following lines](https://github.com/Tribler/tribler/blob/55d02e606d16edb1d09100a486da0deaf0385cea/src/tribler/core/components/restapi/restapi_component.py#L92):

```python
torrent_checker = None if config.gui_test_mode else torrent_checker_component.torrent_checker
tunnel_community = None if config.gui_test_mode else tunnel_component.community
gigachannel_manager = None if config.gui_test_mode else gigachannel_manager_component.gigachannel_manager
```

That is, `tunnel_community` is `None` when Tribler is started for GUI tests.

At the same time, the `DebugEndpoint` in the `RESTComponent.run` method is initialized [in the following way](https://github.com/Tribler/tribler/blob/55d02e606d16edb1d09100a486da0deaf0385cea/src/tribler/core/components/restapi/restapi_component.py#L100):
```python
self.maybe_add('/debug', DebugEndpoint, config.state_dir, log_dir,
               tunnel_community=tunnel_community,
               resource_monitor=resource_monitor_component.resource_monitor,
               core_exception_handler=self._core_exception_handler)
```
Here, `tunnel_community` is passed as `None` when Tribler is in `gui_test_mode`.

The `maybe_add` method does not affect this situation, as it only handles special `NoneComponent` arguments and not normal `None` values.

Therefore, the code of `DebugEndpoint` should expect to handle the situation gracefully when the `tunnel_community` is None. But in the `get_circuit_slots` method, it currently expects a non-None instance of `tunnel_community`.

This PR fixes the problem by handling the case when `self.tunnel_community` is None in `DebugEndpoint`