### PR TITLE
Fix "ValueError: relative path can't be expressed as a file URI"

### DIFF
--- a/src/tribler/gui/tests/test_tribler_window.py
+++ b/src/tribler/gui/tests/test_tribler_window.py
@@ -1,0 +1,29 @@
+from unittest.mock import Mock, patch
+
+import pytest
+from PyQt5.QtWidgets import QFileDialog
+
+from tribler.gui.tribler_window import TriblerWindow
+
+
+# pylint: disable=redefined-outer-name
+@pytest.fixture
+def tribler_window():
+    """ Create mocked TriblerWindow instance"""
+    with patch('tribler.gui.tribler_window.TriblerWindow.__init__', Mock(return_value=None)):
+        window = TriblerWindow(Mock(), Mock(), Mock(), Mock())
+        window.pending_uri_requests = []
+        return window
+
+
+def test_on_add_torrent_browse_file(tribler_window: TriblerWindow):
+    """ Test that the on_add_torrent_browse_file method works correctly"""
+    tribler_window.raise_window = Mock()
+    tribler_window.process_uri_request = Mock()
+
+    with patch.object(QFileDialog, 'getOpenFileNames', Mock(return_value=['.'])) as patched_getOpenFileNames:
+        tribler_window.on_add_torrent_browse_file()
+
+    assert tribler_window.raise_window.called
+    assert patched_getOpenFileNames.called
+    assert tribler_window.process_uri_request.called

--- a/src/tribler/gui/tribler_window.py
+++ b/src/tribler/gui/tribler_window.py
@@ -83,7 +83,6 @@ from tribler.gui.upgrade_manager import UpgradeManager
 from tribler.gui.utilities import (
     connect,
     create_api_key,
-    disconnect,
     format_api_key,
     get_font_path,
     get_gui_setting,
@@ -91,7 +90,6 @@ from tribler.gui.utilities import (
     get_ui_file_path,
     is_dir_writable,
     set_api_key,
-    show_message_box,
     tr,
 )
 from tribler.gui.widgets.instanttooltipstyle import InstantTooltipStyle
@@ -681,13 +679,16 @@ class TriblerWindow(QMainWindow):
 
     def on_add_torrent_browse_file(self, *_):
         self.raise_window()  # For the case when the action is triggered by tray icon
-        filenames = QFileDialog.getOpenFileNames(
+        filenames, *_ = QFileDialog.getOpenFileNames(
             self, tr("Please select the .torrent file"), QDir.homePath(), tr("Torrent files%s") % " (*.torrent)"
         )
-        if len(filenames[0]) > 0:
-            for filename in filenames[0]:
-                self.pending_uri_requests.append(Path(filename).as_uri())
-            self.process_uri_request()
+        if not filenames:
+            return
+
+        for filename in filenames:
+            uri = Path(filename).resolve().as_uri()
+            self.pending_uri_requests.append(uri)
+        self.process_uri_request()
 
     def start_download_from_uri(self, uri):
         uri = uri.decode('utf-8') if isinstance(uri, bytes) else uri


### PR DESCRIPTION
This PR adds a new test case to the `test_tribler_window.py` file. The test checks that the `on_add_torrent_browse_file` method in the `TriblerWindow` class works correctly. It mocks certain methods and uses patching to simulate user interaction with a file dialog. The test verifies that the appropriate methods are called and asserts their expected behavior.

The code changes in `tribler_window.py` modify the implementation of the `on_add_torrent_browse_file` method. It now handles cases where no filenames are selected from the file dialog, preventing unnecessary processing. Additionally, it resolves each filename to its absolute URI path before appending it to the list of pending URI requests.

These changes improve the functionality and reliability of adding torrent files through browsing in TriblerWindow.

Fixes #6345