### PR TITLE
Remove incorrect warning "Either file does not exist or is not file (in `Download.checkpoint()`)

### DIFF
--- a/src/tribler/core/components/libtorrent/download_manager/download.py
+++ b/src/tribler/core/components/libtorrent/download_manager/download.py
@@ -727,8 +727,6 @@ class Download(TaskManager):
                     b'info-hash': self.tdef.get_infohash()
                 }
                 self.post_alert('save_resume_data_alert', dict(resume_data=resume_data))
-            else:
-                self._logger.warning("Either file does not exist or is not file")
             return succeed(None)
         return self.save_resume_data()
 


### PR DESCRIPTION
The code of the `Download.checkpoint()` method contains an incorrect warning. It erroneously warns "Either file does not exist or is not file" when the file exists. It should just be removed.