### PR TITLE
Update the Application Tester

### DIFF
--- a/scripts/application-tester/README.md
+++ b/scripts/application-tester/README.md
@@ -16,12 +16,14 @@ Each action contains a weight, indicating the probability that it is selected as
 You can specify how long Tribler should be tested by specifying a `-d` (duration) flag, e.g. to run the application tester for two minutes:
 
 ```
-python scripts/application-tester/main.py -p "python src/run_tribler.py" -d 120
+export CORE_API_PORT=20100
+python scripts/application-tester/main.py -p "python src/run_tribler.py" -d 120 
 ```
 
 To disable all actions and run Tribler idle, specify the `-s` (silent) flag:
 
 ```
+export CORE_API_PORT=20100
 python scripts/application-tester/main.py -p "python src/run_tribler.py" -s
 ```
 

--- a/scripts/application-tester/main.py
+++ b/scripts/application-tester/main.py
@@ -1,4 +1,5 @@
 import argparse
+import asyncio
 import logging
 import os
 from asyncio import ensure_future, get_event_loop
@@ -6,7 +7,9 @@ from pathlib import Path
 
 import sentry_sdk
 
+from tribler.core.utilities.utilities import make_async_loop_fragile
 from tribler_apptester.executor import Executor
+from tribler_apptester.logger.logger import init_logger
 
 sentry_sdk.init(
     os.environ.get('SENTRY_URL', 'https://e489691c2e214c03961e18069a71d76c@sentry.tribler.org/6'),
@@ -21,17 +24,20 @@ if __name__ == "__main__":
     parser.add_argument('-d', '--duration', default=None, type=int, help='run the Tribler application tester for a specific period of time')
     parser.add_argument('-s', '--silent', action='store_true', help='do not execute random actions')
     parser.add_argument('--codeport', default=5500, type=int, help='the port used to execute code')
-    parser.add_argument('--apiport', default=52194, type=int, help='the port used by Tribler REST API')
     parser.add_argument('--monitordownloads', default=None, type=int, help='monitor the downloads with a specified interval in seconds')
     parser.add_argument('--monitorresources', default=None, type=int, help='monitor the resources with a specified interval in seconds')
     parser.add_argument('--monitoripv8', default=None, type=int, help='monitor IPv8 overlays with a specified interval in seconds')
     parser.add_argument('--magnetsfile', default=Path("tribler_apptester") / "data" / "torrent_links.txt", type=str, help='specify the location of the file with magnet links')
+    parser.add_argument('--fragile', '-f', help='Fail at the first error', action='store_true')
 
-    # Setup logging
-    logging_level = os.environ.get('APPTESTER_LOGGING_LEVEL', 'INFO')
-    logging.basicConfig(level=logging_level)
+    init_logger()
 
     args = parser.parse_args()
+
+    loop = asyncio.get_event_loop()
+    if args.fragile:
+        make_async_loop_fragile(loop)
+
     executor = Executor(args)
 
     loop = get_event_loop()

--- a/scripts/application-tester/requirements.txt
+++ b/scripts/application-tester/requirements.txt
@@ -1,3 +1,3 @@
 aiohttp==3.8.5
-configobj==5.0.8
 sentry-sdk==1.31.0
+colorlog==6.7.0

--- a/scripts/application-tester/tribler_apptester/logger/logger.py
+++ b/scripts/application-tester/tribler_apptester/logger/logger.py
@@ -1,0 +1,12 @@
+import logging
+import os
+
+import colorlog
+
+
+def init_logger():
+    logging_level = os.environ.get('APPTESTER_LOGGING_LEVEL', 'INFO')
+
+    handler = colorlog.StreamHandler()
+    handler.setFormatter(colorlog.ColoredFormatter('%(log_color)s%(levelname)s - %(name)s(%(lineno)d): %(message)s'))
+    logging.basicConfig(level=logging_level, handlers=[handler])

--- a/scripts/application-tester/tribler_apptester/requestmgr.py
+++ b/scripts/application-tester/tribler_apptester/requestmgr.py
@@ -26,6 +26,8 @@ class HTTPRequestManager(object):
         with open(self.request_times_file_path, "w") as output_file:
             output_file.write("request_type,start_time,duration\n")
 
+        self._logger.info(f'Initialized. Key: {api_key}. Port: {api_port}')
+
     def write_request_time(self, request_type, start_time):
         current_time = int(round(time.time() * 1000))
         request_time = current_time - start_time


### PR DESCRIPTION
This PR encompasses two categories of modifications.

### Essential Changes for Application Tester's Functionality

The only amendment in this section pertains to updating the `readme.md` and the code within the Application Tester to correctly set the API port for Tribler Core.

### Improvements to Enhance Developers Experience with Application Tester

- Introducing colored logging to differentiate between Tribler logs and Application Tester logs.
  
<img width="790" alt="image" src="https://github.com/Tribler/tribler/assets/13798583/abc1641b-b919-46c8-a86c-cc72847170be">

- Incorporated the `--fragile` flag to make the asyncio loop fragile, mirroring the modifications applied to other tools within the `scripts` directory.

- Replaced the `configobj` dependency with the utilization of `TriblerConfig`.