### PR TITLE
Handle the "DatabaseError: database disk image is malformed" error

### DIFF
--- a/src/tribler/core/components/bandwidth_accounting/db/database.py
+++ b/src/tribler/core/components/bandwidth_accounting/db/database.py
@@ -34,7 +34,7 @@ class BandwidthDatabase:
         # with the static analysis.
         # pylint: disable=unused-variable
 
-        @self.database.on_connect(provider='sqlite')
+        @self.database.on_connect
         def sqlite_sync_pragmas(_, connection):
             cursor = connection.cursor()
             cursor.execute("PRAGMA journal_mode = WAL")

--- a/src/tribler/core/components/bandwidth_accounting/db/database.py
+++ b/src/tribler/core/components/bandwidth_accounting/db/database.py
@@ -5,7 +5,8 @@ from pony.orm import count, db_session, desc, select
 
 from tribler.core.components.bandwidth_accounting.db import history, misc, transaction as db_transaction
 from tribler.core.components.bandwidth_accounting.db.transaction import BandwidthTransactionData
-from tribler.core.utilities.pony_utils import TriblerDatabase, handle_db_if_corrupted
+from tribler.core.utilities.db_corruption_handling.base import handle_db_if_corrupted
+from tribler.core.utilities.pony_utils import TriblerDatabase
 from tribler.core.utilities.utilities import MEMORY_DB
 
 
@@ -50,6 +51,7 @@ class BandwidthDatabase:
             create_db = True
             db_path_string = ":memory:"
         else:
+            # We need to handle the database corruption case before determining the state of the create_db flag.
             handle_db_if_corrupted(db_path)
             create_db = not db_path.is_file()
             db_path_string = str(db_path)

--- a/src/tribler/core/components/bandwidth_accounting/db/database.py
+++ b/src/tribler/core/components/bandwidth_accounting/db/database.py
@@ -5,7 +5,7 @@ from pony.orm import count, db_session, desc, select
 
 from tribler.core.components.bandwidth_accounting.db import history, misc, transaction as db_transaction
 from tribler.core.components.bandwidth_accounting.db.transaction import BandwidthTransactionData
-from tribler.core.utilities.pony_utils import TriblerDatabase
+from tribler.core.utilities.pony_utils import TriblerDatabase, handle_db_if_corrupted
 from tribler.core.utilities.utilities import MEMORY_DB
 
 
@@ -50,6 +50,7 @@ class BandwidthDatabase:
             create_db = True
             db_path_string = ":memory:"
         else:
+            handle_db_if_corrupted(db_path)
             create_db = not db_path.is_file()
             db_path_string = str(db_path)
 

--- a/src/tribler/core/components/component.py
+++ b/src/tribler/core/components/component.py
@@ -9,9 +9,9 @@ from typing import Optional, Set, TYPE_CHECKING, Type, Union
 from tribler.core.components.exceptions import ComponentStartupException, MissedDependency, NoneComponent
 from tribler.core.components.reporter.exception_handler import default_core_exception_handler
 from tribler.core.sentry_reporter.sentry_reporter import SentryReporter
+from tribler.core.utilities.exit_codes import EXITCODE_DATABASE_IS_CORRUPTED
 from tribler.core.utilities.pony_utils import DatabaseIsCorrupted
 from tribler.core.utilities.process_manager import get_global_process_manager
-from tribler.gui.defs import EXITCODE_DATABASE_IS_CORRUPTED
 
 if TYPE_CHECKING:
     from tribler.core.components.session import Session, T

--- a/src/tribler/core/components/component.py
+++ b/src/tribler/core/components/component.py
@@ -9,8 +9,8 @@ from typing import Optional, Set, TYPE_CHECKING, Type, Union
 from tribler.core.components.exceptions import ComponentStartupException, MissedDependency, NoneComponent
 from tribler.core.components.reporter.exception_handler import default_core_exception_handler
 from tribler.core.sentry_reporter.sentry_reporter import SentryReporter
+from tribler.core.utilities.db_corruption_handling.base import DatabaseIsCorrupted
 from tribler.core.utilities.exit_codes import EXITCODE_DATABASE_IS_CORRUPTED
-from tribler.core.utilities.pony_utils import DatabaseIsCorrupted
 from tribler.core.utilities.process_manager import get_global_process_manager
 
 if TYPE_CHECKING:
@@ -52,8 +52,20 @@ class Component:
             self.started_event.set()
 
             if isinstance(e, DatabaseIsCorrupted):
+                # When the database corruption is detected, we should stop the process immediately.
+                # Tribler GUI will restart the process and the database will be recreated.
+
+                # Usually we wrap an exception into ComponentStartupException, and allow
+                # CoreExceptionHandler.unhandled_error_observer to handle it after all components are started,
+                # but in this case we don't do it. The reason is that handling ComponentStartupException
+                # starts the shutting down of Tribler, and due to some obscure reasons it is not possible to
+                # raise any exception, even SystemExit, from CoreExceptionHandler.unhandled_error_observer when
+                # Tribler is shutting down. It looks like in this case unhandled_error_observer is called from
+                # Task.__del__ method and all exceptions that are raised from __del__ are ignored.
+                # See https://bugs.python.org/issue25489 for similar case.
                 process_manager = get_global_process_manager()
                 process_manager.sys_exit(EXITCODE_DATABASE_IS_CORRUPTED, e)
+                return  # Added for clarity; actually, the code raised SystemExit on the previous line
 
             if self.session.failfast:
                 raise e

--- a/src/tribler/core/components/gigachannel_manager/gigachannel_manager.py
+++ b/src/tribler/core/components/gigachannel_manager/gigachannel_manager.py
@@ -13,7 +13,7 @@ from tribler.core.components.metadata_store.db.orm_bindings.channel_node import 
 from tribler.core.components.metadata_store.db.serialization import CHANNEL_TORRENT
 from tribler.core.components.metadata_store.db.store import MetadataStore
 from tribler.core.utilities.notifier import Notifier
-from tribler.core.utilities.pony_utils import run_threaded
+from tribler.core.utilities.pony_utils import DatabaseIsCorrupted, run_threaded
 from tribler.core.utilities.simpledefs import DownloadStatus
 from tribler.core.utilities.unicode import hexlify
 
@@ -80,6 +80,8 @@ class GigaChannelManager(TaskManager):
                             channel.id_,
                             channel_download,
                         )
+        except DatabaseIsCorrupted:
+            raise  # re-raise this exception and terminate the Core process
         except Exception:
             self._logger.exception("Error when tried to resume personal channel seeding on GigaChannel Manager startup")
 

--- a/src/tribler/core/components/gigachannel_manager/gigachannel_manager.py
+++ b/src/tribler/core/components/gigachannel_manager/gigachannel_manager.py
@@ -12,8 +12,9 @@ from tribler.core.components.libtorrent.torrentdef import TorrentDef
 from tribler.core.components.metadata_store.db.orm_bindings.channel_node import COMMITTED
 from tribler.core.components.metadata_store.db.serialization import CHANNEL_TORRENT
 from tribler.core.components.metadata_store.db.store import MetadataStore
+from tribler.core.utilities.db_corruption_handling.base import DatabaseIsCorrupted
 from tribler.core.utilities.notifier import Notifier
-from tribler.core.utilities.pony_utils import DatabaseIsCorrupted, run_threaded
+from tribler.core.utilities.pony_utils import run_threaded
 from tribler.core.utilities.simpledefs import DownloadStatus
 from tribler.core.utilities.unicode import hexlify
 

--- a/src/tribler/core/components/knowledge/db/knowledge_db.py
+++ b/src/tribler/core/components/knowledge/db/knowledge_db.py
@@ -66,7 +66,7 @@ class KnowledgeDatabase:
     def __init__(self, filename: Optional[str] = None, *, create_tables: bool = True, **generate_mapping_kwargs):
         self.instance = TriblerDatabase()
         self.define_binding(self.instance)
-        self.instance.bind('sqlite', filename or ':memory:', create_db=True)
+        self.instance.bind(provider='sqlite', filename=filename or ':memory:', create_db=True)
         generate_mapping_kwargs['create_tables'] = create_tables
         self.instance.generate_mapping(**generate_mapping_kwargs)
         self.logger = logging.getLogger(self.__class__.__name__)

--- a/src/tribler/core/components/metadata_store/db/store.py
+++ b/src/tribler/core/components/metadata_store/db/store.py
@@ -166,7 +166,7 @@ class MetadataStore:
         # This attribute is internally called by Pony on startup, though pylint cannot detect it
         # with the static analysis.
         # pylint: disable=unused-variable
-        @self.db.on_connect(provider='sqlite')
+        @self.db.on_connect
         def on_connect(_, connection):
             cursor = connection.cursor()
             cursor.execute("PRAGMA journal_mode = WAL")

--- a/src/tribler/core/components/metadata_store/db/store.py
+++ b/src/tribler/core/components/metadata_store/db/store.py
@@ -48,7 +48,8 @@ from tribler.core.components.torrent_checker.torrent_checker.dataclasses import 
 from tribler.core.exceptions import InvalidSignatureException
 from tribler.core.utilities.notifier import Notifier
 from tribler.core.utilities.path_util import Path
-from tribler.core.utilities.pony_utils import TriblerDatabase, get_max, get_or_create, run_threaded
+from tribler.core.utilities.pony_utils import TriblerDatabase, get_max, get_or_create, handle_db_if_corrupted, \
+    run_threaded
 from tribler.core.utilities.search_utils import torrent_rank
 from tribler.core.utilities.unicode import hexlify
 from tribler.core.utilities.utilities import MEMORY_DB
@@ -218,6 +219,7 @@ class MetadataStore:
             create_db = True
             db_path_string = ":memory:"
         else:
+            handle_db_if_corrupted(db_filename)
             create_db = not db_filename.is_file()
             db_path_string = str(db_filename)
 

--- a/src/tribler/core/components/metadata_store/db/store.py
+++ b/src/tribler/core/components/metadata_store/db/store.py
@@ -46,11 +46,10 @@ from tribler.core.components.metadata_store.db.serialization import (
 from tribler.core.components.metadata_store.remote_query_community.payload_checker import process_payload
 from tribler.core.components.torrent_checker.torrent_checker.dataclasses import HealthInfo
 from tribler.core.exceptions import InvalidSignatureException
+from tribler.core.utilities.db_corruption_handling.base import DatabaseIsCorrupted, handle_db_if_corrupted
 from tribler.core.utilities.notifier import Notifier
 from tribler.core.utilities.path_util import Path
-from tribler.core.utilities.pony_utils import DatabaseIsCorrupted, TriblerDatabase, get_max, get_or_create, \
-    handle_db_if_corrupted, \
-    run_threaded
+from tribler.core.utilities.pony_utils import TriblerDatabase, get_max, get_or_create, run_threaded
 from tribler.core.utilities.search_utils import torrent_rank
 from tribler.core.utilities.unicode import hexlify
 from tribler.core.utilities.utilities import MEMORY_DB
@@ -220,6 +219,7 @@ class MetadataStore:
             create_db = True
             db_path_string = ":memory:"
         else:
+            # We need to handle the database corruption case before determining the state of the create_db flag.
             handle_db_if_corrupted(db_filename)
             create_db = not db_filename.is_file()
             db_path_string = str(db_filename)

--- a/src/tribler/core/components/reporter/exception_handler.py
+++ b/src/tribler/core/components/reporter/exception_handler.py
@@ -10,8 +10,8 @@ from typing import Callable, Dict, Optional, Set, Tuple, Type
 from tribler.core.components.exceptions import ComponentStartupException
 from tribler.core.components.reporter.reported_error import ReportedError
 from tribler.core.sentry_reporter.sentry_reporter import SentryReporter
+from tribler.core.utilities.db_corruption_handling.base import DatabaseIsCorrupted
 from tribler.core.utilities.exit_codes import EXITCODE_DATABASE_IS_CORRUPTED
-from tribler.core.utilities.pony_utils import DatabaseIsCorrupted
 from tribler.core.utilities.process_manager import get_global_process_manager
 
 # There are some errors that we are ignoring.

--- a/src/tribler/core/components/reporter/exception_handler.py
+++ b/src/tribler/core/components/reporter/exception_handler.py
@@ -10,7 +10,9 @@ from typing import Callable, Dict, Optional, Set, Tuple, Type
 from tribler.core.components.exceptions import ComponentStartupException
 from tribler.core.components.reporter.reported_error import ReportedError
 from tribler.core.sentry_reporter.sentry_reporter import SentryReporter
+from tribler.core.utilities.pony_utils import DatabaseIsCorrupted
 from tribler.core.utilities.process_manager import get_global_process_manager
+from tribler.gui.defs import EXITCODE_DATABASE_IS_CORRUPTED
 
 # There are some errors that we are ignoring.
 
@@ -93,12 +95,18 @@ class CoreExceptionHandler:
             should_stop = context.pop('should_stop', True)
             message = context.pop('message', 'no message')
             exception = context.pop('exception', None) or self._create_exception_from(message)
-            # Exception
-            text = str(exception)
+
+            self.logger.exception(f'{exception.__class__.__name__}: {exception}', exc_info=exception)
+
+            if isinstance(exception, DatabaseIsCorrupted):
+                process_manager.sys_exit(EXITCODE_DATABASE_IS_CORRUPTED, exception)
+                return  # Added for clarity; actually, the code raised SystemExit on the previous line
+
             if isinstance(exception, ComponentStartupException):
                 self.logger.info('The exception is ComponentStartupException')
                 should_stop = exception.component.tribler_should_stop_on_component_error
                 exception = exception.__cause__
+
             if isinstance(exception, NoCrashException):
                 self.logger.info('The exception is NoCrashException')
                 should_stop = False
@@ -113,7 +121,7 @@ class CoreExceptionHandler:
 
             reported_error = ReportedError(
                 type=exception.__class__.__name__,
-                text=text,
+                text=str(exception),
                 long_text=long_text,
                 context=str(context),
                 event=self.sentry_reporter.event_from_exception(exception) or {},

--- a/src/tribler/core/components/reporter/exception_handler.py
+++ b/src/tribler/core/components/reporter/exception_handler.py
@@ -10,9 +10,9 @@ from typing import Callable, Dict, Optional, Set, Tuple, Type
 from tribler.core.components.exceptions import ComponentStartupException
 from tribler.core.components.reporter.reported_error import ReportedError
 from tribler.core.sentry_reporter.sentry_reporter import SentryReporter
+from tribler.core.utilities.exit_codes import EXITCODE_DATABASE_IS_CORRUPTED
 from tribler.core.utilities.pony_utils import DatabaseIsCorrupted
 from tribler.core.utilities.process_manager import get_global_process_manager
-from tribler.gui.defs import EXITCODE_DATABASE_IS_CORRUPTED
 
 # There are some errors that we are ignoring.
 

--- a/src/tribler/core/components/restapi/rest/rest_manager.py
+++ b/src/tribler/core/components/restapi/rest/rest_manager.py
@@ -67,9 +67,7 @@ async def error_middleware(request, handler):
             'message': f'Request size is larger than {MAX_REQUEST_SIZE} bytes'
         }}, status=HTTP_REQUEST_ENTITY_TOO_LARGE)
     except Exception as e:
-        logger.exception(e)
         full_exception = traceback.format_exc()
-
         default_core_exception_handler.unhandled_error_observer(None, {'exception': e, 'should_stop': False})
 
         return RESTResponse({"error": {

--- a/src/tribler/core/upgrade/tags_to_knowledge/tags_db.py
+++ b/src/tribler/core/upgrade/tags_to_knowledge/tags_db.py
@@ -10,7 +10,7 @@ class TagDatabase:
     def __init__(self, filename: Optional[str] = None, *, create_tables: bool = True, **generate_mapping_kwargs):
         self.instance = TriblerDatabase()
         self.define_binding(self.instance)
-        self.instance.bind('sqlite', filename or ':memory:', create_db=True)
+        self.instance.bind(provider='sqlite', filename=filename or ':memory:', create_db=True)
         generate_mapping_kwargs['create_tables'] = create_tables
         self.instance.generate_mapping(**generate_mapping_kwargs)
 

--- a/src/tribler/core/upgrade/tests/test_upgrader.py
+++ b/src/tribler/core/upgrade/tests/test_upgrader.py
@@ -18,7 +18,7 @@ from tribler.core.upgrade.tags_to_knowledge.tags_db import TagDatabase
 from tribler.core.upgrade.upgrade import TriblerUpgrader, catch_db_is_corrupted_exception, \
     cleanup_noncompliant_channel_torrents
 from tribler.core.utilities.configparser import CallbackConfigParser
-from tribler.core.utilities.pony_utils import DatabaseIsCorrupted
+from tribler.core.utilities.db_corruption_handling.base import DatabaseIsCorrupted
 from tribler.core.utilities.utilities import random_infohash
 
 

--- a/src/tribler/core/upgrade/tests/test_upgrader.py
+++ b/src/tribler/core/upgrade/tests/test_upgrader.py
@@ -3,7 +3,7 @@ import shutil
 import time
 from pathlib import Path
 from typing import Set
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 from ipv8.keyvault.private.libnaclkey import LibNaCLSK
@@ -15,8 +15,10 @@ from tribler.core.components.metadata_store.db.store import CURRENT_DB_VERSION, 
 from tribler.core.tests.tools.common import TESTS_DATA_DIR
 from tribler.core.upgrade.db8_to_db10 import calc_progress
 from tribler.core.upgrade.tags_to_knowledge.tags_db import TagDatabase
-from tribler.core.upgrade.upgrade import TriblerUpgrader, cleanup_noncompliant_channel_torrents
+from tribler.core.upgrade.upgrade import TriblerUpgrader, catch_db_is_corrupted_exception, \
+    cleanup_noncompliant_channel_torrents
 from tribler.core.utilities.configparser import CallbackConfigParser
+from tribler.core.utilities.pony_utils import DatabaseIsCorrupted
 from tribler.core.utilities.utilities import random_infohash
 
 
@@ -53,6 +55,35 @@ def mds_path(state_dir):
 def _copy(source_name, target):
     source = TESTS_DATA_DIR / 'upgrade_databases' / source_name
     shutil.copyfile(source, target)
+
+
+def test_catch_db_is_corrupted_exception_with_exception():
+    upgrader = Mock(_db_is_corrupted_exception=None)
+    upgrader_method = Mock(side_effect=DatabaseIsCorrupted())
+    decorated_method = catch_db_is_corrupted_exception(upgrader_method)
+
+    # Call the decorated method and expect it to catch the exception
+    decorated_method(upgrader)
+    upgrader_method.assert_called_once()
+
+    # Check if the exception was caught and stored
+    upgrader_method.assert_called_once()
+    assert isinstance(upgrader._db_is_corrupted_exception, DatabaseIsCorrupted)
+    upgrader._logger.exception.assert_called_once()
+
+
+def test_catch_db_is_corrupted_exception_without_exception():
+    upgrader = Mock(_db_is_corrupted_exception=None)
+    upgrader_method = Mock()
+    decorated_method = catch_db_is_corrupted_exception(upgrader_method)
+
+    # Call the decorated method and expect it to run without exceptions
+    decorated_method(upgrader)
+
+    # Check if the method was called and no exception was stored
+    upgrader_method.assert_called_once()
+    assert upgrader._db_is_corrupted_exception is None
+    upgrader._logger.exception.assert_not_called()
 
 
 def test_upgrade_pony_db_complete(upgrader, channels_dir, state_dir, trustchain_keypair,

--- a/src/tribler/core/upgrade/upgrade.py
+++ b/src/tribler/core/upgrade/upgrade.py
@@ -377,9 +377,11 @@ class TriblerUpgrader:
         """
         self._logger.info('Upgrading GigaChannel DB from version 8 to 10')
         database_path = self.state_dir / STATEDIR_DB_DIR / 'metadata.db'
+
         if not database_path.exists() or get_db_version(database_path) >= 10:
             # Either no old db exists, or the old db version is up to date  - nothing to do
             return
+
         self._logger.info('8->10')
         # Otherwise, start upgrading
         self.update_status("STARTING")

--- a/src/tribler/core/upgrade/upgrade.py
+++ b/src/tribler/core/upgrade/upgrade.py
@@ -125,7 +125,7 @@ class TriblerUpgrader:
         self.upgrade_pony_db_14to15()
 
         if self._db_is_corrupted_exception:
-            raise self._db_is_corrupted_exception
+            raise self._db_is_corrupted_exception  # pylint: disable=raising-bad-type
 
     def remove_old_logs(self) -> Tuple[List[Path], List[Path]]:
         self._logger.info(f'Remove old logs')

--- a/src/tribler/core/upgrade/upgrade.py
+++ b/src/tribler/core/upgrade/upgrade.py
@@ -18,11 +18,12 @@ from tribler.core.components.metadata_store.db.store import (
     sql_create_partial_index_torrentstate_last_check,
 )
 from tribler.core.upgrade.config_converter import convert_config_to_tribler76
-from tribler.core.upgrade.db8_to_db10 import PonyToPonyMigration, get_db_version
+from tribler.core.upgrade.db8_to_db10 import PonyToPonyMigration
 from tribler.core.upgrade.tags_to_knowledge.migration import MigrationTagsToKnowledge
 from tribler.core.upgrade.tags_to_knowledge.tags_db import TagDatabase
 from tribler.core.utilities.configparser import CallbackConfigParser
 from tribler.core.utilities.path_util import Path
+from tribler.core.utilities.pony_utils import get_db_version
 from tribler.core.utilities.simpledefs import STATEDIR_CHANNELS_DIR, STATEDIR_DB_DIR
 
 

--- a/src/tribler/core/upgrade/version_manager.py
+++ b/src/tribler/core/upgrade/version_manager.py
@@ -280,9 +280,10 @@ class VersionHistory:
                     code_version.should_be_copied = True
                     code_version.should_recreate_directory = True
                 else:
+                    prev_version_str = code_version.can_be_copied_from.version_str
                     self.logger.info(f"The state directory for the current version {code_version.version_str} "
-                                     f"is present, but the version does not listed in version history. Will not copy state "
-                                     f"from a previous version {code_version.can_be_copied_from.version_str}")
+                                     "is present, but the version does not listed in version history. "
+                                     f"Will not copy state from a previous version {prev_version_str}")
 
             else:
                 self.logger.info("Cannot find the previous suitable version to copy state directory")

--- a/src/tribler/core/utilities/db_corruption_handling/base.py
+++ b/src/tribler/core/utilities/db_corruption_handling/base.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import logging
+import sqlite3
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Union
+
+logger = logging.getLogger('db_corruption_handling')
+
+
+class DatabaseIsCorrupted(Exception):
+    pass
+
+
+@contextmanager
+def handling_malformed_db_error(db_filepath: Path):
+    # Used in all methods of Connection and Cursor classes where the database corruption error can occur
+    try:
+        yield
+    except Exception as e:
+        if _is_malformed_db_exception(e):
+            _mark_db_as_corrupted(db_filepath)
+            raise DatabaseIsCorrupted(str(db_filepath)) from e
+        raise
+
+
+def handle_db_if_corrupted(db_filename: Union[str, Path]):
+    # Checks if the database is marked as corrupted and handles it by removing the database file and the marker file
+    db_path = Path(db_filename)
+    marker_path = get_corrupted_db_marker_path(db_path)
+    if marker_path.exists():
+        _handle_corrupted_db(db_path)
+
+
+def get_corrupted_db_marker_path(db_filepath: Path) -> Path:
+    return Path(str(db_filepath) + '.is_corrupted')
+
+
+def _is_malformed_db_exception(exception):
+    return isinstance(exception, sqlite3.DatabaseError) and 'malformed' in str(exception)
+
+
+def _mark_db_as_corrupted(db_filepath: Path):
+    # Creates a new `*.is_corrupted` marker file alongside the database file
+    marker_path = get_corrupted_db_marker_path(db_filepath)
+    marker_path.touch()
+
+
+def _handle_corrupted_db(db_path: Path):
+    # Removes the database file and the marker file
+    if db_path.exists():
+        logger.warning(f'Database file was marked as corrupted, removing it: {db_path}')
+        db_path.unlink()
+
+    marker_path = get_corrupted_db_marker_path(db_path)
+    if marker_path.exists():
+        logger.warning(f'Removing the corrupted database marker: {marker_path}')
+        marker_path.unlink()

--- a/src/tribler/core/utilities/db_corruption_handling/sqlite_replacement.py
+++ b/src/tribler/core/utilities/db_corruption_handling/sqlite_replacement.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+from sqlite3 import DataError, DatabaseError, Error, IntegrityError, InterfaceError, InternalError, NotSupportedError, \
+    OperationalError, ProgrammingError, Warning, sqlite_version_info  # pylint: disable=unused-import, redefined-builtin
+
+from tribler.core.utilities.db_corruption_handling.base import handling_malformed_db_error
+
+
+# This module serves as a replacement to the sqlite3 module and handles the case when the database is corrupted.
+# It provides the `connect` function that should be used instead of `sqlite3.connect` and the `Cursor` and `Connection`
+# classes that replaces `sqlite3.Cursor` and `sqlite3.Connection` classes respectively. If the `connect` function or
+# any Connectoin or Cursor method is called and the database is corrupted, the database is marked as corrupted and
+# the DatabaseIsCorrupted exception is raised. It should be handled by terminating the Tribler Core with the exit code
+# EXITCODE_DATABASE_IS_CORRUPTED (99). After the Core restarts, the `handle_db_if_corrupted` function checks the
+# presense of the database corruption marker and handles it by removing the database file and the corruption marker.
+# After that, the database is recreated upon the next attempt to connect to it.
+
+
+def connect(db_filename: str, **kwargs) -> sqlite3.Connection:
+    # Replaces the sqlite3.connect function
+    kwargs['factory'] = Connection
+    with handling_malformed_db_error(Path(db_filename)):
+        return sqlite3.connect(db_filename, **kwargs)
+
+
+def _add_method_wrapper_that_handles_malformed_db_exception(cls, method_name: str):
+    # Creates a wrapper for the given method that handles the case when the database is corrupted
+
+    def wrapper(self, *args, **kwargs):
+        with handling_malformed_db_error(self._db_filepath):  # pylint: disable=protected-access
+            return getattr(super(cls, self), method_name)(*args, **kwargs)
+
+    wrapper.__name__ = method_name
+    wrapper.is_wrapped = True  # for testing purposes
+    setattr(cls, method_name, wrapper)
+
+
+class Cursor(sqlite3.Cursor):
+    # Handles the case when the database is corrupted in all relevant methods.
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._db_filepath = self.connection._db_filepath
+
+
+for method_name_ in ['execute', 'executemany', 'executescript', 'fetchall', 'fetchmany', 'fetchone', '__next__']:
+    _add_method_wrapper_that_handles_malformed_db_exception(Cursor, method_name_)
+
+
+
+class ConnectionBase(sqlite3.Connection):
+    # This class simplifies testing of the Connection class by allowing mocking of base class methods.
+    # Direct mocking of sqlite3.Connection methods is not possible because they are C functions.
+
+    if sys.version_info < (3, 11):
+        def blobopen(self, *args, **kwargs) -> Blob:
+            raise NotImplementedError
+
+
+class Connection(ConnectionBase):
+    # Handles the case when the database is corrupted in all relevant methods.
+    def __init__(self, db_filepath: str, *args, **kwargs):
+        super().__init__(db_filepath, *args, **kwargs)
+        self._db_filepath = Path(db_filepath)
+
+    def cursor(self, factory=None) -> Cursor:
+        return super().cursor(factory or Cursor)
+
+    def iterdump(self):
+        # Not implemented because it is not used in Tribler.
+        # Can be added later with an iterator class that handles the malformed db error during the iteration
+        raise NotImplementedError
+
+    def blobopen(self, *args, **kwargs) -> Blob:  # Works for Python >= 3.11
+        with handling_malformed_db_error(self._db_filepath):
+            blob = super().blobopen(*args, **kwargs)
+        return Blob(blob, self._db_filepath)
+
+
+for method_name_ in ['commit', 'execute', 'executemany', 'executescript', 'backup', '__enter__', '__exit__',
+                    'serialize', 'deserialize']:
+    _add_method_wrapper_that_handles_malformed_db_exception(Connection, method_name_)
+
+
+class Blob:  # For Python >= 3.11. Added now, so we do not forgot to add it later when upgrading to 3.11.
+    def __init__(self, blob, db_filepath: Path):
+        self._blob = blob
+        self._db_filepath = db_filepath
+
+
+for method_name_ in ['close', 'read', 'write', 'seek', '__len__', '__enter__', '__exit__', '__getitem__',
+                     '__setitem__']:
+    _add_method_wrapper_that_handles_malformed_db_exception(Blob, method_name_)

--- a/src/tribler/core/utilities/db_corruption_handling/tests/conftest.py
+++ b/src/tribler/core/utilities/db_corruption_handling/tests/conftest.py
@@ -1,0 +1,15 @@
+import pytest
+
+from tribler.core.utilities.db_corruption_handling.sqlite_replacement import connect
+
+
+@pytest.fixture(name='db_filepath')
+def db_filepath_fixture(tmp_path):
+    return tmp_path / 'test.db'
+
+
+@pytest.fixture(name='connection')
+def connection_fixture(db_filepath):
+    connection = connect(str(db_filepath))
+    yield connection
+    connection.close()

--- a/src/tribler/core/utilities/db_corruption_handling/tests/test_base.py
+++ b/src/tribler/core/utilities/db_corruption_handling/tests/test_base.py
@@ -1,0 +1,57 @@
+import sqlite3
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+
+
+from tribler.core.utilities.db_corruption_handling.base import DatabaseIsCorrupted, handle_db_if_corrupted, \
+    handling_malformed_db_error
+
+malformed_error = sqlite3.DatabaseError('database disk image is malformed')
+
+
+def test_handling_malformed_db_error__no_error(db_filepath):
+    # If no error is raised, the database should not be marked as corrupted
+    with handling_malformed_db_error(db_filepath):
+        pass
+
+    assert not Path(str(db_filepath) + '.is_corrupted').exists()
+
+
+def test_handling_malformed_db_error__malformed_error(db_filepath):
+    # Malformed database errors should be handled by marking the database as corrupted
+    with pytest.raises(DatabaseIsCorrupted):
+        with handling_malformed_db_error(db_filepath):
+            raise malformed_error
+
+    assert Path(str(db_filepath) + '.is_corrupted').exists()
+
+
+def test_handling_malformed_db_error__other_error(db_filepath):
+    # Other errors should not be handled like malformed database errors
+    class TestError(Exception):
+        pass
+
+    with pytest.raises(TestError):
+        with handling_malformed_db_error(db_filepath):
+            raise TestError()
+
+    assert not Path(str(db_filepath) + '.is_corrupted').exists()
+
+
+def test_handle_db_if_corrupted__corrupted(db_filepath: Path):
+    # If the corruption marker is found, the corrupted database file is removed
+    marker_path = Path(str(db_filepath) + '.is_corrupted')
+    marker_path.touch()
+
+    handle_db_if_corrupted(db_filepath)
+    assert not db_filepath.exists()
+    assert not marker_path.exists()
+
+
+@patch('tribler.core.utilities.db_corruption_handling.base._handle_corrupted_db')
+def test_handle_db_if_corrupted__not_corrupted(handle_corrupted_db: Mock, db_filepath: Path):
+    # If the corruption marker is not found, the handling of the database is not performed
+    handle_db_if_corrupted(db_filepath)
+    handle_corrupted_db.assert_not_called()

--- a/src/tribler/core/utilities/db_corruption_handling/tests/test_sqlite_replacement.py
+++ b/src/tribler/core/utilities/db_corruption_handling/tests/test_sqlite_replacement.py
@@ -1,0 +1,77 @@
+import sqlite3
+from unittest.mock import Mock, patch
+
+import pytest
+
+from tribler.core.utilities.db_corruption_handling.base import DatabaseIsCorrupted
+from tribler.core.utilities.db_corruption_handling.sqlite_replacement import Blob, Connection, \
+    Cursor, _add_method_wrapper_that_handles_malformed_db_exception, connect
+
+
+# pylint: disable=protected-access
+
+
+malformed_error = sqlite3.DatabaseError('database disk image is malformed')
+
+
+def test_connect(db_filepath):
+    connection = connect(str(db_filepath))
+    assert isinstance(connection, Connection)
+    connection.close()
+
+
+def test_make_method_that_handles_malformed_db_exception(db_filepath):
+    # Tests that the _make_method_that_handles_malformed_db_exception function creates a method that handles
+    # the malformed database exception
+
+    class BaseClass:
+        method1 = Mock(return_value=Mock())
+
+    class TestClass(BaseClass):
+        _db_filepath = db_filepath
+
+    _add_method_wrapper_that_handles_malformed_db_exception(TestClass, 'method1')
+
+    # The method should be successfully wrapped
+    assert TestClass.method1.is_wrapped
+    assert TestClass.method1.__name__ == 'method1'
+
+    test_instance = TestClass()
+    result = test_instance.method1(1, 2, x=3, y=4)
+
+    # *args and **kwargs should be passed to the original method, and the result should be returned
+    BaseClass.method1.assert_called_once_with(1, 2, x=3, y=4)
+    assert result is BaseClass.method1.return_value
+
+    # When the base method raises a malformed database exception, the DatabaseIsCorrupted exception should be raised
+    BaseClass.method1.side_effect = malformed_error
+    with pytest.raises(DatabaseIsCorrupted):
+        test_instance.method1(1, 2, x=3, y=4)
+
+
+def test_connection_cursor(connection):
+    cursor = connection.cursor()
+    assert isinstance(cursor, Cursor)
+
+
+def test_connection_iterdump(connection):
+    with pytest.raises(NotImplementedError):
+        connection.iterdump()
+
+
+@patch('tribler.core.utilities.db_corruption_handling.sqlite_replacement.ConnectionBase.blobopen',
+       Mock(side_effect=malformed_error))
+def test_connection_blobopen__exception(connection):
+    with pytest.raises(DatabaseIsCorrupted):
+        connection.blobopen()
+
+
+@patch('tribler.core.utilities.db_corruption_handling.sqlite_replacement.ConnectionBase.blobopen')
+def test_connection_blobopen__no_exception(blobopen, connection):
+    blobopen.return_value = Mock()
+    result = connection.blobopen()
+
+    blobopen.assert_called_once()
+    assert isinstance(result, Blob)
+    assert result._blob is blobopen.return_value
+    assert result._db_filepath == connection._db_filepath

--- a/src/tribler/core/utilities/exit_codes.py
+++ b/src/tribler/core/utilities/exit_codes.py
@@ -1,0 +1,3 @@
+
+# Valid range for custom errors is 1..127
+EXITCODE_DATABASE_IS_CORRUPTED = 99  # If the Core process finishes with this error, the GUI process restarts it.

--- a/src/tribler/core/utilities/pony_utils.py
+++ b/src/tribler/core/utilities/pony_utils.py
@@ -45,16 +45,14 @@ def table_exists(cursor: sqlite3.Cursor, table_name: str) -> bool:
 
 def get_db_version(db_path, default: int = None) -> int:
     handle_db_if_corrupted(db_path)
-    if not db_path.exists():
-        version = None
-    else:
+    version = None
+
+    if db_path.exists():
         with marking_corrupted_db(db_path):
             with contextlib.closing(sqlite3.connect(db_path)) as connection:
                 with connection:
                     cursor = connection.cursor()
-                    if not table_exists(cursor, 'MiscData'):
-                        version = None
-                    else:
+                    if table_exists(cursor, 'MiscData'):
                         cursor.execute("SELECT value FROM MiscData WHERE name == 'db_version'")
                         row = cursor.fetchone()
                         version = int(row[0]) if row else None

--- a/src/tribler/core/utilities/pony_utils.py
+++ b/src/tribler/core/utilities/pony_utils.py
@@ -408,6 +408,8 @@ class TriblerSQLiteProvider(sqlite.SQLiteProvider):
 
 
 class TriblerPool(SQLitePool):
+    # TriblerSQLiteProvider instantiates this class instead of a standard SQLitePool class. It allows to catch
+    # the "database is malformed" error when new connection is establishing to the database from the ORM
     def _connect(self):
         with marking_corrupted_db(self.filename):
             return super()._connect()

--- a/src/tribler/core/utilities/pony_utils.py
+++ b/src/tribler/core/utilities/pony_utils.py
@@ -372,11 +372,9 @@ class TriblerSQLiteProvider(sqlite.SQLiteProvider):
         Path(marker_filename).touch()
 
     def get_pool(self, is_shared_memory_db, filename, create_db=False, **kwargs):
-        if is_shared_memory_db or filename == ':memory:':
-            pass
-        else:
+        if not (is_shared_memory_db or filename == ':memory:'):
             filename = absolutize_path(filename, frame_depth=cut_traceback_depth+5)  # see the base method for details
-        handle_db_if_corrupted(filename)
+            handle_db_if_corrupted(filename)
         return TriblerPool(is_shared_memory_db, filename, create_db, **kwargs)
 
 

--- a/src/tribler/core/utilities/pony_utils.py
+++ b/src/tribler/core/utilities/pony_utils.py
@@ -269,6 +269,7 @@ class PatchedSQLiteProvider(sqlite.SQLiteProvider):
     _acquire_time: float = 0  # A time when the current provider were able to acquire the database lock
 
     def acquire_lock(self):
+        # Adds tracking of a db_session's lock wait duration and lock acquire count
         t1 = time.time()
         super().acquire_lock()
         info = local.db_session_info
@@ -280,6 +281,7 @@ class PatchedSQLiteProvider(sqlite.SQLiteProvider):
             info.lock_wait_total_duration += lock_wait_duration
 
     def release_lock(self):
+        # Adds tracking of a db_session's total lock hold duration
         super().release_lock()
         info = local.db_session_info
         if info is not None:

--- a/src/tribler/core/utilities/pony_utils.py
+++ b/src/tribler/core/utilities/pony_utils.py
@@ -444,5 +444,10 @@ class TriblerDatabase(Database):
 
         self._bind(TriblerSQLiteProvider, **kwargs)
 
+    def call_on_connect(self, con):
+        if self.provider is not None:
+            with marking_corrupted_db(self.provider.pool.filename):
+                super().call_on_connect(con)
+
 def track_slow_db_sessions():
     TriblerDbSession.track_slow_db_sessions = True

--- a/src/tribler/core/utilities/pony_utils.py
+++ b/src/tribler/core/utilities/pony_utils.py
@@ -261,7 +261,7 @@ class TriblerDbSession(core.DBSessionContextManager):
         return result
 
 
-class PatchedSQLiteProvider(sqlite.SQLiteProvider):
+class TriblerSQLiteProvider(sqlite.SQLiteProvider):
 
     # It is impossible to override the __init__ method without breaking the `SQLiteProvider.get_pool` method's logic.
     # Therefore, we don't initialize a new attribute `_acquire_time` inside a class constructor method.
@@ -305,4 +305,4 @@ class TriblerDatabase(Database):
 def track_slow_db_sessions():
     # The method enables tracking of slow db_sessions
     orm.db_session = orm.core.db_session = db_session
-    sqlite.provider_cls = PatchedSQLiteProvider
+    sqlite.provider_cls = TriblerSQLiteProvider

--- a/src/tribler/core/utilities/pony_utils.py
+++ b/src/tribler/core/utilities/pony_utils.py
@@ -262,12 +262,11 @@ class TriblerDbSession(core.DBSessionContextManager):
 
 
 class PatchedSQLiteProvider(sqlite.SQLiteProvider):
-    _acquire_time: float = 0  # A time when the current provider were able to acquire the database lock
 
-    # It is impossible to override the __init__ method of `SQLiteProvider` without breaking
-    # the `SQLiteProvider.get_pool` method's logic. Therefore, we don't initialize
-    # a new attribute `_acquire_time` inside a class constructor method;
-    # instead, we set its initial value at a class level.
+    # It is impossible to override the __init__ method without breaking the `SQLiteProvider.get_pool` method's logic.
+    # Therefore, we don't initialize a new attribute `_acquire_time` inside a class constructor method.
+    # Instead, we set its initial value at a class level.
+    _acquire_time: float = 0  # A time when the current provider were able to acquire the database lock
 
     def acquire_lock(self):
         t1 = time.time()

--- a/src/tribler/core/utilities/tests/test_pony_utils.py
+++ b/src/tribler/core/utilities/tests/test_pony_utils.py
@@ -135,11 +135,13 @@ def db_path_fixture(tmp_path: Path):
 
 @patch('tribler.core.utilities.pony_utils._handle_corrupted_db')
 def test_handle_db_if_corrupted__not_corrupted(handle_corrupted_db: Mock, db_path: Path):
+    # If the corruption marker is not found, the handling of the database is not performed
     handle_db_if_corrupted(db_path)
     handle_corrupted_db.assert_not_called()
 
 
 def test_handle_db_if_corrupted__corrupted(db_path: Path):
+    # If the corruption marker is found, the corrupted database file is removed
     marker_path = Path(str(db_path) + '.is_corrupted')
     marker_path.touch()
 
@@ -149,6 +151,7 @@ def test_handle_db_if_corrupted__corrupted(db_path: Path):
 
 
 def test_marking_corrupted_db__not_malformed(db_path: Path):
+    # When the context manger encounters an exception not related to database corruption, it does nothing
     with pytest.raises(ZeroDivisionError):
         with marking_corrupted_db(db_path):
             raise ZeroDivisionError()
@@ -157,6 +160,7 @@ def test_marking_corrupted_db__not_malformed(db_path: Path):
 
 
 def test_marking_corrupted_db__malformed(db_path: Path):
+    # When the context manger encounters an exception not related to database corruption, it adds a corruption marker
     with pytest.raises(DatabaseIsCorrupted):
         with marking_corrupted_db(db_path):
             raise sqlite3.DatabaseError('database disk image is malformed')
@@ -165,6 +169,7 @@ def test_marking_corrupted_db__malformed(db_path: Path):
 
 
 def test_get_db_version__db_does_not_exist(tmp_path: Path):
+    # When the database does not exist, the call to get_db_version generates RuntimeError
     db_path = tmp_path / 'doesnotexist.db'
 
     with pytest.raises(RuntimeError, match='^The version value is not found in database .*doesnotexist.db$'):
@@ -172,6 +177,7 @@ def test_get_db_version__db_does_not_exist(tmp_path: Path):
 
 
 def test_get_db_version__db_does_not_exist_default_version(tmp_path: Path):
+    # When the database does not exist, and the default is specified, get_db_version returns the default value
     db_path = tmp_path / 'doesnotexist.db'
 
     default_version = 123
@@ -180,17 +186,21 @@ def test_get_db_version__db_does_not_exist_default_version(tmp_path: Path):
 
 
 def test_get_db_version__version_table_does_not_exist(db_path: Path):
+    # When the version table does not exist, the call to get_db_version generates RuntimeError
     with pytest.raises(RuntimeError, match='^The version value is not found in database .*test.db$'):
         get_db_version(db_path)
 
 
 def test_get_db_version__version_table_does_not_exist_default_version(db_path: Path):
+    # When the version table does not exist, and the default is specified, get_db_version returns the default value
     default_version = 123
     version = get_db_version(db_path, default=default_version)
     assert version == default_version
 
 
 def test_get_db_version(db_path: Path):
+    # Tests that if the database schema version is specified in the database, the default value is completely ignored.
+
     with sqlite3.connect(db_path) as connection:
         connection.execute('create table MiscData(name text primary key, value text)')
         connection.execute("insert into MiscData(name, value) values('db_version', '100')")
@@ -206,6 +216,9 @@ def test_get_db_version(db_path: Path):
 
 
 def test_get_db_version__corrupted_db(tmp_path: Path):
+    # Tests that if the database file is marked as corrupted, then the version from the db is ignored,
+    # and default version is used after the database file is re-created.
+
     db_path = tmp_path / 'test.db'
 
     connection = sqlite3.connect(db_path)
@@ -227,6 +240,10 @@ def test_get_db_version__corrupted_db(tmp_path: Path):
 
 
 def test_mark_db_as_corrupted_file_does_not_exist(tmp_path: Path):
+    # The database file apparently was corrupted, and `_mark_db_as_corrupted(db_path)` is called to mark it as such.
+    # But the function was not able to find the database file at the specified path. In this unnormal situation,
+    # it raises an exception.
+
     db_path = tmp_path / 'doesnotexist.db'
     with pytest.raises(RuntimeError, match='^Corrupted database file not found: .*doesnotexist.db$'):
         _mark_db_as_corrupted(db_path)

--- a/src/tribler/core/utilities/tests/test_pony_utils.py
+++ b/src/tribler/core/utilities/tests/test_pony_utils.py
@@ -43,7 +43,7 @@ def test_merge_stats():
 def test_patched_db_session(tmp_path):
     # The test is added for better coverage of TriblerDbSession methods
 
-    with patch('pony.orm.dbproviders.sqlite.provider_cls', pony_utils.PatchedSQLiteProvider):
+    with patch('pony.orm.dbproviders.sqlite.provider_cls', pony_utils.TriblerSQLiteProvider):
         db = pony_utils.TriblerDatabase()
         db.bind('sqlite', str(tmp_path / 'db.sqlite'), create_db=True)
 
@@ -81,7 +81,7 @@ def test_patched_db_session_default_duration_threshold(tmp_path):
     # The test checks that db_session uses the current dynamic value of SLOW_DB_SESSION_DURATION_THRESHOLD
     # if no duration_threshold was explicitly specified for db_session
 
-    with patch('pony.orm.dbproviders.sqlite.provider_cls', pony_utils.PatchedSQLiteProvider):
+    with patch('pony.orm.dbproviders.sqlite.provider_cls', pony_utils.TriblerSQLiteProvider):
         db = pony_utils.TriblerDatabase()
         db.bind('sqlite', str(tmp_path / 'db.sqlite'), create_db=True)
 

--- a/src/tribler/gui/core_manager.py
+++ b/src/tribler/gui/core_manager.py
@@ -12,10 +12,10 @@ from typing import Optional
 from PyQt5.QtCore import QObject, QProcess, QProcessEnvironment, QTimer
 from PyQt5.QtNetwork import QNetworkRequest
 
+from tribler.core.utilities.exit_codes import EXITCODE_DATABASE_IS_CORRUPTED
 from tribler.core.utilities.process_manager import ProcessManager
 from tribler.gui import gui_sentry_reporter
 from tribler.gui.app_manager import AppManager
-from tribler.gui.defs import EXITCODE_DATABASE_IS_CORRUPTED
 from tribler.gui.event_request_manager import EventRequestManager
 from tribler.gui.exceptions import CoreConnectTimeoutError, CoreCrashedError
 from tribler.gui.network.request_manager import SHUTDOWN_ENDPOINT, request_manager

--- a/src/tribler/gui/core_manager.py
+++ b/src/tribler/gui/core_manager.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import os
 import re
@@ -13,10 +15,11 @@ from PyQt5.QtNetwork import QNetworkRequest
 from tribler.core.utilities.process_manager import ProcessManager
 from tribler.gui import gui_sentry_reporter
 from tribler.gui.app_manager import AppManager
+from tribler.gui.defs import EXITCODE_DATABASE_IS_CORRUPTED
 from tribler.gui.event_request_manager import EventRequestManager
 from tribler.gui.exceptions import CoreConnectTimeoutError, CoreCrashedError
 from tribler.gui.network.request_manager import SHUTDOWN_ENDPOINT, request_manager
-from tribler.gui.utilities import connect
+from tribler.gui.utilities import connect, show_message_corrupted_database_was_fixed
 
 API_PORT_CHECK_INTERVAL = 100  # 0.1 seconds between attempts to retrieve Core API port
 API_PORT_CHECK_TIMEOUT = 120  # Stop trying to determine API port after this number of seconds
@@ -288,6 +291,14 @@ class CoreManager(QObject):
     def on_core_finished(self, exit_code, exit_status):
         self._logger.info("Core process finished")
         self.core_running = False
+        self.core_connected = False
+        if exit_code == EXITCODE_DATABASE_IS_CORRUPTED:
+            self._logger.error(f"Core process crashed with code {exit_code}: the database is corrupted. "
+                               "Restarting Core...")
+            self.start_tribler_core()
+            show_message_corrupted_database_was_fixed()
+            return
+
         self.core_finished = True
         if self.shutting_down:
             if self.should_quit_app_on_core_finished:

--- a/src/tribler/gui/defs.py
+++ b/src/tribler/gui/defs.py
@@ -216,5 +216,3 @@ NO_DISK_SPACE_ERROR_MESSAGE = "Not enough storage space available. \n" \
                               "Please free up the required space and re-run Tribler. "
 
 CORRUPTED_DB_WAS_FIXED_MESSAGE = "The corrupted database file was fixed"
-
-EXITCODE_DATABASE_IS_CORRUPTED = 99  # Valid range for custom errors is 1..127

--- a/src/tribler/gui/defs.py
+++ b/src/tribler/gui/defs.py
@@ -210,6 +210,11 @@ TAG_HORIZONTAL_MARGIN = 6
 
 
 UPGRADE_CANCELLED_ERROR_TITLE = "Tribler Upgrade cancelled"
+
 NO_DISK_SPACE_ERROR_MESSAGE = "Not enough storage space available. \n" \
                               "Tribler requires at least %s space to continue. \n\n" \
                               "Please free up the required space and re-run Tribler. "
+
+DATABASE_IS_CORRUPTED_ERROR_MESSAGE = "The database file of the previous version found to be corrupted: \n\n" \
+                                      "%s\n\n" \
+                                      "Press OK to re-create the database file"

--- a/src/tribler/gui/defs.py
+++ b/src/tribler/gui/defs.py
@@ -218,3 +218,5 @@ NO_DISK_SPACE_ERROR_MESSAGE = "Not enough storage space available. \n" \
 CORRUPTED_DB_WAS_FIXED_MESSAGE = "The corrupted database file was fixed"
 
 RESTART_TO_FIX_CORRUPTED_DB_MESSAGE = "Please start Tribler again to fix the corrupted database file"
+
+EXITCODE_DATABASE_IS_CORRUPTED = 99  # Valid range for custom errors is 1..127

--- a/src/tribler/gui/defs.py
+++ b/src/tribler/gui/defs.py
@@ -215,6 +215,6 @@ NO_DISK_SPACE_ERROR_MESSAGE = "Not enough storage space available. \n" \
                               "Tribler requires at least %s space to continue. \n\n" \
                               "Please free up the required space and re-run Tribler. "
 
-DATABASE_IS_CORRUPTED_ERROR_MESSAGE = "The database file of the previous version found to be corrupted: \n\n" \
-                                      "%s\n\n" \
-                                      "Press OK to re-create the database file"
+CORRUPTED_DB_WAS_FIXED_MESSAGE = "The corrupted database file was fixed"
+
+RESTART_TO_FIX_CORRUPTED_DB_MESSAGE = "Please start Tribler again to fix the corrupted database file"

--- a/src/tribler/gui/defs.py
+++ b/src/tribler/gui/defs.py
@@ -217,6 +217,4 @@ NO_DISK_SPACE_ERROR_MESSAGE = "Not enough storage space available. \n" \
 
 CORRUPTED_DB_WAS_FIXED_MESSAGE = "The corrupted database file was fixed"
 
-RESTART_TO_FIX_CORRUPTED_DB_MESSAGE = "Please start Tribler again to fix the corrupted database file"
-
 EXITCODE_DATABASE_IS_CORRUPTED = 99  # Valid range for custom errors is 1..127

--- a/src/tribler/gui/error_handler.py
+++ b/src/tribler/gui/error_handler.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import traceback
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from tribler.core.components.reporter.reported_error import ReportedError
@@ -98,6 +99,14 @@ class ErrorHandler:
 
         error_text = f'{reported_error.text}\n{reported_error.long_text}'
         self._logger.error(error_text)
+
+        if reported_error.type == 'DatabaseIsCorrupted':
+            db_file_path = Path(reported_error.text)
+            if not db_file_path.exists():
+                db_file_path = ''
+            self.tribler_window.show_database_is_corrupted_dialog(db_file_path)
+            self._stop_tribler(error_text)
+            return
 
         if reported_error.should_stop:
             self._stop_tribler(error_text)

--- a/src/tribler/gui/error_handler.py
+++ b/src/tribler/gui/error_handler.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 import traceback
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 from tribler.core.components.reporter.reported_error import ReportedError

--- a/src/tribler/gui/error_handler.py
+++ b/src/tribler/gui/error_handler.py
@@ -100,14 +100,6 @@ class ErrorHandler:
         error_text = f'{reported_error.text}\n{reported_error.long_text}'
         self._logger.error(error_text)
 
-        if reported_error.type == 'DatabaseIsCorrupted':
-            db_file_path = Path(reported_error.text)
-            if not db_file_path.exists():
-                db_file_path = ''
-            self.tribler_window.show_database_is_corrupted_dialog(db_file_path)
-            self._stop_tribler(error_text)
-            return
-
         if reported_error.should_stop:
             self._stop_tribler(error_text)
 

--- a/src/tribler/gui/event_request_manager.py
+++ b/src/tribler/gui/event_request_manager.py
@@ -130,11 +130,10 @@ class EventRequestManager(QNetworkAccessManager):
             return
 
         if self.receiving_data:
-            # We are performing reconnect on the initial connection error only.
-            # In the future, if we consider it useful, we can immediately call here
-            # `self.reconnect(reschedule_on_err=False)`
-            # and raise an exception if it fails to reconnect
-            raise CoreConnectionError('The connection to the Tribler Core was lost')
+            # Most probably Core is crashed. If CoreManager decides to restart the core,
+            # it will also call event_manager.connect_to_core()
+            self._logger.error('The connection to the Tribler Core was lost')
+            return
 
         should_retry = reschedule_on_err and time.time() < self.start_time + CORE_CONNECTION_TIMEOUT
         error_name = self.network_errors.get(error, error)

--- a/src/tribler/gui/tribler_window.py
+++ b/src/tribler/gui/tribler_window.py
@@ -75,7 +75,7 @@ from tribler.gui.defs import (
     PAGE_SETTINGS,
     PAGE_TRUST,
     PAGE_TRUST_GRAPH_PAGE,
-    RESTART_TO_FIX_CORRUPTED_DB_MESSAGE, SHUTDOWN_WAITING_PERIOD,
+    SHUTDOWN_WAITING_PERIOD,
 )
 from tribler.gui.dialogs.addtopersonalchanneldialog import AddToChannelDialog
 from tribler.gui.dialogs.confirmationdialog import ConfirmationDialog
@@ -1259,15 +1259,3 @@ class TriblerWindow(QMainWindow):
         self.pending_uri_requests.append(uri)
         if self.ui_started and not self.start_download_dialog_active:
             self.process_uri_request()
-
-    def show_database_is_corrupted_dialog(self, db_file_path: Path):
-        message = tr(RESTART_TO_FIX_CORRUPTED_DB_MESSAGE)
-        formatted_message = f'{message}:<br/><br/>{db_file_path}'
-
-        self.dialog = ConfirmationDialog(
-            self,
-            tr("Database corruption detected"),
-            formatted_message,
-            [(tr("OK"), BUTTON_TYPE_CONFIRM)],
-        )
-        self.dialog.show()

--- a/src/tribler/gui/tribler_window.py
+++ b/src/tribler/gui/tribler_window.py
@@ -545,7 +545,6 @@ class TriblerWindow(QMainWindow):
     def on_core_connected(self, version):
         if self.core_connected:
             self._logger.warning("Received duplicate Tribler Core connected event")
-            return
 
         self._logger.info("Core connected")
         self.core_connected = True
@@ -559,6 +558,10 @@ class TriblerWindow(QMainWindow):
         self.start_ui()
 
     def start_ui(self):
+        if self.ui_started:
+            self._logger.info("UI already started")
+            return
+
         self.top_menu_button.setHidden(False)
         self.left_menu.setHidden(False)
         # self.token_balance_widget.setHidden(False)  # restore it after the token balance calculation is fixed

--- a/src/tribler/gui/tribler_window.py
+++ b/src/tribler/gui/tribler_window.py
@@ -75,7 +75,7 @@ from tribler.gui.defs import (
     PAGE_SETTINGS,
     PAGE_TRUST,
     PAGE_TRUST_GRAPH_PAGE,
-    SHUTDOWN_WAITING_PERIOD,
+    RESTART_TO_FIX_CORRUPTED_DB_MESSAGE, SHUTDOWN_WAITING_PERIOD,
 )
 from tribler.gui.dialogs.addtopersonalchanneldialog import AddToChannelDialog
 from tribler.gui.dialogs.confirmationdialog import ConfirmationDialog
@@ -1261,12 +1261,13 @@ class TriblerWindow(QMainWindow):
             self.process_uri_request()
 
     def show_database_is_corrupted_dialog(self, db_file_path: Path):
+        message = tr(RESTART_TO_FIX_CORRUPTED_DB_MESSAGE)
+        formatted_message = f'{message}:<br/><br/>{db_file_path}'
+
         self.dialog = ConfirmationDialog(
             self,
-            tr("Database is corrupted: restart needed"),
-            tr("The database file found to be corrupted") + ":<br/>"
-            + f"<b>{db_file_path}</b><br/><br/>"
-            + tr("Press OK to re-create the database file"),
+            tr("Database corruption detected"),
+            formatted_message,
             [(tr("OK"), BUTTON_TYPE_CONFIRM)],
         )
         self.dialog.show()

--- a/src/tribler/gui/tribler_window.py
+++ b/src/tribler/gui/tribler_window.py
@@ -1259,3 +1259,14 @@ class TriblerWindow(QMainWindow):
         self.pending_uri_requests.append(uri)
         if self.ui_started and not self.start_download_dialog_active:
             self.process_uri_request()
+
+    def show_database_is_corrupted_dialog(self, db_file_path: Path):
+        self.dialog = ConfirmationDialog(
+            self,
+            tr("Database is corrupted: restart needed"),
+            tr("The database file found to be corrupted") + ":<br/>"
+            + f"<b>{db_file_path}</b><br/><br/>"
+            + tr("Press OK to re-create the database file"),
+            [(tr("OK"), BUTTON_TYPE_CONFIRM)],
+        )
+        self.dialog.show()

--- a/src/tribler/gui/upgrade_manager.py
+++ b/src/tribler/gui/upgrade_manager.py
@@ -16,7 +16,7 @@ from tribler.gui.defs import BUTTON_TYPE_NORMAL, CORRUPTED_DB_WAS_FIXED_MESSAGE,
     UPGRADE_CANCELLED_ERROR_TITLE
 from tribler.gui.dialogs.confirmationdialog import ConfirmationDialog
 from tribler.gui.exceptions import UpgradeError
-from tribler.gui.utilities import connect, format_size, tr
+from tribler.gui.utilities import connect, format_size, show_message_corrupted_database_was_fixed, tr
 
 if TYPE_CHECKING:
     from tribler.gui.tribler_window import TriblerWindow
@@ -251,16 +251,10 @@ class UpgradeManager(QObject):
         if exc is None:
             self.upgrader_finished.emit()
         elif isinstance(exc, DatabaseIsCorrupted):
-            self.show_db_corruption_fixed_message(exc)
             self.upgrader_finished.emit()
+            show_message_corrupted_database_was_fixed(db_path=str(exc))
         else:
             raise UpgradeError(f'{exc.__class__.__name__}: {exc}') from exc
-
-    def show_db_corruption_fixed_message(self, exc):
-        msg = self._format_database_corruption_fixed_message(exc)
-        message_box = QMessageBox(icon=QMessageBox.Critical, text=msg)
-        message_box.setWindowTitle(tr("Database corruption fixed"))
-        message_box.exec()
 
     @staticmethod
     def _format_database_corruption_fixed_message(exc: DatabaseIsCorrupted) -> str:

--- a/src/tribler/gui/upgrade_manager.py
+++ b/src/tribler/gui/upgrade_manager.py
@@ -12,7 +12,7 @@ from tribler.core.config.tribler_config import TriblerConfig
 from tribler.core.upgrade.upgrade import TriblerUpgrader
 from tribler.core.upgrade.version_manager import TriblerVersion, VersionHistory, NoDiskSpaceAvailableError
 from tribler.core.utilities.pony_utils import DatabaseIsCorrupted
-from tribler.gui.defs import BUTTON_TYPE_NORMAL, DATABASE_IS_CORRUPTED_ERROR_MESSAGE, NO_DISK_SPACE_ERROR_MESSAGE, \
+from tribler.gui.defs import BUTTON_TYPE_NORMAL, CORRUPTED_DB_WAS_FIXED_MESSAGE, NO_DISK_SPACE_ERROR_MESSAGE, \
     UPGRADE_CANCELLED_ERROR_TITLE
 from tribler.gui.dialogs.confirmationdialog import ConfirmationDialog
 from tribler.gui.exceptions import UpgradeError
@@ -264,7 +264,8 @@ class UpgradeManager(QObject):
 
     @staticmethod
     def _format_database_corruption_fixed_message(exc: DatabaseIsCorrupted) -> str:
-        formatted_error = tr(DATABASE_IS_CORRUPTED_ERROR_MESSAGE) % str(exc)
+        message = tr(CORRUPTED_DB_WAS_FIXED_MESSAGE)
+        formatted_error = f'{message}:\n\n{exc}'
         return formatted_error
 
     def on_worker_cancelled(self, reason: str):

--- a/src/tribler/gui/upgrade_manager.py
+++ b/src/tribler/gui/upgrade_manager.py
@@ -11,7 +11,7 @@ from tribler.core.components.key.key_component import KeyComponent
 from tribler.core.config.tribler_config import TriblerConfig
 from tribler.core.upgrade.upgrade import TriblerUpgrader
 from tribler.core.upgrade.version_manager import TriblerVersion, VersionHistory, NoDiskSpaceAvailableError
-from tribler.core.utilities.pony_utils import DatabaseIsCorrupted
+from tribler.core.utilities.db_corruption_handling.base import DatabaseIsCorrupted
 from tribler.gui.defs import BUTTON_TYPE_NORMAL, CORRUPTED_DB_WAS_FIXED_MESSAGE, NO_DISK_SPACE_ERROR_MESSAGE, \
     UPGRADE_CANCELLED_ERROR_TITLE
 from tribler.gui.dialogs.confirmationdialog import ConfirmationDialog

--- a/src/tribler/gui/utilities.py
+++ b/src/tribler/gui/utilities.py
@@ -9,7 +9,7 @@ import traceback
 import types
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Callable, Dict, List
+from typing import Callable, Dict, List, Optional
 from urllib.parse import quote_plus
 from uuid import uuid4
 
@@ -27,7 +27,7 @@ from PyQt5.QtWidgets import QApplication, QMessageBox
 
 import tribler.gui
 from tribler.core.components.knowledge.db.knowledge_db import ResourceType
-from tribler.gui.defs import HEALTH_DEAD, HEALTH_GOOD, HEALTH_MOOT, HEALTH_UNCHECKED
+from tribler.gui.defs import CORRUPTED_DB_WAS_FIXED_MESSAGE, HEALTH_DEAD, HEALTH_GOOD, HEALTH_MOOT, HEALTH_UNCHECKED
 
 # fmt: off
 
@@ -519,6 +519,16 @@ def show_message_box(text: str = '', title: str = 'Error', icon: QMessageBox.Ico
     message_box.setWindowTitle(title)
     message_box.setText(text)
     message_box.exec_()
+
+
+def show_message_corrupted_database_was_fixed(db_path: Optional[str] = None):
+    text = tr(CORRUPTED_DB_WAS_FIXED_MESSAGE)
+    if db_path:
+        text = f'{text}:\n\n{db_path}'
+
+    message_box = QMessageBox(icon=QMessageBox.Critical, text=text)
+    message_box.setWindowTitle(tr("Database corruption detected"))
+    message_box.exec()
 
 
 def make_network_errors_dict() -> Dict[int, str]:


### PR DESCRIPTION
Fixes #7623, #7037, #5252, and #1993 (the latter is the pre-ORM version of the same problem)

This PR adds handling to the error "DatabaseError: database disk image is malformed". The error is handled in all databases that Tribler has: "metadata.db", "knowledge.db", "bandwidth.db", and "tags.db" (if it presents during the migration). The database "processes.sqlite" is already handled separately.

The main goal of the PR is to restore normal Tribler functionality by deleting the corrupted database file and allowing Tribler to create a new, fresh database file. Instead of deleting the file, we can rename it as an alternative way to handle the issue. Still, I'm not sure it is worth it, as it will take some valuable disk space, and not many users will try to restore information from the corrupted database file. It is possible to extract *some* data from the corrupted file, but I doubt it is worth it for us to provide such recovery tools.

What the PR does:
1. It adds tracking of the corresponding error to most places where the error can arise
2. In case of an error, the file "<db_filename>.is_corrupted" is created near the corresponding database file.
3. The notification message box about the database corruption fixing is displayed to the user.
4. The Tribler Core is automatically restarting under the hood, so the user does not need to restart Tibler.

