### PR TITLE
Make TriblerCoreTestException inherit CoreError

### DIFF
--- a/src/tribler/core/exceptions.py
+++ b/src/tribler/core/exceptions.py
@@ -33,5 +33,9 @@ class TrustGraphException(TriblerException):
     """Exception specific to Trust graph."""
 
 
-class TriblerCoreTestException(TriblerException):
+class CoreError(TriblerException):
+    """This is the base class for exceptions that causes GUI shutdown"""
+
+
+class TriblerCoreTestException(CoreError):
     """Can be intentionally generated in Core by pressing Ctrl+Alt+Shift+C"""

--- a/src/tribler/gui/exceptions.py
+++ b/src/tribler/gui/exceptions.py
@@ -1,5 +1,4 @@
-class CoreError(Exception):
-    """This is the base class for exceptions that causes GUI shutdown"""
+from tribler.core.exceptions import CoreError
 
 
 class CoreConnectionError(CoreError):


### PR DESCRIPTION
This helps with testing the restart of the core on manually triggered core exceptions using Debug endpoints.