### PR TITLE
Update Tribler version to 7.14

### DIFF
--- a/src/tribler/core/version.py
+++ b/src/tribler/core/version.py
@@ -1,4 +1,4 @@
-version_id = "7.13.0-GIT"
+version_id = "7.14.0-GIT"
 build_date = "Mon Jan 01 00:00:01 1970"
 commit_id = "none"
 sentry_url = ""


### PR DESCRIPTION
This PR updates Tribler version in the main branch to `7.14.0-GIT`