### PR TITLE
Refactor exception parsing logic and add exclusion for specific excep…

### DIFF
--- a/src/tribler/core/sentry_reporter/sentry_tools.py
+++ b/src/tribler/core/sentry_reporter/sentry_tools.py
@@ -9,6 +9,7 @@ from faker import Faker
 
 # Find an exception in the string like: "OverflowError: bind(): port must be 0-65535"
 _re_search_exception = re.compile(r'^(\S+)\s*:\s*(.+)')
+_re_search_exception_exclusions = re.compile(r'(?:warning)', re.RegexFlag.IGNORECASE)
 
 # Remove the substring like "Sentry is attempting to send 1 pending error messages"
 _re_remove_sentry = re.compile(r'Sentry is attempting.*')
@@ -29,7 +30,11 @@ def parse_last_core_output(text: str) -> Optional[LastCoreException]:
 
     for line in reversed(text.split('\n')):
         if m := _re_search_exception.match(line):
-            return LastCoreException(type=_clean_up(m.group(1)),
+            exception_type = m.group(1)
+            if _re_search_exception_exclusions.search(exception_type):
+                continue  # find an exclusion
+
+            return LastCoreException(type=_clean_up(exception_type),
                                      message=_clean_up(m.group(2)))
     return None
 

--- a/src/tribler/core/sentry_reporter/tests/test_sentry_tools.py
+++ b/src/tribler/core/sentry_reporter/tests/test_sentry_tools.py
@@ -1,7 +1,7 @@
 import pytest
 
 from tribler.core.sentry_reporter.sentry_tools import (
-    _re_search_exception, delete_item,
+    _re_search_exception, _re_search_exception_exclusions, delete_item,
     distinct_by,
     extract_dict,
     format_version,
@@ -139,6 +139,18 @@ def test_parse_last_core_output_re(given, expected):
         assert m == expected
 
 
+EXCEPTION_EXCLUSIONS_STRINGS = [
+    'UserWarning',
+]
+
+
+@pytest.mark.parametrize('given', EXCEPTION_EXCLUSIONS_STRINGS)
+def test_re_search_exception_exclusions(given):
+    # Test that `_re_search_exception_exclusions` matches with the expected values from the
+    # `EXCEPTION_EXCLUSIONS_STRINGS`
+    assert _re_search_exception_exclusions.search(given)
+
+
 def test_parse_last_core_output():
     # Test that `parse_last_core_output` correctly extract the last core exception from the real raw core output
 
@@ -169,4 +181,9 @@ def test_parse_last_core_output_no_match():
     # Test that `parse_last_core_output` returns None in the case there is no exceptions in the raw core output
 
     last_core_exception = parse_last_core_output('last core output without exceptions')
+    assert not last_core_exception
+
+
+def test_parse_last_core_output_exclusion():
+    last_core_exception = parse_last_core_output('UserWarning: You are using cryptography on a 32-bit Python on a...')
     assert not last_core_exception


### PR DESCRIPTION
This PR adds an exclusion for the exception type found in the latest core output. Specifically, it includes the word 'warning' in the list of exclusions.

- Refactored the `parse_last_core_output` function to improve readability and maintainability.
- Added a regular expression pattern `_re_search_exception_exclusions` to exclude specific exception types from being parsed.
- Modified the `parse_last_core_output` function to skip parsing if an excluded exception type is found.

Fixes #7713