### PR TITLE
Fix GH actions download and install libsodium windows dependencies

### DIFF
--- a/.github/actions/windows_dependencies/action.yml
+++ b/.github/actions/windows_dependencies/action.yml
@@ -29,17 +29,23 @@ runs:
 
     - name: Download Libsodium
       if: steps.check_libsodium.outputs.files_exists == 'false'
-      env:
-        RELEASE_FOLDER: .\libsodium\x64\Release
-      shell: cmd
+      shell: pwsh
       run: |
-        C:\msys64\usr\bin\wget.exe -q https://download.libsodium.org/libsodium/releases/libsodium-${{inputs.libsodium-version}}-msvc.zip
+        echo Downloading libsodium-${{inputs.libsodium-version}}-msvc.zip
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+        Invoke-WebRequest -Uri https://download.libsodium.org/libsodium/releases/libsodium-${{inputs.libsodium-version}}-msvc.zip -OutFile libsodium-${{inputs.libsodium-version}}-msvc.zip
+
         7z x libsodium-${{inputs.libsodium-version}}-msvc.zip
-        dir %RELEASE_FOLDER% /ad /b /o-n > latest_release_file
-        set /p latest_release= < latest_release_file
-        echo Latest release: %latest_release%
-        if not exist "cached-bin\libsodium-${{inputs.libsodium-version}}" mkdir "cached-bin\libsodium-${{inputs.libsodium-version}}"
-        copy %RELEASE_FOLDER%\%latest_release%\dynamic\libsodium.dll .\cached-bin\libsodium-${{inputs.libsodium-version}}\libsodium.dll
+
+        $RELEASE_FOLDER = (Get-Location).Path + "\libsodium\x64\Release"
+        $latest_release = Get-ChildItem -Path $RELEASE_FOLDER -Directory | Sort-Object CreationTime -Descending | Select-Object -First 1 -ExpandProperty Name
+
+        $targetDir = ".\cached-bin\libsodium-${{inputs.libsodium-version}}"
+        if (-not (Test-Path -Path $targetDir)) {
+            New-Item -ItemType Directory -Path $targetDir
+        }
+
+        Copy-Item "$RELEASE_FOLDER\$latest_release\dynamic\libsodium.dll" -Destination "$targetDir\libsodium.dll"
 
     - name: Install Libsodium
       shell: cmd


### PR DESCRIPTION
`Setup windows dependencies for Tribler` GitHub action has been failing for me on my personal repo test for PR. The failure was caused by the following line not working:
```
C:\msys64\usr\bin\wget.exe -q https://download.libsodium.org/libsodium/releases/libsodium-${{inputs.libsodium-version}}-msvc.zip
```
No zip file is downloaded.

This issue is not visible on the Tribler repo because the libsodium is used from the cache and not downloaded, so the code with the issue is not normally executed.

Here, I have replaced wget with PowerShell `Invoke-WebRequest` along with defining the TLS protocol support type. The rest of the changes are converting batch script to PowerShell script.