### PR TITLE
Ported Bandwidth/GigaChannel tests to modern TestBase

### DIFF
--- a/src/tribler/core/components/bandwidth_accounting/tests/test_community.py
+++ b/src/tribler/core/components/bandwidth_accounting/tests/test_community.py
@@ -1,5 +1,3 @@
-from asyncio import sleep
-
 from ipv8.keyvault.crypto import default_eccrypto
 from ipv8.peer import Peer
 from ipv8.test.base import TestBase
@@ -13,6 +11,8 @@ from tribler.core.components.bandwidth_accounting.db.database import BandwidthDa
 from tribler.core.components.bandwidth_accounting.db.transaction import BandwidthTransactionData, EMPTY_SIGNATURE
 from tribler.core.components.bandwidth_accounting.settings import BandwidthAccountingSettings
 from tribler.core.utilities.utilities import MEMORY_DB
+
+ID1, ID2, ID3 = range(3)
 
 
 class TestBandwidthAccountingCommunity(TestBase):
@@ -28,128 +28,121 @@ class TestBandwidthAccountingCommunity(TestBase):
                         settings=BandwidthAccountingSettings())
         return ipv8
 
+    def database(self, i):
+        return self.overlay(i).database
+
+    def add_cache(self, i, cache):
+        return self.overlay(i).request_cache.add(cache)
+
     async def test_single_transaction(self):
         """
         Test a simple transaction between two parties.
         """
-        await self.nodes[0].overlay.do_payout(self.nodes[1].overlay.my_peer, 1024)
+        await self.overlay(ID1).do_payout(self.peer(ID2), 1024)
 
-        from_pk = self.nodes[0].my_peer.public_key.key_to_bin()
-        assert self.nodes[0].overlay.database.get_total_taken(from_pk) == 1024
-        assert self.nodes[1].overlay.database.get_total_taken(from_pk) == 1024
+        assert self.database(ID1).get_total_taken(self.key_bin(ID1)) == 1024
+        assert self.database(ID2).get_total_taken(self.key_bin(ID1)) == 1024
 
     async def test_multiple_transactions(self):
         """
         Test multiple, subsequent transactions between two parties.
         """
-        await self.nodes[0].overlay.do_payout(self.nodes[1].overlay.my_peer, 500)
-        await self.nodes[0].overlay.do_payout(self.nodes[1].overlay.my_peer, 1500)
+        await self.overlay(ID1).do_payout(self.peer(ID2), 500)
+        await self.overlay(ID1).do_payout(self.peer(ID2), 1500)
 
-        from_pk = self.nodes[0].my_peer.public_key.key_to_bin()
-        assert self.nodes[0].overlay.database.get_total_taken(from_pk) == 2000
-        assert self.nodes[1].overlay.database.get_total_taken(from_pk) == 2000
+        assert self.database(ID1).get_total_taken(self.key_bin(ID1)) == 2000
+        assert self.database(ID2).get_total_taken(self.key_bin(ID1)) == 2000
 
     async def test_bilateral_transaction(self):
         """
         Test creating a transaction from A to B and one from B to A.
         """
-        await self.nodes[0].overlay.do_payout(self.nodes[1].overlay.my_peer, 500)
-        await self.nodes[1].overlay.do_payout(self.nodes[0].overlay.my_peer, 1500)
+        await self.overlay(ID1).do_payout(self.peer(ID2), 500)
+        await self.overlay(ID2).do_payout(self.peer(ID1), 1500)
 
-        pk1 = self.nodes[0].my_peer.public_key.key_to_bin()
-        pk2 = self.nodes[1].my_peer.public_key.key_to_bin()
-        assert self.nodes[0].overlay.database.get_total_taken(pk1) == 500
-        assert self.nodes[1].overlay.database.get_total_taken(pk1) == 500
-        assert self.nodes[0].overlay.database.get_total_taken(pk2) == 1500
-        assert self.nodes[1].overlay.database.get_total_taken(pk2) == 1500
+        assert self.database(ID1).get_total_taken(self.key_bin(ID1)) == 500
+        assert self.database(ID2).get_total_taken(self.key_bin(ID1)) == 500
+        assert self.database(ID1).get_total_taken(self.key_bin(ID2)) == 1500
+        assert self.database(ID2).get_total_taken(self.key_bin(ID2)) == 1500
 
     async def test_bilateral_transaction_timestamps(self):
         """
         Test creating subsequent transactions and check whether the timestamps are different.
         """
-        tx1 = await self.nodes[0].overlay.do_payout(self.nodes[1].overlay.my_peer, 500)
-        await sleep(0.1)
-        tx2 = await self.nodes[0].overlay.do_payout(self.nodes[1].overlay.my_peer, 500)
+        tx1 = await self.overlay(ID1).do_payout(self.peer(ID2), 500)
+        tx2 = await self.overlay(ID1).do_payout(self.peer(ID2), 500)
+
         assert tx1.timestamp != tx2.timestamp
 
     async def test_invalid_transaction(self):
         """
         Test sending a transaction with an invalid signature to the counterparty, which should be ignored.
         """
-        other_peer = self.nodes[1].my_peer
-        tx = self.nodes[0].overlay.construct_signed_transaction(other_peer, 300)
+        tx = self.overlay(ID1).construct_signed_transaction(self.peer(ID2), 300)
         tx.signature_a = b"invalid"
-        self.nodes[0].overlay.database.BandwidthTransaction.insert(tx)
-        cache = self.nodes[0].overlay.request_cache.add(BandwidthTransactionSignCache(self.nodes[0].overlay, tx))
-        self.nodes[0].overlay.send_transaction(tx, other_peer.address, cache.number)
+        self.database(ID1).BandwidthTransaction.insert(tx)
+        cache = self.add_cache(ID1, BandwidthTransactionSignCache(self.overlay(ID1), tx))
+        self.overlay(ID1).send_transaction(tx, self.address(ID2), cache.number)
 
         await self.deliver_messages()
 
-        assert self.nodes[1].overlay.database.get_total_taken(self.nodes[0].my_peer.public_key.key_to_bin()) == 0
+        assert self.database(ID2).get_total_taken(self.key_bin(ID1)) == 0
 
     async def test_ignore_unknown_transaction(self):
         """
         Test whether we are ignoring a transaction that is not in our cache.
         """
-        pk1 = self.nodes[0].my_peer.public_key.key_to_bin()
-        pk2 = self.nodes[1].my_peer.public_key.key_to_bin()
+        tx = BandwidthTransactionData(ID2, self.key_bin(ID1), self.key_bin(ID2), EMPTY_SIGNATURE, EMPTY_SIGNATURE, 1000)
+        tx.sign(self.private_key(ID1), as_a=True)
+        self.overlay(ID1).send_transaction(tx, self.address(ID2), 1234)
 
-        tx = BandwidthTransactionData(1, pk1, pk2, EMPTY_SIGNATURE, EMPTY_SIGNATURE, 1000)
-        tx.sign(self.nodes[0].my_peer.key, as_a=True)
-        self.nodes[0].overlay.send_transaction(tx, self.nodes[1].my_peer.address, 1234)
         await self.deliver_messages()
-        assert not self.nodes[0].overlay.database.get_latest_transaction(pk1, pk2)
+
+        assert not self.database(ID1).get_latest_transaction(self.key_bin(ID1), self.key_bin(ID2))
 
     async def test_concurrent_transaction_out_of_order(self):
         """
         Test creating multiple transactions, while the other party is offline and receives messages out of order.
         """
-        pk1 = self.nodes[0].my_peer.public_key.key_to_bin()
-        pk2 = self.nodes[1].my_peer.public_key.key_to_bin()
-
-        tx1 = BandwidthTransactionData(1, pk1, pk2, EMPTY_SIGNATURE, EMPTY_SIGNATURE, 1000)
-        tx2 = BandwidthTransactionData(2, pk1, pk2, EMPTY_SIGNATURE, EMPTY_SIGNATURE, 2000)
+        tx1 = BandwidthTransactionData(1, self.key_bin(ID1), self.key_bin(ID2), EMPTY_SIGNATURE, EMPTY_SIGNATURE, 1000)
+        tx2 = BandwidthTransactionData(2, self.key_bin(ID1), self.key_bin(ID2), EMPTY_SIGNATURE, EMPTY_SIGNATURE, 2000)
 
         # Send them in reverse order
-        cache = self.nodes[0].overlay.request_cache.add(BandwidthTransactionSignCache(self.nodes[0].overlay, tx1))
-        self.nodes[0].overlay.send_transaction(tx2, self.nodes[1].my_peer.address, cache.number)
+        cache = self.add_cache(ID1, BandwidthTransactionSignCache(self.overlay(ID1), tx1))
+        self.overlay(ID1).send_transaction(tx2, self.address(ID2), cache.number)
         await self.deliver_messages()
 
         # This one should be ignored by node 1
-        cache = self.nodes[0].overlay.request_cache.add(BandwidthTransactionSignCache(self.nodes[0].overlay, tx1))
-        self.nodes[0].overlay.send_transaction(tx1, self.nodes[1].my_peer.address, cache.number)
+        cache = self.add_cache(ID1, BandwidthTransactionSignCache(self.overlay(ID1), tx1))
+        self.overlay(ID1).send_transaction(tx1, self.address(ID2), cache.number)
         await self.deliver_messages()
 
         # Both parties should have the transaction with amount 2000 in their database
-        assert self.nodes[0].overlay.database.get_total_taken(pk1) == 2000
-        assert self.nodes[1].overlay.database.get_total_taken(pk1) == 2000
+        assert self.database(ID1).get_total_taken(self.key_bin(ID1)) == 2000
+        assert self.database(ID2).get_total_taken(self.key_bin(ID1)) == 2000
 
     async def test_querying_peer(self):
         """
         Test whether node C can query node B to get the transaction between A and B.
         """
-        await self.nodes[0].overlay.do_payout(self.nodes[1].overlay.my_peer, 500)
+        await self.overlay(ID1).do_payout(self.peer(ID2), 500)
 
-        # Add an additional node to the experiment
         self.add_node_to_experiment(self.create_node())
-        self.nodes[2].overlay.query_transactions(self.nodes[1].my_peer)
+        self.overlay(ID3).query_transactions(self.peer(ID2))
 
         await self.deliver_messages()
 
-        pk1 = self.nodes[0].my_peer.public_key.key_to_bin()
-        assert self.nodes[2].overlay.database.get_total_taken(pk1) == 500
+        assert self.database(ID3).get_total_taken(self.key_bin(ID1)) == 500
 
     async def test_query_random_peer(self):
         """
         Test whether node C can query node B to get the transaction between A and B.
         """
-        await self.nodes[0].overlay.do_payout(self.nodes[1].overlay.my_peer, 500)
+        await self.overlay(ID1).do_payout(self.peer(ID2), 500)
 
-        # Add an additional node to the experiment
         self.add_node_to_experiment(self.create_node())
-        self.nodes[2].overlay.query_random_peer()
+        self.overlay(ID3).query_random_peer()
 
         await self.deliver_messages()
 
-        pk1 = self.nodes[0].my_peer.public_key.key_to_bin()
-        assert self.nodes[2].overlay.database.get_total_taken(pk1) == 500
+        assert self.database(ID3).get_total_taken(self.key_bin(ID1)) == 500

--- a/src/tribler/core/components/gigachannel/community/tests/test_gigachannel_community.py
+++ b/src/tribler/core/components/gigachannel/community/tests/test_gigachannel_community.py
@@ -1,6 +1,8 @@
 import time
-from datetime import datetime
-from unittest.mock import AsyncMock, Mock, PropertyMock, patch
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass, fields
+from typing import Callable
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 from ipv8.keyvault.crypto import default_eccrypto
@@ -12,31 +14,52 @@ from tribler.core.components.gigachannel.community.gigachannel_community import 
     ChannelsPeersMapping,
     GigaChannelCommunity,
     NoChannelSourcesException,
+    happy_eyeballs_delay
 )
 from tribler.core.components.gigachannel.community.settings import ChantSettings
 from tribler.core.components.metadata_store.db.store import MetadataStore
 from tribler.core.components.metadata_store.remote_query_community.remote_query_community import EvaSelectRequest, \
-    SelectRequest
+    SelectRequest, RemoteSelectPayload, RemoteSelectPayloadEva, SelectResponsePayload
 from tribler.core.components.metadata_store.remote_query_community.settings import RemoteQueryCommunitySettings
 from tribler.core.components.metadata_store.utils import RequestTimeoutException
 from tribler.core.utilities.notifier import Notifier
 from tribler.core.utilities.path_util import Path
 from tribler.core.utilities.utilities import random_infohash
 
-EMPTY_BLOB = b""
-
 # pylint:disable=protected-access
 
+EMPTY_BLOB = b""
+U_CHANNEL = "ubuntu channel"
+U_TORRENT = "ubuntu torrent"
+CHANNEL_ID = 123
 BASE_PATH = 'tribler.core.components.metadata_store.remote_query_community.remote_query_community'
+ID1, ID2, ID3 = range(3)
+
+
+@dataclass
+class ChannelKey(Mapping):
+    channel_pk: bytes
+    origin_id: int
+
+    # The following methods allow for use as a Mapping (i.e., the "**key"-syntax)
+    def __iter__(self):
+        return iter(asdict(self))
+
+    def __getitem__(self, item):
+        return getattr(self, item)
+
+    def __len__(self):
+        return len(fields(self))
 
 
 class TestGigaChannelUnits(TestBase):
+    overlay: Callable[[int], GigaChannelCommunity]
+
     def setUp(self):
         super().setUp()
         self.count = 0
         self.metadata_store_set = set()
         self.initialize(GigaChannelCommunity, 3)
-        self.torrent_template = {"title": "", "infohash": b"", "torrent_date": datetime(1970, 1, 1), "tags": "video"}
 
     async def tearDown(self):
         for metadata_store in self.metadata_store_set:
@@ -54,43 +77,37 @@ class TestGigaChannelUnits(TestBase):
         kwargs['metadata_store'] = metadata_store
         kwargs['settings'] = ChantSettings()
         kwargs['rqc_settings'] = RemoteQueryCommunitySettings()
-        with patch('tribler.core.components.gigachannel.community.gigachannel_community.DiscoveryBooster'):
-            node = super().create_node(*args, **kwargs)
+        node = super().create_node(*args, **kwargs)
+
+        node.overlay.discovery_booster.finish()
+        notifier = Notifier(loop=self.loop)
+        notifier.notify = Mock()
+        node.overlay.notifier = notifier
+
         self.count += 1
         return node
 
     def channel_metadata(self, i):
-        return self.nodes[i].overlay.mds.ChannelMetadata
+        return self.overlay(i).mds.ChannelMetadata
 
     def torrent_metadata(self, i):
-        return self.nodes[i].overlay.mds.TorrentMetadata
+        return self.overlay(i).mds.TorrentMetadata
 
-    def generate_torrents(self, overlay):
-        key = default_eccrypto.generate_key("curve25519")
-        channel_pk = key.pub().key_to_bin()[10:]
-        channel_id = 123
-        kwargs = {"channel_pk": channel_pk, "origin_id": channel_id}
+    def notifier(self, i):
+        return self.overlay(i).notifier
+
+    def channel_pk(self, i):
+        return self.key_bin(i)[10:]
+
+    def generate_torrents(self, overlay) -> ChannelKey:
+        private_key = default_eccrypto.generate_key("curve25519")
+        channel_key = ChannelKey(private_key.pub().key_to_bin()[10:], CHANNEL_ID)
         with db_session:
             for m in range(0, 50):
                 overlay.mds.TorrentMetadata(
-                    title=f"bla-{m}", origin_id=channel_id, infohash=random_infohash(), sign_with=key
+                    title=f"bla-{m}", origin_id=channel_key.origin_id, infohash=random_infohash(), sign_with=private_key
                 )
-        return kwargs
-
-    def client_server_request_setup(self):
-        client = self.overlay(0)
-        server = self.overlay(2)
-        kwargs = self.generate_torrents(server)
-        client.get_known_subscribed_peers_for_node = lambda *_: [server.my_peer]
-        return client, server, kwargs
-
-    def double_client_server_request_setup(self):
-        client = self.overlay(0)
-        server1 = self.overlay(1)
-        server2 = self.overlay(2)
-        kwargs_server2 = self.generate_torrents(server2)
-        client.get_known_subscribed_peers_for_node = lambda *_: [server1.my_peer, server2.my_peer]
-        return client, server1, server2, kwargs_server2
+        return channel_key
 
     async def test_gigachannel_search(self):
         """
@@ -101,73 +118,58 @@ class TestGigaChannelUnits(TestBase):
         for node in self.nodes:
             node.overlay.rqc_settings.max_channel_query_back = 0
 
-        await self.introduce_nodes()
-
-        U_CHANNEL = "ubuntu channel"
-        U_TORRENT = "ubuntu torrent"
-
-        # Add test metadata to node 0
         with db_session:
-            self.nodes[0].overlay.mds.ChannelMetadata.create_channel(U_CHANNEL, "")
-            self.nodes[0].overlay.mds.ChannelMetadata.create_channel("debian channel", "")
+            # Add test metadata to node ID1
+            self.channel_metadata(ID1).create_channel(U_CHANNEL, "")
+            self.channel_metadata(ID1).create_channel("debian channel", "")
+            # Add test metadata to node ID2
+            self.torrent_metadata(ID2)(title=U_TORRENT, infohash=random_infohash())
+            self.torrent_metadata(ID2)(title="debian torrent", infohash=random_infohash())
 
-        # Add test metadata to node 1
-        with db_session:
-            self.nodes[1].overlay.mds.TorrentMetadata(title=U_TORRENT, infohash=random_infohash())
-            self.nodes[1].overlay.mds.TorrentMetadata(title="debian torrent", infohash=random_infohash())
+        self.overlay(ID3).send_search_request(**{"txt_filter": "ubuntu*"})
 
-        notifier = Notifier(loop=self.loop)
-        notifier.notify = Mock()
-        self.nodes[2].overlay.notifier = notifier
-
-        self.nodes[2].overlay.send_search_request(**{"txt_filter": "ubuntu*"})
-
-        await self.deliver_messages(timeout=0.5)
+        await self.deliver_messages()
 
         # Check that the notifier callback was called on both entries
-        titles = sorted(call.args[1]["results"][0]["name"] for call in notifier.notify.call_args_list)
+        titles = sorted(call.args[1]["results"][0]["name"] for call in self.notifier(ID3).notify.call_args_list)
         assert titles == [U_CHANNEL, U_TORRENT]
 
         with db_session:
-            assert self.nodes[2].overlay.mds.ChannelNode.select().count() == 2
-            assert (
-                    self.nodes[2].overlay.mds.ChannelNode.select(
-                        lambda g: g.title in (U_CHANNEL, U_TORRENT)).count() == 2
-            )
+            assert self.overlay(ID3).mds.ChannelNode.select().count() == 2
+            assert self.overlay(ID3).mds.ChannelNode.select(lambda g: g.title in (U_CHANNEL, U_TORRENT)).count() == 2
 
-    def test_query_on_introduction(self):
+    async def test_query_on_introduction(self):
         """
         Test querying a peer that was just introduced to us.
         """
-
-        send_ok = []
-
-        def mock_send(_):
-            send_ok.append(1)
-
-        self.nodes[1].overlay.send_remote_select_subscribed_channels = mock_send
-        peer = self.nodes[0].my_peer
-        payload = Mock()
-        self.nodes[1].overlay.introduction_response_callback(peer, None, payload)
-        self.assertIn(peer.mid, self.nodes[1].overlay.queried_peers)
-        self.assertTrue(send_ok)
+        with self.assertReceivedBy(ID1, [SelectResponsePayload], message_filter=[SelectResponsePayload]):
+            self.overlay(ID2).send_introduction_request(self.peer(ID1))
+            await self.deliver_messages()
+        self.assertIn(self.mid(ID1), self.overlay(ID2).queried_peers)
 
         # Make sure the same peer will not be queried twice in case the walker returns to it
-        self.nodes[1].overlay.introduction_response_callback(peer, None, payload)
-        self.assertEqual(len(send_ok), 1)
+        with self.assertReceivedBy(ID1, [], message_filter=[SelectResponsePayload]):
+            self.overlay(ID2).send_introduction_request(self.peer(ID1))
+            await self.deliver_messages()
 
         # Test clearing queried peers set when it outgrows its capacity
-        self.nodes[1].overlay.settings.queried_peers_limit = 2
-        self.nodes[1].overlay.introduction_response_callback(Peer(default_eccrypto.generate_key("low")), None, payload)
-        self.assertEqual(len(self.nodes[1].overlay.queried_peers), 2)
+        self.overlay(ID2).settings.queried_peers_limit = 2
+        with self.assertReceivedBy(ID3, [SelectResponsePayload], message_filter=[SelectResponsePayload]):
+            self.overlay(ID2).send_introduction_request(self.peer(ID3))
+            await self.deliver_messages()
+        self.assertEqual(len(self.overlay(ID2).queried_peers), 2)
 
-        self.nodes[1].overlay.introduction_response_callback(Peer(default_eccrypto.generate_key("low")), None, payload)
+        self.add_node_to_experiment(self.create_node())
+        with self.assertReceivedBy(3, [SelectResponsePayload], message_filter=[SelectResponsePayload]):
+            self.overlay(ID2).send_introduction_request(self.peer(3))
+            await self.deliver_messages()
         # The set has been cleared, so the number of queried peers must be dropped back to 1
-        self.assertEqual(len(self.nodes[1].overlay.queried_peers), 1)
+        self.assertEqual(len(self.overlay(ID2).queried_peers), 1)
 
         # Ensure that we're not going to query ourselves
-        self.nodes[1].overlay.introduction_response_callback(self.nodes[1].overlay.my_peer, None, payload)
-        self.assertEqual(len(send_ok), 3)
+        with self.assertReceivedBy(ID1, [], message_filter=[SelectResponsePayload]):
+            self.overlay(ID2).send_introduction_request(self.peer(ID2))
+        self.assertEqual(len(self.overlay(ID2).queried_peers), 1)
 
     async def test_remote_select_subscribed_channels(self):
         """
@@ -175,51 +177,44 @@ class TestGigaChannelUnits(TestBase):
         """
 
         # We do not want the query back mechanism to interfere with this test
-        self.nodes[1].overlay.rqc_settings.max_channel_query_back = 0
+        self.overlay(ID2).rqc_settings.max_channel_query_back = 0
 
         num_channels = 5
 
         with db_session:
             # Create one channel with zero contents, to check that only non-empty channels are served
-            self.nodes[0].overlay.mds.ChannelMetadata.create_channel("channel sub", "")
+            self.channel_metadata(ID1).create_channel("channel sub", "")
             # Create one channel that has not yet been processed (with local_version<timestamp)
-            incomplete_chan = self.nodes[0].overlay.mds.ChannelMetadata.create_channel("channel sub", "")
+            incomplete_chan = self.channel_metadata(ID1).create_channel("channel sub", "")
             incomplete_chan.num_entries = 10
             incomplete_chan.sign()
             for _ in range(0, num_channels):
-                chan = self.nodes[0].overlay.mds.ChannelMetadata.create_channel("channel sub", "")
+                chan = self.channel_metadata(ID1).create_channel("channel sub", "")
                 chan.local_version = chan.timestamp
                 chan.num_entries = 10
                 chan.sign()
             for _ in range(0, num_channels):
-                channel_uns = self.nodes[0].overlay.mds.ChannelMetadata.create_channel("channel unsub", "")
+                channel_uns = self.channel_metadata(ID1).create_channel("channel unsub", "")
                 channel_uns.subscribed = False
 
-        notifier = Notifier(loop=self.loop)
-        notifier.notify = Mock()
-        self.nodes[1].overlay.notifier = notifier
-
-        peer = self.nodes[0].my_peer
         await self.introduce_nodes()
-        await self.deliver_messages(timeout=0.5)
+        await self.deliver_messages()
 
         # Check that the notifier callback is called on new channel entries
-        notifier.notify.assert_called()
-        assert "results" in notifier.notify.call_args.args[1]
+        self.notifier(ID2).notify.assert_called()
+        assert "results" in self.notifier(ID2).notify.call_args.args[1]
 
         with db_session:
-            received_channels = self.nodes[1].overlay.mds.ChannelMetadata.select(lambda g: g.title == "channel sub")
+            received_channels = self.channel_metadata(ID2).select(lambda g: g.title == "channel sub")
             self.assertEqual(num_channels, received_channels.count())
 
             # Only subscribed channels should have been transported
-            received_channels_all = self.nodes[1].overlay.mds.ChannelMetadata.select()
+            received_channels_all = self.channel_metadata(ID2).select()
             self.assertEqual(num_channels, received_channels_all.count())
 
             # Make sure the subscribed channels transport counted as voting
-            self.assertEqual(
-                self.nodes[1].overlay.mds.ChannelPeer.select().first().public_key, peer.public_key.key_to_bin()[10:]
-            )
-            for chan in self.nodes[1].overlay.mds.ChannelMetadata.select():
+            self.assertEqual(self.overlay(ID2).mds.ChannelPeer.select().first().public_key, self.channel_pk(ID1))
+            for chan in self.channel_metadata(ID2).select():
                 self.assertTrue(chan.votes > 0.0)
 
     def test_channels_peers_mapping_drop_excess_peers(self):
@@ -227,8 +222,7 @@ class TestGigaChannelUnits(TestBase):
         Test dropping old excess peers from a channel to peers mapping
         """
         mapping = ChannelsPeersMapping()
-        chan_pk = Mock()
-        chan_id = 123
+        key = ChannelKey(self.channel_pk(ID1), CHANNEL_ID)
 
         num_excess_peers = 20
         t = time.time() - 1000
@@ -237,14 +231,14 @@ class TestGigaChannelUnits(TestBase):
             peer = Peer(default_eccrypto.generate_key("very-low"), ("1.2.3.4", 5))
             peer.last_response = t
             t += 1.0
-            mapping.add(peer, chan_pk, chan_id)
+            mapping.add(peer, *key.values())
             if k == 0:
                 first_peer_timestamp = peer.last_response
 
-        chan_peers_3 = mapping.get_last_seen_peers_for_channel(chan_pk, chan_id, 3)
+        chan_peers_3 = mapping.get_last_seen_peers_for_channel(*key.values(), limit=3)
         assert len(chan_peers_3) == 3
 
-        chan_peers = mapping.get_last_seen_peers_for_channel(chan_pk, chan_id)
+        chan_peers = mapping.get_last_seen_peers_for_channel(*key.values())
         assert len(chan_peers) == mapping.max_peers_per_channel
 
         assert chan_peers_3 == chan_peers[0:3]
@@ -256,12 +250,12 @@ class TestGigaChannelUnits(TestBase):
 
         # Test removing a peer directly, e.g. as a result of a query timeout
         peer = Peer(default_eccrypto.generate_key("very-low"), ("1.2.3.4", 5))
-        mapping.add(peer, chan_pk, chan_id)
+        mapping.add(peer, *key.values())
         mapping.remove_peer(peer)
         for p in chan_peers:
             mapping.remove_peer(p)
 
-        assert mapping.get_last_seen_peers_for_channel(chan_pk, chan_id) == []
+        assert mapping.get_last_seen_peers_for_channel(*key.values()) == []
 
         # Make sure the stuff is cleaned up
         assert len(mapping._peers_channels) == 0
@@ -270,114 +264,128 @@ class TestGigaChannelUnits(TestBase):
     def test_get_known_subscribed_peers_for_node(self):
         key = default_eccrypto.generate_key("curve25519")
         with db_session:
-            channel = self.overlay(0).mds.ChannelMetadata(origin_id=0, infohash=random_infohash(), sign_with=key)
-            folder1 = self.overlay(0).mds.CollectionNode(origin_id=channel.id_, sign_with=key)
-            folder2 = self.overlay(0).mds.CollectionNode(origin_id=folder1.id_, sign_with=key)
+            channel = self.channel_metadata(ID1)(origin_id=0, infohash=random_infohash(), sign_with=key)
+            folder1 = self.overlay(ID1).mds.CollectionNode(origin_id=channel.id_, sign_with=key)
+            folder2 = self.overlay(ID1).mds.CollectionNode(origin_id=folder1.id_, sign_with=key)
 
-            orphan = self.overlay(0).mds.CollectionNode(origin_id=123123, sign_with=key)
+            orphan = self.overlay(ID1).mds.CollectionNode(origin_id=123123, sign_with=key)
 
-        source_peer = self.nodes[1].my_peer
-        self.overlay(0).channels_peers.add(source_peer, channel.public_key, channel.id_)
-        assert [source_peer] == self.overlay(0).get_known_subscribed_peers_for_node(channel.public_key, channel.id_)
-        assert [source_peer] == self.overlay(0).get_known_subscribed_peers_for_node(folder1.public_key, folder1.id_)
-        assert [source_peer] == self.overlay(0).get_known_subscribed_peers_for_node(folder2.public_key, folder2.id_)
-        assert [] == self.overlay(0).get_known_subscribed_peers_for_node(orphan.public_key, orphan.id_)
+        self.overlay(ID1).channels_peers.add(self.peer(ID2), channel.public_key, channel.id_)
+        expected = [self.peer(ID2)]
+        assert expected == self.overlay(ID1).get_known_subscribed_peers_for_node(channel.public_key, channel.id_)
+        assert expected == self.overlay(ID1).get_known_subscribed_peers_for_node(folder1.public_key, folder1.id_)
+        assert expected == self.overlay(ID1).get_known_subscribed_peers_for_node(folder2.public_key, folder2.id_)
+        assert [] == self.overlay(ID1).get_known_subscribed_peers_for_node(orphan.public_key, orphan.id_)
 
     async def test_remote_search_mapped_peers(self):
         """
         Test using mapped peers for channel queries.
         """
-        key = default_eccrypto.generate_key("curve25519")
-        channel_pk = key.pub().key_to_bin()[10:]
-        channel_id = 123
-        kwargs = {"channel_pk": channel_pk, "origin_id": channel_id}
+        key = ChannelKey(self.channel_pk(ID1), CHANNEL_ID)
+        self.network(ID3).remove_peer(self.peer(ID1))
+        self.network(ID3).remove_peer(self.peer(ID2))
+        self.overlay(ID3).channels_peers.add(self.peer(ID2), *key.values())
 
-        await self.introduce_nodes()
+        # The only source for peers is channels peers map
+        # The peer must have queried its known channel peer
+        with self.assertReceivedBy(ID2, [RemoteSelectPayload, SelectResponsePayload]):
+            self.overlay(ID3).send_search_request(**key)
+            await self.deliver_messages()
 
-        source_peer = self.nodes[2].overlay.get_peers()[0]
-        self.nodes[2].overlay.channels_peers.add(source_peer, channel_pk, channel_id)
-
-        self.nodes[2].overlay.notifier = None
-
-        # We disable getting random peers, so the only source for peers is channels peers map
-        self.nodes[2].overlay.get_random_peers = lambda _: []
-
-        self.nodes[2].overlay.send_remote_select = Mock()
-        self.nodes[2].overlay.send_search_request(**kwargs)
-
-        # The peer must have queried at least one peer
-        self.nodes[2].overlay.send_remote_select.assert_called()
-
-    @patch.object(SelectRequest, 'timeout_delay', PropertyMock(return_value=0.001))
-    @patch.object(ChannelsPeersMapping, 'remove_peer')
-    async def test_drop_silent_peer(self, mocked_remove_peer: Mock):
+    async def test_drop_silent_peer(self):
         # We do not want the query back mechanism to interfere with this test
-        self.overlay(1).rqc_settings.max_channel_query_back = 0
+        self.overlay(ID2).rqc_settings.max_channel_query_back = 0
+        self.overlay(ID2).channels_peers.add(self.peer(ID1), self.channel_pk(ID1), CHANNEL_ID)
 
-        self.overlay(1).send_remote_select(self.peer(0), txt_filter="ubuntu*")
-        await self.deliver_messages(timeout=0.1)
+        seen_peers = self.overlay(ID2).channels_peers.get_last_seen_peers_for_channel(self.channel_pk(ID1), CHANNEL_ID)
+        assert [self.peer(ID1)] == seen_peers
+
+        with self.overlay(ID2).request_cache.passthrough(SelectRequest):
+            self.overlay(ID2).send_remote_select(self.peer(ID1), txt_filter="ubuntu*")
+            await self.deliver_messages()
 
         # the `remove_peer` function must have been called because of the timeout
-        assert mocked_remove_peer.called
+        seen_peers = self.overlay(ID2).channels_peers.get_last_seen_peers_for_channel(self.channel_pk(ID1), CHANNEL_ID)
+        assert [] == seen_peers
 
-    @patch.object(ChannelsPeersMapping, 'remove_peer')
-    async def test_drop_silent_peer_empty_response_packet(self, mocked_remove_peer: Mock):
+    async def test_drop_silent_peer_empty_response_packet(self):
         # We do not want the query back mechanism to interfere with this test
-        self.overlay(1).rqc_settings.max_channel_query_back = 0
+        self.overlay(ID2).rqc_settings.max_channel_query_back = 0
+        self.overlay(ID2).channels_peers.add(self.peer(ID1), self.channel_pk(ID1), CHANNEL_ID)
+
+        seen_peers = self.overlay(ID2).channels_peers.get_last_seen_peers_for_channel(self.channel_pk(ID1), CHANNEL_ID)
+        assert [self.peer(ID1)] == seen_peers
 
         # Now test that even in the case of an empty response packet, remove_peer is not called on timeout
-        self.overlay(1).send_remote_select(self.peer(0), txt_filter="ubuntu*")
-        await self.deliver_messages(timeout=0.1)
+        self.overlay(ID2).send_remote_select(self.peer(ID1), txt_filter="ubuntu*")
+        await self.deliver_messages()
 
         # the `remove_peer` function must not have been called because of the timeout
-        assert not mocked_remove_peer.called
+        seen_peers = self.overlay(ID2).channels_peers.get_last_seen_peers_for_channel(self.channel_pk(ID1), CHANNEL_ID)
+        assert [self.peer(ID1)] == seen_peers
 
     async def test_remote_select_channel_contents(self):
         """
         Test awaiting for response from remote peer
         """
-        client, server, kwargs = self.client_server_request_setup()
+        key = self.generate_torrents(self.overlay(ID2))
         with db_session:
-            results = [p.to_simple_dict() for p in server.mds.get_entries(**kwargs)]
-        assert results == await client.remote_select_channel_contents(**kwargs)
+            self.overlay(ID1).channels_peers.add(self.peer(ID2), *key.values())
+            generated = [p.to_simple_dict() for p in self.overlay(ID2).mds.get_entries(**key)]
+
+        results = await self.overlay(ID1).remote_select_channel_contents(**key)
+
+        assert results == generated
         assert len(results) == 50
 
     async def test_remote_select_channel_contents_empty(self):
         """
         Test awaiting for response from remote peer and getting empty results
         """
-        client, _, kwargs = self.client_server_request_setup()
-        kwargs["origin_id"] = 333
-        assert [] == await client.remote_select_channel_contents(**kwargs)
+        key = ChannelKey(self.channel_pk(ID3), CHANNEL_ID)
+        with db_session:
+            self.overlay(ID1).channels_peers.add(self.peer(ID2), *key.values())
 
-    @patch.object(EvaSelectRequest, 'timeout_delay', new=PropertyMock(return_value=0.1))
+        results = await self.overlay(ID1).remote_select_channel_contents(**key)
+
+        assert [] == results
+
     async def test_remote_select_channel_timeout(self):
-        client, server, kwargs = self.client_server_request_setup()
-        server.send_db_results = Mock()
+        key = self.generate_torrents(self.overlay(ID2))
+        with db_session:
+            self.overlay(ID1).channels_peers.add(self.peer(ID2), *key.values())
+        self.overlay(ID2).endpoint.close()
+
         with pytest.raises(RequestTimeoutException):
-            await client.remote_select_channel_contents(**kwargs)
+            with self.overlay(ID1).request_cache.passthrough(EvaSelectRequest):  # Immediately timeout the cache
+                await self.overlay(ID1).remote_select_channel_contents(**key)
 
     async def test_remote_select_channel_no_peers(self):
-        client, _, kwargs = self.client_server_request_setup()
-        client.get_known_subscribed_peers_for_node = lambda *_: []
-        with pytest.raises(NoChannelSourcesException):
-            await client.remote_select_channel_contents(**kwargs)
+        key = self.generate_torrents(self.overlay(ID2))
 
-    @patch.object(EvaSelectRequest, 'timeout_delay', new=PropertyMock(return_value=10))
+        with pytest.raises(NoChannelSourcesException):
+            await self.overlay(ID1).remote_select_channel_contents(**key)
+
     async def test_remote_select_channel_contents_happy_eyeballs(self):
         """
         Test trying to connect to the first server, then timing out and falling back to the second one
         """
-        client, server1, server2, kwargs_server2 = self.double_client_server_request_setup()
+        key = self.generate_torrents(self.overlay(ID3))
         with db_session:
-            results = [p.to_simple_dict() for p in server2.mds.get_entries(**kwargs_server2)]
+            self.overlay(ID1).channels_peers.add(self.peer(ID2), *key.values())
+            self.overlay(ID1).channels_peers.add(self.peer(ID3), *key.values())
 
-        # Force the first server to remain silent
-        server1._on_remote_select_basic = AsyncMock()
+        # Neither responds early, so each should act as each others fallback.
+        # Neither responds at all actually, so the remote select will time out.
+        self.overlay(ID2)._on_remote_select_basic = AsyncMock()
+        self.overlay(ID3)._on_remote_select_basic = AsyncMock()
 
-        # Check that the results came from the second server
-        assert results == await client.remote_select_channel_contents(**kwargs_server2)
-        assert len(results) == 50
-
-        # Check that the first server actually received a call
-        server1._on_remote_select_basic.assert_called_once()
+        # Check that ID2 received a call
+        with self.assertReceivedBy(ID2, [RemoteSelectPayloadEva]):
+            # Check that ID3 received a call
+            with self.assertReceivedBy(ID3, [RemoteSelectPayloadEva]):
+                # Make sure that happy_eyeballs_delay finishes.
+                # Both ID2 and ID3 should then have received a request (asserted by assertReceivedBy)
+                with self.overlay(ID1).request_cache.passthrough(timeout=happy_eyeballs_delay + 0.05):
+                    with self.assertRaises(RequestTimeoutException):
+                        await self.overlay(ID1).remote_select_channel_contents(**key)


### PR DESCRIPTION
I've been told nobody uses the advanced `TestBase` functionality because there is no example code to copy-paste from in the Tribler source. So, I modernized the tests for the `BandwidthCommunity` and the `GigaChannelCommunity`.

In passing, I've also changed up some test code that has test nodes be able to observe each other's private keys (by being sent each other's `my_peer`). Secondarily, it seems to me that `test_remote_select_channel_contents_happy_eyeballs` had a 50/50 chance of succeeding when not fixing random numbers, which I also changed into a 100% success guarantee.

The `TestGigaChannelUnits` could probably be cleaned up even further by extracting string literals, etc. However, that is not the goal of this PR. The goal of this PR is only to showcase advanced `TestBase` functionality.