### PR TITLE
Bump `pony` and `sentry-sdk` versions

### DIFF
--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -9,12 +9,12 @@ libnacl==1.8.0
 lz4==4.3.2
 marshmallow==3.19.0
 networkx==3.1
-pony==0.7.16
+pony==0.7.17
 psutil==5.9.5
 pydantic==1.10.11
 PyOpenSSL==23.2.0
 pyyaml==6.0
-sentry-sdk==1.27.1
+sentry-sdk==1.31.0
 yappi==1.4.0
 yarl==1.9.2 # keep this dependency higher than 1.6.3. See: https://github.com/aio-libs/yarl/issues/517
 bitarray==2.7.6


### PR DESCRIPTION
Related to #7282, #7597 and #7556