### PR TITLE
Add a title to knowledge processing

### DIFF
--- a/src/tribler/core/components/knowledge/db/tests/test_knowledge_db.py
+++ b/src/tribler/core/components/knowledge/db/tests/test_knowledge_db.py
@@ -168,6 +168,21 @@ class TestTagDB(TestTagDBBase):
         assert self.db.instance.Peer.get().public_key == PUBLIC_KEY_FOR_AUTO_GENERATED_OPERATIONS
 
     @db_session
+    def test_double_add_auto_generated_tag(self):
+        """ Test that adding the same auto-generated tag twice will not create a new Statement entity."""
+        kwargs = {
+            'subject_type': ResourceType.TORRENT,
+            'subject': 'infohash',
+            'predicate': ResourceType.TAG,
+            'obj': 'tag'
+        }
+        self.db.add_auto_generated(**kwargs)
+        self.db.add_auto_generated(**kwargs)
+
+        assert len(self.db.instance.Statement.select()) == 1
+        assert self.db.instance.Statement.get().added_count == SHOW_THRESHOLD
+
+    @db_session
     def test_multiple_tags(self):
         self.add_operation_set(
             self.db,

--- a/src/tribler/core/components/knowledge/rules/tests/test_knowledge_rules_processor.py
+++ b/src/tribler/core/components/knowledge/rules/tests/test_knowledge_rules_processor.py
@@ -41,11 +41,12 @@ async def test_process_torrent_file(mocked_save_tags: MagicMock, tag_rules_proce
     assert not await tag_rules_processor.process_torrent_title(infohash=b'infohash', title=None)
 
     # test that process_torrent_title doesn't find any tags in the title
-    assert not await tag_rules_processor.process_torrent_title(infohash=b'infohash', title='title')
-    mocked_save_tags.assert_not_called()
+    # the function should return `1` as it should process only one statement -- the TITLE itself
+    assert await tag_rules_processor.process_torrent_title(infohash=b'infohash', title='title') == 1
+    assert mocked_save_tags.call_count == 1
 
     # test that process_torrent_title does find tags in the title
-    assert await tag_rules_processor.process_torrent_title(infohash=b'infohash', title='title [tag]') == 1
+    assert await tag_rules_processor.process_torrent_title(infohash=b'infohash', title='title [tag]') == 2
     mocked_save_tags.assert_called_with(subject_type=ResourceType.TORRENT, subject='696e666f68617368', objects={'tag'},
                                         predicate=ResourceType.TAG)
 


### PR DESCRIPTION
This PR is related to issue #7398 and serves as the first step in the migration process.

After the implementation of this PR, all incoming titles will be stored in `knowledge.db`. Additionally, all existing titles will be moved to `knowledge.db` in the background.

In addition, this PR introduces estimated time calculation to the `KnowledgeRulesProcessor`.