### PR TITLE
Update pytest configuration to include the `--forced-gc` option

### DIFF
--- a/.github/workflows/vars/pytest.env
+++ b/.github/workflows/vars/pytest.env
@@ -1,6 +1,6 @@
 PYTEST_ARGUMENTS='--randomly-seed=1 --disable-warnings --verbose --durations=3 --showlocals'
 
-PYTEST_CORE_ARGUMENTS='./src/tribler/core ${PYTEST_ARGUMENTS}'
+PYTEST_CORE_ARGUMENTS='./src/tribler/core ${PYTEST_ARGUMENTS} --forced-gc'
 PYTEST_CORE_ARGUMENTS_WIN='${PYTEST_CORE_ARGUMENTS}'
 PYTEST_CORE_ARGUMENTS_LINUX='${PYTEST_CORE_ARGUMENTS} --looptime'
 PYTEST_CORE_ARGUMENTS_MAC='${PYTEST_CORE_ARGUMENTS} --looptime'

--- a/src/tribler/core/conftest.py
+++ b/src/tribler/core/conftest.py
@@ -37,6 +37,10 @@ def pytest_configure(config):
     logging.getLogger('faker.factory').propagate = False
 
 
+def pytest_addoption(parser):
+    parser.addoption("--forced-gc", action="store_true", help="Enable forced garbage collection")
+
+
 @pytest.hookimpl
 def pytest_cmdline_main(config: Config):
     """ Enable extended logging if the verbose option is used """
@@ -70,7 +74,7 @@ def pytest_runtest_protocol(item: Function, log=True, nextitem=None):
 
 
 @pytest.fixture(autouse=True)
-def ensure_gc():
+def ensure_gc(request):
     """ Ensure that the garbage collector runs after each test.
     This is critical for test stability as we use Libtorrent and need to ensure all its destructors are called. """
     # For this fixture, it is necessary for it to be called as late as possible within the current test's scope.
@@ -87,8 +91,8 @@ def ensure_gc():
     #
     # By adding the yield we move the garbage collection phase to the end of the current test, to not affect the next
     # test.
-
-    gc.collect()
+    if request.config.getoption("--forced-gc"):
+        gc.collect()
 
 
 @pytest.fixture

--- a/src/tribler/gui/tests/conftest.py
+++ b/src/tribler/gui/tests/conftest.py
@@ -1,4 +1,3 @@
-import gc
 import logging
 import time
 
@@ -62,25 +61,3 @@ def pytest_runtest_protocol(item, log=True, nextitem=None):
     total = time.time() - pytest_start_time
     if enable_extended_logging:
         print(f' in {duration:.3f}s ({total:.1f}s in total)', end='')
-
-
-@pytest.fixture(autouse=True)
-def ensure_gc():
-    """ Ensure that the garbage collector runs after each test.
-    This is critical for test stability as we use Libtorrent and need to ensure all its destructors are called. """
-    # For this fixture, it is necessary for it to be called as late as possible within the current test's scope.
-    # Therefore it should be placed at the first place in the "function" scope.
-    # If there are two or more autouse fixtures within this scope, the order should be explicitly set through using
-    # this fixture as a dependency.
-    # See the discussion in https://github.com/Tribler/tribler/pull/7542 for more information.
-
-    yield
-    # Without "yield" the fixture triggers the garbage collection at the beginning of the (next) test.
-    # For that reason, the errors triggered during the garbage collection phase will take place not in the erroneous
-    # test but in the randomly scheduled next test. Usually, these errors are silently suppressed, as any exception in
-    # __del__ methods is silently suppressed, but they still can somehow affect the test.
-    #
-    # By adding the yield we move the garbage collection phase to the end of the current test, to not affect the next
-    # test.
-
-    gc.collect()


### PR DESCRIPTION
This PR fixes #7753 by disabling forced garbage collections for tunnel tests and for GUI tests.

There is a possibility that GUI tests may become less stable. If this happens, we should consider reinstating the `ensure_gc` for them. It is uncertain because `ensure_gc` was an experimental feature added when our test suite was quite unstable. Now that it is stable, we can gradually disable experimental features that were implemented to stabilize the test suite.

Ref:
- #7542