### PR TITLE
Change `timeout_method`

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,6 +2,7 @@
 timeout = 60
 ;https://pypi.org/project/pytest-asyncio/
 asyncio_mode = auto
+addopts = --capture=no --timeout_method=thread
 log_level = INFO
 log_format = %(asctime)s.%(msecs)03d %(levelname)s %(name)s(%(lineno)d) %(message)s
 log_cli_format = %(asctime)s.%(msecs)03d %(levelname)s %(name)s(%(lineno)d) %(message)s

--- a/src/tribler/core/conftest.py
+++ b/src/tribler/core/conftest.py
@@ -65,7 +65,6 @@ def pytest_runtest_protocol(item: Function, log=True, nextitem=None):
         yield
 
 
-
 @pytest.fixture(autouse=True)
 def ensure_gc():
     """ Ensure that the garbage collector runs after each test.


### PR DESCRIPTION
I haven't found any mentions of problems with the default `timeout_method` for Windows runs. However, this change seems to decrease the likelihood of freezes during the Windows pytest run (zero failed runs with this change, without this change most runs freeze).

Ref:
* https://github.com/pytest-dev/pytest-timeout#specifying-the-timeout-method

Related to #7495  #7498