### PR TITLE
Utilize the `subjects_type` parameter

### DIFF
--- a/src/tribler/core/components/database/db/tests/test_tribler_database.py
+++ b/src/tribler/core/components/database/db/tests/test_tribler_database.py
@@ -3,9 +3,9 @@ from unittest.mock import Mock, patch
 
 from pony.orm import commit, db_session
 
-from tribler.core.components.database.db.tribler_database import TriblerDatabase, Operation, \
-    PUBLIC_KEY_FOR_AUTO_GENERATED_OPERATIONS, ResourceType, SHOW_THRESHOLD, SimpleStatement
 from tribler.core.components.database.db.tests.test_tribler_database_base import Resource, TestTagDBBase
+from tribler.core.components.database.db.tribler_database import Operation, PUBLIC_KEY_FOR_AUTO_GENERATED_OPERATIONS, \
+    ResourceType, SHOW_THRESHOLD, SimpleStatement, TriblerDatabase
 from tribler.core.utilities.pony_utils import TrackedDatabase, get_or_create
 
 
@@ -402,6 +402,12 @@ class TestTagDB(TestTagDBBase):
         self.add_operation_set(
             self.db,
             {
+                ('zero', ResourceType.TITLE): [
+                    # It should not appear in the results due to the differing subject type, although it possesses all
+                    # the necessary tags.
+                    Resource(name='tag1'),
+                    Resource(name='tag2'),
+                ],
                 'infohash1': [
                     Resource(name='tag1'),
                     Resource(name='tag2'),

--- a/src/tribler/core/components/database/db/tests/test_tribler_database_base.py
+++ b/src/tribler/core/components/database/db/tests/test_tribler_database_base.py
@@ -79,8 +79,12 @@ class TestTagDBBase(TestBase):
                 yield f'peer{next(index)}'.encode('utf8')
 
         for subject, objects in dictionary.items():
+            subject_type = ResourceType.TORRENT
+            if isinstance(subject, tuple):
+                subject, subject_type = subject
+
             for obj in objects:
                 for peer in generate_n_peer_names(obj.count):
                     # assume that for test purposes all subject by default could be `Predicate.TORRENT`
-                    TestTagDBBase.add_operation(tag_db, ResourceType.TORRENT, subject, obj.predicate, obj.name, peer,
+                    TestTagDBBase.add_operation(tag_db, subject_type, subject, obj.predicate, obj.name, peer,
                                                 is_auto_generated=obj.auto_generated)

--- a/src/tribler/core/components/database/db/tribler_database.py
+++ b/src/tribler/core/components/database/db/tribler_database.py
@@ -361,9 +361,9 @@ class TriblerDatabase:
         )
         return suggestions
 
-    def get_subjects_intersection(self, subjects_type: Optional[ResourceType], objects: Set[str],
-                                  predicate: Optional[ResourceType],
-                                  case_sensitive: bool = True) -> Set[str]:
+    def get_subjects_intersection(self, objects: Set[str], predicate: Optional[ResourceType],
+                                  subjects_type: Optional[ResourceType] = ResourceType.TORRENT,
+                                  case_sensitive: bool = True) -> Set[str]:  # pylint: disable=unused-argument
         if not objects:
             return set()
 
@@ -371,9 +371,8 @@ class TriblerDatabase:
             name_condition = '"obj"."name" = $obj_name'
         else:
             name_condition = 'py_lower("obj"."name") = py_lower($obj_name)'
-
-        query = select(r.name for r in self.instance.Resource)
-        for obj_name in objects:
+        query = select(r.name for r in self.instance.Resource if r.type == subjects_type.value)
+        for obj_name in objects:  # pylint: disable=unused-variable
             query = query.filter(raw_sql(f"""
     r.id IN (
         SELECT "s"."subject"


### PR DESCRIPTION
During the optimization of the `get_subjects_intersection` function (https://github.com/Tribler/tribler/pull/7153/commits/3619ca52e4ce09d11cf47559b02162d695bad208), the parameter `subjects_type` was overlooked. This became clear in #7606 during the Codacy check.