### PR TITLE
Extract `INT32_MAX` to utilities.py

### DIFF
--- a/src/tribler/core/components/libtorrent/settings.py
+++ b/src/tribler/core/components/libtorrent/settings.py
@@ -7,8 +7,7 @@ from tribler.core.config.tribler_config_section import TriblerConfigSection
 from tribler.core.utilities.network_utils import NetworkUtils
 from tribler.core.utilities.osutils import get_home_dir
 from tribler.core.utilities.path_util import Path
-
-INT32_MAX = 2147483647  # max int value for C
+from tribler.core.utilities.utilities import INT32_MAX
 
 TRIBLER_DOWNLOADS_DEFAULT = "TriblerDownloads"
 

--- a/src/tribler/core/components/libtorrent/tests/test_settings.py
+++ b/src/tribler/core/components/libtorrent/tests/test_settings.py
@@ -1,6 +1,7 @@
-from tribler.core.components.libtorrent.settings import INT32_MAX, TRIBLER_DOWNLOADS_DEFAULT, get_default_download_dir
+from tribler.core.components.libtorrent.settings import TRIBLER_DOWNLOADS_DEFAULT, get_default_download_dir
 from tribler.core.config.tribler_config import TriblerConfig
 from tribler.core.utilities.path_util import Path
+from tribler.core.utilities.utilities import INT32_MAX
 
 
 def test_get_default_download_dir_exists(tmp_path, monkeypatch):

--- a/src/tribler/core/components/torrent_checker/torrent_checker/torrentchecker_session.py
+++ b/src/tribler/core/components/torrent_checker/torrent_checker/torrentchecker_session.py
@@ -20,7 +20,7 @@ from tribler.core.components.torrent_checker.torrent_checker import DHT
 from tribler.core.components.torrent_checker.torrent_checker.dataclasses import HealthInfo, TrackerResponse
 from tribler.core.components.torrent_checker.torrent_checker.utils import filter_non_exceptions, gather_coros
 from tribler.core.utilities.tracker_utils import add_url_params, parse_tracker_url
-from tribler.core.utilities.utilities import bdecode_compat
+from tribler.core.utilities.utilities import INT32_MAX, bdecode_compat
 
 if TYPE_CHECKING:
     from tribler.core.components.libtorrent.download_manager.download_manager import DownloadManager
@@ -30,8 +30,6 @@ if TYPE_CHECKING:
 TRACKER_ACTION_CONNECT = 0
 TRACKER_ACTION_ANNOUNCE = 1
 TRACKER_ACTION_SCRAPE = 2
-
-INT32_MAX = 2 ** 31 - 1
 
 UDP_TRACKER_INIT_CONNECTION_ID = 0x41727101980
 

--- a/src/tribler/core/utilities/utilities.py
+++ b/src/tribler/core/utilities/utilities.py
@@ -26,6 +26,7 @@ logger = logging.getLogger(__name__)
 
 # Sentinel representing that SQLite must create database in-memory with ":memory:" argument
 MEMORY_DB = sentinel('MEMORY_DB')
+INT32_MAX = 2 ** 31 - 1
 
 _switch_interval_lock = threading.Lock()
 


### PR DESCRIPTION
This PR moves `INT32_MAX` to `utilities.py` as a recommended refactoring for #7650 and #7651.