### PR TITLE
Fix ImportError: DLL load failed while importing libtorrent: The specified module could not be found

### DIFF
--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 
-PyInstaller==5.11.0; sys_platform != 'darwin'
+PyInstaller==5.1; sys_platform != 'darwin'
 
 setuptools==65.5.1; sys_platform == 'darwin'
 text-unidecode==1.3; sys_platform == 'darwin'

--- a/tribler.spec
+++ b/tribler.spec
@@ -83,26 +83,29 @@ def get_sentry_hooks():
 
 # Hidden imports
 hiddenimports = [
-                    'csv',
-                    'dataclasses',  # https://github.com/pyinstaller/pyinstaller/issues/5432
-                    'ecdsa',
-                    'ipv8',
-                    'PIL',
-                    'pkg_resources',
-                    # 'pkg_resources.py2_warn', # Workaround PyInstaller & SetupTools, https://github.com/pypa/setuptools/issues/1963
-                    'pyaes',
-                    'pydantic',
-                    'pyqtgraph',
-                    'pyqtgraph.graphicsItems.PlotItem.plotConfigTemplate_pyqt5',
-                    'pyqtgraph.graphicsItems.ViewBox.axisCtrlTemplate_pyqt5',
-                    'pyqtgraph.imageview.ImageViewTemplate_pyqt5',
-                    'PyQt5.QtTest',
-                    'requests',
-                    'scrypt', '_scrypt',
-                    'sqlalchemy', 'sqlalchemy.ext.baked', 'sqlalchemy.ext.declarative',
-                    'tribler.core.logger.logger_streams',
-                    'typing_extensions',
-                ] + widget_files + pony_deps + get_sentry_hooks()
+    'csv',
+    'dataclasses',  # https://github.com/pyinstaller/pyinstaller/issues/5432
+    'ecdsa',
+    'ipv8',
+    'PIL',
+    'pkg_resources',
+    # 'pkg_resources.py2_warn', # Workaround PyInstaller & SetupTools, https://github.com/pypa/setuptools/issues/1963
+    'pyaes',
+    'pydantic',
+    'pyqtgraph',
+    'pyqtgraph.graphicsItems.PlotItem.plotConfigTemplate_pyqt5',
+    'pyqtgraph.graphicsItems.ViewBox.axisCtrlTemplate_pyqt5',
+    'pyqtgraph.imageview.ImageViewTemplate_pyqt5',
+    'PyQt5.QtTest',
+    'requests',
+    'scrypt', '_scrypt',
+    'sqlalchemy', 'sqlalchemy.ext.baked', 'sqlalchemy.ext.declarative',
+    'tribler.core.logger.logger_streams',
+    'typing_extensions',
+]
+hiddenimports += widget_files
+hiddenimports += pony_deps
+hiddenimports += get_sentry_hooks()
 
 # Fix for issue: Could not load a pixbuf from icon theme.
 # Unrecognized image file format (gdk-pixbuf-error-quark, 3).


### PR DESCRIPTION
This PR fixes #7532 by downgrading the PyInstaller version back to 5.1