### PR TITLE
Make `rest_api` fixture async

### DIFF
--- a/src/tribler/core/components/conftest.py
+++ b/src/tribler/core/components/conftest.py
@@ -1,7 +1,6 @@
 from unittest.mock import MagicMock
 
 import pytest
-from aiohttp.abc import Application
 from ipv8.keyvault.private.libnaclkey import LibNaCLSK
 from ipv8.util import succeed
 
@@ -11,7 +10,6 @@ from tribler.core.components.libtorrent.download_manager.download_manager import
 from tribler.core.components.libtorrent.settings import LibtorrentSettings
 from tribler.core.components.libtorrent.torrentdef import TorrentDef
 from tribler.core.components.metadata_store.db.store import MetadataStore
-from tribler.core.components.restapi.rest.rest_manager import error_middleware
 from tribler.core.config.tribler_config import TriblerConfig
 from tribler.core.tests.tools.common import TESTS_DATA_DIR
 from tribler.core.utilities.path_util import Path
@@ -132,10 +130,3 @@ async def download_manager(tmp_path_factory):
     yield download_manager
 
     await download_manager.shutdown()
-
-
-@pytest.fixture(name='web_app')
-async def web_app_fixture():
-    app = Application(middlewares=[error_middleware])
-    yield app
-    await app.shutdown()

--- a/src/tribler/core/components/knowledge/restapi/tests/test_knowledge_endpoint.py
+++ b/src/tribler/core/components/knowledge/restapi/tests/test_knowledge_endpoint.py
@@ -27,9 +27,13 @@ def knowledge_endpoint(knowledge_db):
 
 
 @pytest.fixture
-def rest_api(web_app, event_loop, aiohttp_client, knowledge_endpoint):
-    web_app.add_subapp('/knowledge', knowledge_endpoint.app)
-    yield event_loop.run_until_complete(aiohttp_client(web_app))
+async def rest_api(event_loop, aiohttp_client, knowledge_endpoint):  # pylint: disable=unused-argument
+    app = Application()
+    app.add_subapp('/knowledge', knowledge_endpoint.app)
+
+    yield await aiohttp_client(app)
+
+    await app.shutdown()
 
 
 def tag_to_statement(tag: str) -> Dict:

--- a/src/tribler/core/components/knowledge/restapi/tests/test_knowledge_endpoint.py
+++ b/src/tribler/core/components/knowledge/restapi/tests/test_knowledge_endpoint.py
@@ -27,7 +27,7 @@ def knowledge_endpoint(knowledge_db):
 
 
 @pytest.fixture
-async def rest_api(event_loop, aiohttp_client, knowledge_endpoint):  # pylint: disable=unused-argument
+async def rest_api(aiohttp_client, knowledge_endpoint):
     app = Application()
     app.add_subapp('/knowledge', knowledge_endpoint.app)
 

--- a/src/tribler/core/components/libtorrent/restapi/tests/test_downloads_endpoint.py
+++ b/src/tribler/core/components/libtorrent/restapi/tests/test_downloads_endpoint.py
@@ -19,7 +19,7 @@ from tribler.core.utilities.unicode import hexlify
 
 
 @pytest.fixture
-async def rest_api(event_loop, aiohttp_client, mock_dlmgr, metadata_store):  # pylint: disable=unused-argument
+async def rest_api(aiohttp_client, mock_dlmgr, metadata_store):
     endpoint = DownloadsEndpoint(mock_dlmgr, metadata_store=metadata_store)
     app = Application(middlewares=[error_middleware])
     app.add_subapp('/downloads', endpoint.app)

--- a/src/tribler/core/components/libtorrent/restapi/tests/test_downloads_endpoint.py
+++ b/src/tribler/core/components/libtorrent/restapi/tests/test_downloads_endpoint.py
@@ -19,10 +19,15 @@ from tribler.core.utilities.unicode import hexlify
 
 
 @pytest.fixture
-def rest_api(web_app, event_loop, aiohttp_client, mock_dlmgr, metadata_store):
+async def rest_api(event_loop, aiohttp_client, mock_dlmgr, metadata_store):  # pylint: disable=unused-argument
     endpoint = DownloadsEndpoint(mock_dlmgr, metadata_store=metadata_store)
-    web_app.add_subapp('/downloads', endpoint.app)
-    yield event_loop.run_until_complete(aiohttp_client(web_app))
+    app = Application(middlewares=[error_middleware])
+    app.add_subapp('/downloads', endpoint.app)
+
+    yield await aiohttp_client(app)
+
+    await endpoint.shutdown()
+    await app.shutdown()
 
 
 def get_hex_infohash(tdef):
@@ -144,12 +149,12 @@ def test_get_extended_status_circuits(mock_extended_status):
 
 
 @unittest.mock.patch("tribler.core.components.libtorrent.restapi.downloads_endpoint.ensure_unicode",
-       Mock(side_effect=UnicodeDecodeError("", b"", 0, 0, "")))
+                     Mock(side_effect=UnicodeDecodeError("", b"", 0, 0, "")))
 def test_safe_extended_peer_info():
     """
     Test that we return the string mapped by `chr` in the case of `UnicodeDecodeError`
     """
-    extended_peer_info = download_endpoint._safe_extended_peer_info(b"abcd") # pylint: disable=protected-access
+    extended_peer_info = download_endpoint._safe_extended_peer_info(b"abcd")  # pylint: disable=protected-access
     assert extended_peer_info == "abcd"
 
 

--- a/src/tribler/core/components/libtorrent/restapi/tests/test_libtorrent_endpoint.py
+++ b/src/tribler/core/components/libtorrent/restapi/tests/test_libtorrent_endpoint.py
@@ -10,14 +10,15 @@ from tribler.core.utilities.unicode import hexlify
 
 
 @pytest.fixture
-def endpoint(mock_dlmgr, mock_lt_session):
-    return LibTorrentEndpoint(mock_dlmgr)
+async def rest_api(event_loop, aiohttp_client, mock_dlmgr, mock_lt_session):  # pylint: disable=unused-argument
+    endpoint = LibTorrentEndpoint(mock_dlmgr)
+    app = Application(middlewares=[error_middleware])
+    app.add_subapp('/libtorrent', endpoint.app)
 
+    yield await aiohttp_client(app)
 
-@pytest.fixture
-def rest_api(web_app, event_loop, aiohttp_client, endpoint):
-    web_app.add_subapp('/libtorrent', endpoint.app)
-    yield event_loop.run_until_complete(aiohttp_client(web_app))
+    await endpoint.shutdown()
+    await app.shutdown()
 
 
 @pytest.fixture

--- a/src/tribler/core/components/libtorrent/restapi/tests/test_libtorrent_endpoint.py
+++ b/src/tribler/core/components/libtorrent/restapi/tests/test_libtorrent_endpoint.py
@@ -10,7 +10,7 @@ from tribler.core.utilities.unicode import hexlify
 
 
 @pytest.fixture
-async def rest_api(event_loop, aiohttp_client, mock_dlmgr, mock_lt_session):  # pylint: disable=unused-argument
+async def rest_api(aiohttp_client, mock_dlmgr, mock_lt_session):
     endpoint = LibTorrentEndpoint(mock_dlmgr)
     app = Application(middlewares=[error_middleware])
     app.add_subapp('/libtorrent', endpoint.app)

--- a/src/tribler/core/components/libtorrent/restapi/tests/test_torrentinfo_endpoint.py
+++ b/src/tribler/core/components/libtorrent/restapi/tests/test_torrentinfo_endpoint.py
@@ -46,7 +46,7 @@ def download_manager(state_dir):
 
 
 @pytest.fixture
-async def rest_api(event_loop, aiohttp_client, download_manager: DownloadManager):  # pylint: disable=unused-argument
+async def rest_api(aiohttp_client, download_manager: DownloadManager):
     endpoint = TorrentInfoEndpoint(download_manager)
     app = Application(middlewares=[error_middleware])
     app.add_subapp('/torrentinfo', endpoint.app)
@@ -114,7 +114,7 @@ async def test_get_torrentinfo(tmp_path, rest_api, download_manager: DownloadMan
         tdef = TorrentDef.load_from_memory(torrent_data)
     metainfo_dict = tdef_to_metadata_dict(TorrentDef.load_from_memory(torrent_data))
 
-    async def get_metainfo(infohash, timeout=20, hops=None, url=None):
+    async def get_metainfo(infohash, timeout=20, hops=None, url=None):  # pylint: disable=unused-argument
         if hops is not None:
             hops_list.append(hops)
         assert url

--- a/src/tribler/core/components/metadata_store/restapi/tests/test_channels_endpoint.py
+++ b/src/tribler/core/components/metadata_store/restapi/tests/test_channels_endpoint.py
@@ -36,8 +36,7 @@ PNG_DATA = unhexlify(
 
 
 @pytest.fixture
-async def rest_api(event_loop, aiohttp_client, mock_dlmgr, metadata_store,
-                   knowledge_db):  # pylint: disable=unused-argument
+async def rest_api(aiohttp_client, mock_dlmgr, metadata_store, knowledge_db):
     mock_gigachannel_manager = Mock()
     mock_gigachannel_community = Mock()
 

--- a/src/tribler/core/components/metadata_store/restapi/tests/test_channels_endpoint.py
+++ b/src/tribler/core/components/metadata_store/restapi/tests/test_channels_endpoint.py
@@ -36,7 +36,8 @@ PNG_DATA = unhexlify(
 
 
 @pytest.fixture
-def rest_api(web_app, event_loop, aiohttp_client, mock_dlmgr, metadata_store, knowledge_db):
+async def rest_api(event_loop, aiohttp_client, mock_dlmgr, metadata_store,
+                   knowledge_db):  # pylint: disable=unused-argument
     mock_gigachannel_manager = Mock()
     mock_gigachannel_community = Mock()
 
@@ -51,9 +52,15 @@ def rest_api(web_app, event_loop, aiohttp_client, mock_dlmgr, metadata_store, kn
     collections_endpoint = ChannelsEndpoint(*ep_args, **ep_kwargs)
     channels_endpoint = ChannelsEndpoint(*ep_args, **ep_kwargs)
 
-    web_app.add_subapp('/channels', channels_endpoint.app)
-    web_app.add_subapp('/collections', collections_endpoint.app)
-    yield event_loop.run_until_complete(aiohttp_client(web_app))
+    app = Application(middlewares=[error_middleware])
+    app.add_subapp('/channels', channels_endpoint.app)
+    app.add_subapp('/collections', collections_endpoint.app)
+
+    yield await aiohttp_client(app)
+
+    await collections_endpoint.shutdown()
+    await channels_endpoint.shutdown()
+    await app.shutdown()
 
 
 async def test_get_channels(rest_api, add_fake_torrents_channels, add_subscribed_and_not_downloaded_channel, mock_dlmgr,

--- a/src/tribler/core/components/metadata_store/restapi/tests/test_metadata_endpoint.py
+++ b/src/tribler/core/components/metadata_store/restapi/tests/test_metadata_endpoint.py
@@ -39,7 +39,7 @@ async def torrent_checker(mock_dlmgr, metadata_store):
 
 
 @pytest.fixture
-async def rest_api(event_loop, aiohttp_client, torrent_checker, metadata_store):
+async def rest_api(aiohttp_client, torrent_checker, metadata_store):
     endpoint = MetadataEndpoint(torrent_checker, metadata_store)
 
     app = Application(middlewares=[error_middleware])

--- a/src/tribler/core/components/metadata_store/restapi/tests/test_metadata_endpoint.py
+++ b/src/tribler/core/components/metadata_store/restapi/tests/test_metadata_endpoint.py
@@ -39,11 +39,15 @@ async def torrent_checker(mock_dlmgr, metadata_store):
 
 
 @pytest.fixture
-def rest_api(web_app, event_loop, aiohttp_client, torrent_checker, metadata_store):
+async def rest_api(event_loop, aiohttp_client, torrent_checker, metadata_store):
     endpoint = MetadataEndpoint(torrent_checker, metadata_store)
 
-    web_app.add_subapp('/metadata', endpoint.app)
-    yield event_loop.run_until_complete(aiohttp_client(web_app))
+    app = Application(middlewares=[error_middleware])
+    app.add_subapp('/metadata', endpoint.app)
+    yield await aiohttp_client(app)
+
+    await endpoint.shutdown()
+    await app.shutdown()
 
 
 async def test_update_multiple_metadata_entries(metadata_store, add_fake_torrents_channels, rest_api):

--- a/src/tribler/core/components/metadata_store/restapi/tests/test_remote_query_endpoint.py
+++ b/src/tribler/core/components/metadata_store/restapi/tests/test_remote_query_endpoint.py
@@ -24,7 +24,7 @@ def mock_gigachannel_community():
 
 
 @pytest.fixture
-async def rest_api(event_loop, aiohttp_client, metadata_store, mock_gigachannel_community):
+async def rest_api(aiohttp_client, metadata_store, mock_gigachannel_community):
     endpoint = RemoteQueryEndpoint(mock_gigachannel_community, metadata_store)
     app = Application(middlewares=[error_middleware])
     app.add_subapp('/remote_query', endpoint.app)

--- a/src/tribler/core/components/metadata_store/restapi/tests/test_remote_query_endpoint.py
+++ b/src/tribler/core/components/metadata_store/restapi/tests/test_remote_query_endpoint.py
@@ -24,19 +24,18 @@ def mock_gigachannel_community():
 
 
 @pytest.fixture
-def endpoint(mock_gigachannel_community, metadata_store):
-    return RemoteQueryEndpoint(mock_gigachannel_community, metadata_store)
-
-
-@pytest.fixture
-def rest_api(event_loop, aiohttp_client, endpoint):
+async def rest_api(event_loop, aiohttp_client, metadata_store, mock_gigachannel_community):
+    endpoint = RemoteQueryEndpoint(mock_gigachannel_community, metadata_store)
     app = Application(middlewares=[error_middleware])
     app.add_subapp('/remote_query', endpoint.app)
-    yield event_loop.run_until_complete(aiohttp_client(app))
-    app.shutdown()
+
+    yield await aiohttp_client(app)
+
+    await endpoint.shutdown()
+    await app.shutdown()
 
 
-async def test_create_remote_search_request(rest_api, endpoint, mock_gigachannel_community):
+async def test_create_remote_search_request(rest_api, mock_gigachannel_community):
     """
     Test that remote search call is sent on a REST API search request
     """
@@ -69,7 +68,7 @@ async def test_create_remote_search_request(rest_api, endpoint, mock_gigachannel
     assert hexlify(sent['channel_pk']) == channel_pk
 
 
-async def test_get_channels_peers(rest_api, endpoint, metadata_store, mock_gigachannel_community):
+async def test_get_channels_peers(rest_api, metadata_store, mock_gigachannel_community):
     """
     Test getting debug info about the state of channels to peers mapping
     """

--- a/src/tribler/core/components/metadata_store/restapi/tests/test_search_endpoint.py
+++ b/src/tribler/core/components/metadata_store/restapi/tests/test_search_endpoint.py
@@ -31,7 +31,7 @@ def needle_in_haystack_mds(metadata_store):
 
 
 @pytest.fixture
-async def rest_api(event_loop, needle_in_haystack_mds, aiohttp_client, knowledge_db):
+async def rest_api(needle_in_haystack_mds, aiohttp_client, knowledge_db):
     channels_endpoint = SearchEndpoint(needle_in_haystack_mds, knowledge_db=knowledge_db)
     app = Application()
     app.add_subapp('/search', channels_endpoint.app)

--- a/src/tribler/core/components/metadata_store/tests/test_channel_download.py
+++ b/src/tribler/core/components/metadata_store/tests/test_channel_download.py
@@ -20,13 +20,15 @@ CHANNEL_METADATA = CHANNEL_DIR / 'channel.mdblob'
 CHANNEL_METADATA_UPDATED = CHANNEL_DIR / 'channel_upd.mdblob'
 
 
+# pylint: disable=redefined-outer-name
+
 @pytest.fixture
 def channel_tdef():
     return TorrentDef.load(TESTS_DATA_DIR / 'sample_channel' / 'channel_upd.torrent')
 
 
 @pytest.fixture
-async def channel_seeder(channel_tdef, tmp_path_factory):  # pylint: disable=unused-argument, redefined-outer-name
+async def channel_seeder(channel_tdef, tmp_path_factory):  # pylint: disable=unused-argument
     config = LibtorrentSettings()
     config.dht = False
     config.upnp = False

--- a/src/tribler/core/components/metadata_store/tests/test_channel_download.py
+++ b/src/tribler/core/components/metadata_store/tests/test_channel_download.py
@@ -45,20 +45,20 @@ async def channel_seeder(channel_tdef, tmp_path_factory):  # pylint: disable=unu
 
 
 @pytest.fixture
-async def gigachannel_manager(metadata_store, download_manager):
-    gigachannel_manager = GigaChannelManager(
+async def gigachannel_manager(metadata_store, download_manager: DownloadManager):
+    manager = GigaChannelManager(
         state_dir=metadata_store.channels_dir.parent,
         download_manager=download_manager,
         metadata_store=metadata_store,
         notifier=MagicMock(),
     )
-    yield gigachannel_manager
-    await gigachannel_manager.shutdown()
+    yield manager
+    await manager.shutdown()
 
 
-async def test_channel_update_and_download(
-        channel_tdef, channel_seeder, metadata_store, download_manager, gigachannel_manager
-):
+async def test_channel_update_and_download(channel_tdef, channel_seeder, metadata_store,
+                                           download_manager: DownloadManager,
+                                           gigachannel_manager: GigaChannelManager):
     """
     Test whether we can successfully update a channel and download the new version
     """

--- a/src/tribler/core/components/resource_monitor/implementation/base.py
+++ b/src/tribler/core/components/resource_monitor/implementation/base.py
@@ -1,6 +1,7 @@
 import logging
 import time
 from collections import deque
+from typing import Optional
 
 import psutil
 
@@ -25,6 +26,7 @@ class ResourceMonitor:
 
         self.cpu_data = deque(maxlen=history_size)
         self.memory_data = deque(maxlen=history_size)
+        self.profiler: Optional = None
 
         self.process = psutil.Process()
         self.last_error = None

--- a/src/tribler/core/components/restapi/rest/debug_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/debug_endpoint.py
@@ -340,6 +340,8 @@ class DebugEndpoint(RESTEndpoint):
         }
     )
     async def stop_profiler(self, _):
+        if not self.resource_monitor.profiler:
+            return
         file_path = self.resource_monitor.profiler.stop()
         return RESTResponse({"success": True, "profiler_file": str(file_path)})
 

--- a/src/tribler/core/components/restapi/rest/tests/test_create_torrent_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/tests/test_create_torrent_endpoint.py
@@ -11,8 +11,11 @@ from tribler.core.components.restapi.rest.rest_manager import error_middleware
 from tribler.core.tests.tools.common import TESTS_DATA_DIR
 
 
+# pylint: disable=redefined-outer-name
+
+
 @pytest.fixture
-async def rest_api(event_loop, aiohttp_client, download_manager):  # pylint: disable=unused-argument
+async def rest_api(aiohttp_client, download_manager):
     endpoint = CreateTorrentEndpoint(download_manager)
     app = Application(middlewares=[error_middleware])
     app.add_subapp('/createtorrent', endpoint.app)

--- a/src/tribler/core/components/restapi/rest/tests/test_create_torrent_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/tests/test_create_torrent_endpoint.py
@@ -12,17 +12,18 @@ from tribler.core.tests.tools.common import TESTS_DATA_DIR
 
 
 @pytest.fixture
-def endpoint():
-    return CreateTorrentEndpoint(Mock())
+async def rest_api(event_loop, aiohttp_client, download_manager):  # pylint: disable=unused-argument
+    endpoint = CreateTorrentEndpoint(download_manager)
+    app = Application(middlewares=[error_middleware])
+    app.add_subapp('/createtorrent', endpoint.app)
+
+    yield await aiohttp_client(app)
+
+    await endpoint.shutdown()
+    await app.shutdown()
 
 
-@pytest.fixture
-def rest_api(web_app, event_loop, aiohttp_client, endpoint):
-    web_app.add_subapp('/createtorrent', endpoint.app)
-    yield event_loop.run_until_complete(aiohttp_client(web_app))
-
-
-async def test_create_torrent(rest_api, tmp_path, endpoint):
+async def test_create_torrent(rest_api, tmp_path, download_manager):
     """
     Testing whether the API returns a proper base64 encoded torrent
     """
@@ -32,9 +33,9 @@ async def test_create_torrent(rest_api, tmp_path, endpoint):
             encoded_metainfo = torrent_file.read()
         return succeed({"metainfo": encoded_metainfo, "base_dir": str(tmp_path)})
 
-    endpoint.download_manager.download_defaults = DownloadDefaultsSettings()
-    endpoint.download_manager.create_torrent_file = fake_create_torrent_file
-    endpoint.download_manager.start_download = start_download = Mock()
+    download_manager.download_defaults = DownloadDefaultsSettings()
+    download_manager.create_torrent_file = fake_create_torrent_file
+    download_manager.start_download = start_download = Mock()
 
     torrent_path = tmp_path / "video.avi.torrent"
     post_data = {
@@ -52,7 +53,7 @@ async def test_create_torrent(rest_api, tmp_path, endpoint):
     ).number_hops  # pylint: disable=unsubscriptable-object
 
 
-async def test_create_torrent_io_error(rest_api, endpoint):
+async def test_create_torrent_io_error(rest_api, download_manager):
     """
     Testing whether the API returns a formatted 500 error if IOError is raised
     """
@@ -60,7 +61,7 @@ async def test_create_torrent_io_error(rest_api, endpoint):
     def fake_create_torrent_file(*_, **__):
         raise OSError("test")
 
-    endpoint.download_manager.create_torrent_file = fake_create_torrent_file
+    download_manager.create_torrent_file = fake_create_torrent_file
 
     post_data = {
         "files": ["non_existing_file.avi"]

--- a/src/tribler/core/components/restapi/rest/tests/test_debug_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/tests/test_debug_endpoint.py
@@ -32,7 +32,7 @@ async def core_resource_monitor(tmp_path):
 
 
 @pytest.fixture
-async def rest_api(event_loop, aiohttp_client, mock_tunnel_community, tmp_path, core_resource_monitor):
+async def rest_api(aiohttp_client, mock_tunnel_community, tmp_path, core_resource_monitor):
     endpoint = DebugEndpoint(tmp_path, tmp_path / 'logs',
                              tunnel_community=mock_tunnel_community,
                              resource_monitor=core_resource_monitor)
@@ -41,6 +41,7 @@ async def rest_api(event_loop, aiohttp_client, mock_tunnel_community, tmp_path, 
 
     app = Application(middlewares=[error_middleware])
     app.add_subapp('/debug', endpoint.app)
+
     yield await aiohttp_client(app)
 
     await endpoint.shutdown()

--- a/src/tribler/core/components/restapi/rest/tests/test_settings_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/tests/test_settings_endpoint.py
@@ -17,9 +17,8 @@ def tribler_config(tmp_path):
     return config
 
 
-
 @pytest.fixture
-async def rest_api(event_loop, aiohttp_client, tribler_config):
+async def rest_api(aiohttp_client, tribler_config):
     endpoint = SettingsEndpoint(tribler_config)
     app = Application(middlewares=[error_middleware])
     app.add_subapp('/settings', endpoint.app)

--- a/src/tribler/core/components/restapi/rest/tests/test_shutdown_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/tests/test_shutdown_endpoint.py
@@ -8,6 +8,9 @@ from tribler.core.components.restapi.rest.rest_manager import error_middleware
 from tribler.core.components.restapi.rest.shutdown_endpoint import ShutdownEndpoint
 
 
+# pylint: disable=redefined-outer-name
+
+
 @pytest.fixture
 async def endpoint():
     endpoint = ShutdownEndpoint(Mock())
@@ -17,7 +20,7 @@ async def endpoint():
 
 
 @pytest.fixture
-async def rest_api(event_loop, aiohttp_client, endpoint):  # pylint: disable=unused-argument
+async def rest_api(aiohttp_client, endpoint):
     app = Application(middlewares=[error_middleware])
     app.add_subapp('/shutdown', endpoint.app)
 

--- a/src/tribler/core/components/restapi/rest/tests/test_statistics_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/tests/test_statistics_endpoint.py
@@ -12,6 +12,9 @@ from tribler.core.components.restapi.rest.rest_manager import error_middleware
 from tribler.core.components.restapi.rest.statistics_endpoint import StatisticsEndpoint
 
 
+# pylint: disable=redefined-outer-name
+
+
 @pytest.fixture
 async def endpoint(metadata_store):
     ipv8 = MockIPv8("low", BandwidthAccountingCommunity, database=Mock(),
@@ -29,7 +32,7 @@ async def endpoint(metadata_store):
 
 
 @pytest.fixture
-async def rest_api(event_loop, aiohttp_client, endpoint):  # pylint: disable=unused-argument
+async def rest_api(aiohttp_client, endpoint):
     app = Application(middlewares=[error_middleware])
     app.add_subapp('/statistics', endpoint.app)
 

--- a/src/tribler/core/components/restapi/rest/tests/test_statistics_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/tests/test_statistics_endpoint.py
@@ -13,51 +13,53 @@ from tribler.core.components.restapi.rest.statistics_endpoint import StatisticsE
 
 
 @pytest.fixture
-async def mock_ipv8():
+async def endpoint(metadata_store):
     ipv8 = MockIPv8("low", BandwidthAccountingCommunity, database=Mock(),
                     settings=BandwidthAccountingSettings())
     ipv8.overlays = [ipv8.overlay]
     ipv8.endpoint.bytes_up = 100
     ipv8.endpoint.bytes_down = 20
-    yield ipv8
+
+    endpoint = StatisticsEndpoint(ipv8, metadata_store)
+
+    yield endpoint
+
     await ipv8.stop()
+    await endpoint.shutdown()
 
 
 @pytest.fixture
-def endpoint():
-    endpoint = StatisticsEndpoint()
-    return endpoint
+async def rest_api(event_loop, aiohttp_client, endpoint):  # pylint: disable=unused-argument
+    app = Application(middlewares=[error_middleware])
+    app.add_subapp('/statistics', endpoint.app)
+
+    yield await aiohttp_client(app)
+
+    await app.shutdown()
 
 
-@pytest.fixture
-def rest_api(web_app, event_loop, aiohttp_client, endpoint):
-    web_app.add_subapp('/statistics', endpoint.app)
-    yield event_loop.run_until_complete(aiohttp_client(web_app))
-
-
-async def test_get_tribler_statistics(rest_api, endpoint, metadata_store):
+async def test_get_tribler_statistics(rest_api):
     """
     Testing whether the API returns a correct Tribler statistics dictionary when requested
     """
-    endpoint.mds = metadata_store
     stats = (await do_request(rest_api, 'statistics/tribler', expected_code=200))['tribler_statistics']
     assert 'db_size' in stats
     assert 'num_channels' in stats
     assert 'num_channels' in stats
 
 
-async def test_get_ipv8_statistics(mock_ipv8, rest_api, endpoint):
+async def test_get_ipv8_statistics(rest_api):
     """
     Testing whether the API returns a correct IPv8 statistics dictionary when requested
     """
-    endpoint.ipv8 = mock_ipv8
     json_data = await do_request(rest_api, 'statistics/ipv8', expected_code=200)
     assert json_data["ipv8_statistics"]
 
 
-async def test_get_ipv8_statistics_unavailable(rest_api):
+async def test_get_ipv8_statistics_unavailable(rest_api, endpoint: StatisticsEndpoint):
     """
     Testing whether the API returns error 500 if IPv8 is not available
     """
+    endpoint.ipv8 = None
     json_data = await do_request(rest_api, 'statistics/ipv8', expected_code=200)
     assert not json_data["ipv8_statistics"]

--- a/src/tribler/core/components/restapi/rest/tests/test_trustview_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/tests/test_trustview_endpoint.py
@@ -16,15 +16,17 @@ from tribler.core.exceptions import TrustGraphException
 from tribler.core.utilities.utilities import MEMORY_DB
 
 
+# pylint: disable=redefined-outer-name
+
 @pytest.fixture
-async def endpoint(bandwidth_db):  # pylint: disable=W0621
+async def endpoint(bandwidth_db):
     endpoint = TrustViewEndpoint(bandwidth_db)
     yield endpoint
     await endpoint.shutdown()
 
 
 @pytest.fixture
-async def rest_api(event_loop, aiohttp_client, endpoint):  # pylint: disable=unused-argument
+async def rest_api(aiohttp_client, endpoint):
     app = Application(middlewares=[error_middleware])
     app.add_subapp('/trustview', endpoint.app)
 

--- a/src/tribler/core/conftest.py
+++ b/src/tribler/core/conftest.py
@@ -1,6 +1,4 @@
-import asyncio
 import logging
-import platform
 import sys
 from datetime import datetime
 from typing import Optional
@@ -64,15 +62,3 @@ def pytest_runtest_protocol(item: Function, log=True, nextitem=None):
 @pytest.fixture
 def free_port():
     return default_network_utils.get_random_free_port(start=1024, stop=50000)
-
-
-@pytest.fixture
-def event_loop():
-    if platform.system() == 'Windows':
-        # to prevent the "Loop is closed" error
-        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
-
-    policy = asyncio.get_event_loop_policy()
-    loop = policy.new_event_loop()
-    yield loop
-    loop.close()


### PR DESCRIPTION
This PR fixes `rest_api` by making it async.

Previously the common pattern was:

```python

@pytest.fixture
def rest_api(event_loop, aiohttp_client, knowledge_endpoint):
    app = Application()
    app.add_subapp('/knowledge', knowledge_endpoint.app)
    yield event_loop.run_until_complete(aiohttp_client(app))
    app.shutdown()
```

which is incorrect as `app.shutdown()` is async call.

Additionally, this PR includes some minor refactoring.

Related to #7495