### PR TITLE
Added torrent file trees to the download endpoint

### DIFF
--- a/src/tribler/core/components/libtorrent/restapi/downloads_endpoint.py
+++ b/src/tribler/core/components/libtorrent/restapi/downloads_endpoint.py
@@ -9,6 +9,7 @@ from ipv8.REST.schema import schema
 from ipv8.messaging.anonymization.tunnel import CIRCUIT_ID_PORT, PEER_FLAG_EXIT_BT
 from marshmallow.fields import Boolean, Float, Integer, List, String
 
+from tribler.core.components.libtorrent.download_manager.download import Download, IllegalFileIndex
 from tribler.core.components.libtorrent.download_manager.download_config import DownloadConfig
 from tribler.core.components.libtorrent.download_manager.download_manager import DownloadManager
 from tribler.core.components.libtorrent.download_manager.stream import STREAM_PAUSE_TIME, StreamChunk
@@ -95,6 +96,10 @@ class DownloadsEndpoint(RESTEndpoint):
                              web.patch('/{infohash}', self.update_download),
                              web.get('/{infohash}/torrent', self.get_torrent),
                              web.get('/{infohash}/files', self.get_files),
+                             web.get('/{infohash}/files/expand', self.expand_tree_directory),
+                             web.get('/{infohash}/files/collapse', self.collapse_tree_directory),
+                             web.get('/{infohash}/files/select', self.select_tree_path),
+                             web.get('/{infohash}/files/deselect', self.deselect_tree_path),
                              web.get('/{infohash}/stream/{fileindex}', self.stream, allow_head=False)])
 
     @staticmethod
@@ -154,6 +159,37 @@ class DownloadsEndpoint(RESTEndpoint):
             })
             file_index += 1
         return files_json
+
+    @staticmethod
+    def get_files_info_json_paged(download: Download, view_start: Path, view_size: int):
+        """
+        Return file info, similar to get_files_info_json() but paged (based on view_start and view_size).
+
+        Note that the view_start path is not included in the return value.
+
+        :param view_start: The last-known path from which to fetch new paths.
+        :param view_size: The requested number of elements (though only less may be available).
+        """
+        if not download.tdef.torrent_info_loaded():
+            download.tdef.load_torrent_info()
+            return [{
+                "index": IllegalFileIndex.unloaded.value,
+                "name": "loading...",
+                "size": 0,
+                "included": 0,
+                "progress": 0.0
+            }]
+        return [
+            {
+                "index": download.get_file_index(path),
+                "name": str(PurePosixPath(path_str)),
+                "size": download.get_file_length(path),
+                "included": download.is_file_selected(path),
+                "progress": download.get_file_completion(path)
+            }
+            for path_str in download.tdef.torrent_file_tree.view(view_start, view_size)
+            if (path := Path(path_str))
+        ]
 
     @docs(
         tags=["Libtorrent"],
@@ -582,7 +618,21 @@ class DownloadsEndpoint(RESTEndpoint):
             'description': 'Infohash of the download to from which to get file information',
             'type': 'string',
             'required': True
-        }],
+        },
+            {
+                'in': 'query',
+                'name': 'view_start_path',
+                'description': 'Path of the file or directory to form a view for',
+                'type': 'string',
+                'required': False
+            },
+            {
+                'in': 'query',
+                'name': 'view_size',
+                'description': 'Number of files to include in the view',
+                'type': 'number',
+                'required': False
+            }],
         responses={
             200: {
                 "schema": schema(GetFilesResponse={"files": [schema(File={'index': Integer,
@@ -598,7 +648,158 @@ class DownloadsEndpoint(RESTEndpoint):
         download = self.download_manager.get_download(infohash)
         if not download:
             return DownloadsEndpoint.return_404(request)
-        return RESTResponse({"files": self.get_files_info_json(download)})
+
+        params = request.query
+        view_start_path = params.get('view_start_path')
+        if view_start_path is None:
+            return RESTResponse({
+                "infohash": request.match_info['infohash'],
+                "files": self.get_files_info_json(download)
+            })
+
+        view_size = int(params.get('view_size', '100'))
+        return RESTResponse({
+            "infohash": request.match_info['infohash'],
+            "query": view_start_path,
+            "files": self.get_files_info_json_paged(download, Path(view_start_path), view_size)
+        })
+
+    @docs(
+        tags=["Libtorrent"],
+        summary="Collapse a tree directory.",
+        parameters=[{
+            'in': 'path',
+            'name': 'infohash',
+            'description': 'Infohash of the download',
+            'type': 'string',
+            'required': True
+        },
+            {
+                'in': 'query',
+                'name': 'path',
+                'description': 'Path of the directory to collapse',
+                'type': 'string',
+                'required': True
+            }],
+        responses={
+            200: {
+                "schema": schema(File={'path': path})
+            }
+        }
+    )
+    async def collapse_tree_directory(self, request):
+        infohash = unhexlify(request.match_info['infohash'])
+        download = self.download_manager.get_download(infohash)
+        if not download:
+            return DownloadsEndpoint.return_404(request)
+
+        params = request.query
+        path = params.get('path')
+        download.tdef.torrent_file_tree.collapse(Path(path))
+
+        return RESTResponse({'path': path})
+
+
+    @docs(
+        tags=["Libtorrent"],
+        summary="Expand a tree directory.",
+        parameters=[{
+            'in': 'path',
+            'name': 'infohash',
+            'description': 'Infohash of the download',
+            'type': 'string',
+            'required': True
+        },
+            {
+                'in': 'query',
+                'name': 'path',
+                'description': 'Path of the directory to expand',
+                'type': 'string',
+                'required': True
+            }],
+        responses={
+            200: {
+                "schema": schema(File={'path': String})
+            }
+        }
+    )
+    async def expand_tree_directory(self, request):
+        infohash = unhexlify(request.match_info['infohash'])
+        download = self.download_manager.get_download(infohash)
+        if not download:
+            return DownloadsEndpoint.return_404(request)
+
+        params = request.query
+        path = params.get('path')
+        download.tdef.torrent_file_tree.expand(Path(path))
+
+        return RESTResponse({'path': path})
+
+    @docs(
+        tags=["Libtorrent"],
+        summary="Select a tree path.",
+        parameters=[{
+            'in': 'path',
+            'name': 'infohash',
+            'description': 'Infohash of the download',
+            'type': 'string',
+            'required': True
+        },
+            {
+                'in': 'query',
+                'name': 'path',
+                'description': 'Path of the directory to select',
+                'type': 'string',
+                'required': True
+            }],
+        responses={
+            200: {}
+        }
+    )
+    async def select_tree_path(self, request):
+        infohash = unhexlify(request.match_info['infohash'])
+        download = self.download_manager.get_download(infohash)
+        if not download:
+            return DownloadsEndpoint.return_404(request)
+
+        params = request.query
+        path = params.get('path')
+        download.set_selected_file_or_dir(Path(path), True)
+
+        return RESTResponse({})
+
+    @docs(
+        tags=["Libtorrent"],
+        summary="Deselect a tree path.",
+        parameters=[{
+            'in': 'path',
+            'name': 'infohash',
+            'description': 'Infohash of the download',
+            'type': 'string',
+            'required': True
+        },
+            {
+                'in': 'query',
+                'name': 'path',
+                'description': 'Path of the directory to deselect',
+                'type': 'string',
+                'required': True
+            }],
+        responses={
+            200: {}
+        }
+    )
+    async def deselect_tree_path(self, request):
+        infohash = unhexlify(request.match_info['infohash'])
+        download = self.download_manager.get_download(infohash)
+        if not download:
+            return DownloadsEndpoint.return_404(request)
+
+        params = request.query
+        path = params.get('path')
+        download.set_selected_file_or_dir(Path(path), False)
+
+        return RESTResponse({})
 
     @docs(
         tags=["Libtorrent"],

--- a/src/tribler/core/components/libtorrent/tests/test_torrent_file_tree.py
+++ b/src/tribler/core/components/libtorrent/tests/test_torrent_file_tree.py
@@ -467,6 +467,19 @@ def test_view_full_collapsed(file_storage_with_dirs):
     ]
 
 
+def test_view_start_at_collapsed(file_storage_with_dirs):
+    """
+    Test if we can form a view starting at a collapsed directory.
+    """
+    tree = TorrentFileTree.from_lt_file_storage(file_storage_with_dirs)
+
+    tree.expand(Path("torrent_create"))
+
+    result = tree.view(Path("torrent_create") / "abc", 2)
+
+    assert [Path(r) for r in result] == [Path("torrent_create") / "def", Path("torrent_create") / "file1.txt"]
+
+
 def test_select_start_selected(file_storage_with_dirs):
     """
     Test if all files start selected.

--- a/src/tribler/gui/qt_resources/mainwindow.ui
+++ b/src/tribler/gui/qt_resources/mainwindow.ui
@@ -3719,65 +3719,6 @@ margin-right: 10px;</string>
                   <property name="bottomMargin">
                    <number>0</number>
                   </property>
-                  <item>
-                   <widget class="TorrentFileTreeWidget" name="download_files_list">
-                    <property name="contextMenuPolicy">
-                     <enum>Qt::CustomContextMenu</enum>
-                    </property>
-                    <property name="styleSheet">
-                     <string notr="true">QHeaderView {
-background-color: transparent;
-}
-QHeaderView::section {
-background-color: transparent;
-border: none;
-color: #B5B5B5;
-padding: 10px;
-font-size: 14px;
-border-bottom: 1px solid #303030;
-}
-QHeaderView::drop-down {
-color: red;
-}
-QHeaderView::section:hover {
-color: white;
-}
-
-
-</string>
-                    </property>
-                    <property name="selectionMode">
-                     <enum>QAbstractItemView::NoSelection</enum>
-                    </property>
-                    <property name="sortingEnabled">
-                     <bool>true</bool>
-                    </property>
-                    <property name="animated">
-                     <bool>true</bool>
-                    </property>
-                    <property name="allColumnsShowFocus">
-                     <bool>false</bool>
-                    </property>
-                    <property name="headerHidden">
-                     <bool>false</bool>
-                    </property>
-                    <column>
-                     <property name="text">
-                      <string>PATH</string>
-                     </property>
-                    </column>
-                    <column>
-                     <property name="text">
-                      <string>SIZE</string>
-                     </property>
-                    </column>
-                    <column>
-                     <property name="text">
-                      <string>% DONE</string>
-                     </property>
-                    </column>
-                   </widget>
-                  </item>
                  </layout>
                 </widget>
                 <widget class="QWidget" name="tab_2">
@@ -5553,6 +5494,11 @@ background: none;</string>
   <customwidget>
    <class>TorrentFileTreeWidget</class>
    <extends>QTreeWidget</extends>
+   <header>tribler.gui.widgets.torrentfiletreewidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>PreformattedTorrentFileTreeWidget</class>
+   <extends>QTableWidget</extends>
    <header>tribler.gui.widgets.torrentfiletreewidget.h</header>
   </customwidget>
   <customwidget>

--- a/src/tribler/gui/widgets/torrentfiletreewidget.py
+++ b/src/tribler/gui/widgets/torrentfiletreewidget.py
@@ -1,8 +1,19 @@
+from __future__ import annotations
+
+import re
 import sys
+from bisect import bisect
+from contextlib import suppress
+from dataclasses import dataclass, field
+from pathlib import Path
 
+import PyQt5
 from PyQt5.QtCore import Qt, pyqtSignal
-from PyQt5.QtWidgets import QHeaderView, QTreeWidget, QTreeWidgetItem
+from PyQt5.QtGui import QIcon, QMovie
+from PyQt5.QtWidgets import QHeaderView, QTreeWidget, QTreeWidgetItem, QTableWidget, QTableWidgetItem, QWidget
 
+from tribler.gui.defs import KB, MB, GB, TB, PB
+from tribler.gui.network.request_manager import request_manager
 from tribler.gui.utilities import connect, format_size, get_image_path
 from tribler.gui.widgets.downloadwidgetitem import create_progress_bar_widget
 
@@ -12,6 +23,8 @@ CHECKBOX_COL = 1
 FILENAME_COL = 0
 SIZE_COL = 1
 PROGRESS_COL = 2
+
+NAT_SORT_PATTERN = re.compile('([0-9]+)')
 
 """
  !!! ACHTUNG !!!!
@@ -233,7 +246,6 @@ class TorrentFileTreeWidget(QTreeWidget):
         self.selected_files_size = sum(
             item.file_size for item in self.get_selected_items() if item.file_index is not None
         )
-        self.selected_files_changed.emit()
 
     def update_progress(self, updates, force_update=False, draw_progress_bars=False):
         self.blockSignals(True)
@@ -277,4 +289,626 @@ class TorrentFileTreeWidget(QTreeWidget):
             self.selected_files_size += item.file_size
         else:
             self.selected_files_size -= item.file_size
-        self.selected_files_changed.emit()
+
+
+@dataclass
+class FilesPage:
+    """
+    A page of file/directory names (and their selected status) in the PreformattedTorrentFileTreeWidget.
+    """
+
+    query: Path
+    """
+    The query that was used (loaded=True) OR can be used (loaded=False) to fetch this page. 
+    """
+
+    index: int
+    """
+    The index of this page in the "PreformattedTorrentFileTreeWidget.pages" list. 
+    """
+
+    states: dict[Path, int] = field(default_factory=dict)
+    """
+    All Paths belonging to this page and their Qt.CheckState (unselected, partially selected, or selected).
+    """
+
+    loaded: bool = False
+    """
+    Whether this is a placeholder (when still unloaded or after memory has been freed) or fully loaded. 
+    """
+
+    next_query: Path | None = None
+    """
+    The Path to use for the next page, or None if there is no next page to be fetched. 
+    """
+
+    def load(self, states: dict[Path, int]) -> None:
+        """
+        Load this page from the given states.
+        """
+        self.states = states
+        self.loaded = True
+
+        # This is black magic: we want to peek the last added entry (the next query) but there is no method for this.
+        # Instead, popitem() removes the last entry, which we then add again (note: this does not violate the order!).
+        with suppress(KeyError):
+            k, v = states.popitem()
+            self.states[k] = v
+            self.next_query = k
+
+    def unload(self) -> None:
+        """
+        Unload the states to free up some memory and lessen the front-end load of shifting rows and selecting files.
+
+        The "query" can be used to fetch the states again.
+        """
+        self.states = {}
+        self.loaded = False
+        self.next_query = None
+
+    def num_files(self) -> int:
+        """
+        Return the number of files in this page.
+        """
+        return len(self.states)
+
+    def is_last_page(self):
+        """
+        Whether there are more pages to be fetched after this page.
+        """
+        return self.loaded and len(self.states) == 0
+
+    @staticmethod
+    def path_to_sort_key(path: Path):
+        """
+        We mimic the sorting of the underlying TorrentFileTree to avoid Qt messing up our pages.
+        """
+        return tuple(int(part) if part.isdigit() else part for part in NAT_SORT_PATTERN.split(str(path)))
+
+    def __lt__(self, other: FilesPage | Path) -> bool:
+        """
+        Python 3.8 quirk/shortcoming is that FilesPage needs to be a SupportsRichComparisonT (instead of using a key).
+        """
+        query = self.path_to_sort_key(self.query)
+        other_query = self.path_to_sort_key(other) if isinstance(other, Path) else self.path_to_sort_key(other.query)
+        return query < other_query
+
+    def __le__(self, other: FilesPage | Path) -> bool:
+        """
+        Python 3.8 quirk/shortcoming is that FilesPage needs to be a SupportsRichComparisonT (instead of using a key).
+        """
+        query = self.path_to_sort_key(self.query)
+        other_query = self.path_to_sort_key(other) if isinstance(other, Path) else self.path_to_sort_key(other.query)
+        return query <= other_query
+
+    def __gt__(self, other: FilesPage | Path) -> bool:
+        """
+        Python 3.8 quirk/shortcoming is that FilesPage needs to be a SupportsRichComparisonT (instead of using a key).
+        """
+        query = self.path_to_sort_key(self.query)
+        other_query = self.path_to_sort_key(other) if isinstance(other, Path) else self.path_to_sort_key(other.query)
+        return query > other_query
+
+    def __ge__(self, other: FilesPage | Path) -> bool:
+        """
+        Python 3.8 quirk/shortcoming is that FilesPage needs to be a SupportsRichComparisonT (instead of using a key).
+        """
+        query = self.path_to_sort_key(self.query)
+        other_query = self.path_to_sort_key(other) if isinstance(other, Path) else self.path_to_sort_key(other.query)
+        return query >= other_query
+
+    def __eq__(self, other: FilesPage | Path) -> bool:
+        """
+        Python 3.8 quirk/shortcoming is that FilesPage needs to be a SupportsRichComparisonT (instead of using a key).
+        """
+        query = self.path_to_sort_key(self.query)
+        other_query = self.path_to_sort_key(other) if isinstance(other, Path) else self.path_to_sort_key(other.query)
+        return query == other_query
+
+    def __ne__(self, other: FilesPage | Path) -> bool:
+        """
+        Python 3.8 quirk/shortcoming is that FilesPage needs to be a SupportsRichComparisonT (instead of using a key).
+        """
+        query = self.path_to_sort_key(self.query)
+        other_query = self.path_to_sort_key(other) if isinstance(other, Path) else self.path_to_sort_key(other.query)
+        return query != other_query
+
+
+class PreformattedTorrentFileTreeWidget(QTableWidget):
+    """
+    A widget for paged file views that use an underlying (core process) TorrentFileTree.
+    """
+
+    def __init__(self, parent: QWidget | None, page_size: int = 20, view_size_pre: int = 1, view_size_post: int = 2):
+        """
+
+        :param page_size: The number of items (directory/file Paths) per page.
+        :param view_size_pre: The number of pages to keep preloaded "above" the visible items.
+        :param view_size_post: The number of pages to keep preloaded "below" the visible items.
+        """
+        super().__init__(1, 4, parent)
+
+        # Parameters
+        self.page_size = page_size
+        self.view_size_pre = view_size_pre
+        self.view_size_post = view_size_post
+
+        # Torrent information variables
+        self.infohash = None
+        self.pages: list[FilesPage] = [FilesPage(Path('.'), 0)]
+
+        # View related variables
+        self.view_start_index: int = 0
+        self.previous_view_start_index: int | None = None
+
+        # GUI state variables
+        self.exp_contr_requests: dict[Path, int] = {}
+
+        # Setup vertical scrollbar
+        self.verticalScrollBar().setPageStep(self.page_size)
+        self.verticalScrollBar().setSingleStep(1)
+        self.reset_scroll_bar()
+        self.setAutoScroll(False)
+
+        # Setup (hide) table columns
+        self.horizontalHeader().hide()
+        self.horizontalHeader().setSectionResizeMode(0, QHeaderView.ResizeMode.ResizeToContents)
+        self.horizontalHeader().setSectionResizeMode(1, QHeaderView.ResizeMode.Stretch)
+        self.horizontalHeader().setSectionResizeMode(2, QHeaderView.ResizeMode.ResizeToContents)
+        self.horizontalHeader().setSectionResizeMode(3, QHeaderView.ResizeMode.ResizeToContents)
+        self.horizontalHeader().setContentsMargins(0, 0, 0, 0)
+        self.setShowGrid(False)
+
+        self.verticalHeader().hide()
+
+        # Setup selection and focus modes
+        self.setEditTriggers(PyQt5.QtWidgets.QAbstractItemView.NoEditTriggers)
+        self.setSelectionBehavior(PyQt5.QtWidgets.QAbstractItemView.SelectRows)
+        self.setSelectionMode(PyQt5.QtWidgets.QAbstractItemView.NoSelection)
+        self.setFocusPolicy(Qt.NoFocus)
+
+        # Set style
+        self.setStyleSheet("""
+                    QTableView::item::hover { background-color: rgba(255,255,255, 0); }
+                    QTableView::item:selected{ background-color: #444; }
+                    """)
+
+        # Reset the underlying data
+        self.clear()
+
+        # Initialize signals and moving graphics
+        connect(self.itemClicked, self.item_clicked)
+
+        self.loading_movie = QMovie()
+        self.loading_movie.setFileName(get_image_path("spinner.gif"))
+        connect(self.loading_movie.frameChanged, self.spin_spinner)
+
+    def clear(self) -> None:
+        """
+        Clear the table data and then add a spinner to signify the loading state.
+        """
+        super().clear()
+
+        self.pages: list[FilesPage] = [FilesPage(Path('.'), 0)]
+        self.infohash = None
+
+        loading_icon = QIcon(get_image_path("spinner.gif"))
+        self.loading_widget = QTableWidgetItem(loading_icon, "", QTableWidgetItem.UserType)
+
+        self.setSelectionMode(PyQt5.QtWidgets.QAbstractItemView.NoSelection)
+
+        self.setRowCount(1)
+        self.setItem(0, 1, self.loading_widget)
+
+    def reset_scroll_bar(self) -> None:
+        """
+        Make sure we never reach the end of the scrollbar, as long as we are not on the first or last page.
+
+        This allows "scroll down" and "scroll up" even though we reached the end of the data loaded in the GUI.
+        Otherwise, we could get "stuck" on a page that is not the last page.
+        """
+        first_visible_row = self.rowAt(0)
+        last_visible_row = self.rowAt(self.height() - 1)
+        if self.verticalScrollBar().sliderPosition() == self.verticalScrollBar().minimum():
+            if first_visible_row != -1 and self.row_to_page_index(first_visible_row) != 0:
+                self.verticalScrollBar().blockSignals(True)
+                self.verticalScrollBar().setSliderPosition(1)
+                self.verticalScrollBar().blockSignals(False)
+        elif self.verticalScrollBar().sliderPosition() == self.verticalScrollBar().maximum():
+            if last_visible_row != -1 and self.row_to_page_index(last_visible_row) != len(self.pages) - 1:
+                self.verticalScrollBar().blockSignals(True)
+                self.verticalScrollBar().setSliderPosition(self.verticalScrollBar().maximum() - 1)
+                self.verticalScrollBar().blockSignals(False)
+
+    def row_to_page_index(self, row: int) -> int:
+        """
+        Convert a row index to a page index.
+
+        Because of the underlying view construction all pages are equal to the page_size, except for the last page.
+        """
+        return self.view_start_index + row // self.page_size
+
+    def initialize(self, infohash: str):
+        """
+        Set the current infohash and fetch its first page after unloading or when first initializing.
+
+        NOTE: This widget is reused between infohashes.
+        """
+        self.infohash = infohash
+        self.fetch_page(0)
+
+    def item_clicked(self, clicked: QTableWidgetItem):
+        """
+        The user clicked on a cell.
+
+        Figure out if we should update the selection or expanded/collapsed state. If we do, let the core know.
+
+        Case 1: When the user clicks the checkbox we want to update the selection state and exit.
+        Case 2: When the user clicks next to the checkbox (or there is no checkbox) we expand/collapse a directory.
+        """
+        file_desc = clicked.data(Qt.UserRole)
+        # Determine if we are in case 1: if the clicked cell doesn't even have a checkbox, we don't investigate further.
+        if isinstance(file_desc, dict):
+            is_checked = clicked.checkState()
+            was_checked = Qt.Checked
+            for page in reversed(self.pages):
+                file_path = Path(file_desc["name"])
+                if file_path in page.states:
+                    was_checked, page.states[file_path] = page.states[file_path], is_checked
+                    break
+            # The checkbox state changed, meaning the user actually clicked the checkbox.
+            if is_checked != was_checked:
+                modifier = "select" if is_checked == Qt.Checked else "deselect"
+                request_manager.get(f"downloads/{self.infohash}/files/{modifier}",
+                                    url_params={"path": file_desc["name"]})
+                # Don't wait for a core refresh but immediately update all loaded rows with the expected check status.
+                for row in range(self.rowCount()):
+                    item = self.item(row, 0)
+                    user_data = item.data(Qt.UserRole)
+                    if user_data["name"].startswith(file_desc["name"]):
+                        item.setCheckState(is_checked)
+                        self.pages[user_data["page"]].states[Path(user_data["name"])] = is_checked
+                return  # End of case 1, exit out!
+        # Case 2: We would've returned if a checkbox got toggled, this is a collapse/expand event!
+        if clicked in self.selectedItems():
+            # Only the first widget stores the data but the entire row can be clicked.
+            expand_select_widget, _, _, _ = self.selectedItems()
+            file_desc = expand_select_widget.data(Qt.UserRole)
+            if file_desc["index"] in [-1, -2]:
+                self.exp_contr_requests[file_desc["name"]] = self.row_to_page_index(self.row(clicked))
+                mode = "expand" if file_desc["index"] == -1 else "collapse"
+                request_manager.get(
+                    endpoint=f"downloads/{self.infohash}/files/{mode}",
+                    url_params={
+                        'path': file_desc["name"]
+                    },
+                    on_success=self.on_expanded_contracted,
+                )
+
+    def fetch_page(self, page_index: int) -> None:
+        """
+        Query the core for a given page index.
+        """
+        search_path = None
+        if page_index < len(self.pages):
+            # We have fetched the query for this page before.
+            search_path = self.pages[page_index].query
+        elif page_index == len(self.pages):
+            # We need to check the previous page for the next query.
+            if self.pages[page_index - 1].next_query is not None:
+                search_path = self.pages[page_index - 1].next_query
+
+        if search_path is None:
+            # This can happen if we request a page more than 1 page past our currently loaded pages or if there are no
+            # more pages to load.
+            # Whatever the case, we can't fetch pages without a query and we simply exit out.
+            return
+
+        request_manager.get(
+            endpoint=f"downloads/{self.infohash}/files",
+            url_params={
+                'view_start_path': search_path,
+                'view_size': self.page_size
+            },
+            on_success=self.fill_entries,
+        )
+
+    def free_page(self, page_index: int) -> None:
+        """
+        Free memory for a single page.
+        """
+        if page_index != 0 and page_index == len(self.pages) - 1:
+            self.pages.pop()
+        else:
+            self.pages[page_index].unload()
+
+    def truncate_pages(self, page_index: int) -> None:
+        """
+        Truncate the list of pages to only CONTAIN UP TO a given page index.
+
+        For example, truncating for page index 3 of the page list [0, 1, 2, 3, 4] will remove the page at index 4.
+        """
+        self.pages = self.pages[:(page_index + 1)]
+
+    def scrollContentsBy(self, dx: int, dy: int) -> None:
+        """
+        The user scrolled. Do the infinite scroll thing.
+        """
+        super().scrollContentsBy(dx, dy)
+        self.reset_scroll_bar()  # Do not allow the user to get into an unrecoverable state, even if we don't update!
+
+        if dy == 0:
+            # No vertical scroll, no change in content
+            return
+
+        first_visible_row = self.rowAt(0)
+        if first_visible_row == -1:
+            # Scrolling without content
+            self.fetch_page(self.view_start_index)
+            return
+
+        last_visible_row = self.rowAt(self.height() - 1)
+        if last_visible_row == -1:
+            # Scrolling when already at the end
+            self.fetch_page(len(self.pages))
+            return
+
+        first_visible_page = self.row_to_page_index(first_visible_row)
+        last_visible_page = self.row_to_page_index(last_visible_row)
+        self.previous_view_start_index = self.view_start_index
+        self.view_start_index = max(0, first_visible_page - self.view_size_pre)
+
+        if dy < 0:
+            # Scrolling down
+            last_loaded_page = len(self.pages) - 1
+            if last_visible_page + self.view_size_post >= last_loaded_page:
+                # Not enough pages! Load more!
+                self.fetch_page(len(self.pages))
+        else:
+            # Scrolling up
+            self.truncate_pages(last_visible_page + self.view_size_post)
+            for page_index in range(self.previous_view_start_index,
+                                    max(0, self.view_start_index - self.view_size_pre),
+                                    -1):
+                # Reload any unloaded pages!
+                if not self.pages[page_index].loaded:
+                    self.fetch_page(page_index)
+                self.reset_scroll_bar()
+
+        # Hard refresh all visible rows, in case of really fast scrolling and tearing. This is important on slower
+        # machines, which can "outscroll" the Qt updates.
+        self.refresh_visible()
+
+    def on_expanded_contracted(self, response) -> None:
+        """
+        The core finished expanding or collapsing a directory.
+
+        ALL pages after and including the page that the expansion/collapse happened need to be refreshed.
+        """
+        if response is None:
+            return
+
+        page_index = self.exp_contr_requests.pop(response["path"])
+        if page_index is None:
+            return
+        page_index = max(0, page_index - 1)
+
+        self.truncate_pages(page_index)
+
+        request_manager.get(
+            endpoint=f"downloads/{self.infohash}/files",
+            url_params={
+                'view_start_path': self.pages[page_index].query,
+                'view_size': self.page_size
+            },
+            on_success=self.fill_entries,
+        )
+
+    def hideEvent(self, a0) -> None:
+        """
+        We are not shown, no need to do the loading animation.
+        """
+        super().hideEvent(a0)
+        self.loading_movie.stop()
+
+    def showEvent(self, a0) -> None:
+        """
+        We are shown, continue the loading animation.
+        """
+        super().showEvent(a0)
+        self.loading_movie.start()
+
+    def resizeEvent(self, e) -> None:
+        """
+        We got resized, causing the previous first and last visible row to be invalidated: perform a hard refresh.
+        """
+        super().resizeEvent(e)
+        if self.isVisible():
+            self.refresh_visible()
+
+    def refresh_visible(self) -> None:
+        """
+        Determine the visible rows and refresh what we are missing.
+
+        Note that fetch_page will drop unattainable pages beyond our current knowledge and fill_entries will recursively
+        pull those pages in afterward.
+        """
+        first_visible_row = self.rowAt(0)
+        if first_visible_row == -1:
+            first_visible_row = 0
+        last_visible_row = self.rowAt(self.height() - 1)
+        if last_visible_row == -1:
+            last_visible_row = first_visible_row
+        for page_index in (range(self.view_start_index, self.view_start_index + last_visible_row - first_visible_row)
+                           or [self.view_start_index]):
+            self.fetch_page(page_index)
+
+    def spin_spinner(self, _) -> None:
+        """
+        Perform the loading square spinning animation.
+
+        Note that the spinner object may be suddenly removed when Qt fills in the table with our data.
+        """
+        if self.isVisible():
+            with suppress(RuntimeError):
+                self.loading_widget.setIcon(QIcon(self.loading_movie.currentPixmap()))
+
+    def format_size(self, size_in_bytes: int) -> str:
+        """
+        Stringify the given number of bytes to more human-readable units.
+        """
+        if size_in_bytes < KB:
+            return f"{size_in_bytes} bytes"
+        if size_in_bytes < MB:
+            return f"{round(size_in_bytes / KB, 2)} KB"
+        if size_in_bytes < GB:
+            return f"{round(size_in_bytes / MB, 2)} MB"
+        if size_in_bytes < TB:
+            return f"{round(size_in_bytes / GB, 2)} GB"
+        if size_in_bytes < PB:
+            return f"{round(size_in_bytes / TB, 2)} TB"
+        return f"{round(size_in_bytes / PB, 2)} PB"
+
+    def render_to_table(self, row: int, page_index: int, states: dict[Path, int], file_desc) -> None:
+        """
+        Render the core's download endpoint response data for a single file (file_desc) to the given row in our table
+        and store the state in the given states dir for the given page index.
+
+        Note that - at this point - the given states dir is not complete yet and not loaded in the page index yet. We
+        use this to our advantage when remembering directory states in between updates.
+        """
+        description = file_desc["name"]
+        file_desc["page"] = page_index
+        collapse_icon = " "
+        if file_desc["index"] >= 0:
+            # Indent with file depth and only show name
+            *folders, name = Path(description).parts
+            description = len(folders) * "    " + name
+        else:
+            collapse_icon = ("\u1405 " if file_desc["index"] == -1 else "\u1401 ")
+
+        # File name
+        file_name_widget = QTableWidgetItem(description)
+        file_name_widget.setTextAlignment(Qt.AlignVCenter)
+
+        # Checkbox and expansion arrow
+        expand_select_widget = QTableWidgetItem(collapse_icon)
+        expand_select_widget.setTextAlignment(Qt.AlignCenter)
+        expand_select_widget.setData(Qt.UserRole, file_desc)
+        expand_select_widget.setFlags(expand_select_widget.flags() | Qt.ItemIsTristate | Qt.ItemIsUserCheckable)
+
+        if file_desc["included"]:
+            expand_select_widget.setCheckState(Qt.Checked)
+            states[Path(file_desc["name"])] = Qt.Checked
+        elif file_desc["index"] >= 0:
+            expand_select_widget.setCheckState(Qt.Unchecked)
+            states[Path(file_desc["name"])] = Qt.Unchecked
+        else:
+            # Directory, determine from previous state
+            checked_state = self.pages[page_index].states.get(file_desc["name"], Qt.Checked)
+            states[Path(file_desc["name"])] = checked_state
+            expand_select_widget.setCheckState(checked_state)
+
+        # File size
+        file_size_widget = QTableWidgetItem(self.format_size(file_desc['size']))
+
+        # Progress
+        # Note: directories are derived: they are not a real entry in the torrent file list and they have no completion.
+        file_progress_widget = QTableWidgetItem(f"{round(file_desc['progress'] * 100.0, 2)} %"
+                                                if file_desc["index"] >= 0 else "")
+
+        self.setItem(row, 0, expand_select_widget)
+        self.setItem(row, 1, file_name_widget)
+        self.setItem(row, 2, file_size_widget)
+        self.setItem(row, 3, file_progress_widget)
+
+    def render_page_to_table(self, page_index: int, files_dict) -> None:
+        """
+        Given the core's response to the view that we requested at a given page index, fill our table.
+        """
+        base_row = (page_index - self.view_start_index) * self.page_size
+        states: dict[Path, int] = {}
+        for row, file_desc in enumerate(files_dict):
+            target_row = base_row + row
+            if 0 <= target_row < self.rowCount():
+                self.render_to_table(target_row, page_index, states, file_desc)
+        self.pages[page_index].load(states)
+
+    def shift_pages(self, previous_row_count: int) -> None:
+        """
+        Shift the old data in our table after a scroll. This avoids waiting for hard refreshes (slow). However,
+        sometimes the user "outscrolls" Qt and hard refreshes have to be used to fill in the gaps. Therefore, this
+        method should be used to complement hard refreshes, not replace them.
+        """
+        if self.view_start_index < self.previous_view_start_index:
+            # Move existing down, start from last existing item.
+            shift = (self.previous_view_start_index - self.view_start_index) * self.page_size
+            for row in range(self.rowCount() - 1, self.rowCount() - previous_row_count - shift + 1, -1):
+                if row < 0 or row - shift < 0:
+                    return
+                self.setItem(row, 0, self.takeItem(row - shift, 0))
+                self.setItem(row, 1, self.takeItem(row - shift, 1))
+                self.setItem(row, 2, self.takeItem(row - shift, 2))
+                self.setItem(row, 3, self.takeItem(row - shift, 3))
+        elif self.view_start_index > self.previous_view_start_index:
+            # Move existing up, start from the first existing item.
+            shift = (self.view_start_index - self.previous_view_start_index) * self.page_size
+            for row in range(0, previous_row_count - shift):
+                if row > self.rowCount() or row + shift > self.rowCount():
+                    return
+                self.setItem(row, 0, self.takeItem(row + shift, 0))
+                self.setItem(row, 1, self.takeItem(row + shift, 1))
+                self.setItem(row, 2, self.takeItem(row + shift, 2))
+                self.setItem(row, 3, self.takeItem(row + shift, 3))
+
+    def fill_entries(self, entry_dict) -> None:
+        """
+        Handle a raw core response.
+        """
+        self.infohash = entry_dict['infohash']
+        files_dict = entry_dict['files']
+        num_files = len(files_dict)
+
+        # Special loading response
+        if num_files == 1 and files_dict[0]["index"] == -3:
+            return
+
+        self.blockSignals(True)
+        self.loading_movie.stop()  # Stop loading and make interactive
+
+        # Determine the page index of the given data and prepare the data structures for it.
+        query = Path(entry_dict["query"])
+        current_page = bisect(self.pages, query)
+        total_files = sum(page.num_files() for page in self.pages[self.view_start_index:])
+        if current_page - 1 >= 0 and self.pages[current_page - 1].query == query:
+            current_page -= 1
+        if current_page == len(self.pages):
+            total_files += len(files_dict)
+            if self.pages[-1].next_query == query:
+                self.pages.append(FilesPage(query, current_page))
+            else:
+                return
+        if len(self.pages) == 1 and query == Path("."):
+            total_files = len(files_dict)
+
+        # Make space for all visible pages
+        previous_row_count = self.rowCount()
+        self.setRowCount(total_files)
+
+        # First shift previous entries out of the way
+        if self.previous_view_start_index is not None:
+            self.shift_pages(previous_row_count)
+            self.previous_view_start_index = None
+
+        # Inject the individual files
+        self.render_page_to_table(current_page, files_dict)
+
+        self.setSelectionMode(PyQt5.QtWidgets.QAbstractItemView.SingleSelection)
+
+        self.blockSignals(False)
+
+        # Fill out the remaining area, if possible.
+        if self.rowAt(self.height() - 1) == -1 and not self.pages[-1].is_last_page():
+            self.fetch_page(current_page + 1)
+
+        self.reset_scroll_bar()


### PR DESCRIPTION
Fixes #5399 but not beautifully<sup>1,2,3</sup> (because this PR is becoming too big).

This PR includes the REST API integrations necessary for paginated views of files in torrents and "infinite" scrolling of the file list. Additionally, a spinner (`gui/images/spinner.gif`) is displayed while loading the file list. Screenshot:

![screenshot](https://github.com/Tribler/tribler/assets/3630389/b5e29fe2-2e68-4958-91e3-e57537087b49)

<sup>1</sup>One of the big remaining beautification steps afterward is partial selection support for folders. Right now, the checkboxes for folders only function as "select all"/"deselect all" triggers. I'll open a separate issue for this afterward.
<sup>2</sup>Another nice feature would be to use our tree arrow icons/images instead of unicode arrows.
<sup>3</sup>Resizes of the download details widget cause all visible information in the files list to be refreshed, bombing the core with requests. This is inelegant, see https://github.com/Tribler/tribler/pull/7705#discussion_r1404391974.