### PR TITLE
Enable `faulthandler`

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,7 @@
 [pytest]
 timeout = 60
+faulthandler_timeout = 70
+
 ;https://pypi.org/project/pytest-asyncio/
 asyncio_mode = auto
 log_level = INFO


### PR DESCRIPTION
This PR addresses frozen test problems and enables `faulthandler` in the hope it can print the stacktrace of frozen tests.

It passes the following test:
```python
@pytest.mark.timeout(1)
def test_block():
    #  This is an example of breaking the `@pytest.mark.timeout(1)`. Just run the test.
    def block_forever():
        while True:
            pass

    blocker = threading.Thread(target=block_forever)
    blocker.start()
    blocker.join()  # This join will block the event loop indefinitely
```

with the following stacktrace:

```
Timeout (0:00:15)!
Thread 0x0000700007d81000 (most recent call first):
  File "/Users/<user>/Projects/github.com/Tribler/tribler/src/tribler/core/upgrade/tests/test_triblerversion.py", line 56 in block_forever
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/threading.py", line 910 in run
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/threading.py", line 973 in _bootstrap_inner
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/threading.py", line 930 in _bootstrap

Thread 0x0000700005d7b000 (most recent call first):
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/socket.py", line 293 in accept
  File "/Users/<user>/Projects/github.com/Tribler/tribler/venv/lib/python3.9/site-packages/pytest_rerunfailures.py", line 500 in run_server
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/threading.py", line 910 in run
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/threading.py", line 973 in _bootstrap_inner
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/threading.py", line 930 in _bootstrap

Thread 0x000000010b58a600 (most recent call first):
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/posixpath.py", line 167 in islink
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/posixpath.py", line 425 in _joinrealpath
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/posixpath.py", line 391 in realpath
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/inspect.py", line 755 in getmodule
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/inspect.py", line 829 in findsource
  File "/Users/<user>/Projects/github.com/Tribler/tribler/venv/lib/python3.9/site-packages/_pytest/_code/source.py", line 121 in findsource
  File "/Users/<user>/Projects/github.com/Tribler/tribler/venv/lib/python3.9/site-packages/_pytest/_code/code.py", line 108 in fullsource
  File "/Users/<user>/Projects/github.com/Tribler/tribler/venv/lib/python3.9/site-packages/_pytest/_code/code.py", line 252 in getsource
  File "/Users/<user>/Projects/github.com/Tribler/tribler/venv/lib/python3.9/site-packages/_pytest/_code/code.py", line 754 in _getentrysource
  File "/Users/<user>/Projects/github.com/Tribler/tribler/venv/lib/python3.9/site-packages/_pytest/_code/code.py", line 852 in repr_traceback_entry
  File "/Users/<user>/Projects/github.com/Tribler/tribler/venv/lib/python3.9/site-packages/_pytest/_code/code.py", line 914 in <listcomp>
  File "/Users/<user>/Projects/github.com/Tribler/tribler/venv/lib/python3.9/site-packages/_pytest/_code/code.py", line 913 in repr_traceback
  File "/Users/<user>/Projects/github.com/Tribler/tribler/venv/lib/python3.9/site-packages/_pytest/_code/code.py", line 989 in repr_excinfo
  File "/Users/<user>/Projects/github.com/Tribler/tribler/venv/lib/python3.9/site-packages/_pytest/_code/code.py", line 701 in getrepr
  File "/Users/<user>/Projects/github.com/Tribler/tribler/venv/lib/python3.9/site-packages/_pytest/nodes.py", line 486 in _repr_failure_py
  File "/Users/<user>/Projects/github.com/Tribler/tribler/venv/lib/python3.9/site-packages/_pytest/python.py", line 1833 in repr_failure
  File "/Users/<user>/Projects/github.com/Tribler/tribler/venv/lib/python3.9/site-packages/_pytest/reports.py", line 362 in from_item_and_call
  File "/Users/<user>/Projects/github.com/Tribler/tribler/venv/lib/python3.9/site-packages/_pytest/runner.py", line 368 in pytest_runtest_makereport
  File "/Users/<user>/Projects/github.com/Tribler/tribler/venv/lib/python3.9/site-packages/pluggy/_callers.py", line 80 in _multicall
  File "/Users/<user>/Projects/github.com/Tribler/tribler/venv/lib/python3.9/site-packages/pluggy/_manager.py", line 112 in _hookexec
  File "/Users/<user>/Projects/github.com/Tribler/tribler/venv/lib/python3.9/site-packages/pluggy/_hooks.py", line 433 in __call__
  File "/Users/<user>/Projects/github.com/Tribler/tribler/venv/lib/python3.9/site-packages/_pytest/runner.py", line 224 in call_and_report
  File "/Users/<user>/Projects/github.com/Tribler/tribler/venv/lib/python3.9/site-packages/_pytest/runner.py", line 133 in runtestprotocol
  File "/Users/<user>/Projects/github.com/Tribler/tribler/venv/lib/python3.9/site-packages/_pytest/runner.py", line 114 in pytest_runtest_protocol
  File "/Users/<user>/Projects/github.com/Tribler/tribler/venv/lib/python3.9/site-packages/pluggy/_callers.py", line 80 in _multicall
  File "/Users/<user>/Projects/github.com/Tribler/tribler/venv/lib/python3.9/site-packages/pluggy/_manager.py", line 112 in _hookexec
  File "/Users/<user>/Projects/github.com/Tribler/tribler/venv/lib/python3.9/site-packages/pluggy/_hooks.py", line 433 in __call__
  File "/Users/<user>/Projects/github.com/Tribler/tribler/venv/lib/python3.9/site-packages/_pytest/main.py", line 350 in pytest_runtestloop
  File "/Users/<user>/Projects/github.com/Tribler/tribler/venv/lib/python3.9/site-packages/pluggy/_callers.py", line 80 in _multicall
  File "/Users/<user>/Projects/github.com/Tribler/tribler/venv/lib/python3.9/site-packages/pluggy/_manager.py", line 112 in _hookexec
  File "/Users/<user>/Projects/github.com/Tribler/tribler/venv/lib/python3.9/site-packages/pluggy/_hooks.py", line 433 in __call__
  File "/Users/<user>/Projects/github.com/Tribler/tribler/venv/lib/python3.9/site-packages/_pytest/main.py", line 325 in _main
  File "/Users/<user>/Projects/github.com/Tribler/tribler/venv/lib/python3.9/site-packages/_pytest/main.py", line 271 in wrap_session
  File "/Users/<user>/Projects/github.com/Tribler/tribler/venv/lib/python3.9/site-packages/_pytest/main.py", line 318 in pytest_cmdline_main
  File "/Users/<user>/Projects/github.com/Tribler/tribler/venv/lib/python3.9/site-packages/pluggy/_callers.py", line 80 in _multicall
  File "/Users/<user>/Projects/github.com/Tribler/tribler/venv/lib/python3.9/site-packages/pluggy/_manager.py", line 112 in _hookexec
  File "/Users/<user>/Projects/github.com/Tribler/tribler/venv/lib/python3.9/site-packages/pluggy/_hooks.py", line 433 in __call__
  File "/Users/<user>/Projects/github.com/Tribler/tribler/venv/lib/python3.9/site-packages/_pytest/config/__init__.py", line 169 in main
  File "/Applications/PyCharm.app/Contents/plugins/python/helpers/pycharm/_jb_pytest_runner.py", line 53 in <module>
```

Related: #7545 #7695

Ref:
* https://docs.pytest.org/en/7.1.x/how-to/failures.html