### PR TITLE
Modernized the ReadTheDocs configuration

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,13 +9,14 @@ sphinx:
   configuration: doc/conf.py
 
 build:
-  image: latest
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
 
 # Include all submodules
 submodules:
   include: all
 
 python:
-  version: "3.8"
   install:
     - requirements: doc/requirements.txt


### PR DESCRIPTION
Fixes #7636

The current legacy config is no longer supported (see also https://docs.readthedocs.io/en/stable/config-file/v2.html#legacy-build-specification).