### PR TITLE
Set the limit for int values of the libtorrent config

### DIFF
--- a/src/tribler/core/components/libtorrent/settings.py
+++ b/src/tribler/core/components/libtorrent/settings.py
@@ -8,7 +8,7 @@ from tribler.core.utilities.network_utils import NetworkUtils
 from tribler.core.utilities.osutils import get_home_dir
 from tribler.core.utilities.path_util import Path
 
-INT_MAX = 2147483647  # max int value for C
+INT32_MAX = 2147483647  # max int value for C
 
 TRIBLER_DOWNLOADS_DEFAULT = "TriblerDownloads"
 
@@ -48,7 +48,7 @@ class LibtorrentSettings(TriblerConfigSection):
     def __setattr__(self, key, value):
         """Override __setattr__ to limit the max int value to `INT_MAX` (the max int value for C)"""
         if isinstance(value, int):
-            value = min(INT_MAX, value)
+            value = min(INT32_MAX, value)
         super().__setattr__(key, value)
 
 

--- a/src/tribler/core/components/libtorrent/settings.py
+++ b/src/tribler/core/components/libtorrent/settings.py
@@ -8,6 +8,8 @@ from tribler.core.utilities.network_utils import NetworkUtils
 from tribler.core.utilities.osutils import get_home_dir
 from tribler.core.utilities.path_util import Path
 
+INT_MAX = 2147483647  # max int value for C
+
 TRIBLER_DOWNLOADS_DEFAULT = "TriblerDownloads"
 
 
@@ -42,6 +44,12 @@ class LibtorrentSettings(TriblerConfigSection):
     def validate_proxy_type(cls, v):
         assert v is None or 0 <= v <= 5, 'Proxy type must be in range [0..5]'
         return v
+
+    def __setattr__(self, key, value):
+        """Override __setattr__ to limit the max int value to `INT_MAX` (the max int value for C)"""
+        if isinstance(value, int):
+            value = min(INT_MAX, value)
+        super().__setattr__(key, value)
 
 
 class SeedingMode(str, Enum):

--- a/src/tribler/core/components/libtorrent/tests/test_settings.py
+++ b/src/tribler/core/components/libtorrent/tests/test_settings.py
@@ -1,4 +1,5 @@
-from tribler.core.components.libtorrent.settings import TRIBLER_DOWNLOADS_DEFAULT, get_default_download_dir
+from tribler.core.components.libtorrent.settings import INT_MAX, TRIBLER_DOWNLOADS_DEFAULT, get_default_download_dir
+from tribler.core.config.tribler_config import TriblerConfig
 from tribler.core.utilities.path_util import Path
 
 
@@ -36,3 +37,11 @@ def test_get_default_home_nothing_exists(tmp_path, monkeypatch):
 
     download_dir = get_default_download_dir(home)
     assert download_dir == (home / TRIBLER_DOWNLOADS_DEFAULT).resolve()
+
+
+def test_big_int_setter(tmpdir):
+    # Test the setter for big integers. In the case of overflow, the value should be set to INT_MAX
+    config = TriblerConfig(state_dir=tmpdir)
+    big_int = 2 ** 1000
+    config.libtorrent.max_connections_download = big_int
+    assert config.libtorrent.max_connections_download == INT_MAX

--- a/src/tribler/core/components/libtorrent/tests/test_settings.py
+++ b/src/tribler/core/components/libtorrent/tests/test_settings.py
@@ -1,4 +1,4 @@
-from tribler.core.components.libtorrent.settings import INT_MAX, TRIBLER_DOWNLOADS_DEFAULT, get_default_download_dir
+from tribler.core.components.libtorrent.settings import INT32_MAX, TRIBLER_DOWNLOADS_DEFAULT, get_default_download_dir
 from tribler.core.config.tribler_config import TriblerConfig
 from tribler.core.utilities.path_util import Path
 
@@ -44,4 +44,4 @@ def test_big_int_setter(tmpdir):
     config = TriblerConfig(state_dir=tmpdir)
     big_int = 2 ** 1000
     config.libtorrent.max_connections_download = big_int
-    assert config.libtorrent.max_connections_download == INT_MAX
+    assert config.libtorrent.max_connections_download == INT32_MAX


### PR DESCRIPTION
This PR fixes #5713 by setting the limit for int fields of the libtorrent config.

Ref: https://libtorrent.org/reference-Torrent_Handle.html#max-connections-set-max-connections