### PR TITLE
Add `@pytest.mark.looptime(False)` for `test_channel_update_and_download`

### DIFF
--- a/src/tribler/core/components/metadata_store/tests/test_channel_download.py
+++ b/src/tribler/core/components/metadata_store/tests/test_channel_download.py
@@ -58,9 +58,10 @@ async def gigachannel_manager(metadata_store, download_manager: DownloadManager)
     await manager.shutdown()
 
 
-async def test_channel_update_and_download(channel_tdef, channel_seeder, metadata_store,
-                                           download_manager: DownloadManager,
-                                           gigachannel_manager: GigaChannelManager):
+@pytest.mark.looptime(False)
+async def test_channel_update_and_download(
+        channel_tdef, channel_seeder, metadata_store, download_manager, gigachannel_manager
+):
     """
     Test whether we can successfully update a channel and download the new version
     """


### PR DESCRIPTION
This PR fixes `test_channel_update_and_download` by adding `@pytest.mark.looptime(False)` decorator as this test depends on a real `sleep`.

See:
https://github.com/Tribler/tribler/blob/9bb752c3fbfe2244724a84c89f2b26749d959c08/src/tribler/core/components/metadata_store/db/store.py#L562-L563

Related to #7495

Refs:
* https://pypi.org/project/looptime/