### PR TITLE
Add an exclusion for the exception type found in the latest core output.

### DIFF
--- a/src/tribler/core/sentry_reporter/sentry_tools.py
+++ b/src/tribler/core/sentry_reporter/sentry_tools.py
@@ -11,7 +11,7 @@ LONG_TEXT_DELIMITER = '--LONG TEXT--'
 CONTEXT_DELIMITER = '--CONTEXT--'
 
 # Find an exception in the string like: "OverflowError: bind(): port must be 0-65535"
-_re_search_exception = re.compile(r'^(\S+)\s*:\s+(.+)')
+_re_search_exception = re.compile(r'^(\S+):\s+(.+)')
 _re_search_exception_exclusions = re.compile(r'(?:warning)', re.RegexFlag.IGNORECASE)
 
 # Remove the substring like "Sentry is attempting to send 1 pending error messages"

--- a/src/tribler/core/sentry_reporter/sentry_tools.py
+++ b/src/tribler/core/sentry_reporter/sentry_tools.py
@@ -11,7 +11,7 @@ LONG_TEXT_DELIMITER = '--LONG TEXT--'
 CONTEXT_DELIMITER = '--CONTEXT--'
 
 # Find an exception in the string like: "OverflowError: bind(): port must be 0-65535"
-_re_search_exception = re.compile(r'^(\S+):\s+(.+)')
+_re_search_exception = re.compile(r'^([A-Za-z0-9_.]+):\s+(.+)')
 _re_search_exception_exclusions = re.compile(r'(?:warning)', re.RegexFlag.IGNORECASE)
 
 # Remove the substring like "Sentry is attempting to send 1 pending error messages"

--- a/src/tribler/core/sentry_reporter/sentry_tools.py
+++ b/src/tribler/core/sentry_reporter/sentry_tools.py
@@ -11,7 +11,7 @@ LONG_TEXT_DELIMITER = '--LONG TEXT--'
 CONTEXT_DELIMITER = '--CONTEXT--'
 
 # Find an exception in the string like: "OverflowError: bind(): port must be 0-65535"
-_re_search_exception = re.compile(r'^(\S+)\s*:\s*(.+)')
+_re_search_exception = re.compile(r'^(\S+)\s*:\s+(.+)')
 _re_search_exception_exclusions = re.compile(r'(?:warning)', re.RegexFlag.IGNORECASE)
 
 # Remove the substring like "Sentry is attempting to send 1 pending error messages"

--- a/src/tribler/core/sentry_reporter/sentry_tools.py
+++ b/src/tribler/core/sentry_reporter/sentry_tools.py
@@ -12,6 +12,7 @@ CONTEXT_DELIMITER = '--CONTEXT--'
 
 # Find an exception in the string like: "OverflowError: bind(): port must be 0-65535"
 _re_search_exception = re.compile(r'^(\S+)\s*:\s*(.+)')
+_re_search_exception_exclusions = re.compile(r'(?:warning)', re.RegexFlag.IGNORECASE)
 
 # Remove the substring like "Sentry is attempting to send 1 pending error messages"
 _re_remove_sentry = re.compile(r'Sentry is attempting.*')
@@ -89,7 +90,11 @@ def parse_last_core_output(text: str) -> Optional[LastCoreException]:
 
     for line in reversed(text.split('\n')):
         if m := _re_search_exception.match(line):
-            return LastCoreException(type=_clean_up(m.group(1)),
+            exception_type = m.group(1)
+            if _re_search_exception_exclusions.search(exception_type):
+                continue  # find an exclusion
+
+            return LastCoreException(type=_clean_up(exception_type),
                                      message=_clean_up(m.group(2)))
     return None
 

--- a/src/tribler/core/sentry_reporter/tests/test_sentry_tools.py
+++ b/src/tribler/core/sentry_reporter/tests/test_sentry_tools.py
@@ -155,7 +155,7 @@ EXCEPTION_STRINGS = [
      ('OverflowError', 'bind(): port must be 0-65535'),
      ),
 
-    ("pony.orm.core.TransactionIntegrityError : MiscData['db_version'] cannot be stored. IntegrityError: UNIQUE",
+    ("pony.orm.core.TransactionIntegrityError: MiscData['db_version'] cannot be stored. IntegrityError: UNIQUE",
      ('pony.orm.core.TransactionIntegrityError', "MiscData['db_version'] cannot be stored. IntegrityError: UNIQUE"),
      ),
 

--- a/src/tribler/core/sentry_reporter/tests/test_sentry_tools.py
+++ b/src/tribler/core/sentry_reporter/tests/test_sentry_tools.py
@@ -151,16 +151,27 @@ OBFUSCATED_STRINGS = [
 ]
 
 EXCEPTION_STRINGS = [
-    ('OverflowError: bind(): port must be 0-65535',
-     ('OverflowError', 'bind(): port must be 0-65535'),
-     ),
+    (
+        'OverflowError: bind(): port must be 0-65535',
+        (
+            'OverflowError',
+            'bind(): port must be 0-65535'
+        ),
+    ),
 
-    ("pony.orm.core.TransactionIntegrityError: MiscData['db_version'] cannot be stored. IntegrityError: UNIQUE",
-     ('pony.orm.core.TransactionIntegrityError', "MiscData['db_version'] cannot be stored. IntegrityError: UNIQUE"),
-     ),
+    (
+        "pony_orm.core.TransactionIntegrityError: MiscData['db_version'] cannot be stored. IntegrityError: UNIQUE",
+        (
+            'pony_orm.core.TransactionIntegrityError',
+            "MiscData['db_version'] cannot be stored. IntegrityError: UNIQUE"
+        ),
+    ),
 
+    # Strings thst should not be matched
     ('ERROR <exception_handler:100>', None),
     ('PyInstaller\loader\pyimod03_importers.py:495', None),
+    ('foo:bar: baz', None),
+    ('foo<bar>: baz', None),
 ]
 
 

--- a/src/tribler/core/sentry_reporter/tests/test_sentry_tools.py
+++ b/src/tribler/core/sentry_reporter/tests/test_sentry_tools.py
@@ -1,7 +1,7 @@
 import pytest
 
 from tribler.core.sentry_reporter.sentry_tools import (
-    _re_search_exception, delete_item,
+    _re_search_exception, _re_search_exception_exclusions, delete_item,
     distinct_by,
     extract_dict,
     format_version,
@@ -180,6 +180,18 @@ def test_parse_last_core_output_re(given, expected):
         assert m == expected
 
 
+EXCEPTION_EXCLUSIONS_STRINGS = [
+    'UserWarning',
+]
+
+
+@pytest.mark.parametrize('given', EXCEPTION_EXCLUSIONS_STRINGS)
+def test_re_search_exception_exclusions(given):
+    # Test that `_re_search_exception_exclusions` matches with the expected values from the
+    # `EXCEPTION_EXCLUSIONS_STRINGS`
+    assert _re_search_exception_exclusions.search(given)
+
+
 def test_parse_last_core_output():
     # Test that `parse_last_core_output` correctly extract the last core exception from the real raw core output
 
@@ -210,4 +222,9 @@ def test_parse_last_core_output_no_match():
     # Test that `parse_last_core_output` returns None in the case there is no exceptions in the raw core output
 
     last_core_exception = parse_last_core_output('last core output without exceptions')
+    assert not last_core_exception
+
+
+def test_parse_last_core_output_exclusion():
+    last_core_exception = parse_last_core_output('UserWarning: You are using cryptography on a 32-bit Python on a...')
     assert not last_core_exception

--- a/src/tribler/core/sentry_reporter/tests/test_sentry_tools.py
+++ b/src/tribler/core/sentry_reporter/tests/test_sentry_tools.py
@@ -159,7 +159,8 @@ EXCEPTION_STRINGS = [
      ('pony.orm.core.TransactionIntegrityError', "MiscData['db_version'] cannot be stored. IntegrityError: UNIQUE"),
      ),
 
-    ('ERROR <exception_handler:100>', None)
+    ('ERROR <exception_handler:100>', None),
+    ('PyInstaller\loader\pyimod03_importers.py:495', None),
 ]
 
 


### PR DESCRIPTION
This PR adds an exclusion for the exception type found in the latest core output. Specifically, it includes the word 'warning' in the list of exclusions.

* Refactored the `parse_last_core_output` function to improve readability and maintainability.
* Added a regular expression pattern `_re_search_exception_exclusions` to exclude specific exception types from being parsed.
* Modified the `parse_last_core_output` function to skip parsing if an excluded exception type is found.

Fixes https://github.com/Tribler/tribler/issues/7713