### PR TITLE
Add `second_reviewer.yml`

### DIFF
--- a/.github/workflows/second_reviewer.yml
+++ b/.github/workflows/second_reviewer.yml
@@ -1,0 +1,100 @@
+name: Second Reviewer Assignment
+
+on:
+  pull_request_target:
+    types: [ labeled ]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign-reviewer:
+    if: ${{ contains(github.event.pull_request.labels.*.name, format('PR{0} second reviewer', ':')) }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Get team members
+        id: get-team-members
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{secrets.PAT_TOKEN_FOR_SECOND_REVIEWER_UNTIL_JAN_2025}}
+          script: |
+            /*
+            * Using PAT_TOKEN_FOR_SECOND_REVIEWER_UNTIL_JAN_2025 because the current workflow
+            * lacks sufficient permissions to view members of the Tribler organization.
+            * This token is valid until January 2025. It's issued for a maximum of one year,
+            * so in January 2025, it will expire and need to be replaced with a new token.
+            */
+            
+            const teamResponse = await github.rest.teams.listMembersInOrg({
+              org: 'Tribler',
+              team_slug: 'reviewers'
+            });
+            const allReviewers = teamResponse.data.map(member => member.login);
+            return allReviewers;
+
+      - name: Add second reviewer
+        uses: actions/github-script@v7
+        env:
+          ALL_REVIEWERS: ${{ steps.get-team-members.outputs.result }}
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const pullRequest = context.payload.pull_request;
+            const author = pullRequest.user.login;
+            console.log("Author:", author);
+
+            const currentReviewers = pullRequest.requested_reviewers.map(reviewer => reviewer.login);
+            console.log("Current Reviewers:", currentReviewers);
+
+            // Get the list of potential reviewers from the previous step
+            const allReviewers = JSON.parse(process.env.ALL_REVIEWERS)
+            console.log("Potential Reviewers:", allReviewers);
+
+            // Filter out the PR author and current reviewers
+            const eligibleReviewers = allReviewers.filter(reviewer => reviewer !== author && !currentReviewers.includes(reviewer));
+            console.log("Eligible Reviewers:", eligibleReviewers);
+
+            // Randomly select a reviewer
+            if (eligibleReviewers.length > 0) {
+                const randomReviewer = eligibleReviewers[Math.floor(Math.random() * eligibleReviewers.length)];
+                console.log("Selected Reviewer:", randomReviewer);
+
+                // Assign the selected reviewer
+                await github.rest.pulls.requestReviewers({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: pullRequest.number,
+                  reviewers: [randomReviewer]
+                });
+
+                // Add a comment explaining the selection
+                const comment = `A 'second reviewer' has been requested for this pull request. @${randomReviewer} has been randomly selected as the second opinion reviewer. This action is part of the Tie Breaker mechanism designed to resolve conflicts. The decision of the 'second reviewer' is considered final in the dispute.`;
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pullRequest.number,
+                  body: comment
+                });
+            } else {
+                // Add a comment indicating no eligible reviewers are left
+                const noReviewerComment = `All eligible reviewers have already been added to this pull request.`;
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pullRequest.number,
+                  body: noReviewerComment
+                });
+                console.log("No eligible reviewers left to add.");
+            }
+            
+            // Remove the 'PR: second reviewer' label
+            await github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pullRequest.number,
+              name: 'PR: second reviewer'
+            });
+            console.log("Label 'PR: second reviewer' removed successfully.");

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -64,6 +64,8 @@ PR policies
 ===========
 * We use `rebase + merge –no–ff <https://www.endoflineblog.com/oneflow-a-git-branching-model-and-workflow#option-3-rebase-merge-no-ff>`_ for merging a branch
 * Responsibility for merging the PR is on the creator of PR
+* In the case where you cannot reach a consensus with the reviewer, you can request a second reviewer to act as a `Tie Breaker <https://github.com/Tribler/tribler/issues/7807>`_.
+
 
 Recommendations:
 


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow titled "Second Reviewer Assignment." The primary objective of this workflow is to automate the process of assigning a second reviewer to pull requests when required, as part of our tie-breaker mechanism in code review processes.

#### Key Features:

1. **Trigger Condition**: The workflow is triggered when a label named `PR: second reviewer` is added to a pull request. It is designed to only respond to this specific label, ensuring that the action is executed intentionally and in the appropriate context.

2. **Fetching Reviewers**: The workflow fetches the list of potential reviewers from the 'reviewers' team within the 'Tribler' GitHub organization. This is done using the `actions/github-script` action with a custom script.

3. **Reviewer Assignment Logic**: 
   - The script filters out the pull request author and any reviewers already assigned to the pull request, ensuring no duplicate assignments.
   - From the remaining list of eligible reviewers, one reviewer is randomly selected and assigned to the pull request.

4. **Commenting on PR**: After assigning the reviewer, the workflow automatically posts a comment on the pull request, explaining the selection. This comment serves to inform all participants about the automated decision and its context.

5. **Handling Unavailability of Reviewers**: In case all potential reviewers are already assigned, the workflow adds a comment to the pull request stating that all eligible reviewers have been exhausted. This serves as a notification for manual intervention.

6. **Usage of PAT Token**: A Personal Access Token (PAT) titled `PAT_TOKEN_FOR_SECOND_REVIEWER_UNTIL_JAN_2025` is used due to the insufficient permissions of the default GitHub token for viewing members of the Tribler organization. This token is valid until January 2025 and will need to be replaced upon expiration.

#### Additional Notes:
- **Token Expiration Reminder**: It's important to note that the `PAT_TOKEN_FOR_SECOND_REVIEWER_UNTIL_JAN_2025` will expire in January 2025. A renewal or replacement will be necessary to maintain the functionality of this workflow.

#### Modifications:
- Added the `.github/workflows/second_reviewer_assignment.yml` file implementing the workflow.

Resolves #7807 

Refs:
 - https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens
 - https://github.com/actions/github-script
 - https://octokit.github.io/rest.js/v20/