### PR TITLE
[TEST] disable sentry on pytest

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,6 +2,7 @@
 timeout = 60
 ;https://pypi.org/project/pytest-asyncio/
 asyncio_mode = auto
+sentry_enabled = False
 log_level = INFO
 log_format = %(asctime)s.%(msecs)03d %(levelname)s %(name)s(%(lineno)d) %(message)s
 log_cli_format = %(asctime)s.%(msecs)03d %(levelname)s %(name)s(%(lineno)d) %(message)s

--- a/src/tribler/core/components/metadata_store/tests/test_channel_metadata.py
+++ b/src/tribler/core/components/metadata_store/tests/test_channel_metadata.py
@@ -43,6 +43,11 @@ def torrent_template():
 
 
 @pytest.fixture
+def use_cached_metadata_store_db():
+    return False
+
+
+@pytest.fixture
 def sample_torrent_dict(my_key):
     return {
         "infohash": b"1" * 20,
@@ -336,7 +341,7 @@ def fixture_freezer():
 
 
 @db_session
-def test_vsids(freezer, metadata_store):
+def test_vsids(freezer, use_cached_metadata_store_db, metadata_store):
     """
     Test VSIDS-based channel popularity system.
     """


### PR DESCRIPTION
Experimental PR to check the impact of sentry performance monitoring on the test total time.