### PR TITLE
Add tests for `Path.fix_win_long_file`

### DIFF
--- a/src/tribler/core/components/libtorrent/download_manager/download.py
+++ b/src/tribler/core/components/libtorrent/download_manager/download.py
@@ -322,7 +322,7 @@ class Download(TaskManager):
         filename = self.download_manager.get_checkpoint_dir() / basename
         self.config.config['download_defaults']['name'] = self.tdef.get_name_as_unicode()  # store name (for debugging)
         try:
-            self.config.write(str(filename))
+            self.config.write(filename)
         except OSError as e:
             self._logger.warning(f'{e.__class__.__name__}: {e}')
         else:

--- a/src/tribler/core/components/libtorrent/download_manager/download_config.py
+++ b/src/tribler/core/components/libtorrent/download_manager/download_config.py
@@ -68,7 +68,7 @@ class DownloadConfig:
         return DownloadConfig(ConfigObj(self.config, configspec=str(CONFIG_SPEC_PATH), default_encoding='utf-8'),
                               state_dir=self.state_dir)
 
-    def write(self, filename):
+    def write(self, filename: Path):
         self.config.filename = Path.fix_win_long_file(filename)
         self.config.write()
 

--- a/src/tribler/core/utilities/tests/test_path_utils.py
+++ b/src/tribler/core/utilities/tests/test_path_utils.py
@@ -1,3 +1,6 @@
+import sys
+from unittest.mock import patch
+
 import pytest
 
 from tribler.core.utilities.path_util import Path, tail
@@ -101,3 +104,17 @@ def test_size_folder(tribler_tmp_path: Path):
 
     assert tribler_tmp_path.size(include_dir_sizes=False) == 300
     assert tribler_tmp_path.size() >= 300
+
+
+@patch.object(sys, 'platform', 'win32')
+def test_fix_win_long_file_win():
+    """ Test that fix_win_long_file works correct on Windows"""
+    path = Path(r'C:\Users\User\AppData\Roaming\.Tribler\7.7')
+    assert Path.fix_win_long_file(path) == r'\\?\C:\Users\User\AppData\Roaming\.Tribler\7.7'
+
+
+@patch.object(sys, 'platform', 'linux')
+def test_fix_win_long_file_linux():
+    """ Test that fix_win_long_file works correct on Linux"""
+    path = Path('/home/user/.Tribler/7.7')
+    assert Path.fix_win_long_file(path) == '/home/user/.Tribler/7.7'


### PR DESCRIPTION
This PR adds tests for `Path.fix_win_long_file` and contains a small refactoring for `DownloadConfig.write` that I've done during the investigation of #5926.