### PR TITLE
Introduce Workflow to Manage Stale Issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,17 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        with:
+          stale-issue-message: 'This issue has not seen activity for 60 days. It is now marked as stale. Please provide additional information or this issue may be closed in the future. We value your contribution and would love to hear more!'
+          stale-issue-label: 'status: stale'
+          only-labels: "status: can't reproduce"
+          days-before-stale: 60
+          days-before-close: -1
+


### PR DESCRIPTION
This PR introduces a new GitHub Actions workflow for managing stale issues in our repository. Key features of this workflow include:

- Automatically marking issues as stale after 60 days of inactivity.
- Not auto-closing stale issues; instead, they will require manual review for closure.

This addition aims to improve our issue tracking and ensure that open issues remain relevant and actively discussed. It also allows for greater flexibility in managing community contributions and feedback.

Adresses: #6135
Ref: 
- https://github.com/actions/stale