### PR TITLE
Added crossref public data file

### DIFF
--- a/scripts/application_tester/tribler_apptester/data/torrent_links.txt
+++ b/scripts/application_tester/tribler_apptester/data/torrent_links.txt
@@ -2,3 +2,4 @@ http://www.frostclick.com/torrents/video/animation/Big_Buck_Bunny_1080p_surround
 https://linuxtracker.org/download.php?id=873dd05bd69f2626e4123887e7bb7922aaeb4efa&f=linuxmint-20.2-cinnamon-64bit.iso.torrent
 https://linuxtracker.org/download.php?id=c91579570815c913b2bd2cd5dd76d8e165d8e57f&f=Kali+Linux+2021.3+Virtualbox+64Bit+OVA.torrent
 https://linuxtracker.org/download.php?id=f62121927d19c7cedf4e41796166f937c698303f&f=CentOS+8.4.2105+x86-64+Boot.torrent
+https://academictorrents.com/download/d9e554f4f0c3047d9f49e448a7004f7aa1701b69.torrent


### PR DESCRIPTION
This PR adds [Crossref's 2023 official public data file](https://www.crossref.org/blog/2023-public-data-file-now-available-with-new-and-improved-retrieval-options/) to the list of torrent links of the app tester.

The added torrent is not small or nice to parse - like our current links - and I wholly expect it to bring down our application tester. Nevertheless, this is _not an impossible torrent for libtorrent_ to download (which you _can_ generate by going beyond the maximum recursion depth etc.) and it can be considered to be otherwise "normal": Tribler _should_ handle this.