### PR TITLE
Appliction Tester: Remove unnecessary requirements

### DIFF
--- a/scripts/application_tester/requirements.txt
+++ b/scripts/application_tester/requirements.txt
@@ -1,3 +1,0 @@
-aiohttp==3.9.0
-sentry-sdk==1.31.0
-colorlog==6.7.0

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,3 +1,2 @@
 -r ../requirements.txt
--r ./application_tester/requirements.txt
 -r ./experiments/requirements.txt


### PR DESCRIPTION
This PR removes the unnecessary `requirements.txt` from the Application Tester directory, as these requirements are superseded by Tribler's requirements.

- Removed `application_tester/requirements.txt` from the project as it was no longer needed.
- Updated `scripts/requirements.txt` to remove the reference to `application_tester/requirements.txt`.

Related #7777