### PR TITLE
Remove dependency on pytest-freezegun plugin

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -7,7 +7,6 @@ pytest-randomly==3.13.0
 pytest-timeout==2.1.0
 pytest-rerunfailures==12.0
 pytest-sentry==0.1.16
-pytest-freezegun==0.4.2
 
 
 coverage==7.2.7

--- a/src/tribler/core/components/knowledge/restapi/tests/test_knowledge_endpoint.py
+++ b/src/tribler/core/components/knowledge/restapi/tests/test_knowledge_endpoint.py
@@ -2,7 +2,6 @@ from typing import Dict
 from unittest.mock import Mock
 
 import pytest
-from freezegun import freeze_time
 from ipv8.keyvault.crypto import default_eccrypto
 from pony.orm import db_session
 
@@ -11,6 +10,7 @@ from tribler.core.components.knowledge.community.knowledge_payload import Statem
 from tribler.core.components.knowledge.db.knowledge_db import Operation, ResourceType
 from tribler.core.components.knowledge.restapi.knowledge_endpoint import KnowledgeEndpoint
 from tribler.core.components.restapi.rest.base_api_test import do_request
+from tribler.core.utilities.date_utils import freeze_time
 from tribler.core.utilities.unicode import hexlify
 
 

--- a/src/tribler/core/components/metadata_store/db/orm_bindings/vsids.py
+++ b/src/tribler/core/components/metadata_store/db/orm_bindings/vsids.py
@@ -1,5 +1,5 @@
+import datetime
 import math
-from datetime import datetime
 
 from pony import orm
 from pony.orm import db_session
@@ -39,7 +39,7 @@ def define_binding(db):
         rowid = orm.PrimaryKey(int)
         bump_amount = orm.Required(float)
         total_activity = orm.Required(float)
-        last_bump = orm.Required(datetime)
+        last_bump = orm.Required(datetime.datetime)
         rescale_threshold = orm.Optional(float, default=10.0 ** 100)
         exp_period = orm.Optional(float, default=24.0 * 60 * 60 * 3)  # decay e times over this period of seconds
         max_val = orm.Optional(float, default=1.0)
@@ -70,7 +70,7 @@ def define_binding(db):
 
         @db_session
         def bump_channel(self, channel, vote):
-            now = datetime.utcnow()
+            now = datetime.datetime.utcnow()
 
             # Subtract the last vote by the same peer from the total vote amount for this channel.
             # This effectively puts a cap of 1.0 vote from a peer on a channel
@@ -108,7 +108,7 @@ def define_binding(db):
                 rowid=0,
                 bump_amount=1.0,
                 total_activity=(orm.sum(g.votes for g in db.ChannelMetadata) or 0.0),
-                last_bump=datetime.utcnow(),
+                last_bump=datetime.datetime.utcnow(),
             )
 
     return Vsids

--- a/src/tribler/core/components/metadata_store/tests/test_channel_metadata.py
+++ b/src/tribler/core/components/metadata_store/tests/test_channel_metadata.py
@@ -1,6 +1,6 @@
 import os
 from binascii import unhexlify
-from datetime import timedelta, datetime
+from datetime import datetime, timedelta
 from itertools import combinations
 from pathlib import Path
 from unittest.mock import Mock, patch

--- a/src/tribler/core/components/metadata_store/tests/test_channel_metadata.py
+++ b/src/tribler/core/components/metadata_store/tests/test_channel_metadata.py
@@ -1,6 +1,6 @@
 import os
 from binascii import unhexlify
-from datetime import datetime, timedelta
+from datetime import timedelta, datetime
 from itertools import combinations
 from pathlib import Path
 from unittest.mock import Mock, patch
@@ -25,6 +25,7 @@ from tribler.core.components.metadata_store.db.serialization import (
 )
 from tribler.core.components.metadata_store.db.store import HealthItemsPayload
 from tribler.core.tests.tools.common import TESTS_DATA_DIR, TORRENT_UBUNTU_FILE
+from tribler.core.utilities.date_utils import freeze_time
 from tribler.core.utilities.simpledefs import CHANNEL_STATE
 from tribler.core.utilities.utilities import random_infohash
 
@@ -328,9 +329,14 @@ def test_correct_commit_of_delete_entries(metadata_store):
         channel.commit_channel_torrent()
 
 
-@pytest.mark.freeze_time('2021-09-24')
+@pytest.fixture(name="freezer")
+def fixture_freezer():
+    with freeze_time("2021-09-24") as freezer:
+        yield freezer
+
+
 @db_session
-def test_vsids(metadata_store, freezer):
+def test_vsids(freezer, metadata_store):
     """
     Test VSIDS-based channel popularity system.
     """

--- a/src/tribler/core/utilities/date_utils.py
+++ b/src/tribler/core/utilities/date_utils.py
@@ -1,0 +1,23 @@
+import datetime
+from contextlib import contextmanager
+from unittest.mock import patch
+
+
+class FrozenDateTime(datetime.datetime):
+    UTC_NOW = datetime.datetime.utcnow()
+
+    @classmethod
+    def move_to(cls, iso_date: str):
+        cls.UTC_NOW = datetime.datetime.fromisoformat(iso_date)
+
+    @classmethod
+    def utcnow(cls):
+        return cls.UTC_NOW
+
+
+@contextmanager
+def freeze_time(iso_date_time: str) -> FrozenDateTime:
+    FrozenDateTime.move_to(iso_date_time)
+
+    with patch('datetime.datetime', FrozenDateTime):
+        yield FrozenDateTime


### PR DESCRIPTION
In this PR, I removed pytest-freezegun plugin used for freezing the date/time on the tests. This plugin was causing performance hits as reported on sentry. This plugin is now removed and replaced with an utility providing similar functionality. The test performance has improved as a result.