### PR TITLE
Accept error values of any type in TriblerProcess.set_error

### DIFF
--- a/src/tribler/core/utilities/process_manager/process.py
+++ b/src/tribler/core/utilities/process_manager/process.py
@@ -6,7 +6,7 @@ import sqlite3
 import time
 from datetime import datetime, timedelta
 from enum import Enum
-from typing import List, Optional, TYPE_CHECKING, Union
+from typing import Any, List, Optional, TYPE_CHECKING
 
 import psutil
 
@@ -183,10 +183,15 @@ class TriblerProcess:
         self.api_port = api_port
         self.save()
 
-    def set_error(self, error: Union[str | Exception], replace: bool = False):
-        if isinstance(error, Exception):
+    def set_error(self, error: Any, replace: bool = False):
+        # It is expected for `error` to be str or an instance of exception, but values of other types
+        # are handled gracefully as well: everything except None is converted to str
+        if error is not None and not isinstance(error, str):
             error = f"{error.__class__.__name__}: {error}"
-        self.error_msg = error if replace else (self.error_msg or error)
+
+        if replace or not self.error_msg:
+            self.error_msg = error
+
         self.save()
 
     def finish(self, exit_code: Optional[int] = None):

--- a/src/tribler/core/utilities/process_manager/tests/test_process.py
+++ b/src/tribler/core/utilities/process_manager/tests/test_process.py
@@ -107,6 +107,14 @@ def test_tribler_process_set_error(current_process):
               r"started='[^']+', duration='\d:\d{2}:\d{2}', error='ValueError: exception text'\)$"
     assert re.match(pattern, str(current_process))
 
+    # If the value of another type is specified, the method converts it to str
+    current_process.set_error({1: 2}, replace=True)
+    assert current_process.error_msg == 'dict: {1: 2}'
+
+    # None is not converted to str
+    current_process.set_error(None, replace=True)
+    assert current_process.error_msg is None
+
 
 def test_tribler_process_mark_finished(current_process):
     p = current_process  # for brevity


### PR DESCRIPTION
I see a significant number of the following errors in GUI logs on my machine and some test machines:
```
[tribler-gui PID:17032] 2023-07-10 08:19:50,079 - ERROR - tribler.gui.start_gui(82) - Error binding parameter 7 - probably unsupported type.
Traceback (most recent call last):
  File "tribler\core\utilities\process_manager\utils.py", line 29, in new_method
  File "tribler\core\utilities\process_manager\process.py", line 74, in save
  File "tribler\core\utilities\process_manager\process.py", line 224, in _update
sqlite3.InterfaceError: Error binding parameter 7 - probably unsupported type.

During the handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "tribler\gui\start_gui.py", line 79, in run_gui
  File "tribler\core\utilities\process_manager\manager.py", line 112, in sys_exit
  File "tribler\core\utilities\process_manager\process.py", line 204, in finish
  File "tribler\core\utilities\process_manager\utils.py", line 32, in new_method
  File "tribler\core\utilities\process_manager\process.py", line 74, in save
  File "tribler\core\utilities\process_manager\process.py", line 224, in _update
sqlite3.InterfaceError: Error binding parameter 7 - probably unsupported type.
```

The "parameter 7" is `error_msg` in the following SQL query (the parameters are counting from zero):
```SQL
UPDATE processes
SET row_version = ?, "primary" = ?, canceled = ?, creator_pid = ?, api_port = ?,
    finished_at = ?, exit_code = ?, error_msg = ?
WHERE rowid = ? and row_version = ? and pid = ? and kind = ? and app_version = ? and started_at = ?
```

It is expected for the `TriblerProcess.error_msg` to be an `str` or exception instance, but it seems that in some situations, when the `TriblerProcess.set_error` method is called, the value of another type is passed into it.

To handle this situation and understand what the actual error is, this PR converts any `error_msg` value to an `str` even if it is a value of an unknown type.