### PR TITLE
Fixed exit node script

### DIFF
--- a/src/tribler/core/components/tunnel/tests/test_full_session/test_tunnel_community.py
+++ b/src/tribler/core/components/tunnel/tests/test_full_session/test_tunnel_community.py
@@ -255,7 +255,7 @@ async def test_hidden_services(proxy_factory: ProxyFactory, hidden_seeder_comm: 
     """
     leecher_community = await proxy_factory.get(exitnode=False, start_lt=True)
     # We don't want libtorrent peers interfering with the download. This is merely to avoid
-    # getting "unregistered address" warnings in the logs and should affect the outcome.
+    # getting "unregistered address" warnings in the logs and should not affect the outcome.
     leecher_community.readd_bittorrent_peers = MagicMock()  # type: ignore
 
     hidden_seeder_comm.build_tunnels(hops=1)


### PR DESCRIPTION
For PR:
* Fixes `circuit_removed`, which was failing when getting IPv8.
* Removes some unneeded components from the exit node script (like starting SOCKS5 servers).
* Refactors the exit node script to use `asyncio.run`.