### PR TITLE
Use dedicated exit codes when another primary GUI/Core process is running

### DIFF
--- a/src/run_tribler_headless.py
+++ b/src/run_tribler_headless.py
@@ -18,6 +18,7 @@ from filelock import FileLock
 from tribler.core.components.session import Session
 from tribler.core.config.tribler_config import TriblerConfig
 from tribler.core.start_core import components_gen
+from tribler.core.utilities.exit_codes import EXITCODE_ANOTHER_CORE_PROCESS_IS_RUNNING
 from tribler.core.utilities.osutils import get_appstate_dir, get_root_state_directory
 from tribler.core.utilities.path_util import Path
 from tribler.core.utilities.process_locking import CORE_LOCK_FILENAME, try_acquire_file_lock
@@ -91,7 +92,7 @@ class TriblerService:
         if not current_process_owns_lock:
             msg = 'Another Core process is already running'
             print(msg)
-            self.process_manager.sys_exit(1, msg)
+            self.process_manager.sys_exit(EXITCODE_ANOTHER_CORE_PROCESS_IS_RUNNING, msg)
 
         print("Starting Tribler")
 

--- a/src/tribler/core/start_core.py
+++ b/src/tribler/core/start_core.py
@@ -40,6 +40,7 @@ from tribler.core.logger.logger import load_logger_config
 from tribler.core.sentry_reporter.sentry_reporter import SentryReporter, SentryStrategy
 from tribler.core.upgrade.version_manager import VersionHistory
 from tribler.core.utilities import slow_coro_detection
+from tribler.core.utilities.exit_codes import EXITCODE_ANOTHER_CORE_PROCESS_IS_RUNNING
 from tribler.core.utilities.process_locking import CORE_LOCK_FILENAME, try_acquire_file_lock
 from tribler.core.utilities.process_manager import ProcessKind
 from tribler.core.utilities.process_manager.manager import setup_process_manager
@@ -195,7 +196,7 @@ def run_core(api_port: Optional[int], api_key: Optional[str], root_state_dir, pa
     if not current_process_owns_lock:
         msg = 'Another Core process is already running'
         logger.warning(msg)
-        process_manager.sys_exit(1, msg)
+        process_manager.sys_exit(EXITCODE_ANOTHER_CORE_PROCESS_IS_RUNNING, msg)
 
     version_history = VersionHistory(root_state_dir)
     state_dir = version_history.code_version.directory

--- a/src/tribler/core/utilities/exit_codes.py
+++ b/src/tribler/core/utilities/exit_codes.py
@@ -1,3 +1,5 @@
 
 # Valid range for custom errors is 1..127
 EXITCODE_DATABASE_IS_CORRUPTED = 99  # If the Core process finishes with this error, the GUI process restarts it.
+EXITCODE_ANOTHER_GUI_PROCESS_IS_RUNNING = 98  # A normal situation when a user double-clicks on the torrent file.
+EXITCODE_ANOTHER_CORE_PROCESS_IS_RUNNING = 97  # Should not happen if process locking is working correctly.

--- a/src/tribler/core/utilities/tiny_tribler_service.py
+++ b/src/tribler/core/utilities/tiny_tribler_service.py
@@ -10,6 +10,7 @@ from tribler.core.components.component import Component
 from tribler.core.components.session import Session
 from tribler.core.config.tribler_config import TriblerConfig
 from tribler.core.utilities.async_group.async_group import AsyncGroup
+from tribler.core.utilities.exit_codes import EXITCODE_ANOTHER_CORE_PROCESS_IS_RUNNING
 from tribler.core.utilities.osutils import get_root_state_directory
 from tribler.core.utilities.process_locking import CORE_LOCK_FILENAME, try_acquire_file_lock
 from tribler.core.utilities.process_manager import ProcessKind, ProcessManager
@@ -86,7 +87,7 @@ class TinyTriblerService:
         if not current_process_owns_lock:
             msg = 'Another Core process is already running'
             self.logger.warning(msg)
-            self.process_manager.sys_exit(1, msg)
+            self.process_manager.sys_exit(EXITCODE_ANOTHER_CORE_PROCESS_IS_RUNNING, msg)
 
     def _enable_graceful_shutdown(self):
         self.logger.info("Enabling graceful shutdown")

--- a/src/tribler/gui/start_gui.py
+++ b/src/tribler/gui/start_gui.py
@@ -14,6 +14,7 @@ from tribler.core.check_os import (
 )
 from tribler.core.logger.logger import load_logger_config
 from tribler.core.sentry_reporter.sentry_reporter import SentryStrategy
+from tribler.core.utilities.exit_codes import EXITCODE_ANOTHER_GUI_PROCESS_IS_RUNNING
 from tribler.core.utilities.process_locking import GUI_LOCK_FILENAME, try_acquire_file_lock
 from tribler.core.utilities.process_manager import ProcessKind
 from tribler.core.utilities.process_manager.manager import setup_process_manager
@@ -66,10 +67,11 @@ def run_gui(api_port: Optional[int], api_key: Optional[str], root_state_dir: Pat
         app.installTranslator(translator)
 
         if not current_process_owns_lock:
-            logger.info('GUI Application is already running.')
+            msg = 'Tribler GUI application is already running'
+            logger.info(msg)
             app.send_torrent_file_path_to_primary_process()
             logger.info('Close the current GUI application.')
-            process_manager.sys_exit(1, 'Tribler GUI application is already running')
+            process_manager.sys_exit(EXITCODE_ANOTHER_GUI_PROCESS_IS_RUNNING, msg)
 
         logger.info('Start Tribler Window')
         window = TriblerWindow(process_manager, app_manager, settings, root_state_dir,


### PR DESCRIPTION
Currently, when the Tribler GUI/Core process detects that another primary process is running, it exits with the generic exit code 1.

It is better to have a separate exit code so CoreManager or ApplicationTester is able to see the reason for the sudden process termination. Introducing the specific exit codes should allow the separation of the different error reports in Sentry and the special handling of specific exit codes.