### PR TITLE
Refactoring `query_http_uri`

### DIFF
--- a/src/tribler/core/components/libtorrent/download_manager/download_manager.py
+++ b/src/tribler/core/components/libtorrent/download_manager/download_manager.py
@@ -24,6 +24,7 @@ from tribler.core.components.libtorrent.torrentdef import TorrentDef, TorrentDef
 from tribler.core.components.libtorrent.utils import torrent_utils
 from tribler.core.components.libtorrent.utils.libtorrent_helper import libtorrent as lt
 from tribler.core.utilities import path_util
+from tribler.core.utilities.aiohttp.aiohttp_utils import unshorten
 from tribler.core.utilities.network_utils import default_network_utils
 from tribler.core.utilities.notifier import Notifier
 from tribler.core.utilities.path_util import Path
@@ -38,7 +39,7 @@ from tribler.core.utilities.rest_utils import (
 )
 from tribler.core.utilities.simpledefs import DownloadStatus, MAX_LIBTORRENT_RATE_LIMIT, STATEDIR_CHECKPOINT_DIR
 from tribler.core.utilities.unicode import hexlify
-from tribler.core.utilities.utilities import bdecode_compat, has_bep33_support, parse_magnetlink, unshorten
+from tribler.core.utilities.utilities import bdecode_compat, has_bep33_support, parse_magnetlink
 from tribler.core.version import version_id
 
 SOCKS5_PROXY_DEF = 2

--- a/src/tribler/core/components/socks_servers/socks5/tests/test_server.py
+++ b/src/tribler/core/components/socks_servers/socks5/tests/test_server.py
@@ -2,12 +2,12 @@ from asyncio import sleep
 from unittest.mock import Mock
 
 import pytest
-from aiohttp import ClientSession
 
 from tribler.core.components.socks_servers.socks5.aiohttp_connector import Socks5Connector
 from tribler.core.components.socks_servers.socks5.client import Socks5Client, Socks5Error
 from tribler.core.components.socks_servers.socks5.conversion import UdpPacket, socks5_serializer
 from tribler.core.components.socks_servers.socks5.server import Socks5Server
+from tribler.core.utilities.aiohttp.aiohttp_utils import query_uri
 
 
 @pytest.fixture(name='socks5_server')
@@ -107,7 +107,8 @@ async def test_socks5_aiohttp_connector(socks5_server):
         conn.transport.close()
 
     socks5_server.output_stream.on_socks5_tcp_data = return_data
-
-    async with ClientSession(connector=Socks5Connector(('127.0.0.1', socks5_server.port))) as session:
-        async with session.get('http://localhost') as response:
-            assert (await response.read()) == b'Hello'
+    result = await query_uri(
+        uri='http://localhost',
+        connector=Socks5Connector(('127.0.0.1', socks5_server.port))
+    )
+    assert result == b'Hello'

--- a/src/tribler/core/utilities/aiohttp/aiohttp_utils.py
+++ b/src/tribler/core/utilities/aiohttp/aiohttp_utils.py
@@ -1,0 +1,62 @@
+import asyncio
+import logging
+from ssl import SSLError
+from typing import Dict, Optional, Union
+
+from aiohttp import BaseConnector, ClientConnectorError, ClientResponseError, ClientSession, ClientTimeout, \
+    ServerConnectionError
+from aiohttp.hdrs import LOCATION
+from aiohttp.typedefs import LooseHeaders
+
+from tribler.core.utilities.aiohttp.exceptions import AiohttpException
+from tribler.core.utilities.rest_utils import HTTPS_SCHEME, HTTP_SCHEME, scheme_from_url
+
+logger = logging.getLogger(__name__)
+
+
+async def query_uri(uri: str, connector: Optional[BaseConnector] = None, headers: Optional[LooseHeaders] = None,
+                    timeout: ClientTimeout = None, return_json: bool = False, ) -> Union[Dict, bytes]:
+    kwargs = {'headers': headers}
+    if timeout:
+        # ClientSession uses a sentinel object for the default timeout. Therefore, it should only be specified if an
+        # actual value has been passed to this function.
+        kwargs['timeout'] = timeout
+
+    async with ClientSession(connector=connector, raise_for_status=True) as session:
+        try:
+            async with await session.get(uri, **kwargs) as response:
+                if return_json:
+                    return await response.json(content_type=None)
+                return await response.read()
+        except (ServerConnectionError, ClientResponseError, SSLError, ClientConnectorError, asyncio.TimeoutError) as e:
+            message = f'Error while querying http uri. {e.__class__.__name__}: {e}'
+            logger.warning(message, exc_info=e)
+            raise AiohttpException(message) from e
+
+
+async def unshorten(uri: str) -> str:
+    """ Unshorten a URI if it is a short URI. Return the original URI if it is not a short URI.
+
+    Args:
+        uri (str): A string representing the shortened URL that needs to be unshortened.
+
+    Returns:
+        str: The unshortened URL. If the original URL does not redirect to another URL, the original URL is returned.
+    """
+
+    scheme = scheme_from_url(uri)
+    if scheme not in (HTTP_SCHEME, HTTPS_SCHEME):
+        return uri
+
+    logger.info(f'Unshortening URI: {uri}')
+
+    async with ClientSession() as session:
+        try:
+            async with await session.get(uri, allow_redirects=False) as response:
+                if response.status in (301, 302, 303, 307, 308):
+                    uri = response.headers.get(LOCATION, uri)
+        except Exception as e:
+            logger.warning(f'Error while unshortening a URI: {e.__class__.__name__}: {e}', exc_info=e)
+
+    logger.info(f'Unshorted URI: {uri}')
+    return uri

--- a/src/tribler/core/utilities/aiohttp/exceptions.py
+++ b/src/tribler/core/utilities/aiohttp/exceptions.py
@@ -1,0 +1,5 @@
+from tribler.core.exceptions import TriblerException
+
+
+class AiohttpException(TriblerException):
+    """ Base class for all aiohttp exceptions. """

--- a/src/tribler/core/utilities/aiohttp/tests/test_aiohttp_utils.py
+++ b/src/tribler/core/utilities/aiohttp/tests/test_aiohttp_utils.py
@@ -1,0 +1,75 @@
+import asyncio
+from ssl import SSLError
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+from aiohttp import ClientConnectorError, ClientResponseError, ClientSession, ServerConnectionError
+from aiohttp.hdrs import LOCATION, URI
+
+from tribler.core.utilities.aiohttp.aiohttp_utils import query_uri, unshorten
+from tribler.core.utilities.aiohttp.exceptions import AiohttpException
+
+UNSHORTEN_TEST_DATA = [
+    SimpleNamespace(
+        # Test that the `unshorten` function returns the unshorten URL if there is a redirect detected by
+        # the right status code and right header.
+        url='http://shorten',
+        response=SimpleNamespace(status=301, headers={LOCATION: 'http://unshorten'}),
+        expected='http://unshorten'
+    ),
+    SimpleNamespace(
+        # Test that the `unshorten` function returns the same URL if there is wrong scheme
+        url='file://shorten',
+        response=SimpleNamespace(status=0, headers={}),
+        expected='file://shorten'
+    ),
+    SimpleNamespace(
+        # Test that the `unshorten` function returns the same URL if there is no redirect detected by the wrong status
+        # code.
+        url='http://shorten',
+        response=SimpleNamespace(status=401, headers={LOCATION: 'http://unshorten'}),
+        expected='http://shorten'
+    ),
+    SimpleNamespace(
+        # Test that the `unshorten` function returns the same URL if there is no redirect detected by the wrong header.
+        url='http://shorten',
+        response=SimpleNamespace(status=301, headers={URI: 'http://unshorten'}),
+        expected='http://shorten'
+    )
+]
+
+
+@pytest.mark.parametrize("test_data", UNSHORTEN_TEST_DATA)
+async def test_unshorten(test_data):
+    # The function mocks the ClientSession.get method to return a mocked response with the given status and headers.
+    # It is used with the test data above to test the unshorten function.
+    response = MagicMock(status=test_data.response.status, headers=test_data.response.headers)
+    mocked_get = AsyncMock(return_value=AsyncMock(__aenter__=AsyncMock(return_value=response)))
+    with patch.object(ClientSession, 'get', mocked_get):
+        assert await unshorten(test_data.url) == test_data.expected
+
+
+# These are the exceptions that are handled query_uri
+HANDLED_EXCEPTIONS = [
+    ServerConnectionError(),
+    ClientResponseError(Mock(), Mock()),
+    SSLError(),
+    ClientConnectorError(Mock(), Mock()),
+    asyncio.TimeoutError()
+]
+
+
+@pytest.mark.parametrize("e", HANDLED_EXCEPTIONS)
+async def test_query_uri_handled_exceptions(e):
+    # test that the function `query_uri` handles exceptions from the `HANDLED_EXCEPTIONS` list
+    with patch.object(ClientSession, 'get', AsyncMock(side_effect=e)):
+        with pytest.raises(AiohttpException):
+            await query_uri('any.uri')
+
+
+async def test_query_uri_unhandled_exceptions():
+    # test that the function `query_uri` does not handle exceptions outside the `HANDLED_EXCEPTIONS` list.
+    with patch.object(ClientSession, 'get', AsyncMock(side_effect=ValueError)):
+        with pytest.raises(ValueError):
+            await query_uri('any.uri')

--- a/src/tribler/core/utilities/utilities.py
+++ b/src/tribler/core/utilities/utilities.py
@@ -17,11 +17,7 @@ from functools import wraps
 from typing import Dict, List, Optional, Set, Tuple, Union
 from urllib.parse import urlsplit
 
-from aiohttp import ClientSession
-from aiohttp.hdrs import LOCATION
-
 from tribler.core.components.libtorrent.utils.libtorrent_helper import libtorrent as lt
-from tribler.core.utilities.rest_utils import HTTPS_SCHEME, HTTP_SCHEME, scheme_from_url
 from tribler.core.utilities.sentinels import sentinel
 
 logger = logging.getLogger(__name__)
@@ -339,31 +335,3 @@ def safe_repr(obj):
         return repr(obj)
     except Exception as e:  # pylint: disable=broad-except
         return f'<Repr of {object.__repr__(obj)} raises {e.__class__.__name__}: {e}>'
-
-
-async def unshorten(uri: str) -> str:
-    """ Unshorten a URI if it is a short URI. Return the original URI if it is not a short URI.
-
-    Args:
-        uri (str): A string representing the shortened URL that needs to be unshortened.
-
-    Returns:
-        str: The unshortened URL. If the original URL does not redirect to another URL, the original URL is returned.
-    """
-
-    scheme = scheme_from_url(uri)
-    if scheme not in (HTTP_SCHEME, HTTPS_SCHEME):
-        return uri
-
-    logger.info(f'Unshortening URI: {uri}')
-
-    async with ClientSession() as session:
-        try:
-            async with await session.get(uri, allow_redirects=False) as response:
-                if response.status in (301, 302, 303, 307, 308):
-                    uri = response.headers.get(LOCATION, uri)
-        except Exception as e:
-            logger.warning(f'Error while unshortening a URI: {e.__class__.__name__}: {e}', exc_info=e)
-
-    logger.info(f'Unshorted URI: {uri}')
-    return uri


### PR DESCRIPTION
While investigating #7671 I found all the places that use the construction `async with ClientSession(...) as session:` and consolidated them into a single place to handle `ServerConnectionError, ClientResponseError, SSLError, ClientConnectorError, asyncio.TimeoutError` with a guarantee.

Unfortunately, it turns out that the issue that led to the reopening of #7671 was caused by a completely different case.

However, I think this refactoring is worthwhile (though it is up to the reviewer to decide).

A new file named `aiohttp_utils.py` has been created. The functions `query_uri` and `unshorten` have been placed in this file.