### PR TITLE
Add the debug parameter to the `RequestManager.add()`

### DIFF
--- a/src/tribler/gui/network/request.py
+++ b/src/tribler/gui/network/request.py
@@ -87,6 +87,7 @@ class Request(QObject):
         self.status_text = "unknown"
         self.cancellable = True
         self.id = 0
+        self.caller = ''
 
     def set_manager(self, manager: RequestManager):
         self.manager = manager
@@ -184,4 +185,7 @@ class Request(QObject):
             self.reply = None
 
     def __str__(self):
-        return f'{self.method} {self.url}'
+        result = f'{self.method} {self.url}'
+        if self.caller:
+            result += f'\nCaller: {self.caller}'
+        return result

--- a/src/tribler/gui/network/request_manager.py
+++ b/src/tribler/gui/network/request_manager.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import traceback
 from collections import deque
 from time import time
 from typing import Callable, Dict, Optional, Set
@@ -118,10 +119,20 @@ class RequestManager(QNetworkAccessManager):
                           method=Request.DELETE)
         return self.add(request)
 
-    def add(self, request: Request) -> Optional[Request]:
+    def add(self, request: Request, debug: bool = False) -> Optional[Request]:
+        """ Add a request to the queue.
+
+        Args:
+            request: The request to add.
+            debug: Whether to print debug information.
+
+        Returns: The request if it was added, None otherwise.
+        """
         if self._is_in_shutting_down(request):
             # Do not send requests when Tribler is shutting down
             return None
+        if debug:
+            request.caller = traceback.extract_stack()[-3]
 
         # Set last request id
         self.last_request_id += 1


### PR DESCRIPTION
This PR introduces a `debug` parameter to `RequestManager.add()`, allowing for the caller information of a request to be printed. 

This is particularly handy when investigating the source of a request call (as I discovered during my recent attempt to remove Channel on Friday).

When the `debug` argument is set to `True`, the output will appear as follows:

```python
[tribler-gui PID:2015] 2023-10-30 12:08:08,351 - INFO - Request(108) - Finished: GET http://localhost:53611/channels?metadata_type=300&metadata_type=220&include_total=1&first=1&last=50&sort_by=votes&sort_desc=1&hide_xxx=0
Caller: <FrameSummary file /Users/<user>/Projects/github.com/Tribler/tribler/src/tribler/gui/widgets/tablecontentmodel.py, line 368 in perform_query>
[tribler-gui PID:2015] 2023-10-30 12:08:08,352 - INFO - DiscoveredChannelsModel(380) - Response. Remote: False, results: 50, uuid: None
[tribler-gui PID:2015] 2023-10-30 12:08:08,355 - INFO - RequestManager(147) - Request: GET http://localhost:53611/channels?subscribed=1&last=1000
Caller: <FrameSummary file /Users/<user>/Projects/github.com/Tribler/tribler/src/tribler/gui/widgets/channelsmenulistwidget.py, line 130 in load_channels>
```