### PR TITLE
Upload binaries by label

### DIFF
--- a/.github/workflows/!PR.yml
+++ b/.github/workflows/!PR.yml
@@ -15,6 +15,9 @@ jobs:
     outputs:
       python-version: '3.8'
       source-ref: refs/pull/${{github.event.pull_request.number}}/merge
+      upload-binaries: >-
+        ${{ contains(github.event.pull_request.labels.*.name, 'PR: upload binaries') }}
+
     steps:
       - run: echo done
 
@@ -141,7 +144,7 @@ jobs:
     if: ${{needs.changes.outputs.build == 'true' && !github.event.pull_request.draft}}
     uses: ./.github/workflows/build_ubuntu.yml
     with:
-      upload: false
+      upload: ${{ needs.env.outputs.upload-binaries == 'true' }}
       os: ubuntu-latest
       python-version: ${{needs.env.outputs.python-version}}
       ref: ${{needs.env.outputs.source-ref}}
@@ -151,7 +154,7 @@ jobs:
     if: ${{needs.changes.outputs.build == 'true' && !github.event.pull_request.draft}}
     uses: ./.github/workflows/build_mac.yml
     with:
-      upload: false
+      upload: ${{ needs.env.outputs.upload-binaries == 'true' }}
       os: macos-latest
       python-version: ${{needs.env.outputs.python-version}}
       ref: ${{needs.env.outputs.source-ref}}
@@ -161,7 +164,7 @@ jobs:
     if: ${{needs.changes.outputs.build == 'true' && !github.event.pull_request.draft}}
     uses: ./.github/workflows/build_windows.yml
     with:
-      upload: false
+      upload: ${{ needs.env.outputs.upload-binaries == 'true' }}
       os: windows-latest
       python-version: ${{needs.env.outputs.python-version}}
       ref: ${{needs.env.outputs.source-ref}}


### PR DESCRIPTION
This PR introduces an option to upload binaries for a PR. This can be done if a developer adds the label `PR: upload binaries` to the PR.

Example: https://github.com/Tribler/tribler/actions/runs/6852711450

<img width="635" alt="image" src="https://github.com/Tribler/tribler/assets/13798583/726f94e4-90d7-46f5-8ccc-0625c5289955">
