### PR TITLE
Increase MacOS build timeout to 15 minutes

### DIFF
--- a/.github/workflows/build_mac.yml
+++ b/.github/workflows/build_mac.yml
@@ -68,7 +68,7 @@ jobs:
           python ./build/update_version.py -r .
 
       - name: Run build script
-        timeout-minutes: 10
+        timeout-minutes: 15
         env:
           QT_QPA_PLATFORM: offscreen
           QT_ACCESSIBILITY: 1


### PR DESCRIPTION
Mac builds sometimes fail because of timeout. Looking at the previous builds, it is taking between 8 to 10 minutes. So, I assume it is safe to increase it to 15 minutes.