### PR TITLE
Fix the asyncio `wait_for` function for the core tests

### DIFF
--- a/src/tribler/core/conftest.py
+++ b/src/tribler/core/conftest.py
@@ -12,6 +12,7 @@ from _pytest.config import Config
 from _pytest.python import Function
 from aiohttp.web_app import Application
 
+from tribler.core import patch_wait_for
 from tribler.core.components.restapi.rest.rest_endpoint import RESTEndpoint
 from tribler.core.components.restapi.rest.rest_manager import error_middleware
 from tribler.core.utilities.network_utils import default_network_utils
@@ -21,9 +22,12 @@ from tribler.core.utilities.network_utils import default_network_utils
 # Note that the error can happen in an unrelated test where the unhandled task from the previous test
 # was garbage collected. Without the origin tracking, it may be hard to see the test that created the task.
 sys.set_coroutine_origin_tracking_depth(10)
-
 enable_extended_logging = False
 pytest_start_time: Optional[datetime] = None  # a time when the test suite started
+
+# Fix the asyncio `wait_for` function to not swallow the `CancelledError` exception.
+# See: https://github.com/Tribler/tribler/issues/7570
+patch_wait_for()
 
 
 # pylint: disable=unused-argument, redefined-outer-name
@@ -63,7 +67,6 @@ def pytest_runtest_protocol(item: Function, log=True, nextitem=None):
         print(f' in {duration:.3f}s ({human_readable.time_delta(total)} in total)', end='')
     else:
         yield
-
 
 
 @pytest.fixture(autouse=True)

--- a/src/tribler/core/utilities/asyncio_fixes/wait_for.py
+++ b/src/tribler/core/utilities/asyncio_fixes/wait_for.py
@@ -136,6 +136,9 @@ wait_for.patched = True
 
 
 def patch_wait_for():
+    """ Patch asyncio.wait_for to fix the bug with swallowing CancelledError
+    See: https://github.com/Tribler/tribler/issues/7570
+    """
     if sys.version_info >= (3, 12):
         return  # wait_for should be fixed in 3.12
 


### PR DESCRIPTION
This PR contains refactoring for `test_http_get_with_redirect`, (in particular, it adds more log output) and it contains an actual fix for the #7767. This refactoring does not fix the problem, but it was a starting point for me to investigate the issue, and I decided to include this change in the PR as it improves logging for the tests and does not clutter the PR too much.

The actual fix is to call `patch_wait_for()` in `conftest.py`, as it addresses the issue 
- #7570 

which I believe we also have in our tests.

Fixes: #7767