### PR TITLE
Fix `PATCH` for the previous download

### DIFF
--- a/src/tribler/gui/widgets/downloadsdetailstabwidget.py
+++ b/src/tribler/gui/widgets/downloadsdetailstabwidget.py
@@ -89,12 +89,13 @@ class DownloadsDetailsTabWidget(QTabWidget):
                 or self.current_download.get('infohash') != download.get('infohash')
                 or self.current_download.get('time_added') != download.get('time_added')
         )
-        self.current_download = download
         # When we switch to another download, we want to fixate the changes user did to selected files.
         # Also, we have to stop the change batching time to prevent carrying the event to the new download
         if did_change and self._batch_changes_timer.isActive():
             self._batch_changes_timer.stop()
             self.set_included_files()
+
+        self.current_download = download
         self.update_pages(new_download=did_change)
 
     @staticmethod


### PR DESCRIPTION
This PR resolves #7646 by correcting a logical error in `DownloadsDetailsTabWidget`.

The issue arises under the following circumstances:
1. A user selects the first download.
2. The user opens the files tab for the first download.
3. The user then selects the second download.

At this juncture, the list of selected files has been determined based on the first download, and a PATCH request is subsequently sent to the core. However, this PATCH request erroneously uses the hash of the second download. As a result, an 'out of range' error is triggered on the core side due to the mismatch.