### PR TITLE
Fix ValueError: Can redirect only to http or https

### DIFF
--- a/src/tribler/core/components/libtorrent/download_manager/download_manager.py
+++ b/src/tribler/core/components/libtorrent/download_manager/download_manager.py
@@ -38,7 +38,7 @@ from tribler.core.utilities.rest_utils import (
 )
 from tribler.core.utilities.simpledefs import DownloadStatus, MAX_LIBTORRENT_RATE_LIMIT, STATEDIR_CHECKPOINT_DIR
 from tribler.core.utilities.unicode import hexlify
-from tribler.core.utilities.utilities import bdecode_compat, has_bep33_support, parse_magnetlink
+from tribler.core.utilities.utilities import bdecode_compat, has_bep33_support, parse_magnetlink, unshorten
 from tribler.core.version import version_id
 
 SOCKS5_PROXY_DEF = 2
@@ -573,6 +573,8 @@ class DownloadManager(TaskManager):
 
     async def start_download_from_uri(self, uri, config=None):
         self._logger.info(f'Start download from URI: {uri}')
+
+        uri = await unshorten(uri)
         scheme = scheme_from_url(uri)
 
         if scheme in (HTTP_SCHEME, HTTPS_SCHEME):

--- a/src/tribler/core/components/libtorrent/restapi/torrentinfo_endpoint.py
+++ b/src/tribler/core/components/libtorrent/restapi/torrentinfo_endpoint.py
@@ -29,7 +29,7 @@ from tribler.core.utilities.rest_utils import (
     url_to_path,
 )
 from tribler.core.utilities.unicode import hexlify, recursive_unicode
-from tribler.core.utilities.utilities import bdecode_compat, froze_it, parse_magnetlink
+from tribler.core.utilities.utilities import bdecode_compat, froze_it, parse_magnetlink, unshorten
 
 
 async def query_http_uri(uri: str) -> bytes:
@@ -87,7 +87,7 @@ class TorrentInfoEndpoint(RESTEndpoint):
         if not uri:
             return RESTResponse({"error": "uri parameter missing"}, status=HTTP_BAD_REQUEST)
 
-        metainfo = None
+        uri = await unshorten(uri)
         scheme = scheme_from_url(uri)
 
         if scheme == FILE_SCHEME:
@@ -110,7 +110,7 @@ class TorrentInfoEndpoint(RESTEndpoint):
                     _, infohash, _ = parse_magnetlink(response)
                 except RuntimeError as e:
                     return RESTResponse(
-                        {"error": f'Error while getting an ingo hash from magnet: {e.__class__.__name__}: {e}'},
+                        {"error": f'Error while getting an infohash from magnet: {e.__class__.__name__}: {e}'},
                         status=HTTP_INTERNAL_SERVER_ERROR
                     )
 
@@ -124,7 +124,7 @@ class TorrentInfoEndpoint(RESTEndpoint):
                 _, infohash, _ = parse_magnetlink(uri)
             except RuntimeError as e:
                 return RESTResponse(
-                    {"error": f'Error while getting an ingo hash from magnet: {e.__class__.__name__}: {e}'},
+                    {"error": f'Error while getting an infohash from magnet: {e.__class__.__name__}: {e}'},
                     status=HTTP_BAD_REQUEST
                 )
 

--- a/src/tribler/core/utilities/tests/test_utilities.py
+++ b/src/tribler/core/utilities/tests/test_utilities.py
@@ -1,8 +1,10 @@
 import logging
-from unittest.mock import MagicMock, Mock, patch
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 from aiohttp import ClientSession, web
+from aiohttp.hdrs import LOCATION, URI
 
 from tribler.core.logger.logger import load_logger_config
 from tribler.core.utilities.patch_import import patch_import
@@ -10,7 +12,7 @@ from tribler.core.utilities.tracker_utils import add_url_params
 from tribler.core.utilities.utilities import (Query, extract_tags, get_normally_distributed_positive_integers,
                                               is_channel_public_key, is_infohash, is_simple_match_query, is_valid_url,
                                               parse_bool, parse_magnetlink, parse_query, random_infohash, safe_repr,
-                                              show_system_popup, to_fts_query)
+                                              show_system_popup, to_fts_query, unshorten)
 
 # pylint: disable=import-outside-toplevel, import-error, redefined-outer-name
 # fmt: off
@@ -370,3 +372,44 @@ def test_safe_repr_exception():
     obj = MagicMock(__repr__=Mock(side_effect=MyException("exception text")))
     result = safe_repr(obj)
     assert result == f'<Repr of {object.__repr__(obj)} raises MyException: exception text>'
+
+
+
+UNSHORTEN_TEST_DATA = [
+    SimpleNamespace(
+        # Test that the `unshorten` function returns the unshorten URL if there is a redirect detected by
+        # the right status code and right header.
+        url='http://shorten',
+        response=SimpleNamespace(status=301, headers={LOCATION: 'http://unshorten'}),
+        expected='http://unshorten'
+    ),
+    SimpleNamespace(
+        # Test that the `unshorten` function returns the same URL if there is wrong scheme
+        url='file://shorten',
+        response=SimpleNamespace(status=0, headers={}),
+        expected='file://shorten'
+    ),
+    SimpleNamespace(
+        # Test that the `unshorten` function returns the same URL if there is no redirect detected by the wrong status
+        # code.
+        url='http://shorten',
+        response=SimpleNamespace(status=401, headers={LOCATION: 'http://unshorten'}),
+        expected='http://shorten'
+    ),
+    SimpleNamespace(
+        # Test that the `unshorten` function returns the same URL if there is no redirect detected by the wrong header.
+        url='http://shorten',
+        response=SimpleNamespace(status=301, headers={URI: 'http://unshorten'}),
+        expected='http://shorten'
+    )
+]
+
+
+@pytest.mark.parametrize("test_data", UNSHORTEN_TEST_DATA)
+async def test_unshorten(test_data):
+    # The function mocks the ClientSession.get method to return a mocked response with the given status and headers.
+    # It is used with the test data above to test the unshorten function.
+    response = MagicMock(status=test_data.response.status, headers=test_data.response.headers)
+    mocked_get = AsyncMock(return_value=AsyncMock(__aenter__=AsyncMock(return_value=response)))
+    with patch.object(ClientSession, 'get', mocked_get):
+        assert await unshorten(test_data.url) == test_data.expected


### PR DESCRIPTION
This PR fixes #7801 by adding the `unshorten` URI logic before querying HTTP URI.