### PR TITLE
Increase the timeout for `pytest.yml`

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -39,7 +39,7 @@ jobs:
     env:
       PYTEST_SENTRY_DSN: ${{secrets.PYTEST_SENTRY_DSN}}
 
-    timeout-minutes: 10
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This PR increases the timeout for `pytest.yml` since it appears that 10 minutes isn't sufficient to run the Windows tests, as evidenced by: https://github.com/Tribler/tribler/actions/workflows/!main.yml

With the merge of #7582, we aim to address the "frozen tests" issue. Thus, it should be safe to extend the timeout from 10 to 15 minutes.