### PR TITLE
Fixes #7592: remove the `wait_for` wrapper around `await site.start()` when starting HTTP REST API server

### DIFF
--- a/src/tribler/core/components/restapi/rest/rest_manager.py
+++ b/src/tribler/core/components/restapi/rest/rest_manager.py
@@ -162,10 +162,7 @@ class RESTManager:
         self._logger.info(f"Starting HTTP REST API server on port {api_port}...")
 
         try:
-            # The self.site.start() is expected to start immediately. It looks like on some machines, it hangs.
-            # The timeout is added to prevent the hypothetical hanging.
-            await asyncio.wait_for(self.site.start(), timeout=SITE_START_TIMEOUT)
-
+            await self.site.start()
         except BaseException as e:
             self._logger.exception(f"Can't start HTTP REST API on port {api_port}: {e.__class__.__name__}: {e}")
             raise


### PR DESCRIPTION
This PR fixes the core issue of #7592. The `wait_for` wrapper actually didn't do anything useful here and provoked the `TimeoutError`. The server itself should start almost immediately, especially now, as it is directly called in the current coroutine. In case it freezes on some machine, we should be able to detect it by looking at the result of the slow coroutine detector.

