### PR TITLE
Change default code owners to @Tribler/reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,6 @@
 
 
 # These owners will be the default owners for everything in the repo.
-*       @Tribler/dev
+*       @Tribler/reviewers
 
 # Order is important; the last matching pattern takes the most precedence.


### PR DESCRIPTION
The default code owners have been updated from @Tribler/dev to @Tribler/reviewers. 

I'm going to rename the actual group after the approval/merge.