### PR TITLE
Add pylint-pytest plugin

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -17,6 +17,7 @@ persistent = yes
 # List of plugins (as comma separated values of python modules names) to load,
 # usually to register additional checkers.
 #load-plugins=pylint_common,pylint.extensions.check_elif,pylint.extensions.check_docs
+load-plugins=pylint_pytest
 
 # To install required plugins:
 # sudo apt install python-pylint-common python-enchant python-pylint-plugin-utils

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,6 +5,7 @@ pytest-aiohttp==1.0.5
 pytest-asyncio==0.21.1
 pytest-randomly==3.15.0
 pytest-timeout==2.2.0
+pylint-pytest==1.1.7
 
 coverage==7.3.2
 looptime==0.2 ; sys_platform != 'win32'


### PR DESCRIPTION
This PR adds the `pylint-pytest` plugin to the `.pylintrc` file, enabling additional checkers for pytest. It also includes the `pylint-pytest` package in the `requirements-test.txt` file, ensuring it is installed when running tests.

The necessity of adding this plugin emerged from the notable discussion in #7764, where @drew2a proposed the use of `pylint-pytest` and @qstokkink supported the idea:

>Just to repeat - myself and the docs - adding a "name" is not the only way to resolve this. Secondarily, this has nothing to do with Pylint, other than that it will also tell you the same thing. I like the idea of adding pylint-pytest though.

Ref:
 - https://github.com/Tribler/tribler/pull/7764#pullrequestreview-1774459402
 - https://github.com/pylint-dev/pylint-pytest