### PR TITLE
The `rest_api` fixture deduplication

### DIFF
--- a/src/tribler/core/components/bandwidth_accounting/restapi/bandwidth_endpoint.py
+++ b/src/tribler/core/components/bandwidth_accounting/restapi/bandwidth_endpoint.py
@@ -15,6 +15,7 @@ class BandwidthEndpoint(RESTEndpoint):
     """
     This endpoint is responsible for handing requests for bandwidth accounting data.
     """
+    path = '/bandwidth'
 
     def __init__(self, bandwidth_community: BandwidthAccountingCommunity):
         super().__init__()

--- a/src/tribler/core/components/knowledge/restapi/knowledge_endpoint.py
+++ b/src/tribler/core/components/knowledge/restapi/knowledge_endpoint.py
@@ -21,6 +21,7 @@ class KnowledgeEndpoint(RESTEndpoint):
     """
     Top-level endpoint for knowledge management.
     """
+    path = '/knowledge'
 
     def __init__(self, db: KnowledgeDatabase, community: KnowledgeCommunity):
         super().__init__()

--- a/src/tribler/core/components/libtorrent/restapi/create_torrent_endpoint.py
+++ b/src/tribler/core/components/libtorrent/restapi/create_torrent_endpoint.py
@@ -23,6 +23,7 @@ class CreateTorrentEndpoint(RESTEndpoint):
     Create a torrent file from local files.
     See: http://www.bittorrent.org/beps/bep_0012.html
     """
+    path = '/createtorrent'
 
     def __init__(self, download_manager: DownloadManager):
         super().__init__()

--- a/src/tribler/core/components/libtorrent/restapi/downloads_endpoint.py
+++ b/src/tribler/core/components/libtorrent/restapi/downloads_endpoint.py
@@ -80,6 +80,7 @@ class DownloadsEndpoint(RESTEndpoint):
     This endpoint is responsible for all requests regarding downloads. Examples include getting all downloads,
     starting, pausing and stopping downloads.
     """
+    path = '/downloads'
 
     def __init__(self, download_manager: DownloadManager, metadata_store=None, tunnel_community=None):
         super().__init__()

--- a/src/tribler/core/components/libtorrent/restapi/libtorrent_endpoint.py
+++ b/src/tribler/core/components/libtorrent/restapi/libtorrent_endpoint.py
@@ -16,6 +16,7 @@ class LibTorrentEndpoint(RESTEndpoint):
     """
     Endpoint for getting information about libtorrent sessions and settings.
     """
+    path = '/libtorrent'
 
     def __init__(self, download_manager: DownloadManager):
         super().__init__()

--- a/src/tribler/core/components/libtorrent/restapi/tests/test_downloads_endpoint.py
+++ b/src/tribler/core/components/libtorrent/restapi/tests/test_downloads_endpoint.py
@@ -4,14 +4,12 @@ import unittest.mock
 from unittest.mock import Mock
 
 import pytest
-from aiohttp.web_app import Application
 from ipv8.util import fail, succeed
 
 import tribler.core.components.libtorrent.restapi.downloads_endpoint as download_endpoint
 from tribler.core.components.libtorrent.download_manager.download_state import DownloadState
 from tribler.core.components.libtorrent.restapi.downloads_endpoint import DownloadsEndpoint, get_extended_status
 from tribler.core.components.restapi.rest.base_api_test import do_request
-from tribler.core.components.restapi.rest.rest_manager import error_middleware
 from tribler.core.tests.tools.common import TESTS_DATA_DIR
 from tribler.core.utilities.rest_utils import HTTP_SCHEME, path_to_url
 from tribler.core.utilities.simpledefs import DownloadStatus
@@ -19,15 +17,8 @@ from tribler.core.utilities.unicode import hexlify
 
 
 @pytest.fixture
-async def rest_api(aiohttp_client, mock_dlmgr, metadata_store):
-    endpoint = DownloadsEndpoint(mock_dlmgr, metadata_store=metadata_store)
-    app = Application(middlewares=[error_middleware])
-    app.add_subapp('/downloads', endpoint.app)
-
-    yield await aiohttp_client(app)
-
-    await endpoint.shutdown()
-    await app.shutdown()
+def endpoint(mock_dlmgr, metadata_store):
+    return DownloadsEndpoint(mock_dlmgr, metadata_store=metadata_store)
 
 
 def get_hex_infohash(tdef):

--- a/src/tribler/core/components/libtorrent/restapi/tests/test_downloads_endpoint.py
+++ b/src/tribler/core/components/libtorrent/restapi/tests/test_downloads_endpoint.py
@@ -15,6 +15,7 @@ from tribler.core.utilities.rest_utils import HTTP_SCHEME, path_to_url
 from tribler.core.utilities.simpledefs import DownloadStatus
 from tribler.core.utilities.unicode import hexlify
 
+# pylint: disable=redefined-outer-name
 
 @pytest.fixture
 def endpoint(mock_dlmgr, metadata_store):

--- a/src/tribler/core/components/libtorrent/restapi/tests/test_libtorrent_endpoint.py
+++ b/src/tribler/core/components/libtorrent/restapi/tests/test_libtorrent_endpoint.py
@@ -7,6 +7,8 @@ from tribler.core.components.restapi.rest.base_api_test import do_request
 from tribler.core.utilities.unicode import hexlify
 
 
+# pylint: disable=redefined-outer-name
+
 @pytest.fixture
 def endpoint(mock_dlmgr, mock_lt_session):
     return LibTorrentEndpoint(mock_dlmgr)

--- a/src/tribler/core/components/libtorrent/restapi/tests/test_libtorrent_endpoint.py
+++ b/src/tribler/core/components/libtorrent/restapi/tests/test_libtorrent_endpoint.py
@@ -1,24 +1,15 @@
 from unittest.mock import Mock
 
 import pytest
-from aiohttp.web_app import Application
 
 from tribler.core.components.libtorrent.restapi.libtorrent_endpoint import LibTorrentEndpoint
 from tribler.core.components.restapi.rest.base_api_test import do_request
-from tribler.core.components.restapi.rest.rest_manager import error_middleware
 from tribler.core.utilities.unicode import hexlify
 
 
 @pytest.fixture
-async def rest_api(aiohttp_client, mock_dlmgr, mock_lt_session):
-    endpoint = LibTorrentEndpoint(mock_dlmgr)
-    app = Application(middlewares=[error_middleware])
-    app.add_subapp('/libtorrent', endpoint.app)
-
-    yield await aiohttp_client(app)
-
-    await endpoint.shutdown()
-    await app.shutdown()
+def endpoint(mock_dlmgr, mock_lt_session):
+    return LibTorrentEndpoint(mock_dlmgr)
 
 
 @pytest.fixture

--- a/src/tribler/core/components/libtorrent/restapi/tests/test_torrentinfo_endpoint.py
+++ b/src/tribler/core/components/libtorrent/restapi/tests/test_torrentinfo_endpoint.py
@@ -5,7 +5,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from urllib.parse import quote_plus, unquote_plus
 
 import pytest
-from aiohttp.web_app import Application
 from ipv8.util import succeed
 
 from tribler.core import notifications
@@ -16,7 +15,6 @@ from tribler.core.components.libtorrent.torrentdef import TorrentDef
 from tribler.core.components.metadata_store.db.orm_bindings.torrent_metadata import tdef_to_metadata_dict
 from tribler.core.components.restapi.rest.base_api_test import do_request
 from tribler.core.components.restapi.rest.rest_endpoint import HTTP_INTERNAL_SERVER_ERROR
-from tribler.core.components.restapi.rest.rest_manager import error_middleware
 from tribler.core.tests.tools.common import TESTS_DATA_DIR, TESTS_DIR, TORRENT_UBUNTU_FILE, UBUNTU_1504_INFOHASH
 from tribler.core.utilities.rest_utils import path_to_url
 from tribler.core.utilities.unicode import hexlify
@@ -46,15 +44,8 @@ def download_manager(state_dir):
 
 
 @pytest.fixture
-async def rest_api(aiohttp_client, download_manager: DownloadManager):
-    endpoint = TorrentInfoEndpoint(download_manager)
-    app = Application(middlewares=[error_middleware])
-    app.add_subapp('/torrentinfo', endpoint.app)
-
-    yield await aiohttp_client(app)
-
-    await endpoint.shutdown()
-    await app.shutdown()
+def endpoint(download_manager: DownloadManager):
+    return TorrentInfoEndpoint(download_manager)
 
 
 async def test_get_torrentinfo_escaped_characters(tmp_path, rest_api):

--- a/src/tribler/core/components/libtorrent/restapi/torrentinfo_endpoint.py
+++ b/src/tribler/core/components/libtorrent/restapi/torrentinfo_endpoint.py
@@ -45,6 +45,7 @@ class TorrentInfoEndpoint(RESTEndpoint):
     """
     This endpoint is responsible for handing all requests regarding torrent info in Tribler.
     """
+    path = '/torrentinfo'
 
     def __init__(self, download_manager: DownloadManager):
         super().__init__()

--- a/src/tribler/core/components/metadata_store/restapi/channels_endpoint.py
+++ b/src/tribler/core/components/metadata_store/restapi/channels_endpoint.py
@@ -37,6 +37,8 @@ async def _fetch_uri(uri):
 
 @froze_it
 class ChannelsEndpoint(MetadataEndpointBase):
+    path = '/channels'
+
     def __init__(self,
                  download_manager: DownloadManager,
                  gigachannel_manager: GigaChannelManager,

--- a/src/tribler/core/components/metadata_store/restapi/metadata_endpoint.py
+++ b/src/tribler/core/components/metadata_store/restapi/metadata_endpoint.py
@@ -50,6 +50,7 @@ class MetadataEndpoint(MetadataEndpointBase, UpdateEntryMixin):
     #          /torrents
     #          /<public_key>
     """
+    path = '/metadata'
 
     def __init__(self, torrent_checker: Optional[TorrentChecker], *args, **kwargs):
         MetadataEndpointBase.__init__(self, *args, **kwargs)

--- a/src/tribler/core/components/metadata_store/restapi/remote_query_endpoint.py
+++ b/src/tribler/core/components/metadata_store/restapi/remote_query_endpoint.py
@@ -20,6 +20,7 @@ class RemoteQueryEndpoint(MetadataEndpointBase):
     """
     This endpoint fires a remote search in the IPv8 GigaChannel Community.
     """
+    path = '/remote_query'
 
     def __init__(self, gigachannel_community: GigaChannelCommunity, *args, **kwargs):
         MetadataEndpointBase.__init__(self, *args, **kwargs)

--- a/src/tribler/core/components/metadata_store/restapi/search_endpoint.py
+++ b/src/tribler/core/components/metadata_store/restapi/search_endpoint.py
@@ -26,6 +26,7 @@ class SearchEndpoint(MetadataEndpointBase):
     """
     This endpoint is responsible for searching in channels and torrents present in the local Tribler database.
     """
+    path = '/search'
 
     def setup_routes(self):
         self.app.add_routes([web.get('', self.search), web.get('/completions', self.completions)])

--- a/src/tribler/core/components/metadata_store/restapi/tests/test_metadata_endpoint.py
+++ b/src/tribler/core/components/metadata_store/restapi/tests/test_metadata_endpoint.py
@@ -2,13 +2,11 @@ import json
 from unittest.mock import MagicMock
 
 import pytest
-from aiohttp.web_app import Application
 from pony.orm import db_session
 
 from tribler.core.components.metadata_store.db.orm_bindings.channel_node import COMMITTED, TODELETE, UPDATED
 from tribler.core.components.metadata_store.restapi.metadata_endpoint import MetadataEndpoint, TORRENT_CHECK_TIMEOUT
 from tribler.core.components.restapi.rest.base_api_test import do_request
-from tribler.core.components.restapi.rest.rest_manager import error_middleware
 from tribler.core.components.torrent_checker.torrent_checker.torrent_checker import TorrentChecker
 from tribler.core.config.tribler_config import TriblerConfig
 from tribler.core.utilities.unicode import hexlify
@@ -39,15 +37,8 @@ async def torrent_checker(mock_dlmgr, metadata_store):
 
 
 @pytest.fixture
-async def rest_api(aiohttp_client, torrent_checker, metadata_store):
-    endpoint = MetadataEndpoint(torrent_checker, metadata_store)
-
-    app = Application(middlewares=[error_middleware])
-    app.add_subapp('/metadata', endpoint.app)
-    yield await aiohttp_client(app)
-
-    await endpoint.shutdown()
-    await app.shutdown()
+def endpoint(torrent_checker, metadata_store):
+    return MetadataEndpoint(torrent_checker, metadata_store)
 
 
 async def test_update_multiple_metadata_entries(metadata_store, add_fake_torrents_channels, rest_api):

--- a/src/tribler/core/components/metadata_store/restapi/tests/test_remote_query_endpoint.py
+++ b/src/tribler/core/components/metadata_store/restapi/tests/test_remote_query_endpoint.py
@@ -2,7 +2,6 @@ import uuid
 from unittest.mock import Mock
 
 import pytest
-from aiohttp.web_app import Application
 from ipv8.keyvault.crypto import default_eccrypto
 from ipv8.peer import Peer
 from pony.orm import db_session
@@ -10,7 +9,6 @@ from pony.orm import db_session
 from tribler.core.components.gigachannel.community.gigachannel_community import ChannelsPeersMapping
 from tribler.core.components.metadata_store.restapi.remote_query_endpoint import RemoteQueryEndpoint
 from tribler.core.components.restapi.rest.base_api_test import do_request
-from tribler.core.components.restapi.rest.rest_manager import error_middleware
 from tribler.core.utilities.unicode import hexlify
 from tribler.core.utilities.utilities import random_infohash
 
@@ -24,15 +22,8 @@ def mock_gigachannel_community():
 
 
 @pytest.fixture
-async def rest_api(aiohttp_client, metadata_store, mock_gigachannel_community):
-    endpoint = RemoteQueryEndpoint(mock_gigachannel_community, metadata_store)
-    app = Application(middlewares=[error_middleware])
-    app.add_subapp('/remote_query', endpoint.app)
-
-    yield await aiohttp_client(app)
-
-    await endpoint.shutdown()
-    await app.shutdown()
+def endpoint(metadata_store, mock_gigachannel_community):
+    return RemoteQueryEndpoint(mock_gigachannel_community, metadata_store)
 
 
 async def test_create_remote_search_request(rest_api, mock_gigachannel_community):

--- a/src/tribler/core/components/metadata_store/restapi/tests/test_search_endpoint.py
+++ b/src/tribler/core/components/metadata_store/restapi/tests/test_search_endpoint.py
@@ -4,7 +4,6 @@ from typing import List, Set
 from unittest.mock import patch
 
 import pytest
-from aiohttp.web_app import Application
 from pony.orm import db_session
 
 from tribler.core.components.knowledge.db.knowledge_db import KnowledgeDatabase
@@ -31,15 +30,8 @@ def needle_in_haystack_mds(metadata_store):
 
 
 @pytest.fixture
-async def rest_api(needle_in_haystack_mds, aiohttp_client, knowledge_db):
-    channels_endpoint = SearchEndpoint(needle_in_haystack_mds, knowledge_db=knowledge_db)
-    app = Application()
-    app.add_subapp('/search', channels_endpoint.app)
-
-    yield await aiohttp_client(app)
-
-    await channels_endpoint.shutdown()
-    await app.shutdown()
+def endpoint(needle_in_haystack_mds, knowledge_db):
+    return SearchEndpoint(needle_in_haystack_mds, knowledge_db=knowledge_db)
 
 
 async def test_search_wrong_mdtype(rest_api):

--- a/src/tribler/core/components/restapi/rest/debug_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/debug_endpoint.py
@@ -43,6 +43,7 @@ class DebugEndpoint(RESTEndpoint):
     """
     This endpoint is responsible for handing requests regarding debug information in Tribler.
     """
+    path = '/debug'
 
     def __init__(self,
                  state_dir: Path,

--- a/src/tribler/core/components/restapi/rest/events_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/events_endpoint.py
@@ -47,6 +47,7 @@ class EventsEndpoint(RESTEndpoint):
     pushed over this endpoint in the form of a JSON dictionary. Each JSON dictionary contains a type field that
     indicates the type of the event. Individual events are separated by a newline character.
     """
+    path = '/events'
 
     def __init__(self, notifier: Notifier, public_key: str = None):
         super().__init__()

--- a/src/tribler/core/components/restapi/rest/rest_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/rest_endpoint.py
@@ -13,9 +13,7 @@ if TYPE_CHECKING:
     from tribler.core.components.restapi.rest.events_endpoint import EventsEndpoint
     from ipv8.REST.root_endpoint import RootEndpoint as IPV8RootEndpoint
 
-
 patch_make_request(web.Application)
-
 
 HTTP_BAD_REQUEST = 400
 HTTP_UNAUTHORIZED = 401
@@ -24,6 +22,7 @@ HTTP_INTERNAL_SERVER_ERROR = 500
 
 
 class RESTEndpoint:
+    path = ''
 
     def __init__(self, middlewares=()):
         self._logger = logging.getLogger(self.__class__.__name__)

--- a/src/tribler/core/components/restapi/rest/settings_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/settings_endpoint.py
@@ -15,6 +15,7 @@ class SettingsEndpoint(RESTEndpoint):
     """
     This endpoint is reponsible for handing all requests regarding settings and configuration.
     """
+    path = '/settings'
 
     def __init__(self, tribler_config: TriblerConfig, download_manager: DownloadManager = None):
         super().__init__()

--- a/src/tribler/core/components/restapi/rest/shutdown_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/shutdown_endpoint.py
@@ -12,6 +12,7 @@ class ShutdownEndpoint(RESTEndpoint):
     """
     With this endpoint you can shutdown Tribler.
     """
+    path = '/shutdown'
 
     def __init__(self, shutdown_callback):
         super().__init__()

--- a/src/tribler/core/components/restapi/rest/statistics_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/statistics_endpoint.py
@@ -14,6 +14,7 @@ class StatisticsEndpoint(RESTEndpoint):
     """
     This endpoint is responsible for handing requests regarding statistics in Tribler.
     """
+    path = '/statistics'
 
     def __init__(self, ipv8: IPv8 = None, metadata_store: MetadataStore = None):
         super().__init__()

--- a/src/tribler/core/components/restapi/rest/tests/test_create_torrent_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/tests/test_create_torrent_endpoint.py
@@ -1,13 +1,11 @@
 from unittest.mock import Mock
 
 import pytest
-from aiohttp.web_app import Application
 from ipv8.util import succeed
 
 from tribler.core.components.libtorrent.restapi.create_torrent_endpoint import CreateTorrentEndpoint
 from tribler.core.components.libtorrent.settings import DownloadDefaultsSettings
 from tribler.core.components.restapi.rest.base_api_test import do_request
-from tribler.core.components.restapi.rest.rest_manager import error_middleware
 from tribler.core.tests.tools.common import TESTS_DATA_DIR
 
 
@@ -15,15 +13,8 @@ from tribler.core.tests.tools.common import TESTS_DATA_DIR
 
 
 @pytest.fixture
-async def rest_api(aiohttp_client, download_manager):
-    endpoint = CreateTorrentEndpoint(download_manager)
-    app = Application(middlewares=[error_middleware])
-    app.add_subapp('/createtorrent', endpoint.app)
-
-    yield await aiohttp_client(app)
-
-    await endpoint.shutdown()
-    await app.shutdown()
+def endpoint(download_manager):
+    return CreateTorrentEndpoint(download_manager)
 
 
 async def test_create_torrent(rest_api, tmp_path, download_manager):

--- a/src/tribler/core/components/restapi/rest/tests/test_debug_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/tests/test_debug_endpoint.py
@@ -3,13 +3,11 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
-from aiohttp.web_app import Application
 
 from tribler.core.components.resource_monitor.implementation.core import CoreResourceMonitor
 from tribler.core.components.resource_monitor.settings import ResourceMonitorSettings
 from tribler.core.components.restapi.rest.base_api_test import do_request
 from tribler.core.components.restapi.rest.debug_endpoint import DebugEndpoint
-from tribler.core.components.restapi.rest.rest_manager import error_middleware
 
 
 # pylint: disable=redefined-outer-name, unused-argument, protected-access
@@ -32,20 +30,9 @@ async def core_resource_monitor(tmp_path):
 
 
 @pytest.fixture
-async def rest_api(aiohttp_client, mock_tunnel_community, tmp_path, core_resource_monitor):
-    endpoint = DebugEndpoint(tmp_path, tmp_path / 'logs',
-                             tunnel_community=mock_tunnel_community,
-                             resource_monitor=core_resource_monitor)
-
-    endpoint.tunnel_community = mock_tunnel_community
-
-    app = Application(middlewares=[error_middleware])
-    app.add_subapp('/debug', endpoint.app)
-
-    yield await aiohttp_client(app)
-
-    await endpoint.shutdown()
-    await app.shutdown()
+def endpoint(mock_tunnel_community, tmp_path, core_resource_monitor):
+    return DebugEndpoint(tmp_path, tmp_path / 'logs', tunnel_community=mock_tunnel_community,
+                         resource_monitor=core_resource_monitor)
 
 
 async def test_get_slots(rest_api, mock_tunnel_community):

--- a/src/tribler/core/components/restapi/rest/tests/test_settings_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/tests/test_settings_endpoint.py
@@ -1,9 +1,7 @@
 import pytest
-from aiohttp.web_app import Application
 
 from tribler.core.components.libtorrent.download_manager.download_manager import DownloadManager
 from tribler.core.components.restapi.rest.base_api_test import do_request
-from tribler.core.components.restapi.rest.rest_manager import error_middleware
 from tribler.core.components.restapi.rest.settings_endpoint import SettingsEndpoint
 from tribler.core.config.tribler_config import TriblerConfig
 from tribler.core.utilities.simpledefs import MAX_LIBTORRENT_RATE_LIMIT
@@ -18,15 +16,8 @@ def tribler_config(tmp_path):
 
 
 @pytest.fixture
-async def rest_api(aiohttp_client, tribler_config):
-    endpoint = SettingsEndpoint(tribler_config)
-    app = Application(middlewares=[error_middleware])
-    app.add_subapp('/settings', endpoint.app)
-
-    yield await aiohttp_client(app)
-
-    await endpoint.shutdown()
-    await app.shutdown()
+def endpoint(tribler_config):
+    return SettingsEndpoint(tribler_config)
 
 
 def verify_settings(settings_dict):

--- a/src/tribler/core/components/restapi/rest/tests/test_shutdown_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/tests/test_shutdown_endpoint.py
@@ -1,10 +1,8 @@
 from unittest.mock import Mock
 
 import pytest
-from aiohttp.web_app import Application
 
 from tribler.core.components.restapi.rest.base_api_test import do_request
-from tribler.core.components.restapi.rest.rest_manager import error_middleware
 from tribler.core.components.restapi.rest.shutdown_endpoint import ShutdownEndpoint
 
 
@@ -12,21 +10,8 @@ from tribler.core.components.restapi.rest.shutdown_endpoint import ShutdownEndpo
 
 
 @pytest.fixture
-async def endpoint():
-    endpoint = ShutdownEndpoint(Mock())
-    yield endpoint
-
-    await endpoint.shutdown()
-
-
-@pytest.fixture
-async def rest_api(aiohttp_client, endpoint):
-    app = Application(middlewares=[error_middleware])
-    app.add_subapp('/shutdown', endpoint.app)
-
-    yield await aiohttp_client(app)
-
-    await app.shutdown()
+def endpoint():
+    return ShutdownEndpoint(Mock())
 
 
 async def test_shutdown(rest_api, endpoint):

--- a/src/tribler/core/components/restapi/rest/tests/test_statistics_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/tests/test_statistics_endpoint.py
@@ -28,17 +28,6 @@ async def endpoint(metadata_store):
     yield endpoint
 
     await ipv8.stop()
-    await endpoint.shutdown()
-
-
-@pytest.fixture
-async def rest_api(aiohttp_client, endpoint):
-    app = Application(middlewares=[error_middleware])
-    app.add_subapp('/statistics', endpoint.app)
-
-    yield await aiohttp_client(app)
-
-    await app.shutdown()
 
 
 async def test_get_tribler_statistics(rest_api):

--- a/src/tribler/core/components/restapi/rest/tests/test_trustview_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/tests/test_trustview_endpoint.py
@@ -3,14 +3,12 @@ import secrets
 from binascii import unhexlify
 
 import pytest
-from aiohttp.web_app import Application
 from ipv8.keyvault.crypto import default_eccrypto
 
 from tribler.core.components.bandwidth_accounting.db.database import BandwidthDatabase
 from tribler.core.components.bandwidth_accounting.db.transaction import BandwidthTransactionData, EMPTY_SIGNATURE
 from tribler.core.components.bandwidth_accounting.trust_calculation.trust_graph import TrustGraph
 from tribler.core.components.restapi.rest.base_api_test import do_request
-from tribler.core.components.restapi.rest.rest_manager import error_middleware
 from tribler.core.components.restapi.rest.trustview_endpoint import TrustViewEndpoint
 from tribler.core.exceptions import TrustGraphException
 from tribler.core.utilities.utilities import MEMORY_DB
@@ -19,20 +17,8 @@ from tribler.core.utilities.utilities import MEMORY_DB
 # pylint: disable=redefined-outer-name
 
 @pytest.fixture
-async def endpoint(bandwidth_db):
-    endpoint = TrustViewEndpoint(bandwidth_db)
-    yield endpoint
-    await endpoint.shutdown()
-
-
-@pytest.fixture
-async def rest_api(aiohttp_client, endpoint):
-    app = Application(middlewares=[error_middleware])
-    app.add_subapp('/trustview', endpoint.app)
-
-    yield await aiohttp_client(app)
-
-    await app.shutdown()
+def endpoint(bandwidth_db):
+    return TrustViewEndpoint(bandwidth_db)
 
 
 @pytest.fixture

--- a/src/tribler/core/components/restapi/rest/trustview_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/trustview_endpoint.py
@@ -14,6 +14,8 @@ from tribler.core.utilities.utilities import froze_it
 
 @froze_it
 class TrustViewEndpoint(RESTEndpoint):
+    path = '/trustview'
+
     def __init__(self, bandwidth_db: BandwidthDatabase):
         super().__init__()
         self.bandwidth_db = bandwidth_db

--- a/src/tribler/core/components/restapi/restapi_component.py
+++ b/src/tribler/core/components/restapi/restapi_component.py
@@ -94,26 +94,28 @@ class RESTComponent(Component):
         gigachannel_manager = None if config.gui_test_mode else gigachannel_manager_component.gigachannel_manager
 
         # add endpoints
-        self.root_endpoint.add_endpoint('/events', self._events_endpoint)
-        self.maybe_add('/settings', SettingsEndpoint, config, download_manager=libtorrent_component.download_manager)
-        self.maybe_add('/shutdown', ShutdownEndpoint, shutdown_event.set)
-        self.maybe_add('/debug', DebugEndpoint, config.state_dir, log_dir,
+        self.root_endpoint.add_endpoint(EventsEndpoint.path, self._events_endpoint)
+        self.maybe_add(SettingsEndpoint.path, SettingsEndpoint, config,
+                       download_manager=libtorrent_component.download_manager)
+        self.maybe_add(ShutdownEndpoint.path, ShutdownEndpoint, shutdown_event.set)
+        self.maybe_add(DebugEndpoint.path, DebugEndpoint, config.state_dir, log_dir,
                        tunnel_community=tunnel_community,
                        resource_monitor=resource_monitor_component.resource_monitor,
                        core_exception_handler=self._core_exception_handler)
-        self.maybe_add('/bandwidth', BandwidthEndpoint, bandwidth_accounting_component.community)
-        self.maybe_add('/trustview', TrustViewEndpoint, bandwidth_accounting_component.database)
-        self.maybe_add('/downloads', DownloadsEndpoint, libtorrent_component.download_manager,
+        self.maybe_add(BandwidthEndpoint.path, BandwidthEndpoint, bandwidth_accounting_component.community)
+        self.maybe_add(TrustViewEndpoint.path, TrustViewEndpoint, bandwidth_accounting_component.database)
+        self.maybe_add(DownloadsEndpoint.path, DownloadsEndpoint, libtorrent_component.download_manager,
                        metadata_store=metadata_store_component.mds, tunnel_community=tunnel_community)
-        self.maybe_add('/createtorrent', CreateTorrentEndpoint, libtorrent_component.download_manager)
-        self.maybe_add('/statistics', StatisticsEndpoint, ipv8=ipv8_component.ipv8,
+        self.maybe_add(CreateTorrentEndpoint.path, CreateTorrentEndpoint, libtorrent_component.download_manager)
+        self.maybe_add(StatisticsEndpoint.path, StatisticsEndpoint, ipv8=ipv8_component.ipv8,
                        metadata_store=metadata_store_component.mds)
-        self.maybe_add('/libtorrent', LibTorrentEndpoint, libtorrent_component.download_manager)
-        self.maybe_add('/torrentinfo', TorrentInfoEndpoint, libtorrent_component.download_manager)
-        self.maybe_add('/metadata', MetadataEndpoint, torrent_checker, metadata_store_component.mds,
+        self.maybe_add(LibTorrentEndpoint.path, LibTorrentEndpoint, libtorrent_component.download_manager)
+        self.maybe_add(TorrentInfoEndpoint.path, TorrentInfoEndpoint, libtorrent_component.download_manager)
+        self.maybe_add(MetadataEndpoint.path, MetadataEndpoint, torrent_checker, metadata_store_component.mds,
                        knowledge_db=knowledge_component.knowledge_db,
                        tag_rules_processor=knowledge_component.rules_processor)
-        self.maybe_add('/channels', ChannelsEndpoint, libtorrent_component.download_manager, gigachannel_manager,
+        self.maybe_add(ChannelsEndpoint.path, ChannelsEndpoint, libtorrent_component.download_manager,
+                       gigachannel_manager,
                        gigachannel_component.community, metadata_store_component.mds,
                        knowledge_db=knowledge_component.knowledge_db,
                        tag_rules_processor=knowledge_component.rules_processor)
@@ -121,11 +123,11 @@ class RESTComponent(Component):
                        gigachannel_component.community, metadata_store_component.mds,
                        knowledge_db=knowledge_component.knowledge_db,
                        tag_rules_processor=knowledge_component.rules_processor)
-        self.maybe_add('/search', SearchEndpoint, metadata_store_component.mds,
+        self.maybe_add(SearchEndpoint.path, SearchEndpoint, metadata_store_component.mds,
                        knowledge_db=knowledge_component.knowledge_db)
-        self.maybe_add('/remote_query', RemoteQueryEndpoint, gigachannel_component.community,
+        self.maybe_add(RemoteQueryEndpoint.path, RemoteQueryEndpoint, gigachannel_component.community,
                        metadata_store_component.mds)
-        self.maybe_add('/knowledge', KnowledgeEndpoint, db=knowledge_component.knowledge_db,
+        self.maybe_add(KnowledgeEndpoint.path, KnowledgeEndpoint, db=knowledge_component.knowledge_db,
                        community=knowledge_component.community)
 
         if not isinstance(ipv8_component, NoneComponent):

--- a/src/tribler/core/components/restapi/restapi_component.py
+++ b/src/tribler/core/components/restapi/restapi_component.py
@@ -119,10 +119,6 @@ class RESTComponent(Component):
                        gigachannel_component.community, metadata_store_component.mds,
                        knowledge_db=knowledge_component.knowledge_db,
                        tag_rules_processor=knowledge_component.rules_processor)
-        self.maybe_add('/collections', ChannelsEndpoint, libtorrent_component.download_manager, gigachannel_manager,
-                       gigachannel_component.community, metadata_store_component.mds,
-                       knowledge_db=knowledge_component.knowledge_db,
-                       tag_rules_processor=knowledge_component.rules_processor)
         self.maybe_add(SearchEndpoint.path, SearchEndpoint, metadata_store_component.mds,
                        knowledge_db=knowledge_component.knowledge_db)
         self.maybe_add(RemoteQueryEndpoint.path, RemoteQueryEndpoint, gigachannel_component.community,

--- a/src/tribler/core/components/restapi/tests/test_restapi_component.py
+++ b/src/tribler/core/components/restapi/tests/test_restapi_component.py
@@ -58,25 +58,25 @@ def rest_component():
 def test_maybe_add_check_args(rest_component, endpoint_cls):
     # test that in case `*args` in `maybe_add` function contains `NoneComponent` instance
     # no root_endpoint methods are called
-    rest_component.maybe_add('path', endpoint_cls, NoneComponent())
+    rest_component.maybe_add(endpoint_cls, NoneComponent())
     rest_component.root_endpoint.assert_not_called()
 
-    rest_component.maybe_add('path', endpoint_cls, NoneComponent(), 'some arg')
+    rest_component.maybe_add(endpoint_cls, NoneComponent(), 'some arg')
     rest_component.root_endpoint.assert_not_called()
 
 
 def test_maybe_add_check_kwargs(rest_component, endpoint_cls):
     # test that in case `**kwargs` in `maybe_add` function contains `NoneComponent` instance
     # no root_endpoint methods are called
-    rest_component.maybe_add('path', endpoint_cls, component=NoneComponent())
+    rest_component.maybe_add(endpoint_cls, component=NoneComponent())
     rest_component.root_endpoint.assert_not_called()
 
-    rest_component.maybe_add('path', endpoint_cls, component=NoneComponent(), another='kwarg')
+    rest_component.maybe_add(endpoint_cls, component=NoneComponent(), another='kwarg')
     rest_component.root_endpoint.assert_not_called()
 
 
 def test_maybe_add(rest_component, endpoint_cls):
     # test that in case there are no `NoneComponent` instances in `**kwargs` or `*args`
     # root_endpoint methods are called
-    rest_component.maybe_add('path', endpoint_cls, 'arg')
+    rest_component.maybe_add(endpoint_cls, 'arg')
     assert rest_component.root_endpoint.add_endpoint.called_once()

--- a/src/tribler/core/conftest.py
+++ b/src/tribler/core/conftest.py
@@ -25,7 +25,7 @@ enable_extended_logging = False
 pytest_start_time: Optional[datetime] = None  # a time when the test suite started
 
 
-# pylint: disable=unused-argument
+# pylint: disable=unused-argument, redefined-outer-name
 
 def pytest_configure(config):
     # Disable logging from faker for all tests

--- a/src/tribler/gui/tribler_window.py
+++ b/src/tribler/gui/tribler_window.py
@@ -934,7 +934,7 @@ class TriblerWindow(QMainWindow):
                         return
 
                     request_manager.put(
-                        endpoint=f"collections/mychannel/{channel_id}/torrents",
+                        endpoint=f"channels/mychannel/{channel_id}/torrents",
                         on_success=lambda _: self.tray_show_message(
                             tr("Channels update"), tr("%s added to your channel") % self.chosen_dir
                         ),

--- a/src/tribler/gui/widgets/channelcontentswidget.py
+++ b/src/tribler/gui/widgets/channelcontentswidget.py
@@ -574,7 +574,7 @@ class ChannelContentsWidget(AddBreadcrumbOnShowMixin, widget_form, widget_class)
 
     def _add_torrent_request(self, data):
         channel_id = self.model.channel_info["id"]
-        request_manager.put(f'collections/mychannel/{channel_id}/torrents',
+        request_manager.put(f'channels/mychannel/{channel_id}/torrents',
                             on_success=self._on_torrent_to_channel_added, data=data)
 
     def add_torrent_to_channel(self, filename):

--- a/src/tribler/gui/widgets/triblertablecontrollers.py
+++ b/src/tribler/gui/widgets/triblertablecontrollers.py
@@ -240,7 +240,7 @@ class ContextMenuMixin:
 
         def on_add_to_channel(_):
             def on_confirm_clicked(channel_id):
-                request_manager.post(f"collections/mychannel/{channel_id}/copy",
+                request_manager.post(f"channels/mychannel/{channel_id}/copy",
                                      on_success=lambda _: self.table_view.window().tray_show_message(
                                          tr("Channel update"), tr("Torrent(s) added to your channel")
                                      ),


### PR DESCRIPTION
This PR removes `rest_api` duplicates by introducing the base `rest_api` fixture

```python
@pytest.fixture
async def rest_api(aiohttp_client, endpoint: RESTEndpoint):
    app = Application(middlewares=[error_middleware])
    app.add_subapp(endpoint.path, endpoint.app)

    yield await aiohttp_client(app)

    await endpoint.shutdown()
    await app.shutdown()
```

In each test file that requires the use of this fixture, the endpoint fixture needs to be specified.

Example:
```python
@pytest.fixture
def endpoint(tribler_config):
    return SettingsEndpoint(tribler_config)
```

Thus, a specialized instance of the endpoint will be used in each test file.

This new logic has been made possible by the introduction of the path property to the `RESTEndpoint` class.

Related to #7522