### PR TITLE
Fix the `get_torrent_health` endpoint in GUI tests

### DIFF
--- a/src/tribler/core/components/metadata_store/restapi/tests/test_metadata_endpoint.py
+++ b/src/tribler/core/components/metadata_store/restapi/tests/test_metadata_endpoint.py
@@ -207,7 +207,7 @@ async def test_check_torrent_health(rest_api, mock_dlmgr, udp_tracker, metadata_
     infohash = b'a' * 20
     url = f'metadata/torrents/{hexlify(infohash)}/health?timeout={TORRENT_CHECK_TIMEOUT}'
     json_response = await do_request(rest_api, url)
-    assert json_response == {'checking': '1'}
+    assert json_response == {'checking': True}
 
 
 async def test_check_torrent_query(rest_api, udp_tracker, metadata_store):


### PR DESCRIPTION
Currently, the `RESTComponent.run` method has the following code lines:

```python
        torrent_checker = None if config.gui_test_mode else torrent_checker_component.torrent_checker
        tunnel_community = None if config.gui_test_mode else tunnel_component.community
        gigachannel_manager = None if config.gui_test_mode else gigachannel_manager_component.gigachannel_manager
```
and
```python
        self.maybe_add('/metadata', MetadataEndpoint, torrent_checker, metadata_store_component.mds,
                       knowledge_db=knowledge_component.knowledge_db,
                       tag_rules_processor=knowledge_component.rules_processor)
```

That is, under GUI tests, the `torrent_checker` argument of `MetadataEndpoint`  can be `None`. The `maybe_add` call does not handle this situation, as it can only handle `NoneComponent` arguments and not the normal `None` values.

But, the `MetadataEndpoint.get_torrent_health` methods expect `self.torrent_checker` to be not-None.

For some reason, during GUI tests, the `get_torrent_health` endpoint can be randomly called in different GUI tests, provoking a Core exception and a test failure.

This PR fixes the `get_torrent_health` endpoint by handling the case when `self.torrent_checker` is `None`.