### PR TITLE
Optimize the large torrent creation test

### DIFF
--- a/src/tribler/core/components/libtorrent/restapi/create_torrent_endpoint.py
+++ b/src/tribler/core/components/libtorrent/restapi/create_torrent_endpoint.py
@@ -9,7 +9,8 @@ from marshmallow.fields import String
 from tribler.core.components.libtorrent.download_manager.download_config import DownloadConfig
 from tribler.core.components.libtorrent.download_manager.download_manager import DownloadManager
 from tribler.core.components.libtorrent.torrentdef import TorrentDef
-from tribler.core.components.restapi.rest.rest_endpoint import HTTP_BAD_REQUEST, RESTEndpoint, RESTResponse
+from tribler.core.components.restapi.rest.rest_endpoint import HTTP_BAD_REQUEST, RESTEndpoint, RESTResponse, \
+    MAX_REQUEST_SIZE
 from tribler.core.components.restapi.rest.schema import HandledErrorSchema
 from tribler.core.components.restapi.rest.utils import return_handled_exception
 from tribler.core.utilities.path_util import Path
@@ -25,8 +26,8 @@ class CreateTorrentEndpoint(RESTEndpoint):
     """
     path = '/createtorrent'
 
-    def __init__(self, download_manager: DownloadManager, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, download_manager: DownloadManager, client_max_size: int = MAX_REQUEST_SIZE):
+        super().__init__(client_max_size=client_max_size)
         self.download_manager = download_manager
 
     def setup_routes(self):

--- a/src/tribler/core/components/libtorrent/restapi/create_torrent_endpoint.py
+++ b/src/tribler/core/components/libtorrent/restapi/create_torrent_endpoint.py
@@ -25,8 +25,8 @@ class CreateTorrentEndpoint(RESTEndpoint):
     """
     path = '/createtorrent'
 
-    def __init__(self, download_manager: DownloadManager):
-        super().__init__()
+    def __init__(self, download_manager: DownloadManager, **kwargs):
+        super().__init__(**kwargs)
         self.download_manager = download_manager
 
     def setup_routes(self):

--- a/src/tribler/core/components/restapi/rest/rest_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/rest_endpoint.py
@@ -27,9 +27,9 @@ MAX_REQUEST_SIZE = 16 * 1024 ** 2  # 16 MB
 class RESTEndpoint:
     path = ''
 
-    def __init__(self, middlewares=()):
+    def __init__(self, middlewares=(), client_max_size=MAX_REQUEST_SIZE):
         self._logger = logging.getLogger(self.__class__.__name__)
-        self.app = web.Application(middlewares=middlewares, client_max_size=MAX_REQUEST_SIZE)
+        self.app = web.Application(middlewares=middlewares, client_max_size=client_max_size)
         self.endpoints: Dict[str, RESTEndpoint] = {}
         self.async_group = AsyncGroup()
         self.setup_routes()

--- a/src/tribler/core/components/restapi/rest/rest_manager.py
+++ b/src/tribler/core/components/restapi/rest/rest_manager.py
@@ -65,10 +65,10 @@ async def error_middleware(request, handler):
             'handled': True,
             'message': f'Could not find {request.path}'
         }}, status=HTTP_NOT_FOUND)
-    except HTTPRequestEntityTooLarge:
+    except HTTPRequestEntityTooLarge as http_error:
         return RESTResponse({'error': {
             'handled': True,
-            'message': f'Request size is larger than {MAX_REQUEST_SIZE} bytes'
+            'message': http_error.text,
         }}, status=HTTP_REQUEST_ENTITY_TOO_LARGE)
     except Exception as e:
         logger.exception(e)

--- a/src/tribler/core/conftest.py
+++ b/src/tribler/core/conftest.py
@@ -108,7 +108,8 @@ def event_loop():
 @pytest.fixture
 async def rest_api(event_loop, aiohttp_client, endpoint: RESTEndpoint):
     # In each test file that requires the use of this fixture, the endpoint fixture needs to be specified.
-    app = Application(middlewares=[error_middleware], client_max_size=endpoint.app._client_max_size)
+    client_max_size: int = endpoint.app._client_max_size  # pylint:disable=protected-access
+    app = Application(middlewares=[error_middleware], client_max_size=client_max_size)
     app.add_subapp(endpoint.path, endpoint.app)
 
     yield await aiohttp_client(app)

--- a/src/tribler/core/conftest.py
+++ b/src/tribler/core/conftest.py
@@ -108,7 +108,7 @@ def event_loop():
 @pytest.fixture
 async def rest_api(event_loop, aiohttp_client, endpoint: RESTEndpoint):
     # In each test file that requires the use of this fixture, the endpoint fixture needs to be specified.
-    app = Application(middlewares=[error_middleware])
+    app = Application(middlewares=[error_middleware], client_max_size=endpoint.app._client_max_size)
     app.add_subapp(endpoint.path, endpoint.app)
 
     yield await aiohttp_client(app)


### PR DESCRIPTION
`test_create_torrent_endpoint.py::test_create_torrent_of_large_size` is consistently taking 20-30 seconds to finish the tests which is one of the contributor to timing out the full test suite.

This PR optimizes the test to reduce the test time to 100-200 ms (hopefully).