### PR TITLE
Fixed non-standard tooltip stylesheet

### DIFF
--- a/src/tribler/gui/i18n/es_ES.ts
+++ b/src/tribler/gui/i18n/es_ES.ts
@@ -2311,7 +2311,7 @@ Alto anonimato</translation>
     </message>
     <message>
         <location filename="../qt_resources/torrents_list.ui" line="269"/>
-        <source>This page show the list of popular torrents collected by Tribler during the last 24 hours.</source>
+        <source>This page shows the list of popular torrents collected by Tribler during the last 24 hours.</source>
         <translation>Esta página muestra la lista de torrents populares recopilados por Tribler durante las últimas 24 horas.</translation>
     </message>
     <message>

--- a/src/tribler/gui/i18n/pt_BR.ts
+++ b/src/tribler/gui/i18n/pt_BR.ts
@@ -129,7 +129,7 @@
     </message>
     <message>
         <location filename="../tribler_window.py" line="451"/>
-        <source>This page show the list of popular torrents collected by Tribler during the last 24 hours.</source>
+        <source>This page shows the list of popular torrents collected by Tribler during the last 24 hours.</source>
         <translation type="obsolete">Essa página mostra uma lista de torrents populares coletados no Tibler nas últimas 24 horas.</translation>
     </message>
     <message>
@@ -2709,7 +2709,7 @@ High anonymity</source>
     </message>
     <message>
         <location filename="../qt_resources/torrents_list.ui" line="269"/>
-        <source>This page show the list of popular torrents collected by Tribler during the last 24 hours.</source>
+        <source>This page shows the list of popular torrents collected by Tribler during the last 24 hours.</source>
         <translation type="unfinished">Essa página mostra uma lista de torrents populares coletados no Tibler nas últimas 24 horas.</translation>
     </message>
     <message>

--- a/src/tribler/gui/i18n/ru_RU.ts
+++ b/src/tribler/gui/i18n/ru_RU.ts
@@ -124,7 +124,7 @@
     </message>
     <message>
         <location filename="../tribler_window.py" line="451"/>
-        <source>This page show the list of popular torrents collected by Tribler during the last 24 hours.</source>
+        <source>This page shows the list of popular torrents collected by Tribler during the last 24 hours.</source>
         <translation type="obsolete">Эта страница показывает список популярных торрентов обнаруженных Tribler за последние 24 часа.</translation>
     </message>
     <message>
@@ -2375,7 +2375,7 @@ High anonymity</source>
     </message>
     <message>
         <location filename="../qt_resources/torrents_list.ui" line="269"/>
-        <source>This page show the list of popular torrents collected by Tribler during the last 24 hours.</source>
+        <source>This page shows the list of popular torrents collected by Tribler during the last 24 hours.</source>
         <translation>Эта страница показывает список популярных торрентов обнаруженных Tribler за последние 24 часа.</translation>
     </message>
     <message>

--- a/src/tribler/gui/i18n/zh_CN.ts
+++ b/src/tribler/gui/i18n/zh_CN.ts
@@ -124,7 +124,7 @@
     </message>
     <message>
         <location filename="../tribler_window.py" line="451"/>
-        <source>This page show the list of popular torrents collected by Tribler during the last 24 hours.</source>
+        <source>This page shows the list of popular torrents collected by Tribler during the last 24 hours.</source>
         <translation type="obsolete">此页面显示 Tribler 最近 24 小时收集到的流行种子列表。</translation>
     </message>
     <message>
@@ -2385,7 +2385,7 @@ High anonymity</source>
     </message>
     <message>
         <location filename="../qt_resources/torrents_list.ui" line="269"/>
-        <source>This page show the list of popular torrents collected by Tribler during the last 24 hours.</source>
+        <source>This page shows the list of popular torrents collected by Tribler during the last 24 hours.</source>
         <translation type="unfinished">此页面显示 Tribler 最近 24 小时收集到的流行种子列表。</translation>
     </message>
     <message>

--- a/src/tribler/gui/qt_resources/torrents_list.ui
+++ b/src/tribler/gui/qt_resources/torrents_list.ui
@@ -266,13 +266,7 @@ color: #B5B5B5;</string>
          </font>
         </property>
         <property name="toolTip">
-         <string>This page show the list of popular torrents collected by Tribler during the last 24 hours.</string>
-        </property>
-        <property name="styleSheet">
-         <string notr="true">border: 1px solid white;
-color: white;
-border-radius: 10px;
-</string>
+         <string>This page shows the list of popular torrents collected by Tribler during the last 24 hours.</string>
         </property>
         <property name="text">
          <string>i</string>


### PR DESCRIPTION
Fixes #6532 by adopting the default tooltip style, consistent with the rest of our tooltips.

Secondarily, this PR fixes a minor misspelling in the tooltip itself.