### PR TITLE
Fixed statistics not being enabled for any overlays

### DIFF
--- a/src/tribler/core/components/ipv8/ipv8_component.py
+++ b/src/tribler/core/components/ipv8/ipv8_component.py
@@ -66,11 +66,6 @@ class Ipv8Component(Component):
         key_component = await self.require_component(KeyComponent)
         self.peer = Peer(key_component.primary_key)
 
-        if config.ipv8.statistics and not config.gui_test_mode:
-            # Enable gathering IPv8 statistics
-            for overlay in ipv8.overlays:
-                ipv8.endpoint.enable_community_statistics(overlay.get_prefix(), True)
-
         if config.ipv8.walk_scaling_enabled and not config.gui_test_mode:
             from tribler.core.components.ipv8.ipv8_health_monitor import IPv8Monitor
             IPv8Monitor(ipv8,
@@ -101,6 +96,9 @@ class Ipv8Component(Component):
         # random_walk_max_peers should be greater than 0
         random_walk_max_peers = max(0, random_walk_max_peers)
         self.ipv8.add_strategy(community, RandomWalk(community), random_walk_max_peers)
+
+        if self.session.config.ipv8.statistics and not self.session.config.gui_test_mode:
+            self.ipv8.endpoint.enable_community_statistics(community.get_prefix(), True)
 
     async def unload_community(self, community):
         await self.ipv8.unload_overlay(community)

--- a/src/tribler/core/components/ipv8/tests/test_ipv8_component.py
+++ b/src/tribler/core/components/ipv8/tests/test_ipv8_component.py
@@ -30,3 +30,13 @@ async def test_ipv8_component_discovery_community_enabled(tribler_config):
     async with Session(tribler_config, [KeyComponent(), Ipv8Component()]) as session:
         comp = session.get_instance(Ipv8Component)
         assert comp._peer_discovery_community
+
+
+async def test_ipv8_component_statistics_enabled(tribler_config):
+    tribler_config.ipv8.enabled = True
+    tribler_config.ipv8.statistics = True
+    tribler_config.gui_test_mode = False
+    tribler_config.dht.enabled = True
+    async with Session(tribler_config, [KeyComponent(), Ipv8Component()]) as session:
+        comp = session.get_instance(Ipv8Component)
+        assert comp.dht_discovery_community.get_prefix() in comp.ipv8.endpoint.statistics


### PR DESCRIPTION
Fixes #7552

The previous code was enabling statistics for all overlays in an empty list of overlays.