### PR TITLE
Support true/false for boolean url query arguments.

### DIFF
--- a/src/tribler/core/components/metadata_store/restapi/metadata_endpoint_base.py
+++ b/src/tribler/core/components/metadata_store/restapi/metadata_endpoint_base.py
@@ -10,6 +10,8 @@ from tribler.core.components.metadata_store.db.serialization import CHANNEL_TORR
 from tribler.core.components.metadata_store.db.store import MetadataStore
 from tribler.core.components.restapi.rest.rest_endpoint import RESTEndpoint
 
+from tribler.core.utilities.utilities import parse_bool
+
 # This dict is used to translate JSON fields into the columns used in Pony for _sorting_.
 # id_ is not in the list because there is not index on it, so we never really want to sort on it.
 
@@ -55,16 +57,16 @@ class MetadataEndpointBase(RESTEndpoint):
             "first": int(parameters.get('first', 1)),
             "last": int(parameters.get('last', 50)),
             "sort_by": json2pony_columns.get(parameters.get('sort_by')),
-            "sort_desc": bool(int(parameters.get('sort_desc', 1)) > 0),
+            "sort_desc": parse_bool(parameters.get('sort_desc', True)),
             "txt_filter": parameters.get('txt_filter'),
-            "hide_xxx": bool(int(parameters.get('hide_xxx', 0)) > 0),
+            "hide_xxx": parse_bool(parameters.get('hide_xxx', False)),
             "category": parameters.get('category'),
-            "exclude_deleted": bool(int(parameters.get('exclude_deleted', 0)) > 0),
+            "exclude_deleted": parse_bool(parameters.get('exclude_deleted', False)),
         }
         if 'tags' in parameters:
             sanitized['tags'] = parameters.getall('tags')
         if "remote" in parameters:
-            sanitized["remote"] = (bool(int(parameters.get('remote', 0)) > 0),)
+            sanitized["remote"] = (parse_bool(parameters.get('remote', False)),)
         if 'metadata_type' in parameters:
             mtypes = []
             for arg in parameters.getall('metadata_type'):

--- a/src/tribler/core/components/metadata_store/restapi/metadata_schema.py
+++ b/src/tribler/core/components/metadata_store/restapi/metadata_schema.py
@@ -11,13 +11,19 @@ class MetadataParameters(Schema):
     hide_xxx = Boolean(default=False, description='Toggles xxx filter')
     category = String()
     exclude_deleted = Boolean(default=False)
-    remote_query = Boolean(default=False)
     metadata_type = List(String(description='Limits query to certain metadata types (e.g. "torrent" or "channel")'))
+
+
+class SearchMetadataParameters(MetadataParameters):
+    include_total = Boolean(default=False, description='Include total rows found in query response, expensive if '
+                                                       'there is many rows')
+    max_rowid = Integer(default=None, description='Only return results with rowid lesser than max_rowid')
 
 
 class RemoteQueryParameters(MetadataParameters):
     uuid = String()
-    channel_pk = String()
+    channel_pk = String(description='Channel to query, must also define origin_id')
+    origin_id = Integer(default=None, description='Peer id to query, must also define channel_pk')
 
 
 class MetadataSchema(Schema):

--- a/src/tribler/core/components/metadata_store/restapi/remote_query_endpoint.py
+++ b/src/tribler/core/components/metadata_store/restapi/remote_query_endpoint.py
@@ -4,7 +4,7 @@ from binascii import unhexlify
 from aiohttp import web
 from aiohttp_apispec import docs, querystring_schema
 from ipv8.REST.schema import schema
-from marshmallow.fields import String
+from marshmallow.fields import String, List
 from pony.orm import db_session
 
 from tribler.core.components.gigachannel.community.gigachannel_community import GigaChannelCommunity
@@ -43,7 +43,15 @@ class RemoteQueryEndpoint(MetadataEndpointBase):
     @docs(
         tags=['Metadata'],
         summary="Perform a search for a given query.",
-        responses={200: {'schema': schema(RemoteSearchResponse={'request_uuid': String()})}},
+        responses={200: {
+            'schema': schema(RemoteSearchResponse={'request_uuid': String(), 'peers': List(String())})},
+            "examples": {
+                'Success': {
+                    "request_uuid": "268560c0-3f28-4e6e-9d85-d5ccb0269693",
+                    "peers": ["50e9a2ce646c373985a8e827e328830e053025c6", "107c84e5d9636c17b46c88c3ddb54842d80081b0"]
+                }
+            }
+        },
     )
     @querystring_schema(RemoteQueryParameters)
     async def create_remote_search_request(self, request):

--- a/src/tribler/core/components/metadata_store/restapi/search_endpoint.py
+++ b/src/tribler/core/components/metadata_store/restapi/search_endpoint.py
@@ -12,7 +12,7 @@ from tribler.core.components.knowledge.db.knowledge_db import ResourceType
 from tribler.core.components.metadata_store.db.serialization import SNIPPET
 from tribler.core.components.metadata_store.db.store import MetadataStore
 from tribler.core.components.metadata_store.restapi.metadata_endpoint import MetadataEndpointBase
-from tribler.core.components.metadata_store.restapi.metadata_schema import MetadataParameters, MetadataSchema
+from tribler.core.components.metadata_store.restapi.metadata_schema import SearchMetadataParameters, MetadataSchema
 from tribler.core.components.restapi.rest.rest_endpoint import HTTP_BAD_REQUEST, RESTResponse
 from tribler.core.utilities.pony_utils import run_threaded
 from tribler.core.utilities.utilities import froze_it
@@ -110,7 +110,7 @@ class SearchEndpoint(MetadataEndpointBase):
             }
         },
     )
-    @querystring_schema(MetadataParameters)
+    @querystring_schema(SearchMetadataParameters)
     async def search(self, request):
         try:
             sanitized = self.sanitize_parameters(request.query)

--- a/src/tribler/core/utilities/tests/test_utilities.py
+++ b/src/tribler/core/utilities/tests/test_utilities.py
@@ -10,7 +10,7 @@ from tribler.core.utilities.tracker_utils import add_url_params
 from tribler.core.utilities.utilities import (Query, extract_tags, get_normally_distributed_positive_integers,
                                               is_channel_public_key,
                                               is_infohash, is_simple_match_query, is_valid_url, parse_magnetlink,
-                                              parse_query, random_infohash, show_system_popup, to_fts_query)
+                                              parse_query, parse_bool, random_infohash, show_system_popup, to_fts_query)
 
 
 # pylint: disable=import-outside-toplevel, import-error, redefined-outer-name
@@ -185,6 +185,21 @@ def test_parse_query():
                      tags={'tag1', 'tag2'},
                      fts_text='query with  and')
     assert actual == expected
+
+
+def test_parse_bool():
+    assert not parse_bool('')
+    assert not parse_bool('false')
+    assert not parse_bool('False')
+    assert not parse_bool('0')
+    assert not parse_bool(0)
+    assert not parse_bool(False)
+    assert parse_bool('true')
+    assert parse_bool('True')
+    assert parse_bool('1')
+    assert parse_bool('-1')
+    assert parse_bool(1)
+    assert parse_bool(True)
 
 
 @patch_import(modules=['win32api'], MessageBox=MagicMock())

--- a/src/tribler/core/utilities/utilities.py
+++ b/src/tribler/core/utilities/utilities.py
@@ -272,6 +272,24 @@ def to_fts_query(text):
     return ' '.join(words)
 
 
+def parse_bool(obj):
+    """
+    Parse input to boolean True or False
+    Allow parsing text 'false', 'true' '1', '0' to boolean
+
+    :param obj: Object to parse
+    """
+    if isinstance(obj, str):
+        if obj.lower() == "false":
+            return False
+
+        try:
+            return bool(int(obj))
+        except ValueError:
+            pass
+    return bool(obj)
+
+
 def show_system_popup(title, text):
     """
     Create a native pop-up without any third party dependency.


### PR DESCRIPTION
Allows using swagger ui & enable/disable boolean flags. Fixes #7562

remote_query have been removed from openapi since it does not appear to be used.
Split definition for search and remote query as they do not take the same args.