### PR TITLE
Reset tracker peers count on tracker error alert

### DIFF
--- a/src/tribler/core/components/libtorrent/download_manager/download.py
+++ b/src/tribler/core/components/libtorrent/download_manager/download.py
@@ -317,13 +317,16 @@ class Download(TaskManager):
         self.tracker_status[alert.url] = [alert.num_peers, 'Working']
 
     def on_tracker_error_alert(self, alert: lt.tracker_error_alert):
+        """
+        This alert is generated on tracker timeouts, premature disconnects, invalid response
+        or an HTTP response other than "200 OK". - From Libtorrent documentation.
+        """
         # The try-except block is added as a workaround to suppress UnicodeDecodeError in `repr(alert)`,
         # `alert.url` and `alert.msg`. See https://github.com/arvidn/libtorrent/issues/143
         try:
             self._logger.error(f'On tracker error alert: {alert}')
             url = alert.url
 
-            peers = self.tracker_status[url][0] if url in self.tracker_status else 0
             if alert.msg:
                 status = 'Error: ' + alert.msg
             elif alert.status_code > 0:
@@ -333,6 +336,7 @@ class Download(TaskManager):
             else:
                 status = 'Not working'
 
+            peers = 0  # If there is a tracker error, alert.num_peers is not available. So resetting peer count to zero.
             self.tracker_status[url] = [peers, status]
         except UnicodeDecodeError as e:
             self._logger.warning(f'UnicodeDecodeError in on_tracker_error_alert: {e}')


### PR DESCRIPTION
From Libtorrent documentation on `tracker_error_alert`
> This alert is generated on tracker timeouts, premature disconnects, invalid response or an HTTP response other than "200 OK"
        
If the tracker is not working, I believe it is sensible to reset the peers reported by the tracker in the past to avoid the UI report as in https://github.com/Tribler/tribler/issues/7538

Fixes https://github.com/Tribler/tribler/issues/7538