### PR TITLE
Fix TorrentDefNoMetainfo.get_name_utf8() to return string

### DIFF
--- a/src/tribler/core/components/libtorrent/download_manager/download_manager.py
+++ b/src/tribler/core/components/libtorrent/download_manager/download_manager.py
@@ -590,7 +590,7 @@ class DownloadManager(TaskManager):
                 tdef = TorrentDef.load_from_dict(self.metainfo_cache[infohash]['meta_info'])
             else:
                 self._logger.info('Metainfo not found in cache')
-                tdef = TorrentDefNoMetainfo(infohash, "Unknown name" if not name else name, url=uri)
+                tdef = TorrentDefNoMetainfo(infohash, b"Unknown name" if not name else name, url=uri)
             return await self.start_download(tdef=tdef, config=config)
         if scheme == FILE_SCHEME:
             self._logger.info('File scheme detected')

--- a/src/tribler/core/components/libtorrent/tests/test_download_manager.py
+++ b/src/tribler/core/components/libtorrent/tests/test_download_manager.py
@@ -179,7 +179,7 @@ async def test_start_download_while_getting_metainfo(fake_dlmgr):
     fake_dlmgr.remove_download = AsyncMock(return_value=succeed(None))
 
     tdef = TorrentDefNoMetainfo(
-        infohash, "name", f"magnet:?xt=urn:btih:{hexlify(infohash)}&"
+        infohash, b"name", f"magnet:?xt=urn:btih:{hexlify(infohash)}&"
     )
     download = await fake_dlmgr.start_download(tdef=tdef, checkpoint_disabled=True)
     assert metainfo_dl != download
@@ -222,7 +222,7 @@ async def test_start_download(fake_dlmgr):
     fake_dlmgr.get_session = MagicMock(return_value=mock_ltsession)
 
     download = await fake_dlmgr.start_download(
-        tdef=TorrentDefNoMetainfo(infohash, ""), checkpoint_disabled=True
+        tdef=TorrentDefNoMetainfo(infohash, b""), checkpoint_disabled=True
     )
     handle = await download.get_handle()
     assert handle == mock_handle
@@ -273,7 +273,7 @@ async def test_start_download_existing_handle(fake_dlmgr):
     fake_dlmgr.get_session = MagicMock(return_value=mock_ltsession)
 
     download = await fake_dlmgr.start_download(
-        tdef=TorrentDefNoMetainfo(infohash, "name"), checkpoint_disabled=True
+        tdef=TorrentDefNoMetainfo(infohash, b"name"), checkpoint_disabled=True
     )
     handle = await download.get_handle()
     assert handle == mock_handle
@@ -508,7 +508,7 @@ async def test_start_download_from_magnet_no_name(fake_dlmgr: DownloadManager):
     # Test whether a download is started with `Unknown name` name when the magnet has no name
     magnet = f'magnet:?xt=urn:btih:{"A" * 40}'
     download = await fake_dlmgr.start_download_from_uri(magnet)
-    assert download.tdef.get_name() == 'Unknown name'
+    assert download.tdef.get_name() == b'Unknown name'
 
 
 def test_update_trackers(fake_dlmgr) -> None:

--- a/src/tribler/core/components/libtorrent/tests/test_torrent_def.py
+++ b/src/tribler/core/components/libtorrent/tests/test_torrent_def.py
@@ -211,8 +211,9 @@ def test_load_from_dict():
 
 
 def test_torrent_no_metainfo():
-    tdef = TorrentDefNoMetainfo(b"12345678901234567890", VIDEO_FILE_NAME, "http://google.com")
-    assert tdef.get_name() == VIDEO_FILE_NAME
+    video_file_name_bytes = VIDEO_FILE_NAME.encode('utf-8')
+    tdef = TorrentDefNoMetainfo(b"12345678901234567890", video_file_name_bytes, "http://google.com")
+    assert tdef.get_name() == video_file_name_bytes
     assert tdef.get_infohash() == b"12345678901234567890"
     assert tdef.get_length() == 0  # there are no files
     assert not tdef.get_metainfo()
@@ -223,13 +224,13 @@ def test_torrent_no_metainfo():
     assert tdef.get_files_with_length() == []
     assert len(tdef.get_trackers()) == 0
     assert not tdef.is_private()
-    assert tdef.get_name_utf8() == "video.avi"
+    assert tdef.get_name_utf8() == VIDEO_FILE_NAME
     assert tdef.get_nr_pieces() == 0
     assert tdef.torrent_info is None
     tdef.load_torrent_info()
     assert tdef.torrent_info is None
 
-    torrent2 = TorrentDefNoMetainfo(b"12345678901234567890", VIDEO_FILE_NAME, "magnet:")
+    torrent2 = TorrentDefNoMetainfo(b"12345678901234567890", video_file_name_bytes, "magnet:")
     assert len(torrent2.get_trackers()) == 0
 
 

--- a/src/tribler/core/components/libtorrent/torrentdef.py
+++ b/src/tribler/core/components/libtorrent/torrentdef.py
@@ -554,5 +554,5 @@ class TorrentDefNoMetainfo(TorrentDef):
     def load_torrent_info(self) -> None:
         pass
 
-    def get_name_as_unicode(self):
+    def get_name_as_unicode(self) -> str:
         return self.get_name_utf8()

--- a/src/tribler/core/components/libtorrent/torrentdef.py
+++ b/src/tribler/core/components/libtorrent/torrentdef.py
@@ -313,7 +313,7 @@ class TorrentDef:
         """
         return self.metainfo
 
-    def get_name(self) -> str:
+    def get_name(self) -> bytes:
         """
         Returns the name as raw string of bytes.
         """
@@ -325,7 +325,7 @@ class TorrentDef:
         """
         return escape_as_utf8(self.get_name(), self.get_encoding())
 
-    def set_name(self, name: str) -> None:
+    def set_name(self, name: bytes) -> None:
         """
         Set the name of this torrent.
         :param name: The new name of the torrent
@@ -554,8 +554,5 @@ class TorrentDefNoMetainfo(TorrentDef):
     def load_torrent_info(self) -> None:
         pass
 
-    def get_name_utf8(self):
-        return self.get_name()
-
     def get_name_as_unicode(self):
-        return self.get_name()
+        return self.get_name_utf8()


### PR DESCRIPTION
Fixes https://github.com/Tribler/tribler/issues/7836

The downloads response was not JSON serializable because the name was still being returned as bytes in case of serialization of name from torrent def of instance `TorrentDefNoMetainfo`. This PR fixes the issue.