### PR TITLE
Refactor magnet link parsing logic and add new test cases

### DIFF
--- a/src/tribler/core/components/libtorrent/restapi/tests/test_torrentinfo_endpoint.py
+++ b/src/tribler/core/components/libtorrent/restapi/tests/test_torrentinfo_endpoint.py
@@ -7,17 +7,17 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 from urllib.parse import quote_plus, unquote_plus
 
 import pytest
-from aiohttp import ServerConnectionError, ClientResponseError, ClientConnectorError
+from aiohttp import ClientConnectorError, ClientResponseError, ServerConnectionError
 from ipv8.util import succeed
 
 from tribler.core import notifications
+from tribler.core.components.database.db.orm_bindings.torrent_metadata import tdef_to_metadata_dict
 from tribler.core.components.libtorrent.download_manager.download_manager import DownloadManager
 from tribler.core.components.libtorrent.restapi.torrentinfo_endpoint import TorrentInfoEndpoint
 from tribler.core.components.libtorrent.settings import DownloadDefaultsSettings, LibtorrentSettings
 from tribler.core.components.libtorrent.torrentdef import TorrentDef
-from tribler.core.components.database.db.orm_bindings.torrent_metadata import tdef_to_metadata_dict
 from tribler.core.components.restapi.rest.base_api_test import do_request
-from tribler.core.components.restapi.rest.rest_endpoint import HTTP_INTERNAL_SERVER_ERROR
+from tribler.core.components.restapi.rest.rest_endpoint import HTTP_BAD_REQUEST, HTTP_INTERNAL_SERVER_ERROR
 from tribler.core.tests.tools.common import TESTS_DATA_DIR, TESTS_DIR, TORRENT_UBUNTU_FILE, UBUNTU_1504_INFOHASH
 from tribler.core.utilities.rest_utils import path_to_url
 from tribler.core.utilities.unicode import hexlify
@@ -77,17 +77,18 @@ async def test_get_torrentinfo(tmp_path, rest_api, download_manager: DownloadMan
         assert 'info' in metainfo_dict
 
     url = 'torrentinfo'
-    await do_request(rest_api, url, expected_code=400)
-    await do_request(rest_api, url, params={'uri': 'def'}, expected_code=400)
+    await do_request(rest_api, url, expected_code=HTTP_BAD_REQUEST)
+    await do_request(rest_api, url, params={'uri': 'def'}, expected_code=HTTP_BAD_REQUEST)
 
     response = await do_request(rest_api, url, params={'uri': _path('bak_single.torrent')}, expected_code=200)
     verify_valid_dict(response)
 
     # Corrupt file
-    await do_request(rest_api, url, params={'uri': _path('test_rss.xml')}, expected_code=500)
+    await do_request(rest_api, url, params={'uri': _path('test_rss.xml')}, expected_code=HTTP_INTERNAL_SERVER_ERROR)
 
     # Non-existing file
-    await do_request(rest_api, url, params={'uri': _path('non_existing.torrent')}, expected_code=500)
+    await do_request(rest_api, url, params={'uri': _path('non_existing.torrent')},
+                     expected_code=HTTP_INTERNAL_SERVER_ERROR)
 
     path = "http://localhost:1234/ubuntu.torrent"
 
@@ -119,11 +120,11 @@ async def test_get_torrentinfo(tmp_path, rest_api, download_manager: DownloadMan
     verify_valid_dict(await do_request(rest_api, f'torrentinfo?uri={path}', expected_code=200))
 
     path = 'magnet:?xt=urn:ed2k:354B15E68FB8F36D7CD88FF94116CDC1'  # No infohash
-    await do_request(rest_api, f'torrentinfo?uri={path}', expected_code=400)
+    await do_request(rest_api, f'torrentinfo?uri={path}', expected_code=HTTP_BAD_REQUEST)
 
     path = quote_plus(f"magnet:?xt=urn:btih:{'a' * 40}&dn=test torrent")
     download_manager.get_metainfo = lambda *_, **__: succeed(None)
-    await do_request(rest_api, f'torrentinfo?uri={path}', expected_code=500)
+    await do_request(rest_api, f'torrentinfo?uri={path}', expected_code=HTTP_INTERNAL_SERVER_ERROR)
 
     # Ensure that correct torrent metadata was sent through notifier (to MetadataStore)
     download_manager.notifier[notifications.torrent_metadata_added].assert_called_with(metainfo_dict)
@@ -134,10 +135,10 @@ async def test_get_torrentinfo(tmp_path, rest_api, download_manager: DownloadMan
     await do_request(rest_api, f'torrentinfo?uri={path}&hops=0', expected_code=200)
     assert [0] == hops_list
 
-    await do_request(rest_api, f'torrentinfo?uri={path}&hops=foo', expected_code=400)
+    await do_request(rest_api, f'torrentinfo?uri={path}&hops=foo', expected_code=HTTP_BAD_REQUEST)
 
     path = 'http://fdsafksdlafdslkdksdlfjs9fsafasdf7lkdzz32.n38/324.torrent'
-    await do_request(rest_api, f'torrentinfo?uri={path}', expected_code=500)
+    await do_request(rest_api, f'torrentinfo?uri={path}', expected_code=HTTP_INTERNAL_SERVER_ERROR)
 
     mock_download = MagicMock(
         stop=AsyncMock(),
@@ -162,23 +163,35 @@ async def test_get_torrentinfo(tmp_path, rest_api, download_manager: DownloadMan
     assert result["download_exists"]
 
 
+async def test_get_torrentinfo_invalid_magnet(rest_api):
+    # Test that invalid magnet link casues an error
+    mocked_query_http_uri = AsyncMock(return_value=b'magnet:?xt=urn:ed2k:' + b"any hash")
+    params = {'uri': 'http://any.uri'}
+
+    with patch('tribler.core.components.libtorrent.restapi.torrentinfo_endpoint.query_http_uri', mocked_query_http_uri):
+        result = await do_request(rest_api, 'torrentinfo', params=params, expected_code=HTTP_INTERNAL_SERVER_ERROR)
+
+    assert 'error' in result
+
+
 async def test_on_got_invalid_metainfo(rest_api):
     """
     Test whether the right operations happen when we receive an invalid metainfo object
     """
 
     path = f"magnet:?xt=urn:btih:{hexlify(UBUNTU_1504_INFOHASH)}&dn={quote_plus('test torrent')}"
-    res = await do_request(rest_api, f'torrentinfo?uri={path}', expected_code=500)
+    res = await do_request(rest_api, f'torrentinfo?uri={path}', expected_code=HTTP_INTERNAL_SERVER_ERROR)
     assert "error" in res
+
 
 # These are the exceptions that are handled by torrent info endpoint when querying an HTTP URI.
 caught_exceptions = [
-        ServerConnectionError(),
-        ClientResponseError(Mock(), Mock()),
-        SSLError(),
-        ClientConnectorError(Mock(), Mock()),
-        AsyncTimeoutError()
-    ]
+    ServerConnectionError(),
+    ClientResponseError(Mock(), Mock()),
+    SSLError(),
+    ClientConnectorError(Mock(), Mock()),
+    AsyncTimeoutError()
+]
 
 
 @patch("tribler.core.components.libtorrent.restapi.torrentinfo_endpoint.query_http_uri")

--- a/src/tribler/core/components/libtorrent/tests/test_download_manager.py
+++ b/src/tribler/core/components/libtorrent/tests/test_download_manager.py
@@ -2,8 +2,7 @@ import asyncio
 import functools
 import itertools
 from asyncio import Future
-from unittest.mock import MagicMock, Mock
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock, Mock
 
 import pytest
 from ipv8.util import succeed
@@ -17,6 +16,8 @@ from tribler.core.utilities.path_util import Path
 from tribler.core.utilities.simpledefs import DownloadStatus
 from tribler.core.utilities.unicode import hexlify
 
+
+# pylint: disable=redefined-outer-name
 
 def create_fake_download_and_state():
     """
@@ -501,6 +502,13 @@ async def test_check_for_dht_ready(fake_dlmgr):
     fake_dlmgr.get_session().status().dht_nodes = 1000
     # If the session has enough peers, it should finish instantly
     await fake_dlmgr._check_dht_ready()
+
+
+async def test_start_download_from_magnet_no_name(fake_dlmgr: DownloadManager):
+    # Test whether a download is started with `Unknown name` name when the magnet has no name
+    magnet = f'magnet:?xt=urn:btih:{"A" * 40}'
+    download = await fake_dlmgr.start_download_from_uri(magnet)
+    assert download.tdef.get_name() == 'Unknown name'
 
 
 def test_update_trackers(fake_dlmgr) -> None:


### PR DESCRIPTION
This PR refactors the `parse_magnetlink` function to use `libtorrent.parse_magnet_uri` for parsing magnet links, as it seems safer and more convenient to rely on the native libtorrent parsing mechanism instead of our own.

It is includes:
- Added a new test case for parsing a magnet link with a wrong hash.
- Added a new test case for parsing a magnet link with bytes input.
- Removed two existing test cases that were testing invalid infohashes, as they are no longer needed.

This refactoring was carried out during the work on:
- #7801