### PR TITLE
Fix multiple instances of Tribler on Flatpak

### DIFF
--- a/src/tribler/core/utilities/process_manager/manager.py
+++ b/src/tribler/core/utilities/process_manager/manager.py
@@ -119,7 +119,7 @@ class ProcessManager:
             row = cursor.fetchone()
             if row is not None:
                 process = TriblerProcess.from_row(self, row)
-                if process.is_running():
+                if process.is_current_process() or process.is_running():
                     return process.rowid
 
                 # Process is not running anymore; mark it as not primary

--- a/src/tribler/core/utilities/process_manager/process.py
+++ b/src/tribler/core/utilities/process_manager/process.py
@@ -140,7 +140,7 @@ class TriblerProcess:
 
     def is_current_process(self) -> bool:
         """Returns True if the object represents the current process"""
-        return self.pid == os.getpid() and self.is_running()
+        return self.pid == os.getpid()
 
     @with_retry
     def become_primary(self) -> bool:

--- a/src/tribler/core/utilities/process_manager/tests/test_manager.py
+++ b/src/tribler/core/utilities/process_manager/tests/test_manager.py
@@ -11,8 +11,8 @@ from tribler.core.utilities.process_manager.process import ProcessKind, TriblerP
 # pylint: disable=protected-access
 
 
-@patch('os.getpid', return_value=1)
-def test_become_primary(os_getpid: Mock, process_manager: ProcessManager):
+@patch('os.getpid', new=lambda: 1)
+def test_become_primary(process_manager: ProcessManager):
     # Initially process manager fixture creates a primary current process that is a single process in DB
     p1 = process_manager.current_process
     assert p1.primary

--- a/src/tribler/core/utilities/process_manager/tests/test_manager.py
+++ b/src/tribler/core/utilities/process_manager/tests/test_manager.py
@@ -11,7 +11,8 @@ from tribler.core.utilities.process_manager.process import ProcessKind, TriblerP
 # pylint: disable=protected-access
 
 
-def test_become_primary(process_manager: ProcessManager):
+@patch('os.getpid', return_value=1)
+def test_become_primary(os_getpid: Mock, process_manager: ProcessManager):
     # Initially process manager fixture creates a primary current process that is a single process in DB
     p1 = process_manager.current_process
     assert p1.primary


### PR DESCRIPTION
~This PR fixes the multiple instances of Tribler running on Flatpak. If the app is connected to the previous instance via QLocalSocket then there is another instance running. In this case, Tribler closes now by passing its arguments to the running process via the QT local socket.~

~In addition to that, in the PR, for the core process, it is now checked if the port is known whether or not REST API is accessible. If the API is not accessible, then the core process is considered not running. Checking on the pid is not sufficient on the Flatpak environment because the pid is not unique anymore on the sandbox environment.~

This PR addresses the issue of multiple instances of Flatpak application running in parallel and crashing Tribler when one of the instances is closed. It is addressed in the following way.

If the last primary process from the database has a PID that either matches the current process PID or can be confirmed to be running, then the current process instance is terminated. This prevents the second instance of Tribler from running.

It could be argued that the PID could be reused and could lead to Tribler terminating itself and no instances running at all. In such a case, the likelihood of the last Tribler process having the same PID as the current process and the database having the process record with a primary set to 1, in my opinion, is negligible. Furthermore, if such a case happens, Tribler will likely start on the next run as the PID would most likely change from the previous run which in my opinion is acceptable.

Fixes https://github.com/Tribler/tribler/issues/7626
Fixes partially https://github.com/Tribler/tribler/issues/7603