### PR TITLE
Remove pytest-rerunfailures and its dependents

### DIFF
--- a/.github/workflows/!PR.yml
+++ b/.github/workflows/!PR.yml
@@ -85,7 +85,6 @@ jobs:
     if: ${{ needs.changes.outputs.src == 'true' }}
     uses: ./.github/workflows/coverage.yml
     secrets:
-      PYTEST_SENTRY_DSN: ${{secrets.PYTEST_SENTRY_DSN}}
       CODACY_PROJECT_TOKEN: ${{secrets.CODACY_PROJECT_TOKEN}}
     with:
       python-version: ${{needs.env.outputs.python-version}}
@@ -95,8 +94,6 @@ jobs:
     needs: [ changes, gatekeeper, env ]
     if: ${{ needs.changes.outputs.src == 'true' }}
     uses: ./.github/workflows/guitest.yml
-    secrets:
-      PYTEST_SENTRY_DSN: ${{secrets.PYTEST_SENTRY_DSN}}
     with:
       python-version: ${{needs.env.outputs.python-version}}
       matrix: '{"os": ["windows-latest"]}'
@@ -117,8 +114,6 @@ jobs:
     needs: [ changes, gatekeeper, env ]
     if: ${{needs.changes.outputs.src == 'true' && !github.event.pull_request.draft}}
     uses: ./.github/workflows/pytest.yml
-    secrets:
-      PYTEST_SENTRY_DSN: ${{secrets.PYTEST_SENTRY_DSN}}
     with:
       python-version: ${{needs.env.outputs.python-version}}
       matrix: '{"os": ["windows-latest", "macos-latest"]}'
@@ -128,8 +123,6 @@ jobs:
     needs: [ changes, gatekeeper, env ]
     if: ${{needs.changes.outputs.src == 'true' && !github.event.pull_request.draft}}
     uses: ./.github/workflows/guitest.yml
-    secrets:
-      PYTEST_SENTRY_DSN: ${{secrets.PYTEST_SENTRY_DSN}}
     with:
       python-version: ${{needs.env.outputs.python-version}}
       matrix: '{"os": ["ubuntu-latest", "macos-latest"]}'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,8 +16,6 @@ on:
     secrets:
       CODACY_PROJECT_TOKEN:
         required: false
-      PYTEST_SENTRY_DSN:
-        required: false
 
 permissions:
   contents: read
@@ -26,9 +24,6 @@ jobs:
   generate_and_upload:
     name: generate and upload
     runs-on: ubuntu-latest
-
-    env:
-      PYTEST_SENTRY_DSN: ${{secrets.PYTEST_SENTRY_DSN}}
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/guitest.yml
+++ b/.github/workflows/guitest.yml
@@ -18,10 +18,6 @@ on:
         type: string
         required: false
 
-    secrets:
-      PYTEST_SENTRY_DSN:
-        required: false
-
 permissions:
   contents: read
 
@@ -35,9 +31,6 @@ jobs:
     defaults:
       run:
         shell: bash
-
-    env:
-      PYTEST_SENTRY_DSN: ${{secrets.PYTEST_SENTRY_DSN}}
 
     timeout-minutes: 10
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -18,10 +18,6 @@ on:
         type: string
         required: false
 
-    secrets:
-      PYTEST_SENTRY_DSN:
-        required: false
-
 permissions:
   contents: read
 
@@ -35,9 +31,6 @@ jobs:
     defaults:
       run:
         shell: bash
-
-    env:
-      PYTEST_SENTRY_DSN: ${{secrets.PYTEST_SENTRY_DSN}}
 
     timeout-minutes: 10
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,9 +5,6 @@ pytest-aiohttp==1.0.4
 pytest-asyncio==0.21.1
 pytest-randomly==3.13.0
 pytest-timeout==2.1.0
-pytest-rerunfailures==12.0
-pytest-sentry==0.1.16
-
 
 coverage==7.2.7
 looptime==0.2 ; sys_platform != 'win32'


### PR DESCRIPTION
This PR is the follow up for https://github.com/Tribler/tribler/pull/7582 which does not include the clean up the depdencies.

The dependencies are:
1. Removing the package from requirements
2. Removing the dependent package. In this case, `pytest-sentry` depends on it. This further implies removing `PYTEST_SENTRY_DSN` environment variable and secret used GitHub workflows.