### PR TITLE
Fix OSError: [WinError 123] for the `_check_watch_folder`

### DIFF
--- a/src/tribler/core/config/tribler_config_section.py
+++ b/src/tribler/core/config/tribler_config_section.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from pathlib import Path
 from typing import Optional
 
 from pydantic import BaseSettings, Extra, root_validator
+
+from tribler.core.utilities.path_util import Path
 
 
 class TriblerConfigSection(BaseSettings):
@@ -38,7 +39,7 @@ class TriblerConfigSection(BaseSettings):
         value = self.__getattribute__(property_name)
         if value is None:
             return None
-        return state_dir / value
+        return Path(state_dir / value)
 
     @root_validator(pre=True)
     def convert_from_none_string_to_none_type(cls, values):  # pylint: disable=no-self-argument

--- a/src/tribler/core/utilities/path_util.py
+++ b/src/tribler/core/utilities/path_util.py
@@ -72,6 +72,16 @@ class Path(type(pathlib.Path())):
     def endswith(self, text: str) -> bool:
         return self.match(f"*{text}")
 
+    def is_valid(self):
+        """ Check if the path is valid.
+
+        Returns: True if the path is valid, False otherwise.
+        """
+        try:
+            return self.is_file() or self.is_dir()
+        except OSError:
+            return False
+
 
 class PosixPath(Path, pathlib.PurePosixPath):
     __slots__ = ()

--- a/src/tribler/core/utilities/rest_utils.py
+++ b/src/tribler/core/utilities/rest_utils.py
@@ -1,8 +1,9 @@
 import os
-from pathlib import Path
 from typing import Any, Union
 
 from yarl import URL
+
+from tribler.core.utilities.path_util import Path
 
 MAGNET_SCHEME = 'magnet'
 FILE_SCHEME = 'file'
@@ -55,7 +56,4 @@ def scheme_from_url(url: str) -> str:
 
 def url_is_valid_file(file_url: str) -> bool:
     file_path = url_to_path(file_url)
-    try:
-        return Path(file_path).is_file()
-    except OSError:
-        return False
+    return Path(file_path).is_valid()

--- a/src/tribler/core/utilities/tests/test_path_utils.py
+++ b/src/tribler/core/utilities/tests/test_path_utils.py
@@ -1,5 +1,5 @@
 import sys
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -118,3 +118,27 @@ def test_fix_win_long_file_linux():
     """ Test that fix_win_long_file works correct on Linux"""
     path = Path('/home/user/.Tribler/7.7')
     assert Path.fix_win_long_file(path) == str(path)
+
+
+def test_is_valid(tmp_path):
+    """ Test that is_valid returns True for valid path"""
+    assert Path(tmp_path).is_valid()
+
+
+def test_is_invalid(tmp_path):
+    """ Test that is_valid returns False for invalid path"""
+    invalid_path = Path(str(tmp_path) * 2)
+    assert not Path(invalid_path).is_valid()
+
+
+@patch.object(Path, 'is_file', Mock(side_effect=OSError))
+def test_is_invalid_by_os_exception(tmp_path):
+    """ Test that is_valid returns False if OSError exception was raised"""
+    assert not Path(tmp_path).is_valid()
+
+
+@patch.object(Path, 'is_file', Mock(side_effect=ValueError))
+def test_is_valid_any_exception(tmp_path):
+    """ Test that is_valid reraise exception if it is not OSError"""
+    with pytest.raises(ValueError):
+        Path(tmp_path).is_valid()


### PR DESCRIPTION
This PR fixes #7794 by adding the following block to check the validity of the path:

```python
        if not directory.is_valid():
            self._logger.warning(f'Cancelled. Directory is not valid: {directory}.')
            return False
```

Where `is_valid` is the following:

```python
    def is_valid(self):
        """ Check if the path is valid.
        Returns: True if the path is valid, False otherwise.
        """
        try:
            return self.is_file() or self.is_dir()
        except OSError:
            return False
```

The bulk of this PR consists of tests for previously written code, which might not be part of the fix. However, I think it's acceptable to include these to increase coverage and satisfy the coverage tool.
