### PR TITLE
Add one single attempt to reconnect to the Core in case of EventReqestManager disconnection

### DIFF
--- a/src/tribler/gui/event_request_manager.py
+++ b/src/tribler/gui/event_request_manager.py
@@ -130,9 +130,12 @@ class EventRequestManager(QNetworkAccessManager):
             return
 
         if self.receiving_data:
-            # Most probably Core is crashed. If CoreManager decides to restart the core,
-            # it will also call event_manager.connect_to_core()
-            self._logger.error('The connection to the Tribler Core was lost')
+            # Most probably Core crashed, but we try to reconnect anyway one single time to be sure.
+            # Later, if Core crashed and CoreManager decides to restart the core, it will also call
+            # event_manager.connect_to_core(reschedule_on_err=True)
+            self.receiving_data = False
+            self._logger.error('The connection to the Tribler Core was lost, trying to reconnect one single time')
+            self.reconnect(reschedule_on_err=False)
             return
 
         should_retry = reschedule_on_err and time.time() < self.start_time + CORE_CONNECTION_TIMEOUT


### PR DESCRIPTION
The connection of EventRequestManager to Core sometimes breaks for unknown reasons. Usually, the broken connection means that the Core process stopped with some error. However, sometimes it seems that the connection can be broken while the Core is still functioning ([an example](https://sentry.tribler.org/organizations/tribler/issues/2003/events/27c5d6b4fa9a4fdb946ab26a93ed2317/?project=7)). In this case, the current logic of EventRequestManager does nothing and does not attempt to reconnect.

This PR adds a single attempt to reconnect to the Core. It should be enough in case the connection is broken by accident.

I checked that the PR logic works as expected; it may be non-trivial to write a full test for it.

If the Core truly crashed because of the database corruption error, CoreManager will restart it and reconnect EventRequestManager again.