### PR TITLE
Refactor SentryReporter to parse last core output for specific exception types

### DIFF
--- a/src/tribler/core/sentry_reporter/sentry_reporter.py
+++ b/src/tribler/core/sentry_reporter/sentry_reporter.py
@@ -15,9 +15,8 @@ from sentry_sdk.integrations.threading import ThreadingIntegration
 
 from tribler.core import version
 from tribler.core.sentry_reporter.sentry_tools import (
-    delete_item,
     get_first_item,
-    get_last_item, get_value,
+    get_value,
     parse_last_core_output
 )
 
@@ -209,20 +208,15 @@ class SentryReporter:
             info[LAST_CORE_OUTPUT] = last_core_output.split('\n')  # split for better representation in the web view
 
             # check is it necessary to parse the last core output
-            exceptions = event.get(EXCEPTION, {})
-            gui_exception = get_last_item(exceptions.get(VALUES, []), {})
-            gui_exception_type = gui_exception.get(TYPE, None)
-            need_to_parse_core_output = gui_exception_type in self._types_that_requires_core_output_parse
+            exceptions = event.get(EXCEPTION, {}).get(VALUES, [])
+            exception_types = (e.get(TYPE) for e in exceptions)
+            need_to_parse_core_output = any(t in self._types_that_requires_core_output_parse for t in exception_types)
+
             if need_to_parse_core_output:
                 if last_core_exception := parse_last_core_output(last_core_output):
                     # create a core exception extracted from the last core output
                     core_exception = {TYPE: last_core_exception.type, VALUE: last_core_exception.message}
-
-                    # remove the stacktrace field as it doesn't give any useful information for the further
-                    # investigation
-                    delete_item(gui_exception, 'stacktrace')
-
-                    exceptions[VALUES] = [gui_exception, core_exception]
+                    exceptions.append(core_exception)
 
         event[CONTEXTS][REPORTER] = info
         event[CONTEXTS][BROWSER] = {VERSION: tribler_version, NAME: TRIBLER}

--- a/src/tribler/core/sentry_reporter/tests/test_sentry_reporter.py
+++ b/src/tribler/core/sentry_reporter/tests/test_sentry_reporter.py
@@ -325,3 +325,22 @@ Press Ctrl-C to quit
     expected[CONTEXTS][REPORTER][LAST_CORE_OUTPUT] = last_core_output.split('\n')
 
     assert actual == expected
+
+
+EXCEPTION_TYPES = [
+    # (exception_type, called)
+    ('CoreCrashedError', True),
+    ('AnyOtherError', False)
+]
+
+
+# The `parse_last_core_output` function is patched to have an indicator that the parse bloc is called
+@patch('tribler.core.sentry_reporter.sentry_reporter.parse_last_core_output')
+@pytest.mark.parametrize('exception_type, called', EXCEPTION_TYPES)
+def test_send_last_core_output_types_that_requires_core_output_parse(patched_parse_last_core_output, exception_type,
+                                                                     called, sentry_reporter):
+    # Test that the `send_event` function parse the "last core output" only for the specific exception types
+    event = {'exception': {'values': [{TYPE: exception_type}]}}
+    sentry_reporter.send_event(event=event, last_core_output='any last core output')
+
+    assert patched_parse_last_core_output.called == called

--- a/src/tribler/core/sentry_reporter/tests/test_sentry_reporter.py
+++ b/src/tribler/core/sentry_reporter/tests/test_sentry_reporter.py
@@ -281,23 +281,17 @@ def test_send_last_core_output(sentry_reporter):
         'exception': {
             'values': [
                 {
-                    'module': 'tribler.gui.utilities',
                     TYPE: 'CreationTraceback',
                     VALUE: '\n  File "/Users/<user>/Projects/github.com/Tribler/tribler/src/run_tribler.py", ',
-                    'mechanism': None
                 },
                 {
-                    'module': 'tribler.gui.exceptions',
                     TYPE: 'CoreCrashedError',
                     VALUE: 'The Tribler core has unexpectedly finished with exit code 1 and status: 0.',
-                    'mechanism': None,
-                    'stacktrace': {
-                        'frames': []
-                    }
                 }
             ]
         }
     }
+
     last_core_output = '''
 File "/Applications/Xcode.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/asyncio/base_events.py", line 1461, in create_server
     sock.bind(sa)
@@ -305,16 +299,19 @@ OverflowError: bind(): port must be 0-65535.Sentry is attempting to send 1 pendi
 Waiting up to 2 seconds
 Press Ctrl-C to quit
     '''
+
     actual = sentry_reporter.send_event(event=event, last_core_output=last_core_output)
     expected = deepcopy(DEFAULT_EVENT)
 
     expected['exception'] = {
         'values': [
             {
-                'module': 'tribler.gui.exceptions',
+                TYPE: 'CreationTraceback',
+                VALUE: '\n  File "/Users/<user>/Projects/github.com/Tribler/tribler/src/run_tribler.py", ',
+            },
+            {
                 TYPE: 'CoreCrashedError',
                 VALUE: 'The Tribler core has unexpectedly finished with exit code 1 and status: 0.',
-                'mechanism': None
             },
             {
                 TYPE: 'OverflowError',


### PR DESCRIPTION
This PR refactors the `SentryReporter` class to parse the "last core output" only for specific exception types. The `send_event` function now checks if the exception type is in a predefined set of types that require parsing. If it is, the last core output is split for better representation in the web view and then parsed using the `parse_last_core_output` function. The resulting core exception is added to the exceptions list, along with some additional modifications to remove unnecessary information.

Additionally, a new test case has been added to ensure that the `send_event` function correctly calls `parse_last_core_output` only for specific exception types.

It continues the work done in #7722 and makes the logic of #7066 safer.