### PR TITLE
Print stacktrace for frozen tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -4,6 +4,7 @@ timeout = 60
 asyncio_mode = auto
 log_level = INFO
 log_format = %(asctime)s.%(msecs)03d %(levelname)s %(name)s(%(lineno)d) %(message)s
+addopts = --capture=no
 log_cli_format = %(asctime)s.%(msecs)03d %(levelname)s %(name)s(%(lineno)d) %(message)s
 markers =
     guitest:Tests for GUI. Skipped by default, use --guitests option to enable them

--- a/pytest.ini
+++ b/pytest.ini
@@ -11,6 +11,7 @@ markers =
     tunneltest:Slow tests for tunnels. Skipped by default, use --tunneltests option to enable them
     enable_https:Use HTTPS instead of HTTP in marked tests
     api_key:Used by rest_manager fixture to inject api_key value
+faulthandler_timeout = 15
 
 filterwarnings =
     ignore:Passing field metadata as a keyword arg is deprecated:DeprecationWarning:marshmallow

--- a/src/tribler/core/components/restapi/rest/tests/test_utils.py
+++ b/src/tribler/core/components/restapi/rest/tests/test_utils.py
@@ -84,12 +84,16 @@ def test_format_frames():
         )
     )
     expected = [
-        "short_file:, line 1, in function\n"
-        "    <source is unknown>\n"
-        "\tkey = 'valu[...]\n",
+        'short_file:, line 1, in function\n'
+        '    <source is unknown>\n'
+        '    --------------------\n'
+        "\tkey = 'valu[...]\n"
+        '    --------------------',
         '[...]elong_file:, line 1, in function\n'
         '    <source is unknown>\n'
+        '    --------------------\n'
         "\tkey = 'long[...]\n"
+        '    --------------------'
     ]
 
     assert list(_format_frames(frames, file_width=10, value_width=5)) == expected

--- a/src/tribler/core/components/restapi/rest/utils.py
+++ b/src/tribler/core/components/restapi/rest/utils.py
@@ -99,11 +99,13 @@ def _format_frames(frame: Optional[FrameType], file_width: int = 50, value_width
             except Exception as e:  # pylint: disable=broad-except
                 value = f'<exception when taking repr: {e.__class__.__name__}: {e}>'
             value = shorten(value, width=value_width)
-            local += f'\t{key} = {value}\n'
+            local += f'\n\t{key} = {value}'
         frame = frame.f_back
         yield f'{header}\n' \
               f'    {source_line}\n' \
-              f'{local}'
+              f'    {"-" * 20}' \
+              f'{local}\n' \
+              f'    {"-" * 20}'
 
 
 def get_threads_info() -> List[Dict]:
@@ -122,3 +124,15 @@ def get_threads_info() -> List[Dict]:
                 'frames': list(_format_frames(frame)),
             })
     return result
+
+
+def print_threads_info():
+    info = get_threads_info()
+    print('\n\nThreads info:', flush=True)
+    for t in info:
+        print('\n', flush=True)
+        print('=' * 40, flush=True)
+        print(f'{t["thread_id"]}: {t["thread_name"]}', flush=True)
+        print('=' * 40, flush=True)
+        for f in t["frames"]:
+            print(f, flush=True)

--- a/src/tribler/core/conftest.py
+++ b/src/tribler/core/conftest.py
@@ -3,7 +3,10 @@ import gc
 import logging
 import platform
 import sys
-from datetime import datetime
+import threading
+import time
+from datetime import datetime, timedelta
+from threading import Thread
 from typing import Optional
 
 import human_readable
@@ -14,6 +17,7 @@ from aiohttp.web_app import Application
 
 from tribler.core.components.restapi.rest.rest_endpoint import RESTEndpoint
 from tribler.core.components.restapi.rest.rest_manager import error_middleware
+from tribler.core.components.restapi.rest.utils import print_threads_info
 from tribler.core.utilities.network_utils import default_network_utils
 
 # Enable origin tracking for coroutine objects in the current thread, so when a test does not handle
@@ -33,12 +37,37 @@ def pytest_configure(config):
     logging.getLogger('faker.factory').propagate = False
 
 
+event_new_test = threading.Event()
+
+
+def watch_dog():
+    last_time = datetime.now()
+    enable_print = False
+
+    while True:
+        time.sleep(1)
+        if event_new_test.is_set():
+            event_new_test.clear()
+            last_time = datetime.now()
+            enable_print = True
+
+        duration = datetime.now() - last_time
+        if enable_print and duration > timedelta(seconds=15):
+            print(f'Watch Dog: Long duration detected: {human_readable.time_delta(duration)}', flush=True)
+            print_threads_info()
+            enable_print = False
+
+
 @pytest.hookimpl
 def pytest_cmdline_main(config: Config):
     """ Enable extended logging if the verbose option is used """
     # Called for performing the main command line action.
     global enable_extended_logging  # pylint: disable=global-statement
     enable_extended_logging = config.option.verbose > 0
+
+    print('Enable watch dog')
+    thread = Thread(target=watch_dog, daemon=True)
+    thread.start()
 
 
 @pytest.hookimpl
@@ -51,6 +80,7 @@ def pytest_collection_finish(session):
 
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_protocol(item: Function, log=True, nextitem=None):
+    event_new_test.set()
     """ Modify the pytest output to include the execution duration for all tests """
     # Perform the runtest protocol for a single test item.
     if enable_extended_logging and pytest_start_time:
@@ -63,7 +93,6 @@ def pytest_runtest_protocol(item: Function, log=True, nextitem=None):
         print(f' in {duration:.3f}s ({human_readable.time_delta(total)} in total)', end='')
     else:
         yield
-
 
 
 @pytest.fixture(autouse=True)

--- a/src/tribler/core/utilities/pytest_watch_dog.py
+++ b/src/tribler/core/utilities/pytest_watch_dog.py
@@ -1,0 +1,38 @@
+import logging
+import threading
+import time
+from datetime import datetime, timedelta
+
+import human_readable
+
+from tribler.core.components.restapi.rest.utils import print_threads_info
+
+TEST_TIMEOUT_SECONDS = 15
+
+event_new_test = threading.Event()
+
+_logger = logging.Logger('PytestWatchDog')
+
+
+def watch_dog_thread():
+    last_time = datetime.now()
+    enable_print = False
+
+    while True:
+        time.sleep(1)
+        if event_new_test.is_set():
+            event_new_test.clear()
+            last_time = datetime.now()
+            enable_print = True
+
+        duration = datetime.now() - last_time
+        if enable_print and duration > timedelta(seconds=TEST_TIMEOUT_SECONDS):
+            _logger.warning(f'Watch Dog: Long duration detected: {human_readable.time_delta(duration)}')
+            print_threads_info()
+            enable_print = False
+
+
+def start_watch_dog():
+    _logger.info('Enable watch dog')
+    thread = threading.Thread(target=watch_dog_thread, daemon=True)
+    thread.start()


### PR DESCRIPTION
Test PR

print by pytest:

```python
Thread 0x00001ab8 (most recent call first):
  File "C:\hostedtoolcache\windows\Python\3.8.10\x64\lib\threading.py", line 306 in wait
  File "C:\hostedtoolcache\windows\Python\3.8.10\x64\lib\threading.py", line 558 in wait
  File "C:\hostedtoolcache\windows\Python\3.8.10\x64\lib\threading.py", line 1252 in run
  File "c:\users\runneradmin\.virtualenvs\.venv\lib\site-packages\sentry_sdk\integrations\threading.py", line 70 in run
  File "C:\hostedtoolcache\windows\Python\3.8.10\x64\lib\threading.py", line 932 in _bootstrap_inner
  File "C:\hostedtoolcache\windows\Python\3.8.10\x64\lib\threading.py", line 890 in _bootstrap
Thread 0x00000730 (most recent call first):
  File "C:\hostedtoolcache\windows\Python\3.8.10\x64\lib\ssl.py", line 1099 in read
  File "C:\hostedtoolcache\windows\Python\3.8.10\x64\lib\ssl.py", line 1241 in recv_into
  File "C:\hostedtoolcache\windows\Python\3.8.10\x64\lib\socket.py", line 669 in readinto
  File "C:\hostedtoolcache\windows\Python\3.8.10\x64\lib\http\client.py", line 268 in _read_status
  File "C:\hostedtoolcache\windows\Python\3.8.10\x64\lib\http\client.py", line 307 in begin
  File "C:\hostedtoolcache\windows\Python\3.8.10\x64\lib\http\client.py", line 1344 in getresponse
  File "c:\users\runneradmin\.virtualenvs\.venv\lib\site-packages\sentry_sdk\integrations\stdlib.py", line 126 in getresponse
  File "c:\users\runneradmin\.virtualenvs\.venv\lib\site-packages\urllib3\connection.py", line 454 in getresponse
  File "c:\users\runneradmin\.virtualenvs\.venv\lib\site-packages\urllib3\connectionpool.py", line 536 in _make_request
  File "c:\users\runneradmin\.virtualenvs\.venv\lib\site-packages\urllib3\connectionpool.py", line 790 in urlopen
  File "c:\users\runneradmin\.virtualenvs\.venv\lib\site-packages\urllib3\poolmanager.py", line 443 in urlopen
  File "c:\users\runneradmin\.virtualenvs\.venv\lib\site-packages\urllib3\_request_methods.py", line 217 in 

...

```

extended (our) print:
```python
Threads info:
========================================
4028: MainThread
========================================
[...]\.venv\lib\site-packages\pony\orm\dbapiprovider.py:, line 241, in commit
    connection.commit()
    --------------------
	provider = <pony.orm.dbproviders.sqlite.SQLiteProvider object at 0x000001D218625610>
	connection = <sqlite3.Connection object at 0x000001D2184CAE40>
	cache = <pony.orm.core.SessionCache object at 0x000001D218646D00>
	core = <module 'pony.orm.core' from 'c:\\users\\runneradmin\\.virtualenvs\\.venv\\lib\\site-packages\\pony\[...]
    --------------------
 [...]\.venv\lib\site-packages\pony\orm\dbapiprovider.py:, line 55, in wrap_dbapi_exceptions
    try: return func(provider, *args, **kwargs)
    --------------------
	func = <function DBAPIProvider.commit at 0x000001D2111CA1F0>
	provider = <pony.orm.dbproviders.sqlite.SQLiteProvider object at 0x000001D218625610>
	args = (<sqlite3.Connection object at 0x000001D2184CAE40>, <pony.orm.core.SessionCache object at 0x000001D2[...]
	kwargs = {}
	dbapi_module = <module 'sqlite3' from 'C:\\hostedtoolcache\\windows\\Python\\3.8.10\\x64\\lib\\sqlite3\\__init__.py[...]
	should_retry = False
    --------------------
<string>:, line 2, in commit
    <source is unknown>
    --------------------
	provider = <pony.orm.dbproviders.sqlite.SQLiteProvider object at 0x000001D218625610>
	connection = <sqlite3.Connection object at 0x000001D2184CAE40>
	cache = <pony.orm.core.SessionCache object at 0x000001D218646D00>
    --------------------
[...]v\lib\site-packages\pony\orm\dbproviders\sqlite.py:, line 402, in commit
    DBAPIProvider.commit(provider, connection, cache)
    --------------------
	provider = <pony.orm.dbproviders.sqlite.SQLiteProvider object at 0x000001D218625610>
	connection = <sqlite3.Connection object at 0x000001D2184CAE40>
	cache = <pony.orm.core.SessionCache object at 0x000001D218646D00>
	in_transaction = True
    --------------------
[...]rtualenvs\.venv\lib\site-packages\pony\orm\core.py:, line 1820, in commit
    cache.database.provider.commit(cache.connection, cache)
    --------------------
	cache = <pony.orm.core.SessionCache object at 0x000001D218646D00>
    --------------------
[...]rtualenvs\.venv\lib\site-packages\pony\orm\core.py:, line 378, in commit
    primary_cache.commit()
    --------------------
	caches = [<pony.orm.core.SessionCache object at 0x000001D218646D00>]
	cache = <pony.orm.core.SessionCache object at 0x000001D218646D00>
	primary_cache = <pony.orm.core.SessionCache object at 0x000001D218646D00>
	other_caches = []
	exceptions = []
    --------------------


...


```