### PR TITLE
Fix TypeError: 'NoneType' object is not subscriptable in StartDownloadDialog.__init__() 

### DIFF
--- a/src/tribler/gui/tests/test_gui.py
+++ b/src/tribler/gui/tests/test_gui.py
@@ -65,7 +65,7 @@ def fixture_window(tmp_path_factory):
     wait_for_signal(
         window.core_manager.events_manager.core_connected,
         timeout=20,
-        condition=lambda: window.tribler_started or (
+        condition=lambda: window.core_connected or (
                 window.core_manager.core_started and not window.core_manager.core_running)
     )
     if not window.core_manager.core_running:

--- a/src/tribler/gui/tribler_window.py
+++ b/src/tribler/gui/tribler_window.py
@@ -190,7 +190,8 @@ class TriblerWindow(QMainWindow):
         request_manager.set_api_key(api_key)
         request_manager.set_api_port(api_port)
 
-        self.tribler_started = False
+        self.core_connected = False
+        self.ui_started = False
         self.tribler_settings = None
         self.tribler_version = version_id
         self.debug_window = None
@@ -541,12 +542,12 @@ class TriblerWindow(QMainWindow):
                 logging.error("Failed to set tray message: %s", str(e))
 
     def on_core_connected(self, version):
-        if self.tribler_started:
+        if self.core_connected:
             self._logger.warning("Received duplicate Tribler Core connected event")
             return
 
         self._logger.info("Core connected")
-        self.tribler_started = True
+        self.core_connected = True
         self.tribler_version = version
 
         request_manager.get("settings", self.on_receive_settings, capture_errors=False)
@@ -602,6 +603,8 @@ class TriblerWindow(QMainWindow):
         self.window().debug_panel_button.setHidden(not get_gui_setting(self.gui_settings, "debug", False, is_bool=True))
 
         QApplication.setStyle(InstantTooltipStyle(QApplication.style()))
+
+        self.ui_started = True
 
     @property
     def hide_xxx(self):
@@ -1252,5 +1255,5 @@ class TriblerWindow(QMainWindow):
 
     def handle_uri(self, uri):
         self.pending_uri_requests.append(uri)
-        if self.tribler_started and not self.start_download_dialog_active:
+        if self.ui_started and not self.start_download_dialog_active:
             self.process_uri_request()


### PR DESCRIPTION
This PR addresses issue #7641 by introducing a new flag `ui_started`, which is utilized to ascertain the appropriate time to proceed with URI handling.