### PR TITLE
Add development agreements documentation

### DIFF
--- a/doc/development/agreements.rst
+++ b/doc/development/agreements.rst
@@ -1,0 +1,26 @@
+=======================================
+Agreements Made Among Developers
+=======================================
+
+To add a change to this document, approval from all current developers is mandatory.
+The current developers are listed here: https://github.com/orgs/Tribler/teams/reviewers
+
+Agreements
+==========
+
+Branching Model
+---------------
+We use the OneFlow branching model, as detailed here: https://www.endoflineblog.com/oneflow-a-git-branching-model-and-workflow
+
+We prefer the fork-centric workflow over the branch-centric workflow.
+
+For the main branch, we use the name `main`.
+
+For merging forks, we use: `rebase + merge --no-ff`
+
+.. image:: https://www.endoflineblog.com/img/oneflow/feature-branch-rebase-and-merge-final.png
+   :width: 600
+
+Related issues:
+ - https://github.com/Tribler/tribler/issues/5569
+ - https://github.com/Tribler/tribler/issues/5575

--- a/doc/development/development.rst
+++ b/doc/development/development.rst
@@ -19,6 +19,11 @@ Linux
 
 .. include:: development_on_linux.rst
 
+======================
+Development agreements
+======================
+
+.. include:: agreements.rst
 
 ======================
 Development guidelines


### PR DESCRIPTION
As demonstrated in #7799, there is currently a lack of clarity regarding our processes and the agreements we have made. To address this and ensure the transfer of knowledge to future team members, I have created the `agreements.rst` file. This file will serve as a central repository for listing all our agreements.

I propose a single rule for this document: any changes must receive approval through pull requests from all current developers. This ensures collective agreement and maintains the integrity of our processes.

To initiate the `agreements.rst` with relevant content, I have included our consensus on the branching model, as discussed in the following issues:

- https://github.com/Tribler/tribler/issues/5569
- https://github.com/Tribler/tribler/issues/5575

The importance of having such a document, particularly in a distributed team with considerable turnover, cannot be overstated. Documenting agreements:

- Facilitates Onboarding: New developers can quickly familiarize themselves with the team's methodologies, significantly reducing the learning curve.
- Preserves Institutional Knowledge: With high turnover (the hight turnover of Tribler's developers has been shown here: https://github.com/drew2a/ivory-tower/issues/1#issuecomment-1884614714), valuable knowledge can be lost. A documented set of agreements helps preserve this knowledge, ensuring continuity and stability in the team's operations.
- Aids in Conflict Resolution: Having a reference point for previously made agreements can significantly reduce misunderstandings and conflicts within the team, as it provides a basis for resolution and decision-making (see also: #7807).
- Ensures Continuous Improvement: By requiring unanimous approval for changes, the document becomes a living entity that evolves with the team, continually improving and adapting to new challenges and insights.