### PR TITLE
Improve Core Process Error Handling

### DIFF
--- a/src/tribler/core/components/reporter/exception_handler.py
+++ b/src/tribler/core/components/reporter/exception_handler.py
@@ -187,7 +187,7 @@ class CoreExceptionHandler:
         self_copy.should_stop = False
         serialized_error = json.dumps(dataclasses.asdict(self_copy), indent=True)
 
-        with open(filepath, 'w') as exc_file:
+        with open(filepath, 'w', encoding='utf-8') as exc_file:
             exc_file.write(serialized_error)
 
     def delete_saved_file(self, reported_error: ReportedError):
@@ -203,7 +203,7 @@ class CoreExceptionHandler:
                 continue
 
             error_file_path = self.crash_dir / error_filename
-            with open(error_file_path, 'r') as file_handle:
+            with open(error_file_path, 'r', encoding='utf-8') as file_handle:
                 try:
                     saved_errors.append(ReportedError(**json.loads(file_handle.read())))
                 except JSONDecodeError:

--- a/src/tribler/core/components/reporter/exception_handler.py
+++ b/src/tribler/core/components/reporter/exception_handler.py
@@ -7,9 +7,10 @@ import re
 import sys
 from io import StringIO
 from json import JSONDecodeError
+from pathlib import Path
 from socket import gaierror
 from traceback import print_exception
-from typing import Callable, Dict, Optional, Set, Tuple, Type
+from typing import Callable, Dict, Optional, Set, Tuple, Type, List
 
 from tribler.core.components.exceptions import ComponentStartupException
 from tribler.core.components.reporter.reported_error import ReportedError
@@ -56,7 +57,7 @@ class CoreExceptionHandler:
         self.report_callback: Optional[Callable[[ReportedError], None]] = None
         self.unreported_error: Optional[ReportedError] = None
         self.sentry_reporter = SentryReporter()
-        self.crash_dir = None
+        self.crash_dir: Optional[Path] = None  # this path is set in ReporterComponent
 
     @staticmethod
     def _get_long_text_from(exception: Exception):
@@ -139,6 +140,9 @@ class CoreExceptionHandler:
             if process_manager:
                 process_manager.current_process.set_error(exception)
 
+            # If should_stop is True, the error is critical, so we first save it to the file to ensure
+            # that it will be reported to the GUI via events endpoint either immediately or later
+            # after core restart. This saved file will be deleted when the error is reported to the GUI.
             if should_stop:
                 self.save_to_file(reported_error)
 
@@ -160,12 +164,20 @@ class CoreExceptionHandler:
             self.logger.exception(f'Error occurred during the error handling: {ex}')
             raise ex
 
-    def get_or_create_log_dir(self):
+    def get_or_create_log_dir(self) -> Path:
+        """
+        Returns the path to the directory where the crash log files will be saved.
+        If the directory doesn't exist, it will be created.
+        """
         if self.crash_dir and not self.crash_dir.exists():
             self.crash_dir.mkdir(exist_ok=True)
         return self.crash_dir
 
-    def get_file_path(self, reported_error: ReportedError):
+    def get_file_path(self, reported_error: ReportedError) -> Optional[Path]:
+        """
+        Returns the path to the file where the error will be saved.
+        If the crash_dir is not set, returns None.
+        """
         if not self.crash_dir:
             return None
 
@@ -176,13 +188,19 @@ class CoreExceptionHandler:
         return filepath
 
     def save_to_file(self, reported_error: ReportedError):
+        """
+        Saves the error to a file.
+
+        While saving the error to the file, `should_stop` field is set to False.
+        This is because this file will be read on restart of the core and sent to the GUI.
+        GUI upon receiving an error with should_stop set to True, will stop or restart the core.
+        We don't want to crash Tribler for the error logged from the last run.
+        The error is saved for the reporting purposes only.
+        """
         filepath = self.get_file_path(reported_error)
         if not filepath:
             return
 
-        # While saving to file, set should_stop=False.
-        # This is because this file will be read on restart of the core, and
-        # we don't want to crash the core for the error from the last run.
         self_copy = dataclasses.replace(reported_error)
         self_copy.should_stop = False
         serialized_error = json.dumps(dataclasses.asdict(self_copy), indent=True)
@@ -191,10 +209,18 @@ class CoreExceptionHandler:
             exc_file.write(serialized_error)
 
     def delete_saved_file(self, reported_error: ReportedError):
+        """
+        Deletes the file where the error was saved.
+        """
         if file_path := self.get_file_path(reported_error):
             file_path.unlink(missing_ok=True)
 
-    def get_saved_errors(self):
+    def get_saved_errors(self) -> List[ReportedError]:
+        """
+        Returns the list of errors saved to the file.
+        Returns an empty list if the crash_dir is not set or doesn't exist.
+        In case of any error while reading the file, the file is deleted.
+        """
         if self.crash_dir and not self.crash_dir.exists():
             return []
 

--- a/src/tribler/core/components/reporter/exception_handler.py
+++ b/src/tribler/core/components/reporter/exception_handler.py
@@ -134,6 +134,9 @@ class CoreExceptionHandler:
             if process_manager:
                 process_manager.current_process.set_error(exception)
 
+            if should_stop:
+                reported_error.save_to_file()
+
             if self.report_callback:
                 self.logger.error('Call report callback')
                 self.report_callback(reported_error)  # pylint: disable=not-callable

--- a/src/tribler/core/components/reporter/exception_handler.py
+++ b/src/tribler/core/components/reporter/exception_handler.py
@@ -191,10 +191,11 @@ class CoreExceptionHandler:
             exc_file.write(serialized_error)
 
     def delete_saved_file(self, reported_error: ReportedError):
-        self.get_file_path(reported_error).unlink(missing_ok=True)
+        if file_path := self.get_file_path(reported_error):
+            file_path.unlink(missing_ok=True)
 
     def get_saved_errors(self):
-        if not self.crash_dir.exists():
+        if self.crash_dir and not self.crash_dir.exists():
             return []
 
         saved_errors = []

--- a/src/tribler/core/components/reporter/reported_error.py
+++ b/src/tribler/core/components/reporter/reported_error.py
@@ -1,6 +1,13 @@
+import dataclasses
+import json
+import logging
 import time
 from dataclasses import dataclass, field
-from typing import Optional
+from json import JSONDecodeError
+from pathlib import Path
+from typing import Optional, Tuple, List
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -15,3 +22,69 @@ class ReportedError:
     context: str = field(default='', repr=False)
     last_core_output: str = field(default='', repr=False)
     should_stop: Optional[bool] = field(default=None)
+
+    def get_filename(self) -> str:
+        """
+        Returns the filename for the error report if it is saved to the file.
+        """
+        return f"{self.created_at}-{self.type}.json"
+
+    def copy(self, **changes) -> 'ReportedError':
+        """
+        Returns a copy of the error report with the given changes.
+        """
+        return dataclasses.replace(self, **changes)
+
+    def serialized_copy(self) -> 'ReportedError':
+        """
+        Returns a copy of the error report with the `should_stop` flag set to False.
+        This is useful when the error report is saved to the file so that the deserialized
+        error report doesn't stop the core.
+        """
+        return self.copy(should_stop=False)
+
+    def serialize(self, **changes) -> str:
+        """
+        Serializes the error report to a string.
+        """
+        serialized_error = json.dumps(dataclasses.asdict(self.copy(**changes)), indent=True)
+        return serialized_error
+
+    @classmethod
+    def deserialize(cls, serialized_error: str) -> Optional['ReportedError']:
+        """
+        Deserializes the given error report.
+        """
+        try:
+            return cls(**json.loads(serialized_error))
+        except JSONDecodeError as e:
+            logger.error(f"Failed to deserialize error: {e}")
+            return None
+
+    def save_to_dir(self, dir_path: Path) -> None:
+        """
+        Saves the error report to the given directory.
+        """
+        file_path = dir_path / self.get_filename()
+        file_path.write_text(self.serialize(should_stop=False))
+
+    @classmethod
+    def load_from_file(cls, file_path: Path) -> Optional['ReportedError']:
+        """
+        Loads the error report from the given file path.
+        """
+        try:
+            return cls.deserialize(file_path.read_text())
+        except Exception as e:
+            logger.error(f"Failed to load error from file: {e}")
+            return None
+
+    @classmethod
+    def load_errors_from_dir(cls, dir_path: Path) -> List[Tuple[Path, 'ReportedError']]:
+        """
+        Loads all the error reports from the given directory.
+        """
+        if not dir_path or not dir_path.exists():
+            return []
+
+        return [(file_path, cls.load_from_file(file_path)) for file_path in dir_path.glob("*.json")]

--- a/src/tribler/core/components/reporter/reported_error.py
+++ b/src/tribler/core/components/reporter/reported_error.py
@@ -1,14 +1,6 @@
-import dataclasses
-import json
-import os
 import time
 from dataclasses import dataclass, field
-from json import JSONDecodeError
 from typing import Optional
-
-from tribler.core.utilities.osutils import get_root_state_directory
-
-CRASH_ERROR_DIR = get_root_state_directory() / 'crashlogs'
 
 
 @dataclass
@@ -23,45 +15,3 @@ class ReportedError:
     context: str = field(default='', repr=False)
     last_core_output: str = field(default='', repr=False)
     should_stop: Optional[bool] = field(default=None)
-
-    @classmethod
-    def get_or_create_log_dir(cls):
-        if not CRASH_ERROR_DIR.exists():
-            CRASH_ERROR_DIR.mkdir(exist_ok=True)
-        return CRASH_ERROR_DIR
-
-    def get_file_path(self):
-        return self.get_or_create_log_dir() / f"{self.type}-{self.created_at}.json"
-
-    def save_to_file(self):
-        # While saving to file, set should_stop=False.
-        # This is because this file will be read on restart of the core, and
-        # we don't want to crash the core for the error from the last run.
-        self_copy = dataclasses.replace(self)
-        self_copy.should_stop = False
-
-        serialized_error = json.dumps(dataclasses.asdict(self_copy), indent=True)
-        with open(self.get_file_path(), 'w') as exc_file:
-            exc_file.write(serialized_error)
-
-    def delete_saved_file(self):
-        self.get_file_path().unlink(missing_ok=True)
-
-    @classmethod
-    def get_saved_errors(cls):
-        if not CRASH_ERROR_DIR.exists():
-            return []
-
-        saved_errors = []
-        for error_filename in os.listdir(CRASH_ERROR_DIR):
-            if not error_filename.endswith('.json'):
-                continue
-
-            error_file_path = CRASH_ERROR_DIR / error_filename
-            with open(error_file_path, 'r') as file_handle:
-                try:
-                    saved_errors.append(ReportedError(**json.loads(file_handle.read())))
-                except JSONDecodeError:
-                    error_file_path.unlink()
-
-        return saved_errors

--- a/src/tribler/core/components/reporter/reported_error.py
+++ b/src/tribler/core/components/reporter/reported_error.py
@@ -29,6 +29,12 @@ class ReportedError:
         """
         return f"{self.created_at}-{self.type}.json"
 
+    def get_file_path_in_dir(self, parent_dir: Path) -> Path:
+        """
+        Returns the path to the file where the error will be saved in given directory.
+        """
+        return parent_dir / self.get_filename()
+
     def copy(self, **changes) -> 'ReportedError':
         """
         Returns a copy of the error report with the given changes.

--- a/src/tribler/core/components/reporter/reported_error.py
+++ b/src/tribler/core/components/reporter/reported_error.py
@@ -1,5 +1,14 @@
+import dataclasses
+import json
+import os
+import time
 from dataclasses import dataclass, field
+from json import JSONDecodeError
 from typing import Optional
+
+from tribler.core.utilities.osutils import get_root_state_directory
+
+CRASH_ERROR_DIR = get_root_state_directory() / 'crashlogs'
 
 
 @dataclass
@@ -7,9 +16,52 @@ class ReportedError:
     type: str
     text: str
     event: dict = field(repr=False)
-    additional_information: dict = field(default_factory=dict, repr=False)
+    additional_information: dict = field(default_factory=lambda: {}, repr=False)
+    created_at: int = field(default_factory=lambda: int(time.time() * 1000), repr=False)
 
     long_text: str = field(default='', repr=False)
     context: str = field(default='', repr=False)
     last_core_output: str = field(default='', repr=False)
     should_stop: Optional[bool] = field(default=None)
+
+    @classmethod
+    def get_or_create_log_dir(cls):
+        if not CRASH_ERROR_DIR.exists():
+            CRASH_ERROR_DIR.mkdir(exist_ok=True)
+        return CRASH_ERROR_DIR
+
+    def get_file_path(self):
+        return self.get_or_create_log_dir() / f"{self.type}-{self.created_at}.json"
+
+    def save_to_file(self):
+        # While saving to file, set should_stop=False.
+        # This is because this file will be read on restart of the core, and
+        # we don't want to crash the core for the error from the last run.
+        self_copy = dataclasses.replace(self)
+        self_copy.should_stop = False
+
+        serialized_error = json.dumps(dataclasses.asdict(self_copy), indent=True)
+        with open(self.get_file_path(), 'w') as exc_file:
+            exc_file.write(serialized_error)
+
+    def delete_saved_file(self):
+        self.get_file_path().unlink(missing_ok=True)
+
+    @classmethod
+    def get_saved_errors(cls):
+        if not CRASH_ERROR_DIR.exists():
+            return []
+
+        saved_errors = []
+        for error_filename in os.listdir(CRASH_ERROR_DIR):
+            if not error_filename.endswith('.json'):
+                continue
+
+            error_file_path = CRASH_ERROR_DIR / error_filename
+            with open(error_file_path, 'r') as file_handle:
+                try:
+                    saved_errors.append(ReportedError(**json.loads(file_handle.read())))
+                except JSONDecodeError:
+                    error_file_path.unlink()
+
+        return saved_errors

--- a/src/tribler/core/components/reporter/reporter_component.py
+++ b/src/tribler/core/components/reporter/reporter_component.py
@@ -12,4 +12,4 @@ class ReporterComponent(Component):
 
         user_id_str = hexlify(key_component.primary_key.key.pk).encode('utf-8')
         default_core_exception_handler.sentry_reporter.set_user(user_id_str)
-        default_core_exception_handler.crash_dir = self.session.config.state_dir / 'crashlogs'
+        default_core_exception_handler.set_crash_dir(self.session.config.state_dir / 'crashlogs')

--- a/src/tribler/core/components/reporter/reporter_component.py
+++ b/src/tribler/core/components/reporter/reporter_component.py
@@ -12,3 +12,4 @@ class ReporterComponent(Component):
 
         user_id_str = hexlify(key_component.primary_key.key.pk).encode('utf-8')
         default_core_exception_handler.sentry_reporter.set_user(user_id_str)
+        default_core_exception_handler.crash_dir = self.session.config.state_dir / 'crashlogs'

--- a/src/tribler/core/components/reporter/tests/test_reported_error.py
+++ b/src/tribler/core/components/reporter/tests/test_reported_error.py
@@ -1,0 +1,61 @@
+from pathlib import Path
+
+from tribler.core.components.reporter.reported_error import ReportedError
+
+
+def test_get_filename():
+    reported_error = ReportedError('type', 'text', {})
+    assert reported_error.get_filename() == f"{reported_error.created_at}-{reported_error.type}.json"
+
+
+def test_serialize_deserialize():
+    reported_error = ReportedError('type', 'text', {})
+    serialized_error = reported_error.serialize()
+    deserialized_error = ReportedError.deserialize(serialized_error)
+    assert deserialized_error == reported_error
+
+    serialized_error_with_change = reported_error.serialize(should_stop=False)
+    deserialized_error_with_change = ReportedError.deserialize(serialized_error_with_change)
+    assert deserialized_error_with_change == reported_error.copy(should_stop=False)
+
+
+def test_copy():
+    reported_error = ReportedError('type', 'text', {})
+    copied_error = reported_error.copy()
+    assert copied_error == reported_error
+
+    copied_error_with_change = reported_error.copy(should_stop=False)
+    assert copied_error_with_change == reported_error.copy(should_stop=False)
+
+
+def test_save_to_dir(tmp_path):
+    reported_error = ReportedError('type', 'text', {})
+    reported_error.save_to_dir(tmp_path)
+    file_path = tmp_path / reported_error.get_filename()
+    assert file_path.exists()
+    assert file_path.read_text() == reported_error.serialized_copy().serialize()
+
+
+def test_load_from_file(tmp_path):
+    reported_error = ReportedError('type', 'text', {})
+    reported_error.save_to_dir(tmp_path)
+    file_path = tmp_path / reported_error.get_filename()
+    loaded_error = ReportedError.load_from_file(file_path)
+    assert loaded_error == reported_error.serialized_copy()
+
+
+def test_load_errors_from_dir(tmp_path):
+    """
+    Test that load_errors_from_dir returns the correct list of errors.
+    """
+    loaded_errors = ReportedError.load_errors_from_dir(None)
+    print(loaded_errors)
+
+    loaded_errors = ReportedError.load_errors_from_dir(Path('non-existent-dir'))
+    assert loaded_errors == []
+
+    reported_error = ReportedError('type', 'text', {})
+    reported_error.save_to_dir(tmp_path)
+    file_path = tmp_path / reported_error.get_filename()
+    loaded_errors = ReportedError.load_errors_from_dir(tmp_path)
+    assert loaded_errors == [(file_path, reported_error.serialized_copy())]

--- a/src/tribler/core/components/reporter/tests/test_reported_error.py
+++ b/src/tribler/core/components/reporter/tests/test_reported_error.py
@@ -19,6 +19,15 @@ def test_serialize_deserialize():
     assert deserialized_error_with_change == reported_error.copy(should_stop=False)
 
 
+def test_deserialize_invalid():
+    reported_error = ReportedError('type', 'text', {})
+    deserialized_error = ReportedError.deserialize(reported_error.serialize())
+    assert deserialized_error == reported_error
+
+    deserialized_error = ReportedError.deserialize('invalid')
+    assert deserialized_error is None
+
+
 def test_copy():
     reported_error = ReportedError('type', 'text', {})
     copied_error = reported_error.copy()
@@ -36,12 +45,17 @@ def test_save_to_dir(tmp_path):
     assert file_path.read_text() == reported_error.serialized_copy().serialize()
 
 
-def test_load_from_file(tmp_path):
+def test_load_from_file_invalid(tmp_path):
     reported_error = ReportedError('type', 'text', {})
     reported_error.save_to_dir(tmp_path)
-    file_path = tmp_path / reported_error.get_filename()
+
+    file_path = reported_error.get_file_path_in_dir(tmp_path)
     loaded_error = ReportedError.load_from_file(file_path)
     assert loaded_error == reported_error.serialized_copy()
+
+    file_path = tmp_path / 'invalid.json'
+    loaded_error = ReportedError.load_from_file(file_path)
+    assert loaded_error is None
 
 
 def test_load_errors_from_dir(tmp_path):

--- a/src/tribler/core/components/restapi/rest/events_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/events_endpoint.py
@@ -183,7 +183,7 @@ class EventsEndpoint(RESTEndpoint):
             self.send_exception(reported_error)
         else:
             if reported_error.should_stop:
-                self.exception_handler.save_to_file(reported_error)
+                self.exception_handler.save_to_file(reported_error.serialized_copy())
             if not self.undelivered_error:
                 # If there are several undelivered errors, we store the first error as more important and skip other
                 self.undelivered_error = self.error_message(reported_error)

--- a/src/tribler/core/components/restapi/rest/events_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/events_endpoint.py
@@ -131,15 +131,12 @@ class EventsEndpoint(RESTEndpoint):
     def send_exception(self, reported_error: ReportedError):
         message = self.error_message(reported_error)
         self.send_event(message)
-        default_core_exception_handler.delete_saved_file(reported_error)
+        self.exception_handler.delete_saved_file(reported_error)
 
     async def send_saved_errors_in_response(self, response):
         """
         Send saved errors from the previous run to GUI in the response.
         """
-        if not self.exception_handler:
-            return
-
         for _, unreported_error in self.exception_handler.get_saved_errors():
             if unreported_error:
                 await response.write(self.encode_message(self.error_message(unreported_error)))
@@ -186,7 +183,7 @@ class EventsEndpoint(RESTEndpoint):
             self.send_exception(reported_error)
         else:
             if reported_error.should_stop:
-                default_core_exception_handler.save_to_file(reported_error)
+                self.exception_handler.save_to_file(reported_error)
             if not self.undelivered_error:
                 # If there are several undelivered errors, we store the first error as more important and skip other
                 self.undelivered_error = self.error_message(reported_error)

--- a/src/tribler/core/components/restapi/rest/events_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/events_endpoint.py
@@ -86,12 +86,6 @@ class EventsEndpoint(RESTEndpoint):
             "kwargs": {"public_key": self.public_key, "version": version_id}
         }
 
-    def send_saved_errors(self):
-        unreported_errors = ReportedError.get_saved_errors()
-        for error in unreported_errors:
-            print(f"listing error: {error}")
-            self.on_tribler_exception(error)
-
     def error_message(self, reported_error: ReportedError) -> MessageDict:
         return {
             "topic": notifications.tribler_exception.__name__,

--- a/src/tribler/core/components/restapi/rest/events_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/events_endpoint.py
@@ -215,9 +215,10 @@ class EventsEndpoint(RESTEndpoint):
             await response.write(self.encode_message(error))
 
         unreported_errors_from_last_run = default_core_exception_handler.get_saved_errors()
-        for unreported_error in unreported_errors_from_last_run:
-            await response.write(self.encode_message(self.error_message(unreported_error)))
-            default_core_exception_handler.delete_saved_file(unreported_error)
+        for _, unreported_error in unreported_errors_from_last_run:
+            if unreported_error:
+                await response.write(self.encode_message(self.error_message(unreported_error)))
+                default_core_exception_handler.delete_saved_file(unreported_error)
 
         self.events_responses.append(response)
 

--- a/src/tribler/core/components/restapi/rest/tests/test_events_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/tests/test_events_endpoint.py
@@ -254,4 +254,3 @@ def test_on_tribler_exception_with_critical_error(mocked_save_to_file,
     assert mocked_save_to_file.called
     assert events_endpoint.undelivered_error
     assert events_endpoint.undelivered_error == events_endpoint.error_message(reported_error)
-

--- a/src/tribler/core/components/restapi/restapi_component.py
+++ b/src/tribler/core/components/restapi/restapi_component.py
@@ -77,7 +77,8 @@ class RESTComponent(Component):
         db_component = await self.maybe_component(DatabaseComponent)
 
         public_key = key_component.primary_key.key.pk if not isinstance(key_component, NoneComponent) else b''
-        self._events_endpoint = EventsEndpoint(notifier, public_key=hexlify(public_key))
+        self._events_endpoint = EventsEndpoint(notifier, public_key=hexlify(public_key),
+                                               exception_handler=default_core_exception_handler)
         self.root_endpoint = RootEndpoint(middlewares=[ApiKeyMiddleware(config.api.key), error_middleware])
 
         torrent_checker = None if config.gui_test_mode else torrent_checker_component.torrent_checker

--- a/src/tribler/gui/core_manager.py
+++ b/src/tribler/gui/core_manager.py
@@ -63,6 +63,8 @@ class CoreManager(QObject):
         self.core_connected = False
         self.shutting_down = False
         self.core_finished = False
+        self.is_restarting = False
+        self.core_old_pid = None
 
         self.should_quit_app_on_core_finished = False
 
@@ -112,6 +114,7 @@ class CoreManager(QObject):
 
     def start_tribler_core(self):
         self.use_existing_core = False
+        self.is_restarting = False
 
         core_env = self.core_env
         if not core_env:
@@ -143,6 +146,7 @@ class CoreManager(QObject):
         self.core_started = True
         self.core_started_at = time.time()
         self.core_running = True
+        self.core_connected = False
         self.check_core_api_port()
 
     def check_core_api_port(self, *args):
@@ -266,6 +270,18 @@ class CoreManager(QObject):
             self._logger.info('Core is not running, quitting GUI application')
             self.app_manager.quit_application()
 
+    def restart_core(self):
+        self.core_old_pid = self.core_process.pid()
+        self.should_quit_app_on_core_finished = False
+        self.shutting_down = False
+
+        self._logger.info("Restarting Core Process ...")
+        self.is_restarting = True
+        if self.core_process:
+            self.kill_core_process()
+
+        self.start_tribler_core()
+
     def kill_core_process(self):
         if not self.core_process or self.use_existing_core:
             self._logger.warning("Cannot kill the Core process as it is not initialized")
@@ -324,6 +340,8 @@ class CoreManager(QObject):
         if self.shutting_down:
             if self.should_quit_app_on_core_finished:
                 self.app_manager.quit_application()
+        elif self.is_restarting:
+            self.is_restarting = False
         else:
             error_message = self.format_error_message(exit_code, exit_status)
             self._logger.warning(error_message)

--- a/src/tribler/gui/core_manager.py
+++ b/src/tribler/gui/core_manager.py
@@ -66,7 +66,6 @@ class CoreManager(QObject):
         self.core_finished = False
         self.is_restarting = False
 
-        self.core_manager_started_at = int(time.time())
         self.core_process_started_at: Optional[int] = None
         self.old_core_process_pid = None
 

--- a/src/tribler/gui/core_manager.py
+++ b/src/tribler/gui/core_manager.py
@@ -20,6 +20,7 @@ from tribler.core.utilities.exit_codes.tribler_exit_codes import EXITCODE_DATABA
 from tribler.core.utilities.process_manager import ProcessManager, ProcessKind, TriblerProcess
 from tribler.gui import gui_sentry_reporter
 from tribler.gui.app_manager import AppManager
+from tribler.gui.core_restart_logs import CoreRestartLog
 from tribler.gui.event_request_manager import EventRequestManager
 from tribler.gui.exceptions import CoreConnectTimeoutError, CoreCrashedError
 from tribler.gui.network.request_manager import SHUTDOWN_ENDPOINT, request_manager
@@ -29,29 +30,7 @@ API_PORT_CHECK_INTERVAL = 100  # 0.1 seconds between attempts to retrieve Core A
 API_PORT_CHECK_TIMEOUT = 120  # Stop trying to determine API port after this number of seconds
 
 CORE_OUTPUT_DEQUE_LENGTH = 10
-CORE_RESTART_TRACK_WINDOW = 120  # seconds
 CORE_RESTART_TRACK_COUNT = 3
-
-
-@dataclass
-class CoreRestartLog:
-    core_pid: int
-    started_at: int
-    finished_at: Optional[int] = None
-    exit_code: Optional[int] = None
-    exit_status: Optional[str] = None
-
-    @classmethod
-    def current(cls, core_pid: int):
-        return CoreRestartLog(core_pid=core_pid, started_at=int(time.time()))
-
-    def finish(self, exit_code, exit_status):
-        self.finished_at = int(time.time())
-        self.exit_code = exit_code
-        self.exit_status = exit_status
-
-    def is_recent_log(self):
-        return int(time.time()) - self.started_at <= CORE_RESTART_TRACK_WINDOW
 
 
 class CoreManager(QObject):

--- a/src/tribler/gui/core_manager.py
+++ b/src/tribler/gui/core_manager.py
@@ -5,12 +5,9 @@ import os
 import re
 import sys
 import time
-import uuid
 from collections import deque
-from dataclasses import dataclass
-from datetime import timedelta
 from pathlib import Path
-from typing import Optional, List, Dict
+from typing import Optional, List
 
 from PyQt5.QtCore import QObject, QProcess, QProcessEnvironment, QTimer
 from PyQt5.QtNetwork import QNetworkRequest

--- a/src/tribler/gui/core_manager.py
+++ b/src/tribler/gui/core_manager.py
@@ -30,6 +30,7 @@ API_PORT_CHECK_TIMEOUT = 120  # Stop trying to determine API port after this num
 
 CORE_OUTPUT_DEQUE_LENGTH = 10
 CORE_RESTART_TRACK_WINDOW = 120  # seconds
+CORE_RESTART_TRACK_COUNT = 3
 
 
 @dataclass
@@ -191,6 +192,9 @@ class CoreManager(QObject):
     def update_last_core_process_log(self, exit_code: int, exit_status: str):
         if self.core_restart_logs:
             self.core_restart_logs[-1].finish(exit_code, exit_status)
+
+    def core_restarted_frequently(self):
+        return len([log for log in self.core_restart_logs if log.is_recent_log()]) > CORE_RESTART_TRACK_COUNT
 
     def check_core_api_port(self, *args):
         """

--- a/src/tribler/gui/core_manager.py
+++ b/src/tribler/gui/core_manager.py
@@ -257,11 +257,8 @@ class CoreManager(QObject):
     def shutdown_request_processed(self, response):
         self._logger.info(f"{SHUTDOWN_ENDPOINT} request was processed by Core. Response: {response}")
 
-    def send_shutdown_request(self, initial=False):
-        if initial:
-            self._logger.info(f"Sending {SHUTDOWN_ENDPOINT} request to Tribler Core")
-        else:
-            self._logger.warning(f"Re-sending {SHUTDOWN_ENDPOINT} request to Tribler Core")
+    def send_shutdown_request(self):
+        self._logger.info(f"Sending {SHUTDOWN_ENDPOINT} request to Tribler Core")
 
         request = request_manager.put(
             endpoint=SHUTDOWN_ENDPOINT,
@@ -289,7 +286,7 @@ class CoreManager(QObject):
                 return
 
             self.events_manager.shutting_down = True
-            self.send_shutdown_request(initial=True)
+            self.send_shutdown_request()
 
         elif self.should_quit_app_on_core_finished:
             self._logger.info('Core is not running, quitting GUI application')
@@ -327,7 +324,7 @@ class CoreManager(QObject):
         elif self.core_process:
             if self.core_connected:
                 self.events_manager.shutting_down = False
-                self.send_shutdown_request(initial=True)
+                self.send_shutdown_request()
             else:
                 # If Core is not connected via events_manager it also most probably cannot process API requests.
                 self._logger.warning('Core is not connected during the CoreManager shutdown, killing it...')
@@ -394,7 +391,6 @@ class CoreManager(QObject):
             if self.should_quit_app_on_core_finished:
                 self.app_manager.quit_application()
         elif self.is_restarting:
-            self.is_restarting = False
             self.start_tribler_core()
         else:
             error_message = self.format_error_message(exit_code, exit_status)

--- a/src/tribler/gui/core_manager.py
+++ b/src/tribler/gui/core_manager.py
@@ -9,7 +9,7 @@ from collections import deque
 from dataclasses import dataclass
 from datetime import timedelta
 from pathlib import Path
-from typing import Optional
+from typing import Optional, List
 
 from PyQt5.QtCore import QObject, QProcess, QProcessEnvironment, QTimer
 from PyQt5.QtNetwork import QNetworkRequest
@@ -80,9 +80,7 @@ class CoreManager(QObject):
         connect(self.events_manager.core_connected, self.on_core_connected)
 
         # Core restart log that tracks when core process was restarted.
-        # For each restart, the following tuple is added.
-        # (core_pid, started_at, finished_at)
-        self.core_restart_logs = []
+        self.core_restart_logs: List[CoreRestartLog] = []
 
     def on_core_connected(self, _):
         if self.core_finished:

--- a/src/tribler/gui/core_manager.py
+++ b/src/tribler/gui/core_manager.py
@@ -256,7 +256,6 @@ class CoreManager(QObject):
         self._logger.info(f"{SHUTDOWN_ENDPOINT} request was processed by Core. Response: {response}")
 
     def send_shutdown_request(self, initial=False):
-        print(f"sending shutdown request")
         if initial:
             self._logger.info(f"Sending {SHUTDOWN_ENDPOINT} request to Tribler Core")
         else:

--- a/src/tribler/gui/core_restart_logs.py
+++ b/src/tribler/gui/core_restart_logs.py
@@ -1,0 +1,39 @@
+import time
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Optional
+
+CORE_RESTART_TRACK_WINDOW = 120  # seconds
+
+
+@dataclass
+class CoreRestartLog:
+    core_pid: int
+    started_at: int
+    finished_at: Optional[int] = None
+    exit_code: Optional[int] = None
+    exit_status: Optional[str] = None
+
+    @classmethod
+    def current(cls, core_pid: int):
+        return CoreRestartLog(core_pid=core_pid, started_at=int(time.time()))
+
+    def finish(self, exit_code, exit_status):
+        self.finished_at = int(time.time())
+        self.exit_code = exit_code
+        self.exit_status = exit_status
+
+    def is_recent_log(self):
+        diff = int(time.time()) - self.started_at
+        print(diff)
+        return int(time.time()) - self.started_at <= CORE_RESTART_TRACK_WINDOW
+
+    def __repr__(self):
+        uptime = timedelta(seconds=self.finished_at-self.started_at) if self.finished_at else 'still running'
+        return f"CoreRestartLog(" \
+               f"pid={self.core_pid}, " \
+               f"started_at='{datetime.fromtimestamp(self.started_at)}', " \
+               f"uptime='{uptime}',  " \
+               f"exit_code={self.exit_code}, " \
+               f"exit_status='{self.exit_status}'" \
+               f")"

--- a/src/tribler/gui/core_restart_logs.py
+++ b/src/tribler/gui/core_restart_logs.py
@@ -10,6 +10,7 @@ CORE_RESTART_TRACK_WINDOW = 120  # seconds
 class CoreRestartLog:
     core_pid: int
     started_at: int
+    restart_triggered_at: Optional[int] = None
     finished_at: Optional[int] = None
     exit_code: Optional[int] = None
     exit_status: Optional[str] = None
@@ -18,22 +19,27 @@ class CoreRestartLog:
     def current(cls, core_pid: int):
         return CoreRestartLog(core_pid=core_pid, started_at=int(time.time()))
 
-    def finish(self, exit_code, exit_status):
+    def log_finished(self, exit_code, exit_status):
         self.finished_at = int(time.time())
         self.exit_code = exit_code
         self.exit_status = exit_status
 
+    def log_restart_triggered(self):
+        self.restart_triggered_at = int(time.time())
+
     def is_recent_log(self):
-        diff = int(time.time()) - self.started_at
-        print(diff)
         return int(time.time()) - self.started_at <= CORE_RESTART_TRACK_WINDOW
 
     def __repr__(self):
-        uptime = timedelta(seconds=self.finished_at-self.started_at) if self.finished_at else 'still running'
+        known_end_time = self.finished_at or self.restart_triggered_at
+        uptime = timedelta(seconds=known_end_time-self.started_at) if known_end_time else 'still running'
+        time_to_shutdown = timedelta(seconds=self.finished_at-self.restart_triggered_at) if self.finished_at and self.restart_triggered_at \
+            else 'unknown'
         return f"CoreRestartLog(" \
                f"pid={self.core_pid}, " \
                f"started_at='{datetime.fromtimestamp(self.started_at)}', " \
                f"uptime='{uptime}',  " \
+               f"time_to_shutdown='{time_to_shutdown}',  " \
                f"exit_code={self.exit_code}, " \
                f"exit_status='{self.exit_status}'" \
                f")"

--- a/src/tribler/gui/core_restart_logs.py
+++ b/src/tribler/gui/core_restart_logs.py
@@ -33,7 +33,8 @@ class CoreRestartLog:
     def __repr__(self):
         known_end_time = self.finished_at or self.restart_triggered_at
         uptime = timedelta(seconds=known_end_time-self.started_at) if known_end_time else 'still running'
-        time_to_shutdown = timedelta(seconds=self.finished_at-self.restart_triggered_at) if self.finished_at and self.restart_triggered_at \
+        time_to_shutdown = timedelta(seconds=self.finished_at-self.restart_triggered_at) \
+            if self.finished_at and self.restart_triggered_at \
             else 'unknown'
         return f"CoreRestartLog(" \
                f"pid={self.core_pid}, " \

--- a/src/tribler/gui/dialogs/feedbackdialog.py
+++ b/src/tribler/gui/dialogs/feedbackdialog.py
@@ -80,7 +80,6 @@ class FeedbackDialog(AddBreadcrumbOnShowMixin, QDialog):
             reported_error: ReportedError,
             tribler_version,
             start_time,
-            stop_application_on_close=True,
             additional_tags=None,
     ):
         QDialog.__init__(self, parent)
@@ -93,7 +92,6 @@ class FeedbackDialog(AddBreadcrumbOnShowMixin, QDialog):
         self.process_manager = parent.process_manager
         self.reported_error = reported_error
         self.sentry_reporter = sentry_reporter
-        self.stop_application_on_close = stop_application_on_close
         self.tribler_version = tribler_version
         self.additional_tags = additional_tags or {}
         # tags
@@ -135,7 +133,6 @@ class FeedbackDialog(AddBreadcrumbOnShowMixin, QDialog):
 
         self.send_automatically = SentryReporter.is_in_test_mode()
         if self.send_automatically:
-            self.stop_application_on_close = True
             self.on_send_clicked(True)
 
         # Qt 5.2 does not have the setPlaceholderText property
@@ -197,8 +194,3 @@ class FeedbackDialog(AddBreadcrumbOnShowMixin, QDialog):
     def closeEvent(self, close_event):
         # start collecting breadcrumbs while the dialog is closed
         self.sentry_reporter.collecting_breadcrumbs_allowed = True
-
-        if self.stop_application_on_close:
-            self.core_manager.stop()
-            if self.core_manager.shutting_down and self.core_manager.core_running:
-                close_event.ignore()

--- a/src/tribler/gui/error_handler.py
+++ b/src/tribler/gui/error_handler.py
@@ -67,7 +67,8 @@ class ErrorHandler:
             quoted_output = self.tribler_window.core_manager.get_last_core_output()
             self._logger.info(f'Last Core output:\n{quoted_output}')
 
-            self._stop_tribler(reported_error.text)
+            # self._stop_tribler(reported_error.text)
+            self._restart_tribler(reported_error.text)
 
         if self.app_manager.quitting_app:
             return
@@ -100,7 +101,8 @@ class ErrorHandler:
         self._logger.error(error_text)
 
         if reported_error.should_stop:
-            self._stop_tribler(error_text)
+            # self._stop_tribler(error_text)
+            self._restart_tribler(error_text)
 
         SentryScrubber.remove_breadcrumbs(reported_error.event)
         gui_sentry_reporter.additional_information.update(reported_error.additional_information)
@@ -139,3 +141,10 @@ class ErrorHandler:
 
         if self.tribler_window.debug_window:
             self.tribler_window.debug_window.setHidden(True)
+
+    def _restart_tribler(self, text):
+        if self._tribler_stopped:
+            return
+
+        self.tribler_window.tribler_crashed.emit(text)
+        self.tribler_window.core_manager.restart_core()

--- a/src/tribler/gui/error_handler.py
+++ b/src/tribler/gui/error_handler.py
@@ -66,7 +66,7 @@ class ErrorHandler:
             quoted_output = self.tribler_window.core_manager.get_last_core_output()
             self._logger.info(f'Last Core output:\n{quoted_output}')
 
-            self._restart_tribler(reported_error.text)
+            self._restart_tribler_core(reported_error.text)
         else:
             self._handled_exceptions.add(exc_type)
 
@@ -129,7 +129,7 @@ class ErrorHandler:
         if self.tribler_window.core_manager.core_restarted_frequently():
             self._stop_tribler(error_text)
         else:
-            self._restart_tribler(error_text)
+            self._restart_tribler_core(error_text)
 
     def _stop_tribler(self, text):
         if self._tribler_stopped:
@@ -151,7 +151,7 @@ class ErrorHandler:
         if self.tribler_window.debug_window:
             self.tribler_window.debug_window.setHidden(True)
 
-    def _restart_tribler(self, text):
+    def _restart_tribler_core(self, text):
         if self._tribler_stopped:
             return
 

--- a/src/tribler/gui/event_request_manager.py
+++ b/src/tribler/gui/event_request_manager.py
@@ -121,12 +121,9 @@ class EventRequestManager(QNetworkAccessManager):
             return
 
         if self.receiving_data:
-            # Most probably Core crashed, but we try to reconnect anyway one single time to be sure.
-            # Later, if Core crashed and CoreManager decides to restart the core, it will also call
-            # event_manager.connect_to_core(reschedule_on_err=True)
             self.receiving_data = False
-            self._logger.error('The connection to the Tribler Core was lost, trying to reconnect one single time')
-            self.reconnect(reschedule_on_err=False)
+            self._logger.error('The connection to the Tribler Core was lost, trying to reconnect')
+            self.reconnect(reschedule_on_err=True)
             return
 
         should_retry = reschedule_on_err and time.time() < self.start_time + CORE_CONNECTION_TIMEOUT

--- a/src/tribler/gui/tests/test_core_manager.py
+++ b/src/tribler/gui/tests/test_core_manager.py
@@ -205,32 +205,32 @@ def test_on_core_started(core_manager):
 
 def test_on_core_finished_during_shutdown(core_manager):
     core_manager.shutting_down = True
-    core_manager.update_last_core_process_log = MagicMock()
+    core_manager.log_core_finished = MagicMock()
 
     # Case 1: Shouldn't quit app on core finished
     core_manager.should_quit_app_on_core_finished = False
     core_manager.on_core_finished(exit_code=0, exit_status='OK')
 
     assert not core_manager.app_manager.quit_application.called
-    assert core_manager.update_last_core_process_log.called
+    assert core_manager.log_core_finished.called
 
     # Case 2: should quit app on core finished
     core_manager.should_quit_app_on_core_finished = True
-    core_manager.update_last_core_process_log.reset_mock()
+    core_manager.log_core_finished.reset_mock()
     core_manager.on_core_finished(exit_code=0, exit_status='OK')
 
     assert core_manager.app_manager.quit_application.called
-    assert core_manager.update_last_core_process_log.called
+    assert core_manager.log_core_finished.called
 
 
 def test_on_core_finished_during_core_restart(core_manager):
     core_manager.is_restarting = True
     core_manager.start_tribler_core = MagicMock()
-    core_manager.update_last_core_process_log = MagicMock()
+    core_manager.log_core_finished = MagicMock()
 
     core_manager.on_core_finished(exit_code=0, exit_status='OK')
 
-    assert core_manager.update_last_core_process_log.called
+    assert core_manager.log_core_finished.called
     assert not core_manager.is_restarting
     assert core_manager.start_tribler_core.called
 

--- a/src/tribler/gui/tests/test_core_manager.py
+++ b/src/tribler/gui/tests/test_core_manager.py
@@ -224,7 +224,7 @@ def test_on_core_finished_during_shutdown(core_manager):
 
 
 def test_on_core_finished_during_core_restart(core_manager):
-    core_manager.is_restarting = True
+    core_manager.wait_for_finished_to_restart_core = True
     core_manager.start_tribler_core = MagicMock()
     core_manager.log_core_finished = MagicMock()
 

--- a/src/tribler/gui/tests/test_core_manager.py
+++ b/src/tribler/gui/tests/test_core_manager.py
@@ -22,7 +22,7 @@ def fixture_core_manager():
 def test_on_core_started_calls_check_core_api_port(core_manager):
     assert not core_manager.core_running
     assert not core_manager.core_started
-    assert core_manager.core_started_at is None
+    assert core_manager.core_process_started_at is None
     with patch.object(core_manager, 'check_core_api_port') as check_core_api_port:
         core_manager.on_core_started()
         assert check_core_api_port.called
@@ -50,7 +50,7 @@ def test_check_core_api_port_shutting_down(core_manager):
 
 def test_check_core_api_port_core_process_not_found(core_manager):
     core_manager.core_running = True
-    core_manager.core_started_at = time.time()
+    core_manager.core_process_started_at = time.time()
     core_manager.process_manager.current_process.get_core_process.return_value = None
     core_manager.process_manager.get_primary_process.return_value = None
     core_manager.check_core_api_port()
@@ -60,7 +60,7 @@ def test_check_core_api_port_core_process_not_found(core_manager):
 
 def test_check_core_api_port_not_set(core_manager):
     core_manager.core_running = True
-    core_manager.core_started_at = time.time()
+    core_manager.core_process_started_at = time.time()
     core_manager.process_manager.current_process.get_core_process().api_port = None
     core_manager.check_core_api_port()
     assert core_manager.process_manager.current_process.get_core_process.called
@@ -70,7 +70,7 @@ def test_check_core_api_port_not_set(core_manager):
 @patch('tribler.gui.core_manager.request_manager')
 def test_check_core_api_port(request_manager: MagicMock, core_manager: CoreManager):
     core_manager.core_running = True
-    core_manager.core_started_at = time.time()
+    core_manager.core_process_started_at = time.time()
     api_port = core_manager.process_manager.current_process.get_core_process().api_port
     core_manager.check_core_api_port()
     assert core_manager.process_manager.current_process.get_core_process.called
@@ -82,7 +82,7 @@ def test_check_core_api_port(request_manager: MagicMock, core_manager: CoreManag
 def test_check_core_api_port_timeout(core_manager):
     core_manager.core_running = True
     # The timeout should be 30 seconds so let's pretend the core started 31 seconds before now
-    core_manager.core_started_at = time.time() - 121
+    core_manager.core_process_started_at = time.time() - 121
     core_manager.process_manager.current_process.get_core_process.return_value = None
     core_manager.process_manager.get_primary_process.return_value = None
     with pytest.raises(CoreConnectTimeoutError, match="^Can't get Core API port value within 120 seconds$"):

--- a/src/tribler/gui/tests/test_core_restart_logs.py
+++ b/src/tribler/gui/tests/test_core_restart_logs.py
@@ -1,0 +1,46 @@
+import time
+from datetime import datetime
+
+from tribler.gui.core_restart_logs import CoreRestartLog, CORE_RESTART_TRACK_WINDOW
+
+
+def test_current_method():
+    core_pid = 123
+    log = CoreRestartLog.current(core_pid)
+    assert log.core_pid == core_pid
+    assert log.started_at <= int(time.time())
+
+
+def test_finish_method():
+    log = CoreRestartLog.current(123)
+    time.sleep(0.1)
+    log.finish(exit_code=0, exit_status="OK")
+    assert log.finished_at >= log.started_at
+    assert log.exit_code == 0
+    assert log.exit_status == "OK"
+
+
+def test_is_recent_log():
+    log = CoreRestartLog.current(123)
+    assert log.is_recent_log() is True
+
+    log.started_at -= CORE_RESTART_TRACK_WINDOW + 1
+    assert log.is_recent_log() is False
+
+
+def test_repr_method():
+    log = CoreRestartLog(
+        core_pid=123,
+        started_at=int(datetime.strptime('2023-11-10', '%Y-%m-%d').timestamp()),
+        finished_at=int(datetime.strptime('2023-11-12', '%Y-%m-%d').timestamp()),
+        exit_code=0,
+        exit_status='OK'
+    )
+    expected_repr = "CoreRestartLog(" \
+                    "pid=123, " \
+                    "started_at='2023-11-10 00:00:00', " \
+                    "uptime='2 days, 0:00:00',  " \
+                    "exit_code=0, " \
+                    "exit_status='OK'" \
+                    ")"
+    assert repr(log) == expected_repr

--- a/src/tribler/gui/tests/test_core_restart_logs.py
+++ b/src/tribler/gui/tests/test_core_restart_logs.py
@@ -14,7 +14,7 @@ def test_current_method():
 def test_finish_method():
     log = CoreRestartLog.current(123)
     time.sleep(0.1)
-    log.finish(exit_code=0, exit_status="OK")
+    log.log_finished(exit_code=0, exit_status="OK")
     assert log.finished_at >= log.started_at
     assert log.exit_code == 0
     assert log.exit_status == "OK"
@@ -33,6 +33,7 @@ def test_repr_method():
         core_pid=123,
         started_at=int(datetime.strptime('2023-11-10', '%Y-%m-%d').timestamp()),
         finished_at=int(datetime.strptime('2023-11-12', '%Y-%m-%d').timestamp()),
+        restart_triggered_at=int(datetime.strptime('2023-11-11', '%Y-%m-%d').timestamp()),
         exit_code=0,
         exit_status='OK'
     )
@@ -40,7 +41,7 @@ def test_repr_method():
                     "pid=123, " \
                     "started_at='2023-11-10 00:00:00', " \
                     "uptime='2 days, 0:00:00',  " \
+                    "time_to_shutdown='1 day, 0:00:00',  " \
                     "exit_code=0, " \
-                    "exit_status='OK'" \
-                    ")"
+                    "exit_status='OK')"
     assert repr(log) == expected_repr

--- a/src/tribler/gui/tests/test_error_handler.py
+++ b/src/tribler/gui/tests/test_error_handler.py
@@ -29,7 +29,7 @@ class TestError(Exception):
 @patch('tribler.gui.error_handler.FeedbackDialog')
 def test_gui_error_tribler_stopped(mocked_feedback_dialog: MagicMock, error_handler: ErrorHandler):
     # test that while tribler_stopped is True FeedbackDialog is not called
-    error_handler._tribler_stopped = True
+    error_handler._tribler_core_stopped = True
     error_handler.gui_error(TestError, TestError("error text"), None)
     mocked_feedback_dialog.assert_not_called()
 
@@ -54,7 +54,7 @@ def test_gui_info_type_in_handled_exceptions(mocked_feedback_dialog: MagicMock, 
 
 @patch('tribler.gui.error_handler.FeedbackDialog')
 @patch.object(ErrorHandler, '_stop_tribler')
-@patch.object(ErrorHandler, '_restart_tribler')
+@patch.object(ErrorHandler, '_restart_tribler_core')
 def test_gui_core_connect_timeout_error(mocked_restart_tribler, mocked_stop_tribler,
                                         mocked_feedback_dialog: MagicMock,
                                         error_handler: ErrorHandler):
@@ -68,7 +68,7 @@ def test_gui_core_connect_timeout_error(mocked_restart_tribler, mocked_stop_trib
 
 @patch('tribler.gui.error_handler.FeedbackDialog')
 @patch.object(ErrorHandler, '_stop_tribler')
-@patch.object(ErrorHandler, '_restart_tribler')
+@patch.object(ErrorHandler, '_restart_tribler_core')
 def test_gui_core_crashed_error(mocked_restart_tribler: MagicMock, mocked_stop_tribler: MagicMock,
                                 mocked_feedback_dialog: MagicMock,
                                 error_handler: ErrorHandler):

--- a/src/tribler/gui/tests/test_error_handler.py
+++ b/src/tribler/gui/tests/test_error_handler.py
@@ -54,24 +54,31 @@ def test_gui_info_type_in_handled_exceptions(mocked_feedback_dialog: MagicMock, 
 
 @patch('tribler.gui.error_handler.FeedbackDialog')
 @patch.object(ErrorHandler, '_stop_tribler')
-def test_gui_core_connect_timeout_error(mocked_stop_tribler, mocked_feedback_dialog: MagicMock,
+@patch.object(ErrorHandler, '_restart_tribler')
+def test_gui_core_connect_timeout_error(mocked_restart_tribler, mocked_stop_tribler,
+                                        mocked_feedback_dialog: MagicMock,
                                         error_handler: ErrorHandler):
     # test that in case of CoreConnectTimeoutError Tribler should stop it's work
     error_handler.gui_error(CoreConnectTimeoutError, None, None)
 
     mocked_feedback_dialog.assert_called_once()
-    mocked_stop_tribler.assert_called_once()
+    mocked_stop_tribler.assert_not_called()
+    mocked_restart_tribler.assert_called_once()
 
 
 @patch('tribler.gui.error_handler.FeedbackDialog')
 @patch.object(ErrorHandler, '_stop_tribler')
-def test_gui_core_crashed_error(mocked_stop_tribler: MagicMock, mocked_feedback_dialog: MagicMock,
+@patch.object(ErrorHandler, '_restart_tribler')
+def test_gui_core_crashed_error(mocked_restart_tribler: MagicMock, mocked_stop_tribler: MagicMock,
+                                mocked_feedback_dialog: MagicMock,
                                 error_handler: ErrorHandler):
+
     # test that in case of CoreRuntimeError Tribler should stop it's work
     error_handler.gui_error(CoreCrashedError, None, None)
 
     mocked_feedback_dialog.assert_called_once()
-    mocked_stop_tribler.assert_called_once()
+    mocked_stop_tribler.assert_not_called()
+    mocked_restart_tribler.assert_called_once()
 
 
 @patch('tribler.gui.error_handler.FeedbackDialog')


### PR DESCRIPTION
This PR addresses
- https://github.com/Tribler/tribler/issues/7647

Here is an example of Sentry report sent:
- https://sentry.tribler.org/organizations/tribler/issues/2500/?project=10&query=&referrer=issue-stream&stream_index=0

The following additional entry is added to the report:
```
core_restart_logs: [
CoreRestartLog(pid=1232211, started_at='2023-11-27 14:36:14', uptime='0:00:11',  time_to_shutdown='0:00:04',  exit_code=1, exit_status='0'), 
CoreRestartLog(pid=1232278, started_at='2023-11-27 14:36:25', uptime='still running',  time_to_shutdown='unknown',  exit_code=None, exit_status='None')
],
```