### PR TITLE
Make the `rest_component` fixture async

### DIFF
--- a/src/tribler/core/components/restapi/tests/test_restapi_component.py
+++ b/src/tribler/core/components/restapi/tests/test_restapi_component.py
@@ -49,7 +49,7 @@ def endpoint_cls():
 
 
 @pytest.fixture
-def rest_component():
+async def rest_component():
     component = RESTComponent()
     component.root_endpoint = MagicMock()
     return component


### PR DESCRIPTION
This PR fixes "no running loop" error for the tests that use the `rest_component` fixture.

The core cause of the error is the fact that each instance of the component class should be created in the environment with the existing event loop as there is an instance of the `Event()` class created in the component's constructor.
 
Related to #7495