### PR TITLE
Make the `libtorrent` tests more responsive

### DIFF
--- a/src/tribler/core/components/libtorrent/download_manager/download.py
+++ b/src/tribler/core/components/libtorrent/download_manager/download.py
@@ -34,7 +34,7 @@ from tribler.core.utilities.simpledefs import DOWNLOAD, DownloadStatus
 from tribler.core.utilities.unicode import ensure_unicode, hexlify
 from tribler.core.utilities.utilities import bdecode_compat
 
-Getter = Optional[Callable[[Any], Any]]
+Getter = Callable[[Any], Any]
 
 
 class Download(TaskManager):
@@ -69,7 +69,7 @@ class Download(TaskManager):
         self.checkpoint_after_next_hashcheck = False
         self.tracker_status = {}  # {url: [num_peers, status_str]}
 
-        self.futures: Dict[str, list[tuple[Future, Callable, Getter]]] = defaultdict(list)
+        self.futures: Dict[str, list[tuple[Future, Callable, Optional[Getter]]]] = defaultdict(list)
         self.alert_handlers = defaultdict(list)
 
         self.future_added = self.wait_for_alert('add_torrent_alert', lambda a: a.handle)
@@ -128,8 +128,8 @@ class Download(TaskManager):
     def register_alert_handler(self, alert_type: str, handler: lt.torrent_handle):
         self.alert_handlers[alert_type].append(handler)
 
-    def wait_for_alert(self, success_type: str, success_getter: Getter = None,
-                       fail_type: str = None, fail_getter: Getter = None) -> Future:
+    def wait_for_alert(self, success_type: str, success_getter: Optional[Getter] = None,
+                       fail_type: str = None, fail_getter: Optional[Getter] = None) -> Future:
         future = Future()
         if success_type:
             self.futures[success_type].append((future, future.set_result, success_getter))

--- a/src/tribler/core/components/libtorrent/download_manager/download_manager.py
+++ b/src/tribler/core/components/libtorrent/download_manager/download_manager.py
@@ -327,7 +327,7 @@ class DownloadManager(TaskManager):
                 ltsession.add_dht_router(*router)
             ltsession.start_lsd()
 
-        self._logger.debug("Started libtorrent session for %d hops on port %d", hops, ltsession.listen_port())
+        self._logger.info(f"Started libtorrent session for {hops} hops on port {ltsession.listen_port()}")
         self.lt_session_shutdown_ready[hops] = False
 
         return ltsession

--- a/src/tribler/core/components/libtorrent/tests/test_download.py
+++ b/src/tribler/core/components/libtorrent/tests/test_download.py
@@ -490,3 +490,14 @@ def test_get_tracker_status_get_peer_info_error(test_download: Download):
     )
     status = test_download.get_tracker_status()
     assert status
+
+
+async def test_shutdown(test_download: Download):
+    """ Test that the `shutdown` method closes the stream and clears the `futures` list."""
+    test_download.stream = Mock()
+    assert len(test_download.futures) == 4
+
+    await test_download.shutdown()
+
+    assert not test_download.futures
+    assert test_download.stream.close.called

--- a/src/tribler/core/components/libtorrent/tests/test_download_manager.py
+++ b/src/tribler/core/components/libtorrent/tests/test_download_manager.py
@@ -50,7 +50,7 @@ async def fake_dlmgr(tmp_path_factory):
     dlmgr.metadata_tmpdir = tmp_path_factory.mktemp('metadata_tmpdir')
     dlmgr.get_session = lambda *_, **__: MagicMock()
     yield dlmgr
-    await dlmgr.shutdown(timeout=0)
+    await dlmgr.shutdown()
 
 
 async def test_get_metainfo_valid_metadata(fake_dlmgr):

--- a/src/tribler/core/utilities/async_force_switch.py
+++ b/src/tribler/core/utilities/async_force_switch.py
@@ -2,6 +2,11 @@ import asyncio
 import functools
 
 
+async def switch():
+    """ Coroutine that yields control to the event loop."""
+    await asyncio.sleep(0)
+
+
 def force_switch(func):
     """Decorator for forced coroutine switch. The switch will occur before calling the function.
 
@@ -11,7 +16,7 @@ def force_switch(func):
 
     @functools.wraps(func)
     async def wrapper(*args, **kwargs):
-        await asyncio.sleep(0)
+        await switch()
         return await func(*args, **kwargs)
 
     return wrapper


### PR DESCRIPTION
This PR doesn't completely solve the issue causing the flakiness of the libtorrent tests. However, the changes have made the tests more responsive and should, at the very least, prevent the main thread from freezing.

Besides minor refactoring, there are two significant changes in this PR:
1. An asyncio switch was added to the `wait_for_status` function due to the potential of blocking the main thread during pytest execution. To understand the possibility, consider this example: https://github.com/Tribler/tribler/blob/018cd5fce25a0d9759d0c0d22b41b158c60428cd/src/tribler/core/utilities/tests/test_async_force_switch.py#L10-L34

2. The shutdown logic has been rewritten to be slightly more accurate. While this change may not directly influence test stability, it could contribute slightly to it.

Related to #7495

Refs:
* https://docs.python.org/3/library/asyncio-task.html#asyncio.Task.cancel
* https://textual.textualize.io/blog/2023/02/11/the-heisenbug-lurking-in-your-async-code/