### PR TITLE
Refactor TorrentInfoEndpoint to fix JSON encoding issue

### DIFF
--- a/src/tribler/core/components/database/db/orm_bindings/torrent_metadata.py
+++ b/src/tribler/core/components/database/db/orm_bindings/torrent_metadata.py
@@ -1,8 +1,8 @@
+import random
 from binascii import unhexlify
 from datetime import datetime
-import random
 from struct import unpack
-from typing import Optional
+from typing import Dict, Optional
 
 from lz4.frame import LZ4FrameCompressor
 from pony import orm
@@ -11,8 +11,8 @@ from pony.orm import db_session
 from tribler.core import notifications
 from tribler.core.components.database.category_filter.category import Category, default_category_filter
 from tribler.core.components.database.category_filter.family_filter import default_xxx_filter
-from tribler.core.components.database.db.serialization import EPOCH, REGULAR_TORRENT, TorrentMetadataPayload, \
-    HealthItemsPayload, time2int
+from tribler.core.components.database.db.serialization import EPOCH, HealthItemsPayload, REGULAR_TORRENT, \
+    TorrentMetadataPayload, time2int
 from tribler.core.utilities.notifier import Notifier
 from tribler.core.utilities.tracker_utils import get_uniformed_tracker_url
 from tribler.core.utilities.unicode import ensure_unicode, hexlify
@@ -42,7 +42,7 @@ def infohash_to_id(infohash):
     return abs(unpack(">q", infohash[:8])[0])
 
 
-def tdef_to_metadata_dict(tdef, category_filter: Category = None):
+def tdef_to_metadata_dict(tdef, category_filter: Category = None) -> Dict:
     """
     Helper function to create a TorrentMetadata-compatible dict from TorrentDef
     """

--- a/src/tribler/core/components/libtorrent/restapi/torrentinfo_endpoint.py
+++ b/src/tribler/core/components/libtorrent/restapi/torrentinfo_endpoint.py
@@ -139,14 +139,11 @@ class TorrentInfoEndpoint(RESTEndpoint):
             self._logger.warning("Received metainfo is not a valid dictionary")
             return RESTResponse({"error": "invalid response"}, status=HTTP_INTERNAL_SERVER_ERROR)
 
-        # Add the torrent to GigaChannel as a free-for-all entry, so others can search it
-        self.download_manager.notifier[notifications.torrent_metadata_added](
-            tdef_to_metadata_dict(TorrentDef.load_from_dict(metainfo)))
+        # Add the torrent to metadata.db
+        metadata_dict = tdef_to_metadata_dict(TorrentDef.load_from_dict(metainfo))
+        self.download_manager.notifier[notifications.torrent_metadata_added](metadata_dict)
 
-        # TODO(Martijn): store the stuff in a database!!!
-        # TODO(Vadim): this means cache the downloaded torrent in a binary storage, like LevelDB
-        infohash = hashlib.sha1(lt.bencode(metainfo[b'info'])).digest()
-
+        infohash = metadata_dict['infohash']
         download = self.download_manager.downloads.get(infohash)
         metainfo_request = self.download_manager.metainfo_requests.get(infohash, [None])[0]
         download_is_metainfo_request = download == metainfo_request

--- a/src/tribler/core/components/libtorrent/restapi/torrentinfo_endpoint.py
+++ b/src/tribler/core/components/libtorrent/restapi/torrentinfo_endpoint.py
@@ -154,9 +154,6 @@ class TorrentInfoEndpoint(RESTEndpoint):
         # Check if the torrent is already in the downloads
         encoded_metainfo = deepcopy(metainfo)
 
-        # FIXME: json.dumps garbles binary data that is used by the 'pieces' field
-        # However, this is fine as long as the GUI does not use this field.
-        encoded_metainfo[b'info'][b'pieces'] = hexlify(encoded_metainfo[b'info'][b'pieces']).encode('utf-8')
         encoded_metainfo = hexlify(json.dumps(recursive_unicode(
             encoded_metainfo, ignore_errors=True), ensure_ascii=False).encode('utf-8'))
         return RESTResponse({"metainfo": encoded_metainfo,


### PR DESCRIPTION
While working on #7823  I realized that there is one instance of dead code and one instance of duplicated code in get_torrent_info, both of which have been removed in this PR, along with disputing comments.