### PR TITLE
Add dependencies for application tester to run

### DIFF
--- a/.github/workflows/application_tester.yml
+++ b/.github/workflows/application_tester.yml
@@ -70,6 +70,10 @@ jobs:
         if: runner.os == 'Linux'
         uses: pyvista/setup-headless-display-action@v1
 
+      - name: Install application tester dependencies
+        run: |
+          pip install -r ./scripts/application_tester/requirements.txt
+
       - name: Application Tester
         timeout-minutes: 5
         env:

--- a/scripts/application_tester/README.md
+++ b/scripts/application_tester/README.md
@@ -3,8 +3,13 @@
 > **_NOTE:_** code moved from: https://github.com/Tribler/application-tester/
 
 This repository hosts code for the Tribler application tester, which aims to automatically test Tribler using code injection.
-To run the Tribler application tester, it requires a path to the Tribler executable, for example:
 
+To run the Tribler application tester, dependencies specified in `scripts/application_tester/requirements.txt` must be installed. 
+```
+pip install -r scripts/application_tester/requirements.txt
+```
+
+Further, the script requires a path to the Tribler executable to be passed as an argument, for example:
 ```
 python scripts/application_tester/main.py -p "python src/run_tribler.py"
 ```

--- a/scripts/application_tester/requirements.txt
+++ b/scripts/application_tester/requirements.txt
@@ -1,0 +1,7 @@
+sentry_sdk==1.31.0
+pydantic==1.10.11
+file-read-backwards==3.0.0
+psutil==5.9.5
+colorlog==6.7.0
+configobj==5.0.8
+aiohttp==3.9.0


### PR DESCRIPTION
While fixing the application tester jobs on Jenkins, I found that some dependencies need to be installed to run the application tester from the Tribler repo application tester code. This is a subset of Tribler dependencies.

Several dependencies are required because of the application tester code dependence on `TriblerConfig` class.

Earlier PR https://github.com/Tribler/tribler/pull/7824 was used to test if application tester-specific dependencies are installed during tests. It was done by adding an extra dependency `requests==2.31.0` and using that dependency in the application tester code. The test is successful and the action run for that is available [here](https://github.com/Tribler/tribler/actions/runs/7555493318/job/20570601421#step:10:14).
