### PR TITLE
Fix the detection of running processes by including process UID to the check

### DIFF
--- a/src/run_tribler_headless.py
+++ b/src/run_tribler_headless.py
@@ -81,6 +81,7 @@ class TriblerService:
         current_process = TriblerProcess.current_process(ProcessKind.Core)
         self.process_manager = ProcessManager(root_state_dir, current_process)
         set_global_process_manager(self.process_manager)
+        current_process.start_updating_thread()
 
         if not self.process_manager.current_process.become_primary():
             msg = 'Another Core process is already running'

--- a/src/tribler/core/components/gui_process_watcher/gui_process_watcher.py
+++ b/src/tribler/core/components/gui_process_watcher/gui_process_watcher.py
@@ -5,6 +5,7 @@ from typing import Callable, Optional
 import psutil
 from ipv8.taskmanager import TaskManager
 
+GUI_UID_ENV_KEY = 'TRIBLER_GUI_UID'
 GUI_PID_ENV_KEY = 'TRIBLER_GUI_PID'
 CHECK_INTERVAL = 10
 
@@ -50,6 +51,16 @@ class GuiProcessWatcher(TaskManager):
                 return int(pid)
             except ValueError:
                 logger.warning(f'Cannot parse {GUI_PID_ENV_KEY} environment variable: {pid}')
+        return None
+
+    @staticmethod
+    def get_gui_uid() -> Optional[int]:
+        uid = os.environ.get(GUI_UID_ENV_KEY, None)
+        if uid:
+            try:
+                return int(uid)
+            except ValueError:
+                logger.warning(f'Cannot parse {GUI_UID_ENV_KEY} environment variable: {uid}')
         return None
 
     @classmethod

--- a/src/tribler/core/components/gui_process_watcher/tests/test_gui_process_watcher.py
+++ b/src/tribler/core/components/gui_process_watcher/tests/test_gui_process_watcher.py
@@ -4,7 +4,8 @@ from unittest.mock import Mock, patch
 import psutil
 import pytest
 
-from tribler.core.components.gui_process_watcher.gui_process_watcher import GUI_PID_ENV_KEY, GuiProcessNotRunning, \
+from tribler.core.components.gui_process_watcher.gui_process_watcher import GUI_PID_ENV_KEY, GUI_UID_ENV_KEY, \
+    GuiProcessNotRunning, \
     GuiProcessWatcher
 
 
@@ -31,6 +32,19 @@ def test_get_gui_pid(caplog):
 
     with patch.dict(os.environ, {GUI_PID_ENV_KEY: '123'}):
         assert GuiProcessWatcher.get_gui_pid() == 123
+
+
+def test_get_gui_uid(caplog):
+    with patch.dict(os.environ, {GUI_UID_ENV_KEY: ''}):
+        assert GuiProcessWatcher.get_gui_pid() is None
+
+    with patch.dict(os.environ, {GUI_UID_ENV_KEY: 'abc'}):
+        caplog.clear()
+        assert GuiProcessWatcher.get_gui_uid() is None
+        assert caplog.records[-1].message == 'Cannot parse TRIBLER_GUI_UID environment variable: abc'
+
+    with patch.dict(os.environ, {GUI_UID_ENV_KEY: '123'}):
+        assert GuiProcessWatcher.get_gui_uid() == 123
 
 
 def test_get_gui_process():

--- a/src/tribler/core/start_core.py
+++ b/src/tribler/core/start_core.py
@@ -186,8 +186,9 @@ def run_tribler_core_session(api_port: Optional[int], api_key: str,
 def run_core(api_port: Optional[int], api_key: Optional[str], root_state_dir, parsed_args):
     logger.info(f"Running Core in {'gui_test_mode' if parsed_args.gui_test_mode else 'normal mode'}")
 
+    gui_uid = GuiProcessWatcher.get_gui_uid()
     gui_pid = GuiProcessWatcher.get_gui_pid()
-    current_process = TriblerProcess.current_process(ProcessKind.Core, creator_pid=gui_pid)
+    current_process = TriblerProcess.current_process(kind=ProcessKind.Core, creator_uid=gui_uid, creator_pid=gui_pid)
     process_manager = ProcessManager(root_state_dir, current_process)
     set_global_process_manager(process_manager)
     current_process_is_primary = process_manager.current_process.become_primary()
@@ -199,6 +200,7 @@ def run_core(api_port: Optional[int], api_key: Optional[str], root_state_dir, pa
         logger.warning(msg)
         process_manager.sys_exit(1, msg)
 
+    current_process.start_updating_thread()
     version_history = VersionHistory(root_state_dir)
     state_dir = version_history.code_version.directory
     exit_code = run_tribler_core_session(api_port, api_key, state_dir, gui_test_mode=parsed_args.gui_test_mode)

--- a/src/tribler/core/utilities/process_manager/sql_scripts.py
+++ b/src/tribler/core/utilities/process_manager/sql_scripts.py
@@ -2,15 +2,18 @@ CREATE_TABLES = """
     CREATE TABLE IF NOT EXISTS processes (
         rowid INTEGER PRIMARY KEY AUTOINCREMENT,
         row_version INTEGER NOT NULL DEFAULT 0, -- incremented every time the row is updated
-        pid INTEGER NOT NULL, -- process ID
-        kind TEXT NOT NULL, -- process type, 'core' or 'gui'
-        "primary" INT NOT NULL, -- 1 means the process is considered to be the "main" process of the specified kind
-        canceled INT NOT NULL, -- 1 means that another process is already working as primary, so this process is stopped 
-        app_version TEXT NOT NULL, -- the Tribler version
-        started_at INT NOT NULL, -- unix timestamp of the time when the process was started
+        uid INTEGER NOT NULL, -- process UID, an unique 32-bit randomly-generated id value (a GUID is overkill here)
+        pid INTEGER NOT NULL, -- process ID. It is not guaranteed for running processes to have an unique PID
+        creator_uid INT, -- for a Core process this is the UID of the corresponding GUI process 
         creator_pid INT,  -- for a Core process this is the pid of the corresponding GUI process
+        kind TEXT NOT NULL, -- process type, 'core' or 'gui'
+        is_primary INT NOT NULL, -- 1 means the process is considered to be the "main" process of the specified kind
+        app_version TEXT NOT NULL, -- the Tribler version
         api_port INT,  -- Core API port, for GUI process this is a suggested port that Core can use
-        finished_at INT,  -- unix timestamp of the time when the process was finished
+        started_at INT NOT NULL, -- unix timestamp of the time when the process was started
+        last_alive_at INT NOT NULL, -- unix timestamp of the last time the process updated its row in the database
+        is_finished INT,  -- 1 means the process was finished
+        is_canceled INT NOT NULL, -- 1 means this process is stopped because another running process is primary 
         exit_code INT, -- for completed process this is the exit code, 0 means successful run without termination
         error_msg TEXT -- a description of an exception that possibly led to the process termination
     )
@@ -18,14 +21,14 @@ CREATE_TABLES = """
 
 DELETE_OLD_RECORDS = """
     DELETE FROM processes -- delete all non-primary records that are older than 30 days or not in the 100 last records
-    WHERE "primary" = 0  -- never delete current primary processes
+    WHERE is_primary = 0  -- never delete current primary processes
       AND (
-        finished_at < strftime('%s') - (60 * 60 * 24) * 30 -- delete record if a process finished more than 30 days ago
+        last_alive_at < strftime('%s') - (60 * 60 * 24) * 30 -- delete processes that were alive more than 30 days ago
         OR rowid NOT IN ( 
             SELECT rowid FROM processes ORDER BY rowid DESC LIMIT 100 -- only keep last 100 processes  
         )
     )
 """
 
-SELECT_COLUMNS = 'rowid, row_version, pid, kind, "primary", canceled, app_version, ' \
-                 'started_at, creator_pid, api_port, finished_at, exit_code, error_msg'
+SELECT_COLUMNS = 'rowid, row_version, uid, pid, creator_uid, creator_pid, kind, is_primary, ' \
+                 'app_version, api_port, started_at, last_alive_at, is_finished, is_canceled, exit_code, error_msg'

--- a/src/tribler/core/utilities/process_manager/tests/conftest.py
+++ b/src/tribler/core/utilities/process_manager/tests/conftest.py
@@ -8,7 +8,7 @@ from tribler.core.utilities.process_manager import ProcessKind, ProcessManager, 
 @pytest.fixture(name='process_manager')
 def process_manager_fixture(tmp_path: Path) -> ProcessManager:
     # Creates a process manager with a new database and adds a primary current process to it
-    current_process = TriblerProcess.current_process(ProcessKind.Core)
+    current_process = TriblerProcess.current_process(kind=ProcessKind.Core)
     process_manager = ProcessManager(tmp_path, current_process)
     current_process.become_primary()
     return process_manager

--- a/src/tribler/core/utilities/process_manager/updating_thread.py
+++ b/src/tribler/core/utilities/process_manager/updating_thread.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import threading
+import time
+import typing
+
+if typing.TYPE_CHECKING:
+    from tribler.core.utilities.process_manager import TriblerProcess
+
+
+WAIT_TIMEOUT = 1.0  # Each running primary Tribler process (GUI & Core) updates its last alive time one time per second
+
+
+class UpdatingThread(threading.Thread):
+    def __init__(self, *args, process: TriblerProcess, **kwargs):
+        kwargs = dict(kwargs)
+        kwargs.setdefault('daemon', True)
+        super().__init__(*args, **kwargs)
+        self.process = process
+        self.should_stop = threading.Event()
+
+    def run(self):
+        while not self.should_stop.wait(WAIT_TIMEOUT):
+            self.process.last_alive_at = int(time.time())
+            self.process.save()

--- a/src/tribler/gui/core_manager.py
+++ b/src/tribler/gui/core_manager.py
@@ -113,7 +113,8 @@ class CoreManager(QObject):
             core_env = QProcessEnvironment.systemEnvironment()
             core_env.insert("CORE_API_KEY", self.api_key)
             core_env.insert("TSTATEDIR", str(self.root_state_dir))
-            core_env.insert("TRIBLER_GUI_PID", str(os.getpid()))
+            core_env.insert("TRIBLER_GUI_UID", str(self.process_manager.current_process.uid))
+            core_env.insert("TRIBLER_GUI_PID", str(self.process_manager.current_process.pid))
 
         core_args = self.core_args
         if not core_args:

--- a/src/tribler/gui/start_gui.py
+++ b/src/tribler/gui/start_gui.py
@@ -38,7 +38,7 @@ def run_gui(api_port: Optional[int], api_key: Optional[str], root_state_dir, par
         logger.info('Enabling a workaround for Ubuntu 21.04+ wayland environment')
         os.environ["GDK_BACKEND"] = "x11"
 
-    current_process = TriblerProcess.current_process(ProcessKind.GUI)
+    current_process = TriblerProcess.current_process(kind=ProcessKind.GUI)
     process_manager = ProcessManager(root_state_dir, current_process)
     set_global_process_manager(process_manager)  # to be able to add information about exception to the process info
     current_process_is_primary = process_manager.current_process.become_primary()
@@ -70,6 +70,7 @@ def run_gui(api_port: Optional[int], api_key: Optional[str], root_state_dir, par
             logger.info('Close the current GUI application.')
             process_manager.sys_exit(1, 'Tribler GUI application is already running')
 
+        current_process.start_updating_thread()
         logger.info('Start Tribler Window')
         window = TriblerWindow(process_manager, app_manager, settings, root_state_dir,
                                api_port=api_port, api_key=api_key)

--- a/src/tribler/gui/tests/test_gui.py
+++ b/src/tribler/gui/tests/test_gui.py
@@ -41,7 +41,7 @@ def fixture_window(tmp_path_factory):
     api_key = hexlify(os.urandom(16))
     root_state_dir = tmp_path_factory.mktemp('tribler_state_dir')
 
-    current_process = TriblerProcess.current_process(ProcessKind.GUI)
+    current_process = TriblerProcess.current_process(kind=ProcessKind.GUI)
     process_manager = ProcessManager(root_state_dir, current_process)
     is_primary_process = process_manager.current_process.become_primary()
     app = TriblerApplication("triblerapp-guitest", sys.argv, start_local_server=is_primary_process)


### PR DESCRIPTION
This PR should fix #7603 by associating a unique UID value with each process. It fixes the problem of non-unique PID values.
In addition, each process periodically (1 time per second) updates its `last_alive_at` time in the database. When the `last_alive_at` time is not updated long enough (for 5 seconds), the process is considered not running.

Now, the following situations should be handled correctly:
1. In Flatpak, when the new GUI process can't find a currently running primary GUI process, it understands that the `last_alive_at`  was recently updated and that the primary process is running in a separate virtual environment.
2. When a GUI process creates a Core process and awaits for the `api_port` value, it understands that the correct Core process should specify the correct UID of the current GUI process. That prevents connecting with the wrong Core process.
3. When Core and GUI processes display the recent process list, they are correctly linked to each other.
