### PR TITLE
Updated IPv8 while keeping Community kwargs

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -9,5 +9,5 @@ sphinxcontrib-openapi==0.7.0
 configobj==5.0.6
 mistune==0.8.4  # sphinxcontrib-openapi==0.7.0 cannot work with the latest mistune version (2.0.0)
 MarkupSafe==2.0.1  # used by jinja2; 2.1.0 version removes soft_unicode and breaks jinja2-2.11.3
-pyipv8==2.11.0
+pyipv8==2.12.0
 setuptools>=65.5.1 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -18,7 +18,7 @@ sentry-sdk==1.31.0
 yappi==1.4.0
 yarl==1.9.2 # keep this dependency higher than 1.6.3. See: https://github.com/aio-libs/yarl/issues/517
 bitarray==2.7.6
-pyipv8==2.11.0
+pyipv8==2.12.0
 libtorrent==1.2.19
 file-read-backwards==3.0.0
 Brotli==1.0.9 # to prevent AttributeError on macOs: module 'brotli' has no attribute 'error' (in urllib3.response)

--- a/src/tribler/core/components/bandwidth_accounting/tests/test_bandwidth_endpoint.py
+++ b/src/tribler/core/components/bandwidth_accounting/tests/test_bandwidth_endpoint.py
@@ -1,7 +1,6 @@
 import pytest
 from ipv8.keyvault.crypto import default_eccrypto
 from ipv8.peer import Peer
-from ipv8.test.mocking.ipv8 import MockIPv8
 
 from tribler.core.components.bandwidth_accounting.community.bandwidth_accounting_community import (
     BandwidthAccountingCommunity,
@@ -10,6 +9,7 @@ from tribler.core.components.bandwidth_accounting.db.database import BandwidthDa
 from tribler.core.components.bandwidth_accounting.db.transaction import BandwidthTransactionData, EMPTY_SIGNATURE
 from tribler.core.components.bandwidth_accounting.restapi.bandwidth_endpoint import BandwidthEndpoint
 from tribler.core.components.bandwidth_accounting.settings import BandwidthAccountingSettings
+from tribler.core.components.ipv8.adapters_tests import TriblerMockIPv8
 from tribler.core.components.restapi.rest.base_api_test import do_request
 from tribler.core.utilities.unicode import hexlify
 
@@ -27,9 +27,9 @@ def bandwidth_database(tmp_path, peer):
 
 @pytest.fixture
 async def bw_community(bandwidth_database, peer):
-    ipv8 = MockIPv8(peer, BandwidthAccountingCommunity,
-                    database=bandwidth_database,
-                    settings=BandwidthAccountingSettings())
+    ipv8 = TriblerMockIPv8(peer, BandwidthAccountingCommunity,
+                           database=bandwidth_database,
+                           settings=BandwidthAccountingSettings())
     community = ipv8.get_overlay(BandwidthAccountingCommunity)
     yield community
     await ipv8.stop()

--- a/src/tribler/core/components/bandwidth_accounting/tests/test_community.py
+++ b/src/tribler/core/components/bandwidth_accounting/tests/test_community.py
@@ -1,7 +1,5 @@
 from ipv8.keyvault.crypto import default_eccrypto
 from ipv8.peer import Peer
-from ipv8.test.base import TestBase
-from ipv8.test.mocking.ipv8 import MockIPv8
 
 from tribler.core.components.bandwidth_accounting.community.bandwidth_accounting_community import (
     BandwidthAccountingCommunity,
@@ -10,22 +8,23 @@ from tribler.core.components.bandwidth_accounting.community.cache import Bandwid
 from tribler.core.components.bandwidth_accounting.db.database import BandwidthDatabase
 from tribler.core.components.bandwidth_accounting.db.transaction import BandwidthTransactionData, EMPTY_SIGNATURE
 from tribler.core.components.bandwidth_accounting.settings import BandwidthAccountingSettings
+from tribler.core.components.ipv8.adapters_tests import TriblerMockIPv8, TriblerTestBase
 from tribler.core.utilities.utilities import MEMORY_DB
 
 ID1, ID2, ID3 = range(3)
 
 
-class TestBandwidthAccountingCommunity(TestBase):
+class TestBandwidthAccountingCommunity(TriblerTestBase):
 
     def setUp(self):
         super().setUp()
         self.initialize(BandwidthAccountingCommunity, 2)
 
-    def create_node(self):
+    def create_node(self, *args, **kwargs):
         peer = Peer(default_eccrypto.generate_key("curve25519"), address=("1.2.3.4", 5))
         db = BandwidthDatabase(db_path=MEMORY_DB, my_pub_key=peer.public_key.key_to_bin())
-        ipv8 = MockIPv8(peer, BandwidthAccountingCommunity, database=db,
-                        settings=BandwidthAccountingSettings())
+        ipv8 = TriblerMockIPv8(peer, BandwidthAccountingCommunity, database=db,
+                               settings=BandwidthAccountingSettings())
         return ipv8
 
     def database(self, i):

--- a/src/tribler/core/components/database/db/tests/test_tribler_database.py
+++ b/src/tribler/core/components/database/db/tests/test_tribler_database.py
@@ -1,13 +1,13 @@
 import pytest
-from ipv8.test.base import TestBase
 from pony.orm import db_session
 
 from tribler.core.components.database.db.tribler_database import TriblerDatabase
+from tribler.core.components.ipv8.adapters_tests import TriblerTestBase
 
 
 # pylint: disable=protected-access
 
-class TestTriblerDatabase(TestBase):
+class TestTriblerDatabase(TriblerTestBase):
     def setUp(self):
         super().setUp()
         self.db = TriblerDatabase()

--- a/src/tribler/core/components/gigachannel/community/tests/test_gigachannel_community.py
+++ b/src/tribler/core/components/gigachannel/community/tests/test_gigachannel_community.py
@@ -7,7 +7,6 @@ from unittest.mock import AsyncMock, Mock
 import pytest
 from ipv8.keyvault.crypto import default_eccrypto
 from ipv8.peer import Peer
-from ipv8.test.base import TestBase
 from pony.orm import db_session
 
 from tribler.core.components.gigachannel.community.gigachannel_community import (
@@ -17,6 +16,7 @@ from tribler.core.components.gigachannel.community.gigachannel_community import 
     happy_eyeballs_delay
 )
 from tribler.core.components.gigachannel.community.settings import ChantSettings
+from tribler.core.components.ipv8.adapters_tests import TriblerTestBase
 from tribler.core.components.metadata_store.db.store import MetadataStore
 from tribler.core.components.metadata_store.remote_query_community.remote_query_community import EvaSelectRequest, \
     SelectRequest, RemoteSelectPayload, RemoteSelectPayloadEva, SelectResponsePayload
@@ -52,7 +52,7 @@ class ChannelKey(Mapping):
         return len(fields(self))
 
 
-class TestGigaChannelUnits(TestBase):
+class TestGigaChannelUnits(TriblerTestBase):
     overlay: Callable[[int], GigaChannelCommunity]
 
     def setUp(self):

--- a/src/tribler/core/components/gigachannel/community/tests/test_sync_strategy.py
+++ b/src/tribler/core/components/gigachannel/community/tests/test_sync_strategy.py
@@ -1,9 +1,9 @@
 from ipv8.keyvault.crypto import default_eccrypto
 from ipv8.peer import Peer
 from ipv8.peerdiscovery.network import Network
-from ipv8.test.base import TestBase
 
 from tribler.core.components.gigachannel.community.sync_strategy import RemovePeers
+from tribler.core.components.ipv8.adapters_tests import TriblerTestBase
 
 
 class MockCommunity:
@@ -23,7 +23,7 @@ class MockCommunity:
         return self.get_peers_return
 
 
-class TestRemovePeers(TestBase):
+class TestRemovePeers(TriblerTestBase):
     def setUp(self):
         self.community = MockCommunity()
         self.strategy = RemovePeers(self.community)

--- a/src/tribler/core/components/ipv8/adapters_tests.py
+++ b/src/tribler/core/components/ipv8/adapters_tests.py
@@ -1,0 +1,35 @@
+import inspect
+
+from ipv8.test.base import TestBase
+from ipv8.test.mocking.ipv8 import MockIPv8
+
+
+def backport_to_settings_class(overlay_class, kwargs):
+    signature = inspect.signature(overlay_class.__init__)
+    defaults = {k: v.default for k, v in signature.parameters.items()
+                if v.default is not inspect.Parameter.empty}
+    defaults.update(kwargs)
+    return overlay_class.settings_class(**defaults)
+
+
+class TriblerMockIPv8(MockIPv8):
+
+    def __init__(self, crypto_curve_or_peer, overlay_class, create_dht = False, enable_statistics = False,
+                 **kwargs):
+        community_settings = backport_to_settings_class(overlay_class, kwargs)
+
+        class ProxyOverlay(overlay_class):
+
+            def __init__(self, settings):
+                super().__init__(**settings.__dict__)
+
+        super().__init__(crypto_curve_or_peer, ProxyOverlay, community_settings, create_dht, enable_statistics)
+
+
+class TriblerTestBase(TestBase):
+
+    def create_node(self, *args, **kwargs):
+        create_dht = args[1] if len(args) > 1 else False
+        enable_statistics = args[2] if len(args) > 2 else False
+        return TriblerMockIPv8("low", self.overlay_class, create_dht=create_dht,
+                               enable_statistics=enable_statistics, **kwargs)

--- a/src/tribler/core/components/ipv8/eva/tests/test_protocol.py
+++ b/src/tribler/core/components/ipv8/eva/tests/test_protocol.py
@@ -11,10 +11,9 @@ from typing import Type
 from unittest.mock import Mock, patch
 
 import pytest
-from ipv8.community import Community
 from ipv8.messaging.lazy_payload import VariablePayload
-from ipv8.test.base import TestBase
 from ipv8.types import Peer
+from tribler.core.components.ipv8.adapters_tests import TriblerTestBase
 
 from tribler.core.components.ipv8.eva.exceptions import RequestRejected, SizeException, TimeoutException, \
     TransferCancelledException, TransferException, \
@@ -23,6 +22,7 @@ from tribler.core.components.ipv8.eva.payload import Acknowledgement, Data, Erro
 from tribler.core.components.ipv8.eva.protocol import EVAProtocol
 from tribler.core.components.ipv8.eva.result import TransferResult
 from tribler.core.components.ipv8.eva.settings import EVASettings, Retransmission, Termination
+from tribler.core.components.ipv8.tribler_community import TriblerCommunity
 
 # pylint: disable=redefined-outer-name, protected-access, attribute-defined-outside-init
 
@@ -45,7 +45,7 @@ async def drain_loop(loop: AbstractEventLoop):
         await asyncio.sleep(0)
 
 
-class MockCommunity(Community):  # pylint: disable=too-many-ancestors
+class MockCommunity(TriblerCommunity):  # pylint: disable=too-many-ancestors
     community_id = os.urandom(20)
 
     def __init__(self, *args, **kwargs):
@@ -83,7 +83,7 @@ class MockCommunity(Community):  # pylint: disable=too-many-ancestors
         self.error_has_been_raised.set()
 
 
-class TestEVA(TestBase):
+class TestEVA(TriblerTestBase):
     def setUp(self):
         super().setUp()
         self.initialize(MockCommunity, 3)

--- a/src/tribler/core/components/ipv8/ipv8_component.py
+++ b/src/tribler/core/components/ipv8/ipv8_component.py
@@ -17,6 +17,7 @@ from ipv8_service import IPv8
 from tribler.core.components.component import Component
 from tribler.core.components.ipv8.rendezvous.db.database import RendezvousDatabase
 from tribler.core.components.ipv8.rendezvous.rendezvous_hook import RendezvousHook
+from tribler.core.components.ipv8.tribler_community import args_kwargs_to_community_settings
 from tribler.core.components.key.key_component import KeyComponent
 from tribler.core.utilities.simpledefs import STATEDIR_DB_DIR
 
@@ -122,7 +123,9 @@ class Ipv8Component(Component):
 
     def _init_peer_discovery_community(self):
         ipv8 = self.ipv8
-        community = DiscoveryCommunity(self.peer, ipv8.endpoint, ipv8.network, max_peers=100)
+        community = DiscoveryCommunity(args_kwargs_to_community_settings(DiscoveryCommunity.settings_class,
+                                                                         [self.peer, ipv8.endpoint, ipv8.network],
+                                                                         {"max_peers": 100}))
         self.initialise_community_by_default(community)
         ipv8.add_strategy(community, RandomChurn(community), INFINITE)
         ipv8.add_strategy(community, PeriodicSimilarity(community), INFINITE)
@@ -130,7 +133,9 @@ class Ipv8Component(Component):
 
     def _init_dht_discovery_community(self):
         ipv8 = self.ipv8
-        community = DHTDiscoveryCommunity(self.peer, ipv8.endpoint, ipv8.network, max_peers=60)
+        community = DHTDiscoveryCommunity(args_kwargs_to_community_settings(DHTDiscoveryCommunity.settings_class,
+                                                                            [self.peer, ipv8.endpoint, ipv8.network],
+                                                                            {"max_peers": 60}))
         self.initialise_community_by_default(community)
         ipv8.add_strategy(community, PingChurn(community), INFINITE)
         self.dht_discovery_community = community
@@ -148,4 +153,4 @@ class Ipv8Component(Component):
         if self.rendevous_hook is not None:
             self.rendevous_hook.shutdown(self.ipv8.network)
         await self._task_manager.shutdown_task_manager()
-        await self.ipv8.stop(stop_loop=False)
+        await self.ipv8.stop()

--- a/src/tribler/core/components/ipv8/tribler_community.py
+++ b/src/tribler/core/components/ipv8/tribler_community.py
@@ -1,6 +1,14 @@
-from ipv8.community import Community
+from ipv8.community import Community, DEFAULT_MAX_PEERS
 
 from tribler.core.config.tribler_config_section import TriblerConfigSection
+
+def args_kwargs_to_community_settings(settings_class, args, kwargs):
+    return settings_class(my_peer=args[0] if len(args) > 0 else kwargs.pop("my_peer"),
+                          endpoint=args[1] if len(args) > 1 else kwargs.pop("endpoint"),
+                          network=args[2] if len(args) > 2 else kwargs.pop("network"),
+                          max_peers=args[4] if len(args) > 3 else kwargs.pop("max_peers", DEFAULT_MAX_PEERS),
+                          anonymize=args[5] if len(args) > 4 else kwargs.pop("anonymize", True),
+                          **kwargs)
 
 
 class TriblerCommunity(Community):
@@ -8,6 +16,7 @@ class TriblerCommunity(Community):
     """
 
     def __init__(self, *args, settings: TriblerConfigSection = None, **kwargs):
-        super().__init__(*args, **kwargs)
+        community_settings = args_kwargs_to_community_settings(self.settings_class, args, kwargs)
+        super().__init__(community_settings)
         self.settings = settings
         self.logger.info(f'Init. Settings: {settings}.')

--- a/src/tribler/core/components/knowledge/community/tests/test_knowledge_community.py
+++ b/src/tribler/core/components/knowledge/community/tests/test_knowledge_community.py
@@ -2,11 +2,10 @@ import datetime
 from unittest.mock import MagicMock, Mock
 
 from ipv8.keyvault.private.libnaclkey import LibNaCLSK
-from ipv8.test.base import TestBase
-from ipv8.test.mocking.ipv8 import MockIPv8
 from pony.orm import db_session
 
 from tribler.core.components.database.db.layers.knowledge_data_access_layer import Operation, ResourceType
+from tribler.core.components.ipv8.adapters_tests import TriblerMockIPv8, TriblerTestBase
 from tribler.core.components.knowledge.community.knowledge_community import KnowledgeCommunity
 from tribler.core.components.knowledge.community.knowledge_payload import StatementOperation
 from tribler.core.components.database.db.tribler_database import TriblerDatabase
@@ -14,7 +13,7 @@ from tribler.core.components.database.db.tribler_database import TriblerDatabase
 REQUEST_INTERVAL_FOR_RANDOM_OPERATIONS = 0.1  # in seconds
 
 
-class TestKnowledgeCommunity(TestBase):
+class TestKnowledgeCommunity(TriblerTestBase):
     def setUp(self):
         super().setUp()
         self.initialize(KnowledgeCommunity, 2)
@@ -23,8 +22,8 @@ class TestKnowledgeCommunity(TestBase):
         await super().tearDown()
 
     def create_node(self, *args, **kwargs):
-        return MockIPv8("curve25519", KnowledgeCommunity, db=TriblerDatabase(), key=LibNaCLSK(),
-                        request_interval=REQUEST_INTERVAL_FOR_RANDOM_OPERATIONS)
+        return TriblerMockIPv8("curve25519", KnowledgeCommunity, db=TriblerDatabase(), key=LibNaCLSK(),
+                               request_interval=REQUEST_INTERVAL_FOR_RANDOM_OPERATIONS)
 
     def create_operation(self, subject='1' * 20, obj=''):
         community = self.overlay(0)

--- a/src/tribler/core/components/metadata_store/remote_query_community/tests/test_remote_query_community.py
+++ b/src/tribler/core/components/metadata_store/remote_query_community/tests/test_remote_query_community.py
@@ -10,10 +10,10 @@ from unittest.mock import Mock, patch
 
 import pytest
 from ipv8.keyvault.crypto import default_eccrypto
-from ipv8.test.base import TestBase
 from pony.orm import db_session
 from pony.orm.dbapiprovider import OperationalError
 
+from tribler.core.components.ipv8.adapters_tests import TriblerTestBase
 from tribler.core.components.metadata_store.db.orm_bindings.channel_node import NEW
 from tribler.core.components.metadata_store.db.serialization import CHANNEL_THUMBNAIL, CHANNEL_TORRENT, REGULAR_TORRENT
 from tribler.core.components.metadata_store.db.store import MetadataStore
@@ -52,7 +52,7 @@ class BasicRemoteQueryCommunity(RemoteQueryCommunity):
     community_id = unhexlify('eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee')
 
 
-class TestRemoteQueryCommunity(TestBase):
+class TestRemoteQueryCommunity(TriblerTestBase):
     """
     Unit tests for the base RemoteQueryCommunity which do not need a real Session.
     """

--- a/src/tribler/core/components/metadata_store/remote_query_community/tests/test_remote_search_by_tags.py
+++ b/src/tribler/core/components/metadata_store/remote_query_community/tests/test_remote_search_by_tags.py
@@ -2,7 +2,6 @@ import os
 from unittest.mock import AsyncMock, Mock, PropertyMock, patch
 
 from ipv8.keyvault.crypto import default_eccrypto
-from ipv8.test.base import TestBase
 from pony.orm import db_session
 
 from tribler.core.components.database.db.layers.knowledge_data_access_layer import KnowledgeDataAccessLayer, \
@@ -10,6 +9,7 @@ from tribler.core.components.database.db.layers.knowledge_data_access_layer impo
 from tribler.core.components.database.db.layers.tests.test_knowledge_data_access_layer_base import Resource, \
     TestKnowledgeAccessLayerBase
 from tribler.core.components.database.db.tribler_database import TriblerDatabase
+from tribler.core.components.ipv8.adapters_tests import TriblerTestBase
 from tribler.core.components.metadata_store.db.orm_bindings.channel_node import NEW
 from tribler.core.components.metadata_store.db.store import MetadataStore
 from tribler.core.components.metadata_store.remote_query_community.remote_query_community import RemoteQueryCommunity
@@ -21,7 +21,7 @@ from tribler.core.utilities.path_util import Path
 from tribler.core.utilities.unicode import hexlify
 
 
-class TestRemoteSearchByTags(TestBase):
+class TestRemoteSearchByTags(TriblerTestBase):
     """ In this test set we will use only one node's instance as it is sufficient
     for testing remote search by tags
     """

--- a/src/tribler/core/components/popularity/community/tests/test_popularity_community.py
+++ b/src/tribler/core/components/popularity/community/tests/test_popularity_community.py
@@ -4,10 +4,9 @@ from typing import List
 from unittest.mock import Mock
 
 from ipv8.keyvault.crypto import default_eccrypto
-from ipv8.test.base import TestBase
-from ipv8.test.mocking.ipv8 import MockIPv8
 from pony.orm import db_session
 
+from tribler.core.components.ipv8.adapters_tests import TriblerMockIPv8, TriblerTestBase
 from tribler.core.components.metadata_store.db.store import MetadataStore
 from tribler.core.components.metadata_store.remote_query_community.settings import RemoteQueryCommunitySettings
 from tribler.core.components.popularity.community.popularity_community import PopularityCommunity
@@ -39,7 +38,7 @@ def _generate_checked_torrents(count: int, status: str = None) -> List[HealthInf
     return [_generate_single_checked_torrent(status) for _ in range(count)]
 
 
-class TestPopularityCommunity(TestBase):
+class TestPopularityCommunity(TriblerTestBase):
     NUM_NODES = 2
 
     def setUp(self):
@@ -64,10 +63,10 @@ class TestPopularityCommunity(TestBase):
         self.count += 1
 
         rqc_settings = RemoteQueryCommunitySettings()
-        return MockIPv8("curve25519", PopularityCommunity, metadata_store=mds,
-                        torrent_checker=torrent_checker,
-                        rqc_settings=rqc_settings
-                        )
+        return TriblerMockIPv8("curve25519", PopularityCommunity, metadata_store=mds,
+                               torrent_checker=torrent_checker,
+                               rqc_settings=rqc_settings
+                               )
 
     @db_session
     def fill_database(self, metadata_store, last_check_now=False):

--- a/src/tribler/core/components/popularity/community/tests/test_version_community_mixin.py
+++ b/src/tribler/core/components/popularity/community/tests/test_version_community_mixin.py
@@ -2,16 +2,15 @@ import os
 import sys
 from asyncio import Future
 
-from ipv8.community import Community
 from ipv8.messaging.serialization import default_serializer
-from ipv8.test.base import TestBase
-from ipv8.test.mocking.ipv8 import MockIPv8
+from tribler.core.components.ipv8.adapters_tests import TriblerMockIPv8, TriblerTestBase
+from tribler.core.components.ipv8.tribler_community import TriblerCommunity
 
 from tribler.core.components.popularity.community.version_community_mixin import VersionCommunityMixin, VersionResponse
 from tribler.core.version import version_id
 
 
-class VersionCommunity(VersionCommunityMixin, Community):
+class VersionCommunity(VersionCommunityMixin, TriblerCommunity):
     community_id = os.urandom(20)
 
     def __init__(self, *args, **kwargs):
@@ -19,7 +18,7 @@ class VersionCommunity(VersionCommunityMixin, Community):
         self.init_version_community()
 
 
-class TestVersionCommunity(TestBase):
+class TestVersionCommunity(TriblerTestBase):
     NUM_NODES = 2
 
     def setUp(self):
@@ -27,7 +26,7 @@ class TestVersionCommunity(TestBase):
         self.initialize(VersionCommunity, self.NUM_NODES)
 
     def create_node(self, *args, **kwargs):
-        return MockIPv8("curve25519", VersionCommunity)
+        return TriblerMockIPv8("curve25519", VersionCommunity)
 
     def test_version_response_payload(self):
         """

--- a/src/tribler/core/components/restapi/rest/tests/test_statistics_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/tests/test_statistics_endpoint.py
@@ -1,14 +1,12 @@
 from unittest.mock import Mock
 
 import pytest
-from aiohttp.web_app import Application
-from ipv8.test.mocking.ipv8 import MockIPv8
 
 from tribler.core.components.bandwidth_accounting.community.bandwidth_accounting_community \
     import BandwidthAccountingCommunity
 from tribler.core.components.bandwidth_accounting.settings import BandwidthAccountingSettings
+from tribler.core.components.ipv8.adapters_tests import TriblerMockIPv8
 from tribler.core.components.restapi.rest.base_api_test import do_request
-from tribler.core.components.restapi.rest.rest_manager import error_middleware
 from tribler.core.components.restapi.rest.statistics_endpoint import StatisticsEndpoint
 
 
@@ -17,8 +15,8 @@ from tribler.core.components.restapi.rest.statistics_endpoint import StatisticsE
 
 @pytest.fixture
 async def endpoint(metadata_store):
-    ipv8 = MockIPv8("low", BandwidthAccountingCommunity, database=Mock(),
-                    settings=BandwidthAccountingSettings())
+    ipv8 = TriblerMockIPv8("low", BandwidthAccountingCommunity, database=Mock(),
+                           settings=BandwidthAccountingSettings())
     ipv8.overlays = [ipv8.overlay]
     ipv8.endpoint.bytes_up = 100
     ipv8.endpoint.bytes_down = 20

--- a/src/tribler/core/components/tunnel/tests/test_full_session/test_tunnel_community.py
+++ b/src/tribler/core/components/tunnel/tests/test_full_session/test_tunnel_community.py
@@ -15,7 +15,7 @@ from ipv8.peer import Peer
 from ipv8.test.messaging.anonymization import test_community
 from ipv8.test.messaging.anonymization.mock import MockDHTProvider
 from ipv8.test.mocking.exit_socket import MockTunnelExitSocket
-from ipv8.test.mocking.ipv8 import MockIPv8
+from tribler.core.components.ipv8.adapters_tests import TriblerMockIPv8
 
 # Pylint does not agree with the way pytest handles fixtures.
 # pylint: disable=W0613,W0621
@@ -133,12 +133,12 @@ async def create_tunnel_community(temp_path_factory: TempPathFactory,
     config = config or TunnelCommunitySettings()
     config.exitnode_enabled = exit_node_enable
 
-    ipv8 = MockIPv8("curve25519",
-                    TriblerTunnelCommunity,
-                    settings={"max_circuits": 1},
-                    config=config,
-                    socks_servers=socks_servers,
-                    dlmgr=download_manager)
+    ipv8 = TriblerMockIPv8("curve25519",
+                           TriblerTunnelCommunity,
+                           settings={"max_circuits": 1},
+                           config=config,
+                           socks_servers=socks_servers,
+                           dlmgr=download_manager)
     if start_lt:
         download_manager.peer_mid = ipv8.my_peer.mid
         download_manager.initialize()

--- a/src/tribler/core/components/tunnel/tests/test_triblertunnel_community.py
+++ b/src/tribler/core/components/tunnel/tests/test_triblertunnel_community.py
@@ -1,10 +1,14 @@
+from __future__ import annotations
+
 import os
 from asyncio import Future, TimeoutError as AsyncTimeoutError, sleep, wait_for
 from collections import defaultdict
 from random import random
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import Mock
 
 import pytest
+
+from ipv8.keyvault.public.libnaclkey import LibNaCLPK
 from ipv8.messaging.anonymization.payload import EstablishIntroPayload
 from ipv8.messaging.anonymization.tunnel import (
     CIRCUIT_STATE_READY,
@@ -12,13 +16,12 @@ from ipv8.messaging.anonymization.tunnel import (
     CIRCUIT_TYPE_RP_SEEDER,
     PEER_FLAG_EXIT_BT,
 )
+from ipv8.messaging.serialization import ADDRESS_TYPE_IPV4
 from ipv8.peer import Peer
-from ipv8.peerdiscovery.network import Network
 from ipv8.test.base import TestBase
 from ipv8.test.messaging.anonymization import test_community
 from ipv8.test.messaging.anonymization.test_community import MockDHTProvider
 from ipv8.test.mocking.exit_socket import MockTunnelExitSocket
-from ipv8.test.mocking.ipv8 import MockIPv8
 from ipv8.util import succeed
 
 from tribler.core.components.bandwidth_accounting.community.bandwidth_accounting_community import (
@@ -26,6 +29,7 @@ from tribler.core.components.bandwidth_accounting.community.bandwidth_accounting
 )
 from tribler.core.components.bandwidth_accounting.db.database import BandwidthDatabase
 from tribler.core.components.bandwidth_accounting.settings import BandwidthAccountingSettings
+from tribler.core.components.ipv8.adapters_tests import TriblerMockIPv8
 from tribler.core.components.tunnel.community.payload import BandwidthTransactionPayload
 from tribler.core.components.tunnel.community.tunnel_community import PEER_FLAG_EXIT_HTTP, TriblerTunnelCommunity
 from tribler.core.components.tunnel.settings import TunnelCommunitySettings
@@ -37,29 +41,16 @@ from tribler.core.utilities.simpledefs import DownloadStatus
 from tribler.core.utilities.utilities import MEMORY_DB
 
 
-# pylint: disable=redefined-outer-name
-
-@pytest.fixture()
-async def tunnel_community():
-    community = TriblerTunnelCommunity(MagicMock(),
-                                       MagicMock(),
-                                       MagicMock(),
-                                       socks_servers=MagicMock(),
-                                       config=MagicMock(),
-                                       notifier=MagicMock(),
-                                       dlmgr=MagicMock(),
-                                       bandwidth_community=MagicMock(),
-                                       dht_provider=MagicMock(),
-                                       exitnode_cache=MagicMock(),
-                                       settings=MagicMock())
-    yield community
-    await community.unload()
-
-
+@pytest.mark.usefixtures("tmp_path")
 class TestTriblerTunnelCommunity(TestBase):  # pylint: disable=too-many-public-methods
+
+    @pytest.fixture(autouse=True)
+    def init_tmp(self, tmp_path):
+        self.tmp_path = tmp_path
 
     def setUp(self):
         self.initialize(TriblerTunnelCommunity, 1)
+        self.tmp_path = self.tmp_path
 
     async def tearDown(self):
         test_community.global_dht_services = defaultdict(list)  # Reset the global_dht_services variable
@@ -67,13 +58,13 @@ class TestTriblerTunnelCommunity(TestBase):  # pylint: disable=too-many-public-m
             await node.overlay.bandwidth_community.unload()
         await super().tearDown()
 
-    def create_node(self):
+    def create_node(self, *args, **kwargs):
         config = TunnelCommunitySettings()
-        mock_ipv8 = MockIPv8("curve25519", TriblerTunnelCommunity,
-                             settings={'remove_tunnel_delay': 0},
-                             config=config,
-                             exitnode_cache=Path(self.temporary_directory()) / "exitnode_cache.dat"
-                             )
+        mock_ipv8 = TriblerMockIPv8("curve25519", TriblerTunnelCommunity,
+                                    settings={'remove_tunnel_delay': 0},
+                                    config=config,
+                                    exitnode_cache=Path(self.temporary_directory()) / "exitnode_cache.dat"
+                                    )
         mock_ipv8.overlay.settings.max_circuits = 1
 
         db = BandwidthDatabase(db_path=MEMORY_DB, my_pub_key=mock_ipv8.my_peer.public_key.key_to_bin())
@@ -345,11 +336,10 @@ class TestTriblerTunnelCommunity(TestBase):  # pylint: disable=too-many-public-m
         self.assertEqual(self.nodes[0].overlay.tunnels_ready(2), 1.0)
 
         # Destroy the circuit
-        for circuit_id, circuit in self.nodes[0].overlay.circuits.items():
+        for circuit_id, circuit in list(self.nodes[0].overlay.circuits.items()):
             circuit.bytes_down = 250 * 1024 * 1024
-            self.nodes[0].overlay.remove_circuit(circuit_id, destroy=1)
-
-        await sleep(0.5)
+            await self.nodes[0].overlay.remove_circuit(circuit_id, destroy=1)
+            await self.deliver_messages()
 
         # Verify whether the downloader (node 0) correctly paid the relay and exit nodes.
         self.assertTrue(self.nodes[0].overlay.bandwidth_community.database.get_my_balance() < 0)
@@ -672,20 +662,18 @@ class TestTriblerTunnelCommunity(TestBase):  # pylint: disable=too-many-public-m
                                                                       b'GET /scrape?info_hash=0 HTTP/1.1\r\n\r\n'),
                            timeout=.3)
 
+    def test_cache_exitnodes_to_disk(self):
+        """ Test whether we can cache exit nodes to disk """
+        self.overlay(0).candidates = {Peer(LibNaCLPK(b'\x00'*64), ("0.1.2.3", 1029)): {PEER_FLAG_EXIT_BT}}
+        self.overlay(0).exitnode_cache = self.tmp_path / 'exitnode_cache.dat'
+        self.overlay(0).cache_exitnodes_to_disk()
 
-@patch.object(Network, 'snapshot', Mock(return_value=b'snapshot'))
-def test_cache_exitnodes_to_disk(tunnel_community: TriblerTunnelCommunity, tmp_path):
-    """ Test whether we can cache exit nodes to disk """
-    tunnel_community.exitnode_cache = tmp_path / 'exitnode_cache.dat'
-    tunnel_community.cache_exitnodes_to_disk()
+        assert self.overlay(0).exitnode_cache.read_bytes() == bytes([ADDRESS_TYPE_IPV4]) + bytes(range(6))
 
-    assert tunnel_community.exitnode_cache.read_bytes() == b'snapshot'
+    def test_cache_exitnodes_to_disk_os_error(self):
+        """ Test whether we can handle an OSError when caching exit nodes to disk and raise no errors """
+        self.overlay(0).candidates = {Peer(LibNaCLPK(b'\x00'*64), ("0.1.2.3", 1029)): {PEER_FLAG_EXIT_BT}}
+        self.overlay(0).exitnode_cache = Mock(write_bytes=Mock(side_effect=FileNotFoundError))
+        self.overlay(0).cache_exitnodes_to_disk()
 
-
-@patch.object(Network, 'snapshot', Mock(return_value=b'snapshot'))
-def test_cache_exitnodes_to_disk_os_error(tunnel_community: TriblerTunnelCommunity):
-    """ Test whether we can handle an OSError when caching exit nodes to disk and raise no errors """
-    tunnel_community.exitnode_cache = Mock(write_bytes=Mock(side_effect=FileNotFoundError))
-    tunnel_community.cache_exitnodes_to_disk()
-
-    assert tunnel_community.exitnode_cache.write_bytes.called
+        assert self.overlay(0).exitnode_cache.write_bytes.called


### PR DESCRIPTION
This PR is the second attempt to update the IPv8 version to `2.12` in Tribler.

The previous PR to update the version, #7620, was rejected because communities could not `__init__` with kwargs. In this PR, I introduce adapters to allow communities to `__init__` with `args` and `kwargs`, like in the previous IPv8 version (`2.11`).

 - The new class `TriblerMockIPv8` provides the old interface using the new `MockIPv8`.
 - The new class `TriblerTestBase` provides the old interface using the new `TestBase`.
 - An update to `TriblerCommunity` provides the old interface using the new `Community`.

_Disclaimer: I still prefer the implementation of #7620 over this._