### PR TITLE
Avoid race conditions when starting Socks5 servers and REST API by allowing OS to choose a free port

### DIFF
--- a/doc/restapi/introduction.rst
+++ b/doc/restapi/introduction.rst
@@ -16,11 +16,11 @@ Some requests require one or more parameters. These parameters are passed using 
 
 .. code-block:: none
 
-    curl -X PUT -H "X-Api-Key: <YOUR API KEY>" http://localhost:20100/mychannel/rssfeeds/http%3A%2F%2Frssfeed.com%2Frss.xml
+    curl -X PUT -H "X-Api-Key: <YOUR API KEY>" http://localhost:<port>/mychannel/rssfeeds/http%3A%2F%2Frssfeed.com%2Frss.xml
 
-Alternatively, requests can be made using Swagger UI by starting Tribler and opening `http://localhost:20100/docs` in a browser.
+Alternatively, requests can be made using Swagger UI by starting Tribler and opening `http://localhost:<port>/docs` in a browser.
 
-Note: 20100 is a default port value. It can be changed by setting up "CORE_API_PORT" environment variable.
+The port can be specified by setting up "CORE_API_PORT" environment variable.
 
 Error handling
 ==============

--- a/src/tribler/core/components/restapi/rest/rest_manager.py
+++ b/src/tribler/core/components/restapi/rest/rest_manager.py
@@ -20,12 +20,12 @@ from tribler.core.components.restapi.rest.rest_endpoint import (
 )
 from tribler.core.components.restapi.rest.root_endpoint import RootEndpoint
 from tribler.core.components.restapi.rest.settings import APISettings
+from tribler.core.utilities.network_utils import default_network_utils
 from tribler.core.utilities.process_manager import get_global_process_manager
 from tribler.core.version import version_id
 
 
 SITE_START_TIMEOUT = 5.0  # seconds
-BIND_ATTEMPTS = 10
 
 
 logger = logging.getLogger(__name__)
@@ -107,8 +107,11 @@ class RESTManager:
         return self.root_endpoint.endpoints.get('/' + name)
 
     def set_api_port(self, api_port: int):
+        default_network_utils.remember(api_port)
+
         if self.config.http_port != api_port:
             self.config.http_port = api_port
+
         process_manager = get_global_process_manager()
         if process_manager:
             process_manager.current_process.set_api_port(api_port)
@@ -117,7 +120,7 @@ class RESTManager:
         """
         Starts the HTTP API with the listen port as specified in the session configuration.
         """
-        self._logger.info(f'An attempt to start REST API on {self.http_host}:{self.config.http_port}')
+        self._logger.info('Starting RESTManager...')
 
         # Not using setup_aiohttp_apispec here, as we need access to the APISpec to set the security scheme
         aiohttp_apispec = AiohttpApiSpec(
@@ -131,12 +134,8 @@ class RESTManager:
             self._logger.info('Set security scheme and apply to all endpoints')
 
             aiohttp_apispec.spec.options['security'] = [{'apiKey': []}]
-            aiohttp_apispec.spec.components.security_scheme('apiKey', {'type': 'apiKey',
-                                                                       'in': 'header',
-                                                                       'name': 'X-Api-Key'})
-
-        self._logger.info(f'Swagger docs: http://{self.http_host}:{self.config.http_port}/docs')
-        self._logger.info(f'Swagger JSON: http://{self.http_host}:{self.config.http_port}/docs/swagger.json')
+            api_key_scheme = {'type': 'apiKey', 'in': 'header', 'name': 'X-Api-Key'}
+            aiohttp_apispec.spec.components.security_scheme('apiKey', api_key_scheme)
 
         if 'head' in VALID_METHODS_OPENAPI_V2:
             self._logger.info('Remove head')
@@ -147,60 +146,47 @@ class RESTManager:
 
         if self.config.http_enabled:
             self._logger.info('Http enabled')
-
-            api_port = self.config.http_port
-            if not self.config.retry_port:
-                self.site = web.TCPSite(self.runner, self.http_host, api_port, shutdown_timeout=self.shutdown_timeout)
-                self.set_api_port(api_port)
-                await self.site.start()
-            else:
-                self._logger.info(f"Searching for a free port starting from {api_port}")
-                for port in range(api_port, api_port + BIND_ATTEMPTS):
-                    try:
-                        await self.start_http_site(port)
-                        break
-
-                    except asyncio.TimeoutError:
-                        self._logger.warning(f"Timeout when starting HTTP REST API server on port {port}")
-
-                    except OSError as e:
-                        self._logger.warning(f"{e.__class__.__name__}: {e}")
-
-                    except BaseException as e:
-                        self._logger.error(f"{e.__class__.__name__}: {e}")
-                        raise  # an unexpected exception; propagate it
-
-                else:
-                    raise RuntimeError("Can't start HTTP REST API on any port in range "
-                                       f"{api_port}..{api_port + BIND_ATTEMPTS}")
-
-            self._logger.info("Started HTTP REST API: %s", self.site.name)
+            await self.start_http_site()
 
         if self.config.https_enabled:
             self._logger.info('Https enabled')
+            await self.start_https_site()
 
-            ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        self._logger.info(f'Swagger docs: http://{self.http_host}:{self.config.http_port}/docs')
+        self._logger.info(f'Swagger JSON: http://{self.http_host}:{self.config.http_port}/docs/swagger.json')
 
-            cert = self.config.get_path_as_absolute('https_certfile', self.state_dir)
-            ssl_context.load_cert_chain(cert)
+    async def start_http_site(self):
+        api_port = max(self.config.http_port, 0)  # if the value in config is -1 we convert it to 0
 
-            port = self.config.https_port
-            self.site_https = web.TCPSite(self.runner, self.https_host, port, ssl_context=ssl_context)
+        self.site = web.TCPSite(self.runner, self.http_host, api_port, shutdown_timeout=self.shutdown_timeout)
+        self._logger.info(f"Starting HTTP REST API server on port {api_port}...")
 
-            await self.site_https.start()
-            self._logger.info("Started HTTPS REST API: %s", self.site_https.name)
+        try:
+            # The self.site.start() is expected to start immediately. It looks like on some machines, it hangs.
+            # The timeout is added to prevent the hypothetical hanging.
+            await asyncio.wait_for(self.site.start(), timeout=SITE_START_TIMEOUT)
 
-    async def start_http_site(self, port):
-        self.site = web.TCPSite(self.runner, self.http_host, port, shutdown_timeout=self.shutdown_timeout)
-        self._logger.info(f"Starting HTTP REST API server on port {port}...")
+        except BaseException as e:
+            self._logger.exception(f"Can't start HTTP REST API on port {api_port}: {e.__class__.__name__}: {e}")
+            raise
 
-        # The self.site.start() is expected to start immediately. It looks like on some machines,
-        # it hangs. The timeout is added to prevent the hypothetical hanging.
-        await asyncio.wait_for(self.site.start(), timeout=SITE_START_TIMEOUT)
+        if not api_port:
+            api_port = self.site._server.sockets[0].getsockname()[1]  # pylint: disable=protected-access
 
-        self._logger.info(f"HTTP REST API server started on port {port}")
-        self.set_api_port(port)
+        self.set_api_port(api_port)
+        self._logger.info(f"HTTP REST API server started on port {api_port}")
 
+    async def start_https_site(self):
+        ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+
+        cert = self.config.get_path_as_absolute('https_certfile', self.state_dir)
+        ssl_context.load_cert_chain(cert)
+
+        port = self.config.https_port
+        self.site_https = web.TCPSite(self.runner, self.https_host, port, ssl_context=ssl_context)
+
+        await self.site_https.start()
+        self._logger.info("Started HTTPS REST API: %s", self.site_https.name)
 
     async def stop(self):
         self._logger.info('Stopping...')

--- a/src/tribler/core/components/socks_servers/socks_servers_component.py
+++ b/src/tribler/core/components/socks_servers/socks_servers_component.py
@@ -18,13 +18,16 @@ class SocksServersComponent(Component):
         self.socks_ports = []
         # Start the SOCKS5 servers
         for _ in range(NUM_SOCKS_PROXIES):
-            # To prevent a once-in-a-blue-moon situation when SOCKS server accidentally occupy
-            # a port reserved by other services (e.g. REST API), we track our ports usage and assign
-            # ports through a single, default NetworkUtils instance
-            socks_server = Socks5Server(port=default_network_utils.get_random_free_port())
+            socks_server = Socks5Server()
             self.socks_servers.append(socks_server)
             await socks_server.start()
-            self.socks_ports.append(socks_server.port)
+            socks_port = socks_server.port
+            self.socks_ports.append(socks_port)
+
+            # To prevent a once-in-a-blue-moon situation when a server accidentally occupies
+            # the port reserved by other services (e.g. REST API), we track our ports usage
+            # and assign ports through a single, default NetworkUtils instance
+            default_network_utils.remember(socks_port)
 
         self.logger.info(f'Socks listen port: {self.socks_ports}')
 

--- a/src/tribler/gui/core_manager.py
+++ b/src/tribler/gui/core_manager.py
@@ -30,7 +30,7 @@ class CoreManager(QObject):
     a fake API will be started.
     """
 
-    def __init__(self, root_state_dir: Path, api_port: int, api_key: str,
+    def __init__(self, root_state_dir: Path, api_port: Optional[int], api_key: str,
                  app_manager: AppManager, process_manager: ProcessManager, events_manager: EventRequestManager):
         QObject.__init__(self, None)
 
@@ -83,16 +83,21 @@ class CoreManager(QObject):
         First test whether we already have a Tribler process listening on port <CORE_API_PORT>.
         If so, use that one and don't start a new, fresh Core.
         """
-        # Connect to the events manager
-        self.events_manager.connect_to_core(reschedule_on_err=False)  # do not retry if tribler Core is not running yet
-
         if run_core:
             self.core_args = core_args
             self.core_env = core_env
             self.upgrade_manager = upgrade_manager
-            connect(self.events_manager.reply.error, self.on_event_manager_initial_error)
 
-    def on_event_manager_initial_error(self, _):
+        # Connect to the events manager
+        if self.events_manager.api_port:
+            self.events_manager.connect_to_core(
+                reschedule_on_err=False  # do not retry if tribler Core is not running yet
+            )
+            connect(self.events_manager.reply.error, self.do_upgrade_and_start_core)
+        else:
+            self.do_upgrade_and_start_core()
+
+    def do_upgrade_and_start_core(self, _=None):
         if self.upgrade_manager:
             # Start Tribler Upgrader. When it finishes, start Tribler Core
             connect(self.upgrade_manager.upgrader_finished, self.start_tribler_core)
@@ -106,7 +111,6 @@ class CoreManager(QObject):
         core_env = self.core_env
         if not core_env:
             core_env = QProcessEnvironment.systemEnvironment()
-            core_env.insert("CORE_API_PORT", f"{self.api_port}")
             core_env.insert("CORE_API_KEY", self.api_key)
             core_env.insert("TSTATEDIR", str(self.root_state_dir))
             core_env.insert("TRIBLER_GUI_PID", str(os.getpid()))
@@ -156,7 +160,7 @@ class CoreManager(QObject):
             self._logger.info(f"Got REST API port value from the Core process: {api_port}")
             if api_port != self.api_port:
                 self.api_port = api_port
-                request_manager.port = api_port
+                request_manager.set_api_port(api_port)
                 self.events_manager.set_api_port(api_port)
 
             # Previously it was necessary to reschedule on error because `events_manager.connect_to_core()` was executed

--- a/src/tribler/gui/core_manager.py
+++ b/src/tribler/gui/core_manager.py
@@ -84,7 +84,7 @@ class CoreManager(QObject):
         If so, use that one and don't start a new, fresh Core.
         """
         # Connect to the events manager
-        self.events_manager.connect(reschedule_on_err=False)  # do not retry if tribler Core is not running yet
+        self.events_manager.connect_to_core(reschedule_on_err=False)  # do not retry if tribler Core is not running yet
 
         if run_core:
             self.core_args = core_args
@@ -158,11 +158,12 @@ class CoreManager(QObject):
                 self.api_port = api_port
                 request_manager.port = api_port
                 self.events_manager.set_api_port(api_port)
-            # Previously it was necessary to reschedule on error because `events_manager.connect()` was executed
+
+            # Previously it was necessary to reschedule on error because `events_manager.connect_to_core()` was executed
             # before the REST API was available, so it retried until the REST API was ready. Now the API is ready
-            # to use when we can read the api_port value from the database, so now we can call
-            # events_manager.connect(reschedule_on_err=False). I kept reschedule_on_err=True just for reinsurance.
-            self.events_manager.connect(reschedule_on_err=True)
+            # to use when we can read the api_port value from the database, so now we can call connect_to_core
+            # with reschedule_on_err=False. I kept reschedule_on_err=True just for reinsurance.
+            self.events_manager.connect_to_core(reschedule_on_err=True)
 
         elif time.time() - self.core_started_at > API_PORT_CHECK_TIMEOUT:
             raise CoreConnectTimeoutError(f"Can't get Core API port value within {API_PORT_CHECK_TIMEOUT} seconds")

--- a/src/tribler/gui/defs.py
+++ b/src/tribler/gui/defs.py
@@ -10,7 +10,6 @@ from tribler.core.utilities.simpledefs import DownloadStatus
 
 DEFAULT_API_PROTOCOL = "http"
 DEFAULT_API_HOST = "localhost"
-DEFAULT_API_PORT = 20100
 
 # Define stacked widget page indices
 PAGE_SEARCH_RESULTS = 0

--- a/src/tribler/gui/event_request_manager.py
+++ b/src/tribler/gui/event_request_manager.py
@@ -185,16 +185,16 @@ class EventRequestManager(QNetworkAccessManager):
         self.start_time = time.time()
         self.connect_timer.start(RECONNECT_INTERVAL_MS)
 
-    def connect(self, reschedule_on_err=True):
+    def connect_to_core(self, reschedule_on_err=True):
         if reschedule_on_err:
             self._logger.info(f"Set event request manager timeout to {CORE_CONNECTION_TIMEOUT} seconds")
             self.start_time = time.time()
-        self._connect(reschedule_on_err)
+        self._connect_to_core(reschedule_on_err)
 
     def reconnect(self, reschedule_on_err=True):
-        self._connect(reschedule_on_err)
+        self._connect_to_core(reschedule_on_err)
 
-    def _connect(self, reschedule_on_err):
+    def _connect_to_core(self, reschedule_on_err):
         self._logger.info(f"Connecting to events endpoint ({'with' if reschedule_on_err else 'without'} retrying)")
         if self.reply is not None:
             self.reply.deleteLater()

--- a/src/tribler/gui/network/request_manager.py
+++ b/src/tribler/gui/network/request_manager.py
@@ -9,7 +9,7 @@ from typing import Callable, Dict, Optional, Set
 from PyQt5.QtCore import QBuffer, QIODevice, QUrl
 from PyQt5.QtNetwork import QNetworkAccessManager, QNetworkRequest
 
-from tribler.gui.defs import BUTTON_TYPE_NORMAL, DEFAULT_API_HOST, DEFAULT_API_PORT, DEFAULT_API_PROTOCOL
+from tribler.gui.defs import BUTTON_TYPE_NORMAL, DEFAULT_API_HOST, DEFAULT_API_PROTOCOL
 from tribler.gui.dialogs.confirmationdialog import ConfirmationDialog
 from tribler.gui.network.request import DATA_TYPE, Request
 from tribler.gui.utilities import connect
@@ -35,11 +35,17 @@ class RequestManager(QNetworkAccessManager):
 
         self.protocol = DEFAULT_API_PROTOCOL
         self.host = DEFAULT_API_HOST
-        self.port = DEFAULT_API_PORT
+        self.port: Optional[int] = None
         self.key = ''
         self.limit = limit
         self.timeout_interval = timeout_interval
         self.last_request_id = 0
+
+    def set_api_key(self, key: str):
+        self.key = key
+
+    def set_api_port(self, api_port: int):
+        self.port = api_port
 
     def get(self,
             endpoint: str,
@@ -167,6 +173,8 @@ class RequestManager(QNetworkAccessManager):
         return text
 
     def get_base_url(self) -> str:
+        if not self.port:
+            raise RuntimeError("API port is not set")
         return f'{self.protocol}://{self.host}:{self.port}/'
 
     @staticmethod

--- a/src/tribler/gui/network/tests/test_request_manager.py
+++ b/src/tribler/gui/network/tests/test_request_manager.py
@@ -2,6 +2,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
+from tribler.core.utilities.network_utils import default_network_utils
 from tribler.gui.network.request_manager import RequestManager
 
 
@@ -9,12 +10,19 @@ from tribler.gui.network.request_manager import RequestManager
 
 
 @pytest.fixture
-def request_manager():
-    return RequestManager()
+def free_port():
+    return default_network_utils.get_random_free_port()
 
 
-def test_get_base_string(request_manager: RequestManager):
-    assert request_manager.get_base_url() == 'http://localhost:20100/'
+@pytest.fixture
+def request_manager(free_port: int):
+    request_manager = RequestManager()
+    request_manager.set_api_port(free_port)
+    return request_manager
+
+
+def test_get_base_string(free_port: int, request_manager: RequestManager):
+    assert request_manager.get_base_url() == f'http://localhost:{free_port}/'
 
 
 def test_get_message_from_error_string(request_manager: RequestManager):

--- a/src/tribler/gui/qt_resources/mainwindow.ui
+++ b/src/tribler/gui/qt_resources/mainwindow.ui
@@ -1809,65 +1809,6 @@ per download</string>
                     </property>
                    </widget>
                   </item>
-                  <item row="12" column="0">
-                   <widget class="QLabel" name="label_61">
-                    <property name="styleSheet">
-                     <string notr="true">font-weight: bold;
-color: white;</string>
-                    </property>
-                    <property name="text">
-                     <string>GUI/Core connection</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="13" column="0">
-                   <widget class="QLabel" name="label_62">
-                    <property name="text">
-                     <string>Port (defaults to 20100)</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="13" column="1">
-                   <widget class="QLineEdit" name="api_port_input">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="minimumSize">
-                     <size>
-                      <width>250</width>
-                      <height>0</height>
-                     </size>
-                    </property>
-                    <property name="maximumSize">
-                     <size>
-                      <width>250</width>
-                      <height>16777215</height>
-                     </size>
-                    </property>
-                    <property name="placeholderText">
-                     <string>Port</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="14" column="1">
-                   <widget class="QLabel" name="label_65">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="text">
-                     <string>You can adjust the port that the interface uses to communicate with the Tribler core. Applied after restarting Tribler. Change this at your own risk!</string>
-                    </property>
-                    <property name="wordWrap">
-                     <bool>true</bool>
-                    </property>
-                   </widget>
-                  </item>
                  </layout>
                 </widget>
                 <widget class="QWidget" name="settings_bandwidth_tab">

--- a/src/tribler/gui/start_gui.py
+++ b/src/tribler/gui/start_gui.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import sys
+from typing import Optional
 
 from PyQt5.QtCore import QSettings
 
@@ -25,7 +26,7 @@ from tribler.gui.utilities import get_translator
 logger = logging.getLogger(__name__)
 
 
-def run_gui(api_port, api_key, root_state_dir, parsed_args):
+def run_gui(api_port: Optional[int], api_key: Optional[str], root_state_dir, parsed_args):
     logger.info(f"Running GUI in {'gui_test_mode' if parsed_args.gui_test_mode else 'normal mode'}")
 
     # Workaround for macOS Big Sur, see https://github.com/Tribler/tribler/issues/5728

--- a/src/tribler/gui/tests/test_core_manager.py
+++ b/src/tribler/gui/tests/test_core_manager.py
@@ -67,7 +67,7 @@ def test_check_core_api_port_not_set(core_manager):
 
 
 @patch('tribler.gui.core_manager.request_manager')
-def test_check_core_api_port(request_manager: MagicMock, core_manager):
+def test_check_core_api_port(request_manager: MagicMock, core_manager: CoreManager):
     core_manager.core_running = True
     core_manager.core_started_at = time.time()
     api_port = core_manager.process_manager.current_process.get_core_process().api_port
@@ -75,7 +75,7 @@ def test_check_core_api_port(request_manager: MagicMock, core_manager):
     assert core_manager.process_manager.current_process.get_core_process.called
     assert not core_manager.check_core_api_port_timer.start.called
     assert core_manager.api_port == api_port
-    assert request_manager.port == api_port
+    assert request_manager.set_api_port.called_once_with(api_port)
 
 
 def test_check_core_api_port_timeout(core_manager):

--- a/src/tribler/gui/widgets/settingspage.py
+++ b/src/tribler/gui/widgets/settingspage.py
@@ -207,8 +207,6 @@ class SettingsPage(AddBreadcrumbOnShowMixin, QWidget):
             max_conn_download = 0
         self.window().max_connections_download_input.setText(str(max_conn_download))
 
-        self.window().api_port_input.setText(f"{get_gui_setting(gui_settings, 'api_port', 0)}")
-
         # Bandwidth settings
         self.window().upload_rate_limit_input.setText(str(settings['libtorrent']['max_upload_rate'] // 1024))
         self.window().download_rate_limit_input.setText(str(settings['libtorrent']['max_download_rate'] // 1024))
@@ -464,20 +462,6 @@ class SettingsPage(AddBreadcrumbOnShowMixin, QWidget):
                     "Note that the decimal values are truncated."
                 )
                 % (MAX_LIBTORRENT_RATE_LIMIT / 1024),
-            )
-            return
-
-        try:
-            if self.window().api_port_input.text():
-                api_port = int(self.window().api_port_input.text())
-                if api_port <= 0 or api_port >= 65536:
-                    raise ValueError()
-                self.window().gui_settings.setValue("api_port", api_port)
-        except ValueError:
-            ConfirmationDialog.show_error(
-                self.window(),
-                tr("Invalid value for api port"),
-                tr("Please enter a valid port for the api (between 0 and 65536)"),
             )
             return
 

--- a/src/tribler/gui/widgets/settingspage.py
+++ b/src/tribler/gui/widgets/settingspage.py
@@ -9,7 +9,6 @@ from tribler.core.utilities.path_util import Path
 from tribler.core.utilities.simpledefs import MAX_LIBTORRENT_RATE_LIMIT
 from tribler.gui.defs import (
     DARWIN,
-    DEFAULT_API_PORT,
     PAGE_SETTINGS_ANONYMITY,
     PAGE_SETTINGS_BANDWIDTH,
     PAGE_SETTINGS_CONNECTION,
@@ -208,7 +207,7 @@ class SettingsPage(AddBreadcrumbOnShowMixin, QWidget):
             max_conn_download = 0
         self.window().max_connections_download_input.setText(str(max_conn_download))
 
-        self.window().api_port_input.setText(f"{get_gui_setting(gui_settings, 'api_port', DEFAULT_API_PORT)}")
+        self.window().api_port_input.setText(f"{get_gui_setting(gui_settings, 'api_port', 0)}")
 
         # Bandwidth settings
         self.window().upload_rate_limit_input.setText(str(settings['libtorrent']['max_upload_rate'] // 1024))


### PR DESCRIPTION
This PR fixes #7564. It stops using `default_network_utils.get_random_free_port()` and passes port value zero when starting a server to allow OS to choose a free port without race conditions.

The PR consists of several commits:
1. The first commit stops using `get_random_free_port()` when starting a new Socks5Server
3. The second commit renames `events_manager.connect(...)` to `events_manager.connect_to_core(...)`. The reason for this is the `connect` name is overused: the same name is used for subscribing to PyQt signals, for opening `UdpTrackerSession`, and for connecting to the sqlite3 database in ProcessManager, so it is better to have a distinct name to find all places when the specific method is used easily.
4. The third commit changes the logic of how REST API Manager gets the port. After the PR changes, Tribler GUI no longer tries to call  `get_random_free_port()` and detect the free port for Tribler Core's REST API usage. Instead, Tribler Core requests a free port directly from OS when starting the server and then passes the port value to Tribler GUI. Now it is unnecessary to have a loop over a range of ports on the Coree side and attempt to start a server with a possible retry, as the suitable port is available from the first attempt.
5. The fifth commit removes the REST API port from Tribler GUI settings. For most users, settings the specific REST API port value is unnecessary, as it is an internal details of Tribler's GUI/Core communication. If it is necessary for sone user to set a specific REST API port, he can do it by setting CORE_API_PORT environment variable (as specified in the documentation). In my opinion, UI settings should only display settings that can actually be important to many Tribler users, and it seems that REST API port value does not belong to this category.

As a result:
1. The logic of starting the servers was simplified and streamlined
2. The possible reasons for race conditions are eliminated
3. The retry logic when starting the REST API was removed as unnecessary
4. Tribler settings in GUI were simplified, and the unnecessary option was removed

Previously, the documentation said 20100 is a default port value for Swagger UI and REST API. It is not entirely true, as the port number was taken from a range. This part of the documentation is clarified: the user should specify the port value in the `CORE_API_PORT` environment variable to start the REST API and Swagger UI on a specific port.