### PR TITLE
Disable background knowledge migration

### DIFF
--- a/src/tribler/core/components/knowledge/rules/knowledge_rules_processor.py
+++ b/src/tribler/core/components/knowledge/rules/knowledge_rules_processor.py
@@ -72,7 +72,8 @@ class KnowledgeRulesProcessor(TaskManager):
 
     def start(self):
         self.logger.info('Start')
-        self.start_batch_processing()
+        # The feature is suspended. See: https://github.com/Tribler/tribler/issues/7398#issuecomment-1772193981
+        # self.start_batch_processing()
         self.start_queue_processing()
 
     async def shutdown(self):
@@ -205,8 +206,9 @@ class KnowledgeRulesProcessor(TaskManager):
             return 0
         infohash_str = hexlify(infohash)
 
-        self.save_statements(subject_type=ResourceType.TORRENT, subject=infohash_str, predicate=ResourceType.TITLE,
-                             objects={title})
+        # The feature is suspended. See: https://github.com/Tribler/tribler/issues/7398#issuecomment-1772193981
+        # self.save_statements(subject_type=ResourceType.TORRENT, subject=infohash_str, predicate=ResourceType.TITLE,
+        #                      objects={title})
 
         if tags := set(extract_only_valid_tags(title, rules=general_rules)):
             self.save_statements(subject_type=ResourceType.TORRENT, subject=infohash_str, predicate=ResourceType.TAG,

--- a/src/tribler/core/components/knowledge/rules/tests/test_knowledge_rules_processor.py
+++ b/src/tribler/core/components/knowledge/rules/tests/test_knowledge_rules_processor.py
@@ -35,21 +35,22 @@ def test_constructor(tag_rules_processor: KnowledgeRulesProcessor):
     assert tag_rules_processor.batch_interval == TEST_INTERVAL
 
 
-@patch.object(KnowledgeRulesProcessor, 'save_statements')
-async def test_process_torrent_file(mocked_save_tags: MagicMock, tag_rules_processor: KnowledgeRulesProcessor):
-    # test on None
-    assert not await tag_rules_processor.process_torrent_title(infohash=None, title='title')
-    assert not await tag_rules_processor.process_torrent_title(infohash=b'infohash', title=None)
-
-    # test that process_torrent_title doesn't find any tags in the title
-    # the function should return `1` as it should process only one statement -- the TITLE itself
-    assert await tag_rules_processor.process_torrent_title(infohash=b'infohash', title='title') == 1
-    assert mocked_save_tags.call_count == 1
-
-    # test that process_torrent_title does find tags in the title
-    assert await tag_rules_processor.process_torrent_title(infohash=b'infohash', title='title [tag]') == 2
-    mocked_save_tags.assert_called_with(subject_type=ResourceType.TORRENT, subject='696e666f68617368', objects={'tag'},
-                                        predicate=ResourceType.TAG)
+# The feature is suspended. See: https://github.com/Tribler/tribler/issues/7398#issuecomment-1772193981
+# @patch.object(KnowledgeRulesProcessor, 'save_statements')
+# async def test_process_torrent_file(mocked_save_tags: MagicMock, tag_rules_processor: KnowledgeRulesProcessor):
+#     # test on None
+#     assert not await tag_rules_processor.process_torrent_title(infohash=None, title='title')
+#     assert not await tag_rules_processor.process_torrent_title(infohash=b'infohash', title=None)
+#
+#     # test that process_torrent_title doesn't find any tags in the title
+#     # the function should return `1` as it should process only one statement -- the TITLE itself
+#     assert await tag_rules_processor.process_torrent_title(infohash=b'infohash', title='title') == 1
+#     assert mocked_save_tags.call_count == 1
+#
+#     # test that process_torrent_title does find tags in the title
+#     assert await tag_rules_processor.process_torrent_title(infohash=b'infohash', title='title [tag]') == 2
+#     mocked_save_tags.assert_called_with(subject_type=ResourceType.TORRENT, subject='696e666f68617368',
+#                                         objects={'tag'}, predicate=ResourceType.TAG)
 
 
 def test_save_tags(tag_rules_processor: KnowledgeRulesProcessor):
@@ -92,34 +93,35 @@ async def test_process_batch(mocked_cancel_pending_task: Mock, tag_rules_process
     assert mocked_cancel_pending_task.called  # it should  be the last batch in the db
 
 
-@db_session
-@patch.object(KnowledgeRulesProcessor, 'register_task', new=MagicMock())
-def test_start_no_previous_version(tag_rules_processor: KnowledgeRulesProcessor):
-    # test that if there is no previous version of the rules processor, it will be created
-    assert tag_rules_processor.get_rules_processor_version() == 0
-    assert tag_rules_processor.get_rules_processor_version() != tag_rules_processor.version
+# The feature is suspended. See: https://github.com/Tribler/tribler/issues/7398#issuecomment-1772193981
+# @db_session
+# @patch.object(KnowledgeRulesProcessor, 'register_task', new=MagicMock())
+# def test_start_no_previous_version(tag_rules_processor: KnowledgeRulesProcessor):
+#     # test that if there is no previous version of the rules processor, it will be created
+#     assert tag_rules_processor.get_rules_processor_version() == 0
+#     assert tag_rules_processor.get_rules_processor_version() != tag_rules_processor.version
+#
+#     tag_rules_processor.start()
+#
+#     # version should be set to the current version
+#     assert tag_rules_processor.get_rules_processor_version() == tag_rules_processor.version
+#     # last processed torrent id should be set to 0
+#     assert tag_rules_processor.get_last_processed_torrent_id() == 0
 
-    tag_rules_processor.start()
-
-    # version should be set to the current version
-    assert tag_rules_processor.get_rules_processor_version() == tag_rules_processor.version
-    # last processed torrent id should be set to 0
-    assert tag_rules_processor.get_last_processed_torrent_id() == 0
-
-
-@db_session
-@patch.object(KnowledgeRulesProcessor, 'register_task', new=MagicMock())
-def test_start_previous_version(tag_rules_processor: KnowledgeRulesProcessor):
-    # test that if there is a previous version of the rules processor, it will be updated to the current
-    tag_rules_processor.set_rules_processor_version(tag_rules_processor.version - 1)
-    tag_rules_processor.set_last_processed_torrent_id(100)
-
-    tag_rules_processor.start()
-
-    # version should be set to the current version
-    assert tag_rules_processor.get_rules_processor_version() == tag_rules_processor.version
-    # last processed torrent id should be set to 0
-    assert tag_rules_processor.get_last_processed_torrent_id() == 0
+# # The feature is suspended. See: https://github.com/Tribler/tribler/issues/7398#issuecomment-1772193981
+# @db_session
+# @patch.object(KnowledgeRulesProcessor, 'register_task', new=MagicMock())
+# def test_start_previous_version(tag_rules_processor: KnowledgeRulesProcessor):
+#     # test that if there is a previous version of the rules processor, it will be updated to the current
+#     tag_rules_processor.set_rules_processor_version(tag_rules_processor.version - 1)
+#     tag_rules_processor.set_last_processed_torrent_id(100)
+#
+#     tag_rules_processor.start()
+#
+#     # version should be set to the current version
+#     assert tag_rules_processor.get_rules_processor_version() == tag_rules_processor.version
+#     # last processed torrent id should be set to 0
+#     assert tag_rules_processor.get_last_processed_torrent_id() == 0
 
 
 @db_session


### PR DESCRIPTION
Following the [suspension](https://github.com/Tribler/tribler/issues/7398#issuecomment-1772193981) of Knowledge Graph Migration, this PR disables two features:
1. The addition of `Title` statements to `knowledge.db`.
2. The batch processing of torrent titles.

This change aims to conserve the user's CPU resources and disk space.