### PR TITLE
Add tests for `recursive_unicode` function

### DIFF
--- a/src/tribler/core/utilities/tests/test_unicode.py
+++ b/src/tribler/core/utilities/tests/test_unicode.py
@@ -1,0 +1,59 @@
+import pytest
+
+from tribler.core.utilities.unicode import recursive_unicode
+
+
+def test_recursive_unicode_empty():
+    # Test that recursive_unicode works on empty items
+    assert recursive_unicode({}) == {}
+    assert recursive_unicode([]) == []
+    assert recursive_unicode(b'') == ''
+    assert recursive_unicode('') == ''
+    assert recursive_unicode(None) is None
+
+
+def test_recursive_unicode_unicode_decode_error():
+    # Test that recursive_unicode raises an exception on invalid bytes
+    with pytest.raises(UnicodeDecodeError):
+        recursive_unicode(b'\x80')
+
+
+def test_recursive_unicode_unicode_decode_error_ignore_errors():
+    # Test that recursive_unicode ignores errors on invalid bytes and returns the converted bytes by using chr()
+    assert recursive_unicode(b'\x80', ignore_errors=True) == '\x80'
+
+
+def test_recursive_unicode_complex_object():
+    # Test that recursive_unicode works on a complex object
+    obj = {
+        'list': [
+            b'binary',
+            {}
+        ],
+        'sub dict': {
+            'sub list': [
+                1,
+                b'binary',
+                {
+                    '': b''
+                },
+            ]
+        }
+    }
+
+    expected = {
+        'list': [
+            'binary',
+            {}
+        ],
+        'sub dict': {
+            'sub list': [
+                1,
+                'binary',
+                {
+                    '': ''
+                },
+            ]
+        }
+    }
+    assert recursive_unicode(obj) == expected


### PR DESCRIPTION
While working on https://github.com/Tribler/tribler/issues/7823 I became suspicious that `recursive_unicode` was not functioning correctly. To confirm this, I wrote tests and found that the function works as expected. This PR includes these tests.