### PR TITLE
Use the filelock library to determine the primary GUI/Core process

### DIFF
--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -27,3 +27,4 @@ libtorrent==1.2.15
 file-read-backwards==2.0.0
 Brotli==1.0.9 # to prevent AttributeError on macOs: module 'brotli' has no attribute 'error' (in urllib3.response)
 human-readable==1.3.2
+filelock==3.13.0

--- a/src/tribler/core/utilities/process_locking.py
+++ b/src/tribler/core/utilities/process_locking.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from filelock import FileLock, Timeout
+
+
+GUI_LOCK_FILENAME = 'tribler-gui.lock'
+CORE_LOCK_FILENAME = 'tribler-core.lock'
+
+
+def try_acquire_file_lock(lock_file_name) -> Optional[FileLock]:
+    lock = FileLock(lock_file_name)
+    try:
+        lock.acquire(blocking=False)
+    except Timeout:
+        return None
+    return lock

--- a/src/tribler/core/utilities/process_manager/tests/conftest.py
+++ b/src/tribler/core/utilities/process_manager/tests/conftest.py
@@ -8,7 +8,6 @@ from tribler.core.utilities.process_manager import ProcessKind, ProcessManager, 
 @pytest.fixture(name='process_manager')
 def process_manager_fixture(tmp_path: Path) -> ProcessManager:
     # Creates a process manager with a new database and adds a primary current process to it
-    current_process = TriblerProcess.current_process(ProcessKind.Core)
-    process_manager = ProcessManager(tmp_path, current_process)
-    current_process.become_primary()
+    process_manager = ProcessManager(tmp_path)
+    process_manager.setup_current_process(kind=ProcessKind.Core, owns_lock=True)
     return process_manager

--- a/src/tribler/core/utilities/process_manager/tests/test_manager.py
+++ b/src/tribler/core/utilities/process_manager/tests/test_manager.py
@@ -1,6 +1,6 @@
 import sqlite3
 import time
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
@@ -11,48 +11,151 @@ from tribler.core.utilities.process_manager.process import ProcessKind, TriblerP
 # pylint: disable=protected-access
 
 
-def test_become_primary(process_manager: ProcessManager):
-    # Initially process manager fixture creates a primary current process that is a single process in DB
-    p1 = process_manager.current_process
-    assert p1.primary
+def test_current_process_not_set(tmp_path):
+    # This test verifies that the `current_process` property of the `ProcessManager` class raises a
+    # RuntimeError when accessed before an actual process is set. This situation occurs immediately
+    # after a new `ProcessManager` instance is created and before its initialization is finalized.
+    # Once initialization is complete, `current_process` is guaranteed to be set, thus the property
+    # is non-Optional to eliminate the need for redundant `None` checks. The test ensures the property
+    # enforces this contract by throwing the expected exception when accessed prematurely.
+    process_manager = ProcessManager(tmp_path)
+    with pytest.raises(RuntimeError, match='^Current process is not set$'):
+        process_manager.current_process  # pylint: disable=pointless-statement
 
-    # Create a new process object with a different PID value
-    # (it is not important for the test do we have an actual process with this PID value or not)
-    p2 = TriblerProcess.current_process(ProcessKind.Core, manager=process_manager)
-    p2.pid += 1
-    # The new process should not be able to become a primary process, as we already have the primary process in the DB
-    assert not p2.become_primary()
-    assert not p2.primary
-
-    with process_manager.connect() as connection:
-        # Here we are emulating the situation that the current process abnormally terminated without updating the row
-        # in the database. To emulate it, we update the `started_at` time of the primary process in the DB.
-
-        # After the update, it looks like the actual process with the PID of the primary process (that is, the process
-        # from which the test suite is running) was created 100 days after the row was added to the database.
-
-        # As a result, TriblerProcess.is_running() returns False for the previous primary process because it
-        # believes the running process with the same PID is a new process, different from the process in the DB
-        connection.execute('update processes set started_at = started_at - (60 * 60 * 24 * 100) where "primary" = 1')
-
-    p3 = TriblerProcess.current_process(ProcessKind.Core, manager=process_manager)
-    p3.pid += 2
-    # Now p3 can become a new primary process, because the previous primary process considered
-    # already finished and replaced with a new unrelated process with the same PID
-    assert p3.become_primary()
-    assert p3.primary
-
-    with process_manager.connect() as connection:
-        rows = connection.execute('select rowid from processes where "primary" = 1').fetchall()
-        # At the end, the DB should contain only one primary process, namely p3
-        assert len(rows) == 1 and rows[0][0] == p3.rowid
+    x = Mock()
+    process_manager._current_process = x
+    assert process_manager.current_process is x
 
 
 def test_save(process_manager: ProcessManager):
-    p = TriblerProcess.current_process(ProcessKind.Core, manager=process_manager)
+    # Tests that saving a new process to the database correctly updates its `rowid` attribute.
+    p = TriblerProcess.current_process(process_manager, ProcessKind.Core, owns_lock=False)
     p.pid = p.pid + 100
+    assert p.rowid is None
     p.save()
     assert p.rowid is not None
+
+
+@patch('tribler.core.utilities.process_manager.process.TriblerProcess.is_running')
+def test_get_primary_process_1(is_running: MagicMock, tmp_path):
+    # Test that `get_primary_process()` returns None when no processes are present in the database.
+    pm = ProcessManager(tmp_path)
+
+    # Validate that no primary processes are returned for both `ProcessKind` options in an empty database scenario.
+    assert pm.get_primary_process(ProcessKind.Core) is None
+    assert pm.get_primary_process(ProcessKind.GUI) is None
+
+    # Ensure that the `TriblerProcess.is_running()` method was not called
+    # since no primary process entries were found in the database.
+    is_running.assert_not_called()
+
+
+def _save_core_process(manager: ProcessManager, pid: int, primary: bool) -> TriblerProcess:
+    process = TriblerProcess(manager=manager, kind=ProcessKind.Core, pid=pid, primary=primary, app_version='1',
+                             started_at=int(time.time()) - 1)
+    process.save()
+    return process
+
+
+@patch('tribler.core.utilities.process_manager.process.TriblerProcess.is_running')
+def test_get_primary_process_2(is_running: MagicMock, tmp_path):
+    # Verify `get_primary_process` returns None when the database only contains non-primary processes.
+    pm = ProcessManager(tmp_path)
+
+    # Populate the database with non-primary Core processes.
+    _save_core_process(pm, pid=100, primary=False)
+    _save_core_process(pm, pid=200, primary=False)
+
+    # Assert no primary process is found for both Core and GUI process kinds.
+    assert pm.get_primary_process(ProcessKind.Core) is None
+    assert pm.get_primary_process(ProcessKind.GUI) is None
+
+    # Confirm that `is_running` was not called due to the absence of primary process entries.
+    is_running.assert_not_called()
+
+
+@patch('tribler.core.utilities.process_manager.process.TriblerProcess.is_running', side_effect=[True])
+def test_get_primary_process_3(is_running: MagicMock, tmp_path):
+    # Test that `get_primary_process` correctly retrieves the primary process for a specified kind.
+    pm = ProcessManager(tmp_path)
+
+    # Set up the database with several non-primary and one primary Core processes.
+    _save_core_process(pm, pid=100, primary=False)
+    _save_core_process(pm, pid=200, primary=False)
+    p3 = _save_core_process(pm, pid=300, primary=True)
+
+    # Retrieve the primary Core process and assert that it matches the expected process.
+    primary_process = pm.get_primary_process(ProcessKind.Core)
+    assert primary_process and primary_process.pid == p3.pid
+
+    # Confirm that `is_running` check was called for the process retrieved from the DB before returning it
+    is_running.assert_called_once()
+
+    # Verify no primary GUI process is retrieved when only primary process of a different kind is in the database.
+    assert pm.get_primary_process(ProcessKind.GUI) is None
+
+
+@patch('tribler.core.utilities.process_manager.process.TriblerProcess.is_running', side_effect=[False])
+def test_get_primary_process_4(is_running: MagicMock, tmp_path):
+    # Test that `get_primary_process` returns None when the process marked as primary in the DB is no longer running
+    pm = ProcessManager(tmp_path)
+
+    # Add a single primary Core process to the database for which process.is_running() returns False
+    _save_core_process(pm, pid=100, primary=False)
+    _save_core_process(pm, pid=200, primary=False)
+    _save_core_process(pm, pid=300, primary=True)
+
+    assert pm.get_primary_process(ProcessKind.Core) is None  # No primary processes should be returned from the DB
+    # Checks that the previous primary process was successfully selected from the DB, but it is not running anymore
+    is_running.assert_called()
+
+    last_processes = pm.get_last_processes()
+    assert len(last_processes) == 3
+
+    # Verifies that the last call of `get_primary_process` update the state of the last process to make it non-primary
+    assert last_processes[-1].pid == 300 and not last_processes[-1].primary
+
+
+@patch('tribler.core.utilities.process_manager.process.TriblerProcess.is_running', side_effect=[True, True])
+def test_get_primary_process_5(is_running: MagicMock, tmp_path):
+    # Verifies that when two processes of the same kind are specified as primary in the database and actually running,
+    # (an incorrect situation that should never happen), then one process should be returned from the
+    # `get_primary_process` call and the error "Multiple primary processes found in the database" should be specified
+    # for all such processes in the database.
+    pm = ProcessManager(tmp_path)
+    now = int(time.time())
+
+    # Incorrect situation, two primary Core processes in the DB, one of them is returned
+    p1 = TriblerProcess(manager=pm, kind=ProcessKind.Core, pid=100, primary=False, app_version='1', started_at=now-3)
+    p2 = TriblerProcess(manager=pm, kind=ProcessKind.Core, pid=200, primary=True, app_version='1', started_at=now-2)
+    p3 = TriblerProcess(manager=pm, kind=ProcessKind.Core, pid=300, primary=True, app_version='1', started_at=now-1)
+    p1.save()
+    p2.save()
+    p3.save()
+
+    p = pm.get_primary_process(ProcessKind.Core)
+    assert p.pid == 200  # When multiple primary processes are found in the database, the first one is returned
+    assert is_running.call_count == 2  # For all retrieved primary processes `is_running` check should be performed
+
+    last_processes = pm.get_last_processes()
+    assert len(last_processes) == 3
+
+    msg = "Multiple primary processes found in the database"
+    # Two last processes in the database should have the specified error message
+    assert [p.error_msg for p in last_processes] == [None, msg, msg]
+
+
+@patch('tribler.core.utilities.process_manager.process.TriblerProcess.is_running', return_value=True)
+def test_setup_current_process(is_running: MagicMock, tmp_path):  # pylint: disable=unused-argument
+    pm = ProcessManager(tmp_path)
+    now = int(time.time())
+
+    # Add a primary Core process to the database for which process.is_running() returns True
+    p1 = TriblerProcess(manager=pm, kind=ProcessKind.Core, pid=100, primary=True, app_version='1', started_at=now-1)
+    p1.save()
+
+    with pytest.raises(RuntimeError, match="^Previous primary process still active: .* Current process: .*"):
+        pm.setup_current_process(kind=ProcessKind.Core, owns_lock=True)
 
 
 def test_set_api_port(process_manager: ProcessManager):
@@ -78,9 +181,9 @@ def test_get_last_processes(process_manager: ProcessManager):
     last_processes = process_manager.get_last_processes()
     assert len(last_processes) == 1 and last_processes[0].rowid == process_manager.current_process.rowid
 
-    fake_process = TriblerProcess.current_process(ProcessKind.Core, manager=process_manager)
+    fake_process = TriblerProcess.current_process(manager=process_manager, kind=ProcessKind.Core, owns_lock=False)
     fake_process.pid = fake_process.pid + 1
-    fake_process.become_primary()
+    fake_process.save()
 
     last_processes = process_manager.get_last_processes()
     assert len(last_processes) == 2
@@ -96,9 +199,9 @@ def test_corrupted_database(logger_exception: Mock, logger_warning: Mock, proces
     process_manager.db_filepath.write_bytes(db_content[:1500])  # corrupt the database file
 
     # no exception, the database is silently re-created:
-    current_process = TriblerProcess.current_process(ProcessKind.Core, manager=process_manager)
-    process_manager2 = ProcessManager(process_manager.root_dir, current_process)
-    current_process.become_primary()
+    process_manager2 = ProcessManager(process_manager.root_dir)
+    process_manager2.setup_current_process(kind=ProcessKind.Core, owns_lock=False)
+
     assert logger_exception.call_args[0][0] == 'DatabaseError: database disk image is malformed'
     assert logger_warning.call_args[0][0] == 'Retrying after the error: DatabaseError: database disk image is malformed'
 

--- a/src/tribler/core/utilities/process_manager/tests/test_process.py
+++ b/src/tribler/core/utilities/process_manager/tests/test_process.py
@@ -10,7 +10,7 @@ from tribler.core.utilities.process_manager.process import ProcessKind, TriblerP
 
 
 def test_tribler_process():
-    p = TriblerProcess.current_process(ProcessKind.Core, 123, manager=Mock())
+    p = TriblerProcess.current_process(manager=Mock(), kind=ProcessKind.Core, owns_lock=False, creator_pid=123)
     assert p.is_current_process()
     assert p.is_running()
 
@@ -26,14 +26,6 @@ def test_tribler_process():
               r"started='\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}'\, api_port=123, duration='\d:\d{2}:\d{2}', " \
               r"exit_code=1\)$"
     assert re.match(pattern, str(p))
-
-
-@pytest.fixture(name='manager')
-def manager_fixture(tmp_path: Path) -> ProcessManager:
-    current_process = TriblerProcess.current_process(ProcessKind.Core)
-    process_manager = ProcessManager(tmp_path, current_process)
-    process_manager.connection = Mock()
-    return process_manager
 
 
 @pytest.fixture(name='current_process')

--- a/src/tribler/core/utilities/tests/test_process_locking.py
+++ b/src/tribler/core/utilities/tests/test_process_locking.py
@@ -1,0 +1,20 @@
+from unittest.mock import patch
+
+from filelock import Timeout
+
+from tribler.core.utilities.process_locking import try_acquire_file_lock
+
+
+def test_try_acquire_file_lock(tmp_path):
+    lockfile_path = tmp_path / 'lockfile.lock'
+    lock = try_acquire_file_lock(lockfile_path)
+    assert lock.is_locked
+    lock.release()
+    assert not lock.is_locked
+
+
+@patch('filelock.FileLock.acquire', side_effect=[Timeout('lockfile-name')])
+def test_try_acquire_file_lock_blocked(acquire, tmp_path):  # pylint: disable=unused-argument
+    lockfile_path = tmp_path / 'lockfile.lock'
+    lock = try_acquire_file_lock(lockfile_path)
+    assert lock is None

--- a/src/tribler/gui/tests/test_gui.py
+++ b/src/tribler/gui/tests/test_gui.py
@@ -41,10 +41,10 @@ def fixture_window(tmp_path_factory):
     api_key = hexlify(os.urandom(16))
     root_state_dir = tmp_path_factory.mktemp('tribler_state_dir')
 
-    current_process = TriblerProcess.current_process(ProcessKind.GUI)
-    process_manager = ProcessManager(root_state_dir, current_process)
-    is_primary_process = process_manager.current_process.become_primary()
-    app = TriblerApplication("triblerapp-guitest", sys.argv, start_local_server=is_primary_process)
+    process_manager = ProcessManager(root_state_dir)
+    process_manager.setup_current_process(kind=ProcessKind.GUI, owns_lock=False)
+
+    app = TriblerApplication("triblerapp-guitest", sys.argv, start_local_server=False)
     app_manager = AppManager(app)
     # We must create a separate instance of QSettings and clear it.
     # Otherwise, previous runs of the same app will affect this run.


### PR DESCRIPTION
This PR provides an alternative way (as compared to #7637) to determine the primary Tribler process. This PR uses the `filelock` library for that purpose:
* Now, when the primary Tribler GUI/Core process is running, the corresponding lock files `'tribler-gui.lock'`/`'tribler-core.lock'` are created and held until the related GUI/Core process is finished.
* ProcessManager still keeps all Tribler processes in the database but does not determine which process can be primary.
* The database of processes is still used to pass the opened REST API port from the Core process to the GUI process. The reason for this is that it is still possible that multiple processes of the same type can run in parallel (for example, one primary and several secondary processes), and it is safer to store port in a process-specific place inside the database instead of using a global variable; this way few errors caused by race conditions can happen.

The typical usage of the new API looks the following way:
1. First, the process tries to acquire the file lock:

    ```python
    process_lock = try_acquire_file_lock(lock_file_name)
    current_process_has_lock = bool(process_lock)
    ```
    
    If the attempt to grab the lock is successful, the process is considered a primary process; otherwise, it is a secondary process and should terminate after passing the magnet link to the primary process.
    
    The current process should hold the lock object returned from the `try_acquire_file_lock` call until the process finishes, as the lock releases if the lock object is garbage collected. The process can do `process_lock.release()` before it finishes, but it is not necessary, as (1) the object will be garbage collected after the program exits the scope where the lock was declared, and (2) even if the lock file was not removed from the disk, the lock is still considered as released after the current process is finished. On Linux, the lock file is not always deleted at the end because of the details of how Linux works with open file descriptors, but it is not a problem.
    
2. The `ProcessManager` is initialized so the current process (primary or secondary) can store information about itself in the database:

    ```python
    process_manager = ProcessManager(root_state_dir)
    process_manager.setup_current_process(kind=ProcessKind.Core, has_lock=current_process_has_lock)
    set_global_process_manager(process_manager)
    ```


3. The process should check whether the attempt to grab the lock was successful, and if not, it should terminate:

    ```python
    if not current_process_has_lock:
        msg = 'Another Core process is already running'
        logger.warning(msg)
        process_manager.sys_exit(1, msg)
    ```
    
So, the API is relatively simple.