### PR TITLE
Prioritise HTTP status code processing over QNetworkReply errors

### DIFF
--- a/src/tribler/gui/network/request.py
+++ b/src/tribler/gui/network/request.py
@@ -116,8 +116,7 @@ class Request(QObject):
 
             # Process any other NetworkReply Error response.
             error_code = self.reply.error()
-            if error_code != QNetworkReply.NoError:
-                self._handle_network_reply_errors(error_code)
+            self._handle_network_reply_errors(error_code)
 
         except Exception as e:  # pylint: disable=broad-except
             self.logger.exception(e)
@@ -126,7 +125,7 @@ class Request(QObject):
             self._delete()
 
     def _handle_network_reply_errors(self, error_code):
-        error_name = reply_errors.get(abs(error_code), '<unknown error>')
+        error_name = reply_errors.get(error_code, '<unknown error>')
         self.status_code = -error_code  # QNetworkReply errors are set negative to distinguish from HTTP response codes.
         self.status_text = f'{error_name}: {self.status_code}'
         self.logger.warning(f'Request {self} finished with error: {self.status_code} ({error_name})')

--- a/src/tribler/gui/network/request.py
+++ b/src/tribler/gui/network/request.py
@@ -114,42 +114,58 @@ class Request(QObject):
 
         self.logger.info(f'Finished: {self}')
         try:
+            # If HTTP status code is available on the reply, we process that first.
+            # This is because self.reply.error() is not always QNetworkReply.NoError even if there is HTTP response.
+            # One example case is for HTTP Status Code 413 (HTTPRequestEntityTooLarge) for which QNetworkReply
+            # error code is QNetworkReply.UnknownContentError
+            if status_code := self.reply.attribute(QNetworkRequest.HttpStatusCodeAttribute):
+                self._handle_http_response(status_code)
+                return
+
+            # Process any other NetworkReply Error response.
             error_code = self.reply.error()
             if error_code != QNetworkReply.NoError:
-                error_name = reply_errors.get(error_code, '<unknown error>')
-                self.logger.warning(f'Request {self} finished with error: {error_code} ({error_name})')
-                self.update_status(-error_code)
-                return
+                self._handle_network_reply_errors(error_code)
 
-            if status_code := self.reply.attribute(QNetworkRequest.HttpStatusCodeAttribute):
-                self.update_status(status_code)
-
-            data = bytes(self.reply.readAll())
-            if self.raw_response:
-                self.logger.debug('Create a raw response')
-                header = self.reply.header(QNetworkRequest.ContentTypeHeader)
-                self.on_finished_signal.emit((data, header))
-                return
-
-            if not data:
-                self.logger.error(f'No data received in the reply for {self}')
-                return
-
-            self.logger.debug('Create a json response')
-            result = json.loads(data)
-            if isinstance(result, dict):
-                result[REQUEST_ID] = self.id
-            is_error = 'error' in result
-            if is_error and self.capture_errors:
-                text = self.manager.show_error(self, result)
-                raise Warning(text)
-
-            self.on_finished_signal.emit(result)
         except Exception as e:  # pylint: disable=broad-except
             self.logger.exception(e)
             self.cancel()
         finally:
             self._delete()
+
+    def _handle_network_reply_errors(self, error_code):
+        self.logger.debug(f'Update {self}: {error_code}')
+        self.status_code = error_code
+        error_name = reply_errors.get(error_code, '<unknown error>')
+        self.status_text = f'{error_name}: {error_code}'
+        self.logger.warning(f'Request {self} finished with error: {error_code} ({error_name})')
+
+    def _handle_http_response(self, status_code):
+        self.logger.debug(f'Update {self}: {status_code}')
+        self.status_code = status_code
+        self.status_text = str(status_code)
+
+        data = bytes(self.reply.readAll())
+        if self.raw_response:
+            self.logger.debug('Create a raw response')
+            header = self.reply.header(QNetworkRequest.ContentTypeHeader)
+            self.on_finished_signal.emit((data, header))
+            return
+
+        if not data:
+            self.logger.error(f'No data received in the reply for {self}')
+            return
+
+        self.logger.debug('Create a json response')
+        result = json.loads(data)
+        if isinstance(result, dict):
+            result[REQUEST_ID] = self.id
+        is_error = 'error' in result
+        if is_error and self.capture_errors:
+            text = self.manager.show_error(self, result)
+            raise Warning(text)
+
+        self.on_finished_signal.emit(result)
 
     def cancel(self):
         """

--- a/src/tribler/gui/network/request.py
+++ b/src/tribler/gui/network/request.py
@@ -127,7 +127,7 @@ class Request(QObject):
     def _handle_network_reply_errors(self, error_code):
         error_name = reply_errors.get(error_code, '<unknown error>')
         self.status_code = -error_code  # QNetworkReply errors are set negative to distinguish from HTTP response codes.
-        self.status_text = f'{error_name}: {self.status_code}'
+        self.status_text = f'{self.status_code}: {error_code}'
         self.logger.warning(f'Request {self} finished with error: {self.status_code} ({error_name})')
 
     def _handle_http_response(self, status_code):

--- a/src/tribler/gui/network/tests/test_request.py
+++ b/src/tribler/gui/network/tests/test_request.py
@@ -60,6 +60,7 @@ def test_on_finished_on_success_http_response():
     Test that if HTTP response is available, it is prioritised for processing
     and any QT NetworkReply errors are ignored.
     """
+    # pylint: disable=protected-access
     request = Request(endpoint='endpoint')
 
     request.manager = MagicMock()
@@ -78,6 +79,7 @@ def test_on_finished_on_network_error():
     Test that if there is no proper HTTP response,
     then QT NetworkReply errors are only handled.
     """
+    # pylint: disable=protected-access
     request = Request(endpoint='endpoint')
 
     request.manager = MagicMock()

--- a/src/tribler/gui/network/tests/test_request.py
+++ b/src/tribler/gui/network/tests/test_request.py
@@ -95,7 +95,6 @@ def test_on_finished_on_network_error():
     request._handle_network_reply_errors.assert_called()
 
 
-@patch.object(Request, 'update_status', Mock())
 def test_set_id():
     # Test that the id is set correctly during `on_finished` callback call
     actual_id = None


### PR DESCRIPTION
This PR updates the HTTP response processing done on `on_finished()` call to prioritise HTTP response processing over QT QNetworkReply errors processing.

This fixes the issue where QNetworkReply error processing masks the processing of HTTP response with status codes like 413 (HTTPEntityTooLarge) as in https://github.com/Tribler/tribler/issues/7558. 

Fixes https://github.com/Tribler/tribler/issues/7558