### PR TITLE
Only load peers, pieces, and files for the selected download

### DIFF
--- a/src/tribler/gui/widgets/downloadprogressbar.py
+++ b/src/tribler/gui/widgets/downloadprogressbar.py
@@ -36,12 +36,9 @@ class DownloadProgressBar(QWidget):
             DownloadStatus.STOPPED_ON_ERROR,
         }
 
-        if status in seeding_or_circuits:
-            self.set_fraction(download["progress"])
-        elif status in downloading_or_stopped:
+        if status in downloading_or_stopped:
             self.set_pieces()
-        else:
-            self.set_fraction(0.0)
+        self.set_fraction(download.get("progress", 0.0))
 
     def set_fraction(self, fraction):
         self.show_pieces = False
@@ -49,9 +46,11 @@ class DownloadProgressBar(QWidget):
         self.repaint()
 
     def set_pieces(self):
-        self.show_pieces = True
-        self.fraction = 0.0
-        self.pieces = self.decode_pieces(self.download["pieces"])[: self.download["total_pieces"]]
+        if self.download.get("pieces"):
+            self.show_pieces = True
+            self.pieces = self.decode_pieces(self.download["pieces"])[: self.download["total_pieces"]]
+        else:
+            self.show_pieces = False
         self.repaint()
 
     def decode_pieces(self, pieces):

--- a/src/tribler/gui/widgets/downloadspage.py
+++ b/src/tribler/gui/widgets/downloadspage.py
@@ -134,11 +134,22 @@ class DownloadsPage(AddBreadcrumbOnShowMixin, QWidget):
     def refresh_downloads(self):
         index = self.window().download_details_widget.currentIndex()
 
-        url_params = {'get_pieces': 1}
-        if index == DownloadDetailsTabs.PEERS:
-            url_params['get_peers'] = 1
-        elif index == DownloadDetailsTabs.FILES:
-            url_params['get_files'] = 1
+        details_shown = not self.window().download_details_widget.isHidden()
+        selected_download = self.window().download_details_widget.current_download
+
+        if details_shown and selected_download is not None:
+            url_params = {
+                'get_pieces': 1,
+                'get_peers': int(index == DownloadDetailsTabs.PEERS),
+                'get_files': int(index == DownloadDetailsTabs.FILES),
+                'infohash': selected_download.get('infohash', "")
+            }
+        else:
+            url_params = {
+                'get_pieces': 0,
+                'get_peers': 0,
+                'get_files': 0
+            }
 
         request_manager.get(
             endpoint="downloads",
@@ -276,6 +287,7 @@ class DownloadsPage(AddBreadcrumbOnShowMixin, QWidget):
         if len(self.selected_items) == 1:
             self.window().download_details_widget.update_with_download(self.selected_items[0].download_info)
             self.window().download_details_widget.show()
+            self.refresh_downloads()
         else:
             self.window().download_details_widget.hide()
 


### PR DESCRIPTION
Related to #5399 (PR 1/4)

In order to filter for the selected download in the downloads list, a new REST API parameter `"infohash"` is added to `get_downloads()` (serving `/downloads`). If the parameter is omitted, `get_downloads()` functions as before. Otherwise, the `get_peers`, `get_pieces`, and `get_files` are only applied to the download with the given infohash.

Because of the change `set_pieces()` may encounter downloads without set pieces. This is now handled.

Tangentially related to the other changes, I added a `refresh_downloads()` whenever the detail tab/window is shown.

---

Test reruns for this PR:

| **name** | **reason** |
| --- | --- |
| guitest_nix / run (macos-latest) | teardown of test_trust_page (Signal <bound PYQT_SIGNAL finished of QProcess object at 0x11fe49ee0> not raised within 10 seconds) |
| guitest_nix / run (macos-latest) | Segmentation fault |
