### PR TITLE
Add CODECOV_TOKEN to secrets and update workflows

### DIFF
--- a/.github/workflows/!PR.yml
+++ b/.github/workflows/!PR.yml
@@ -88,7 +88,7 @@ jobs:
     if: ${{ needs.changes.outputs.src == 'true' }}
     uses: ./.github/workflows/coverage.yml
     secrets:
-      CODACY_PROJECT_TOKEN: ${{secrets.CODACY_PROJECT_TOKEN}}
+      CODECOV_TOKEN: ${{secrets.CODECOV_TOKEN}}
     with:
       python-version: ${{needs.env.outputs.python-version}}
       ref: ${{needs.env.outputs.source-ref}}

--- a/.github/workflows/!main.yml
+++ b/.github/workflows/!main.yml
@@ -18,6 +18,7 @@ jobs:
       python-version: 3.8
     secrets:
       CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   pytest:
     uses: ./.github/workflows/pytest.yml

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,6 +17,9 @@ on:
       CODACY_PROJECT_TOKEN:
         required: false
 
+      CODECOV_TOKEN:
+        required: true
+
 permissions:
   contents: read
 
@@ -54,6 +57,7 @@ jobs:
       - name: Upload to Codecov
         uses: codecov/codecov-action@v3
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
 
       - name: Upload to Codacy


### PR DESCRIPTION
This PR adds the `CODECOV_TOKEN` secret and updates the necessary workflows for integrating with Codecov.

- Added CODECOV_TOKEN to the secrets in `.github/workflows/!main.yml` and `.github/workflows/!PR.yml`
- Updated `.github/workflows/coverage.yml` to make CODECOV_TOKEN required in the secrets
- Updated `.github/workflows/coverage.yml` to use CODECOV_TOKEN when uploading coverage results to Codecov

Fixes #7719