### PR TITLE
An experimental watcher for slow tests that shows the current stack trace of the main thread

### DIFF
--- a/src/tribler/core/conftest.py
+++ b/src/tribler/core/conftest.py
@@ -3,8 +3,10 @@ import gc
 import logging
 import platform
 import sys
+import threading
+import time
 from datetime import datetime
-from typing import Optional
+from typing import Generator, Optional
 
 import human_readable
 import pytest
@@ -15,6 +17,8 @@ from aiohttp.web_app import Application
 from tribler.core.components.restapi.rest.rest_endpoint import RESTEndpoint
 from tribler.core.components.restapi.rest.rest_manager import error_middleware
 from tribler.core.utilities.network_utils import default_network_utils
+from tribler.core.utilities.slow_coro_detection.main_thread_stack_tracking import get_main_thread_stack, \
+    main_stack_tracking_is_enabled, start_main_thread_stack_tracing, stop_main_thread_stack_tracing
 
 # Enable origin tracking for coroutine objects in the current thread, so when a test does not handle
 # some coroutine properly, we can see a traceback with the name of the test which created the coroutine.
@@ -49,21 +53,95 @@ def pytest_collection_finish(session):
     pytest_start_time = datetime.now()
 
 
+LONG_TEST_DURATION = 10.0
+STACK_CUT_DURATION = 0.1
+
+
+class LongTestWatchThread(threading.Thread):
+    def __init__(self):
+        super().__init__()
+        self.daemon = True
+        self.running = True
+        self.current_test_start_time = None
+        self.current_test_name = None
+
+    def run(self):
+        while self.running:
+            time.sleep(0.1)
+            self.check_test_duration()
+
+    def check_test_duration(self):
+        if self.current_test_start_time is not None:
+            elapsed_time = time.time() - self.current_test_start_time
+            if elapsed_time > LONG_TEST_DURATION:
+                msg = f"\n***** Long test: {self.current_test_name}\n\n"
+                if main_stack_tracking_is_enabled():
+                    stack = get_main_thread_stack(stack_cut_duration=STACK_CUT_DURATION)
+                    msg = f'{msg}{stack}\n'
+
+                sys.__stderr__.write(msg)
+                sys.__stderr__.flush()
+                # Reset start time to avoid repeated messages
+                self.current_test_start_time = time.time()
+
+    def stop(self):
+        self.running = False
+
+
+long_test_watch_thread = None
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtestloop(session) -> Generator[None, None, None]:
+    if session.config.option.collectonly:
+        yield
+        return
+
+    global long_test_watch_thread
+    long_test_watch_thread = LongTestWatchThread()
+    long_test_watch_thread.start()
+
+    yield  # This yields control to the main test loop
+
+    long_test_watch_thread.stop()
+    long_test_watch_thread.join()  # Wait for the thread to finish
+
+
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_protocol(item: Function, log=True, nextitem=None):
     """ Modify the pytest output to include the execution duration for all tests """
     # Perform the runtest protocol for a single test item.
+
     if enable_extended_logging and pytest_start_time:
         start_time = datetime.now()
         print(f'\n{start_time.strftime("%H:%M:%S.%f")[:-3]} Starting "{item.name}"...', end='', flush=True)
-        yield
+
+        # Skip modules that test profiling or stack tracing functionality to avoid accidentally affecting the test
+        modules_to_skip = ['test_pony_utils.py', 'test_profile.py', 'test_resource_monitor.py',
+                           'test_main_thread_stack_tracing.py']
+
+        long_test_watch_thread.current_test_start_time = time.time()
+        long_test_watch_thread.current_test_name = item.nodeid
+        try:
+            if any(m in item.nodeid for m in modules_to_skip):
+                # Do not enable stack tracing in modules that test stack tracing or profiling
+                yield
+            else:
+                start_main_thread_stack_tracing()
+                try:
+                    yield
+                finally:
+                    stop_main_thread_stack_tracing()
+        finally:
+            long_test_watch_thread.current_test_name = None
+            long_test_watch_thread.current_test_start_time = None
+
         now = datetime.now()
         duration = (now - start_time).total_seconds()
         total = now - pytest_start_time
         print(f' in {duration:.3f}s ({human_readable.time_delta(total)} in total)', end='')
     else:
         yield
-
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
This experimental PR enables stack tracing in tests. If some test freezes, with this PR, we should be able to see the stack trace of the main thread and understand the reason why the test is stuck. The check is performed from the separate thread that writes the stack trace directly to the stderr. It is possible to polish the code further, but right now, I just want to test the usefulness of the main idea. The PR works for my local tests and shows tracebacks like the following:

```
Long test: src/tribler/core/components/restapi/tests/test_restapi_component.py::test_rest_component

Traceback (most recent call last):
  File "C:\dev\tribler\venv\lib\site-packages\_pytest\runner.py", line 112, in pytest_runtest_protocol (function started 11.491 seconds ago)
    runtestprotocol(item, nextitem=nextitem)
  File "C:\dev\tribler\venv\lib\site-packages\_pytest\runner.py", line 132, in runtestprotocol (function started 11.491 seconds ago)
    reports.append(call_and_report(item, "teardown", log, nextitem=nextitem))
  File "C:\dev\tribler\venv\lib\site-packages\_pytest\runner.py", line 220, in call_and_report (function started 10.041 seconds ago)
    call = call_runtest_hook(item, when, **kwds)
  File "C:\dev\tribler\venv\lib\site-packages\_pytest\runner.py", line 259, in call_runtest_hook (function started 10.041 seconds ago)
    return CallInfo.from_call(
  File "C:\dev\tribler\venv\lib\site-packages\_pytest\runner.py", line 339, in from_call (function started 10.041 seconds ago)
    result: Optional[TResult] = func()
  File "C:\dev\tribler\venv\lib\site-packages\_pytest\runner.py", line 260, in <lambda> (function started 10.041 seconds ago)
    lambda: ihook(item=item, **kwds), when=when, reraise=reraise
  File "C:\dev\tribler\venv\lib\site-packages\pluggy\hooks.py", line 286, in __call__ (function started 10.041 seconds ago)
    return self._hookexec(self, self.get_hookimpls(), kwargs)
  File "C:\dev\tribler\venv\lib\site-packages\pluggy\manager.py", line 93, in _hookexec (function started 10.041 seconds ago)
    return self._inner_hookexec(hook, methods, kwargs)
  File "C:\dev\tribler\venv\lib\site-packages\pluggy\manager.py", line 84, in <lambda> (function started 10.041 seconds ago)
    self._inner_hookexec = lambda hook, methods, kwargs: hook.multicall(
  File "C:\dev\tribler\venv\lib\site-packages\pluggy\callers.py", line 187, in _multicall (function started 10.041 seconds ago)
    res = hook_impl.function(*args)
  File "C:\dev\tribler\venv\lib\site-packages\_pytest\runner.py", line 180, in pytest_runtest_teardown (function started 10.041 seconds ago)
    item.session._setupstate.teardown_exact(nextitem)
  File "C:\dev\tribler\venv\lib\site-packages\_pytest\runner.py", line 523, in teardown_exact (function started 10.041 seconds ago)
    fin()
  File "C:\dev\tribler\venv\lib\site-packages\_pytest\fixtures.py", line 685, in <lambda> (function started 10.041 seconds ago)
    subrequest.node.addfinalizer(lambda: fixturedef.finish(request=subrequest))
  File "C:\dev\tribler\venv\lib\site-packages\_pytest\fixtures.py", line 1030, in finish (function started 10.041 seconds ago)
    func()
  File "C:\dev\tribler\venv\lib\site-packages\_pytest\fixtures.py", line 917, in _teardown_yield_fixture (function started 10.041 seconds ago)
    next(it)
  File "C:\dev\tribler\src\tribler\core\conftest.py", line 166, in ensure_gc (function started 10.041 seconds ago)
    gc.collect()
```
(here, we apparently freeze in the garbage collector)

The following is from the release branch:
```
Long test: src/tribler/core/components/libtorrent/tests/test_seeding.py::test_seeding

Traceback (most recent call last):
  File "C:\dev\tribler\venv\lib\site-packages\_pytest\runner.py", line 112, in pytest_runtest_protocol (function started 5.012 seconds ago)
    runtestprotocol(item, nextitem=nextitem)
  File "C:\dev\tribler\venv\lib\site-packages\_pytest\runner.py", line 132, in runtestprotocol (function started 5.012 seconds ago)
    reports.append(call_and_report(item, "teardown", log, nextitem=nextitem))
  File "C:\dev\tribler\venv\lib\site-packages\_pytest\runner.py", line 220, in call_and_report (function started 0.980 seconds ago)
    call = call_runtest_hook(item, when, **kwds)
  File "C:\dev\tribler\venv\lib\site-packages\_pytest\runner.py", line 259, in call_runtest_hook (function started 0.980 seconds ago)
    return CallInfo.from_call(
  File "C:\dev\tribler\venv\lib\site-packages\_pytest\runner.py", line 339, in from_call (function started 0.980 seconds ago)
    result: Optional[TResult] = func()
  File "C:\dev\tribler\venv\lib\site-packages\_pytest\runner.py", line 260, in <lambda> (function started 0.980 seconds ago)
    lambda: ihook(item=item, **kwds), when=when, reraise=reraise
  File "C:\dev\tribler\venv\lib\site-packages\pluggy\hooks.py", line 286, in __call__ (function started 0.980 seconds ago)
    return self._hookexec(self, self.get_hookimpls(), kwargs)
  File "C:\dev\tribler\venv\lib\site-packages\pluggy\manager.py", line 93, in _hookexec (function started 0.980 seconds ago)
    return self._inner_hookexec(hook, methods, kwargs)
  File "C:\dev\tribler\venv\lib\site-packages\pluggy\manager.py", line 84, in <lambda> (function started 0.980 seconds ago)
    self._inner_hookexec = lambda hook, methods, kwargs: hook.multicall(
  File "C:\dev\tribler\venv\lib\site-packages\pluggy\callers.py", line 187, in _multicall (function started 0.980 seconds ago)
    res = hook_impl.function(*args)
  File "C:\dev\tribler\venv\lib\site-packages\_pytest\runner.py", line 180, in pytest_runtest_teardown (function started 0.980 seconds ago)
    item.session._setupstate.teardown_exact(nextitem)
  File "C:\dev\tribler\venv\lib\site-packages\_pytest\runner.py", line 523, in teardown_exact (function started 0.980 seconds ago)
    fin()
  File "C:\dev\tribler\venv\lib\site-packages\_pytest\fixtures.py", line 685, in <lambda> (function started 0.980 seconds ago)
    subrequest.node.addfinalizer(lambda: fixturedef.finish(request=subrequest))
  File "C:\dev\tribler\venv\lib\site-packages\_pytest\fixtures.py", line 1030, in finish (function started 0.980 seconds ago)
    func()
  File "C:\dev\tribler\venv\lib\site-packages\pytest_asyncio\plugin.py", line 297, in finalizer (function started 0.980 seconds ago)
    event_loop.run_until_complete(async_finalizer())
  File "C:\Python39\lib\asyncio\base_events.py", line 629, in run_until_complete (function started 0.980 seconds ago)
    self.run_forever()
  File "C:\Python39\lib\asyncio\base_events.py", line 596, in run_forever (function started 0.980 seconds ago)
    self._run_once()
  File "C:\Python39\lib\asyncio\base_events.py", line 1854, in _run_once (function started 0.940 seconds ago)
    event_list = self._selector.select(timeout)
  File "C:\Python39\lib\selectors.py", line 324, in select (function started 0.940 seconds ago)
    r, w, _ = self._select(self._readers, self._writers, [], timeout)
  File "C:\Python39\lib\selectors.py", line 315, in _select (function started 0.940 seconds ago)
    r, w, x = select.select(r, w, w, timeout)
```

So, there is a hope it can find the reason for long freezes as well.