### PR TITLE
Fix RuntimeError: invalid torrent handle used

### DIFF
--- a/src/tribler/core/components/libtorrent/tests/test_torrent_utils.py
+++ b/src/tribler/core/components/libtorrent/tests/test_torrent_utils.py
@@ -1,0 +1,118 @@
+from asyncio import Future
+from unittest.mock import Mock
+
+import pytest
+
+from tribler.core.components.libtorrent.utils.torrent_utils import require_handle
+
+
+def create_download(handle=None, handle_future_cancelled=False):
+    """ Create a download object with a handle.
+
+    Args:
+        handle: The handle to use for the download
+        handle_future_cancelled: Whether the future for the handle should be cancelled
+
+    Returns: A download object with a handle
+    """
+    handle = handle or Mock()
+    future_for_handle = Future()
+    if not handle_future_cancelled:
+        future_for_handle.set_result(handle)
+    else:
+        future_for_handle.cancel()
+
+    download = Mock(get_handle=Mock(return_value=future_for_handle))
+    download.handle = handle
+    return download
+
+
+async def test_require_handle_not_valid():
+    # Test that the function is not invoked when the handle is not valid
+
+    @require_handle
+    def f(_):
+        return "result"
+
+    handle = Mock(is_valid=Mock(return_value=False))
+    download = create_download(handle)
+
+    result = await f(download)
+
+    assert result is None
+
+
+async def test_require_handles_not_equal():
+    # Test that the function is not invoked when the handles is not equal
+
+    @require_handle
+    def f(_):
+        return "result"
+
+    download = create_download()
+    download.handle = Mock()  # Change the handle to a different object to provoke the not equal check
+
+    result = await f(download)
+
+    assert result is None
+
+
+async def test_require_handle_future_cancelled():
+    # Test that the function is not invoked when the handle future is cancelled
+
+    @require_handle
+    def f(_):
+        return "result"
+
+    download = create_download(handle_future_cancelled=True)
+
+    result = await f(download)
+
+    assert result is None
+
+
+async def test_require_handle_result_future_done():
+    # Test that the function is not invoked when the result future is done
+
+    @require_handle
+    def f(_):
+        return "result"
+
+    download = create_download()
+
+    future = f(download)
+    future.set_result('any result')  # Set the result future to done to provoke the result_future.done() check
+    result = await future
+
+    # The result should not be the result of the function which is indicator that the function was not invoked
+    assert result != "result"
+
+
+async def test_require_handle_result_exception():
+    # Test that the require_handle re-raises an exception when the function raises an exception
+
+    class TestException(Exception):
+        """ Exception for testing """
+
+    @require_handle
+    def f(_):
+        raise TestException
+
+    download = create_download()
+
+    with pytest.raises(TestException):
+        await f(download)
+
+
+async def test_require_handle_result_runtime_error():
+    # RuntimeError is treated specially in the require_handle decorator exceptions of this type are logged
+    # but not re-raised
+    @require_handle
+    def f(_):
+        raise RuntimeError
+
+    download = create_download()
+
+    result = await f(download)
+
+    assert result is None

--- a/src/tribler/core/components/libtorrent/utils/torrent_utils.py
+++ b/src/tribler/core/components/libtorrent/utils/torrent_utils.py
@@ -4,7 +4,6 @@ from contextlib import suppress
 from hashlib import sha1
 from typing import Any, Dict, Iterable, List, Optional
 
-from tribler.core.components.libtorrent import torrentdef
 from tribler.core.components.libtorrent.utils.libtorrent_helper import libtorrent as lt
 from tribler.core.utilities.path_util import Path
 
@@ -34,6 +33,7 @@ def require_handle(func):
     Invoke the function once the handle is available. Returns a future that will fire once the function has completed.
     Author(s): Egbert Bouman
     """
+
     def invoke_func(*args, **kwargs):
         result_future = Future()
 
@@ -41,11 +41,13 @@ def require_handle(func):
             with suppress(CancelledError):
                 handle = fut.result()
 
-            if not fut.cancelled() \
-                    and not result_future.done() \
-                    and handle == download.handle \
-                    and handle.is_valid():
+            if fut.cancelled() or result_future.done() or handle != download.handle or not handle.is_valid():
+                return
+
+            try:
                 result_future.set_result(func(*args, **kwargs))
+            except RuntimeError as e:
+                logger.exception(e)
 
         download = args[0]
         handle_future = download.get_handle()

--- a/src/tribler/core/components/libtorrent/utils/torrent_utils.py
+++ b/src/tribler/core/components/libtorrent/utils/torrent_utils.py
@@ -44,8 +44,7 @@ def require_handle(func):
             if not fut.cancelled() \
                     and not result_future.done() \
                     and handle == download.handle \
-                    and handle.is_valid() \
-                    and not isinstance(download.tdef, torrentdef.TorrentDefNoMetainfo):
+                    and handle.is_valid():
                 result_future.set_result(func(*args, **kwargs))
 
         download = args[0]


### PR DESCRIPTION
This PR fixes `RuntimeError: invalid torrent handle used` by adding try-except block:

```python
            try:
                result_future.set_result(func(*args, **kwargs))
            except RuntimeError as e:
                logger.exception(e)
```

The reasoning for eating the exception is the following:
1. Originally the `require_handle` decorator ensures that there is a handle present and the handle is valid before calling the function. If the handle is invalid, then the function will not be called.
2. The suggested change just extends this to the call itself and, in the case of a `RuntimeError`, suppresses it. 
3. For the caller, the behavior will be the same as if the check `handle.is_valid()` returns a False value.

The drawback of this change is the fact that, besides the "invalid torrent handle used," there could be another `RuntimeError` caused by a different reason.

Fixes #7412, fixes #6915

Also, this PR reverted back the change applied in #7415 as it has been shown that this change does not fix the original problem:  
- https://github.com/Tribler/tribler/issues/6915#issuecomment-1722776498

The last commit adds tests for `require_handle` and fixes some execution paths that, according to the decorator definition, could be executed but were never executed before due to the way it is used in Tribler's code.