### PR TITLE
Remove `pytest-rerunfailures`

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,7 +5,6 @@ pytest-aiohttp==1.0.5
 pytest-asyncio==0.21.1
 pytest-randomly==3.15.0
 pytest-timeout==2.2.0
-pytest-rerunfailures==12.0
 
 coverage==7.3.2
 looptime==0.2 ; sys_platform != 'win32'


### PR DESCRIPTION
This PR removes `pytest-rerunfailures` dependency as unused since #7581