### PR TITLE
Refactor SimpleStatement class in knowledge_data_access_layer.py

### DIFF
--- a/src/tribler/core/components/database/db/layers/knowledge_data_access_layer.py
+++ b/src/tribler/core/components/database/db/layers/knowledge_data_access_layer.py
@@ -60,9 +60,9 @@ class ResourceType(IntEnum):
 @dataclass
 class SimpleStatement:
     subject_type: ResourceType
-    object: str
-    predicate: ResourceType
     subject: str
+    predicate: ResourceType
+    object: str
 
 
 class KnowledgeDataAccessLayer:


### PR DESCRIPTION
While writing the follow-up for KnowledgeCommunity in [#6214](https://github.com/Tribler/tribler/issues/6214), I realized that the order of attributes in the `SimpleStatement` could be changed to appear more natural, following the (subject, predicate, object) notation.

Ref:
- https://en.wikipedia.org/wiki/Semantic_triple