### PR TITLE
Use curl for the windows_dependencies action

### DIFF
--- a/.github/actions/windows_dependencies/action.yml
+++ b/.github/actions/windows_dependencies/action.yml
@@ -33,8 +33,8 @@ runs:
         RELEASE_FOLDER: .\libsodium\x64\Release
       shell: cmd
       run: |
-        C:\msys64\usr\bin\wget.exe -q https://download.libsodium.org/libsodium/releases/libsodium-${{inputs.libsodium-version}}-msvc.zip
-        7z x libsodium-${{inputs.libsodium-version}}-msvc.zip
+        curl -o libsodium.zip https://download.libsodium.org/libsodium/releases/libsodium-${{inputs.libsodium-version}}-msvc.zip
+        7z x libsodium.zip
         dir %RELEASE_FOLDER% /ad /b /o-n > latest_release_file
         set /p latest_release= < latest_release_file
         echo Latest release: %latest_release%


### PR DESCRIPTION
This PR fixes https://github.com/Tribler/tribler/actions/runs/6298097466/job/17096579998?pr=7604#step:4:96

Ref: https://github.com/actions/runner-images/blob/main/images/win/Windows2022-Readme.md