### PR TITLE
WIP Update build dependencies and remove unnecessary package versions

### DIFF
--- a/build/mac/makedist_macos.sh
+++ b/build/mac/makedist_macos.sh
@@ -21,8 +21,6 @@ export RESOURCES=build/mac/resources
 
 python3 -m venv build-env
 . ./build-env/bin/activate
-python3 -m pip install pip==23.0.1 # pin pip version to avoid "--no-use-pep517" issues with the latest version
-python3 -m pip install PyInstaller==4.2 --no-use-pep517
 python3 -m pip install --upgrade -r requirements-build.txt
 
 # ----- Build

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 
-PyInstaller==6.3
+PyInstaller==5.13.2
 
 defusedxml==0.7.1; sys_platform == 'linux2' or sys_platform == 'linux'
 markupsafe==2.0.1; sys_platform == 'linux2' or sys_platform == 'linux'

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,9 +1,6 @@
 -r requirements.txt
 
-PyInstaller==5.1; sys_platform != 'darwin'
-
-setuptools==65.5.1; sys_platform == 'darwin'
-text-unidecode==1.3; sys_platform == 'darwin'
+PyInstaller==6.3
 
 defusedxml==0.7.1; sys_platform == 'linux2' or sys_platform == 'linux'
 markupsafe==2.0.1; sys_platform == 'linux2' or sys_platform == 'linux'

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -2,6 +2,8 @@
 
 PyInstaller==5.13.2
 
+setuptools==69.0.2; sys_platform == 'darwin'
+
 defusedxml==0.7.1; sys_platform == 'linux2' or sys_platform == 'linux'
 markupsafe==2.0.1; sys_platform == 'linux2' or sys_platform == 'linux'
 PyGObject==3.44.1; sys_platform == 'linux2' or sys_platform == 'linux'


### PR DESCRIPTION
This PR cleans up `requirements-build.txt`

- Update build dependencies in `makedist_macos.sh` script
- Remove specific package versions from `requirements-build.txt`
- Update PyInstaller version to `5.13.2`

It is better to have a list of requirements in the `requirements.txt` instead of having it in a bash script, as if it were a file, Dependabot could review it as well.