### PR TITLE
Use the default event loop on Windows

### DIFF
--- a/src/tribler/core/start_core.py
+++ b/src/tribler/core/start_core.py
@@ -163,11 +163,6 @@ def run_tribler_core_session(api_port: Optional[int], api_key: str,
     log_dir = config.general.get_path_as_absolute('log_dir', config.state_dir)
     trace_logger = check_and_enable_code_tracing('core', log_dir)
 
-    if sys.platform.startswith('win'):
-        # TODO for the moment being, we use the SelectorEventLoop on Windows, since with the ProactorEventLoop, ipv8
-        # peer discovery becomes unstable. Also see issue #5485.
-        asyncio.set_event_loop(asyncio.SelectorEventLoop())
-
     loop = asyncio.get_event_loop()
     exception_handler = default_core_exception_handler
     loop.set_exception_handler(exception_handler.unhandled_error_observer)


### PR DESCRIPTION
Fixes #5435 by removing the workaround for #5485.

Note that I will use the branch of this PR to make sure #5485 _remains resolved_. To that end, this PR _may_ be amended with fixes related to #5485. I'll keep running a custom build for this PR (https://jenkins-ci.tribler.org/job/pers/job/Build-Win64-Custom/2/) for about an hour and keep an eye on the peers. If #5485 still does not appear, I will consider it resolved.