### PR TITLE
Refactor resource monitor code and remove unused methods

### DIFF
--- a/src/tribler/core/components/resource_monitor/implementation/core.py
+++ b/src/tribler/core/components/resource_monitor/implementation/core.py
@@ -55,12 +55,6 @@ class CoreResourceMonitor(ResourceMonitor, TaskManager):
         # Additionally, record the disk and notify on low disk space available.
         self.record_disk_usage()
 
-    def set_resource_log_enabled(self, enabled):
-        self.resource_log_enabled = enabled
-
-    def is_resource_log_enabled(self):
-        return self.resource_log_enabled
-
     def record_disk_usage(self, recorded_at=None):
         recorded_at = recorded_at or time.time()
 

--- a/src/tribler/core/components/resource_monitor/implementation/tests/test_resource_monitor.py
+++ b/src/tribler/core/components/resource_monitor/implementation/tests/test_resource_monitor.py
@@ -96,11 +96,6 @@ def test_get_disk_usage_exception(resource_monitor: CoreResourceMonitor):
     assert not resource_monitor.get_disk_usage()
 
 
-def test_enable_resource_log(resource_monitor):
-    resource_monitor.set_resource_log_enabled(True)
-    assert resource_monitor.is_resource_log_enabled()
-
-
 def test_profiler(resource_monitor):
     """
     Test the profiler start(), stop() methods.


### PR DESCRIPTION
- Removed `set_resource_log_enabled` and `is_resource_log_enabled` methods from `CoreResourceMonitor` class.
- Updated corresponding test case in `test_resource_monitor.py`.
- No functional changes made, only code cleanup.

This PR removes leftovers from #7160