### PR TITLE
Fixed reporting error without event crashing reporter

### DIFF
--- a/src/tribler/gui/dialogs/feedbackdialog.py
+++ b/src/tribler/gui/dialogs/feedbackdialog.py
@@ -172,7 +172,7 @@ class FeedbackDialog(AddBreadcrumbOnShowMixin, QDialog):
         self.send_report_button.setText(tr("SENDING..."))
 
         self.sentry_reporter.send_event(
-            event=self.reported_error.event,
+            event=self.reported_error.event or {},
             tags=self.additional_tags,
             info=self.info,
             last_core_output=self.reported_error.last_core_output,


### PR DESCRIPTION
Fixes #7697

Basically, `reported_error.event` can be `None`.

---

🙂 Re-running Windows tests due to #7701 (fixed in #7703)
🙁 Re-running Windows tests again due to #7701 (fixed in #7703)