### PR TITLE
Fix error on downloading magnetlink

### DIFF
--- a/src/tribler/core/components/libtorrent/download_manager/download_manager.py
+++ b/src/tribler/core/components/libtorrent/download_manager/download_manager.py
@@ -511,7 +511,7 @@ class DownloadManager(TaskManager):
         elif infohash in self.downloads:
             download = self.downloads[infohash]
         else:
-            tdef = TorrentDefNoMetainfo(infohash, 'metainfo request', url=url)
+            tdef = TorrentDefNoMetainfo(infohash, b'metainfo request', url=url)
             dcfg = DownloadConfig()
             dcfg.set_hops(hops or self.download_defaults.number_hops)
             dcfg.set_upload_mode(True)  # Upload mode should prevent libtorrent from creating files

--- a/src/tribler/core/components/libtorrent/tests/conftest.py
+++ b/src/tribler/core/components/libtorrent/tests/conftest.py
@@ -5,7 +5,7 @@ from tribler.core.components.libtorrent.torrentdef import TorrentDef, TorrentDef
 
 @pytest.fixture
 def test_tdef_no_metainfo(state_dir):
-    tdef = TorrentDefNoMetainfo(b"1" * 20, "test")
+    tdef = TorrentDefNoMetainfo(b"1" * 20, b"test")
     return tdef
 
 

--- a/src/tribler/core/components/libtorrent/tests/test_download.py
+++ b/src/tribler/core/components/libtorrent/tests/test_download.py
@@ -541,7 +541,7 @@ async def test_apply_ip_filter(test_download, mock_handle):  # pylint: disable=u
     await test_download.apply_ip_filter(True)
     test_download.handle.apply_ip_filter.assert_called_with(True)
 
-    test_download.tdef = TorrentDefNoMetainfo(b'a' * 20, 'metainfo request')
+    test_download.tdef = TorrentDefNoMetainfo(b'a' * 20, b'metainfo request')
     test_download.handle.reset_mock()
     test_download.apply_ip_filter(False)
     test_download.handle.apply_ip_filter.assert_not_called()

--- a/src/tribler/core/components/libtorrent/tests/test_download_manager.py
+++ b/src/tribler/core/components/libtorrent/tests/test_download_manager.py
@@ -312,7 +312,7 @@ async def test_start_download_existing_download(fake_dlmgr):
     fake_dlmgr.get_session = lambda *_: mock_ltsession
 
     download = await fake_dlmgr.start_download(
-        tdef=TorrentDefNoMetainfo(infohash, "name"), checkpoint_disabled=True
+        tdef=TorrentDefNoMetainfo(infohash, b"name"), checkpoint_disabled=True
     )
     assert download == mock_download
     fake_dlmgr.downloads.clear()


### PR DESCRIPTION
With PR https://github.com/Tribler/tribler/pull/7842 merged, it raised a bug in creating TorrentDefNoMetainfo object while doing metainfo check. The metainfo check failed with the following stacktrace.
```python
[tribler-gui PID:1197156] 2024-01-24 14:13:33,359 - ERROR <error_handler:100> ErrorHandler.core_error(): 'str' object has no attribute 'decode'
Traceback (most recent call last):
  File "/home/user/tribler/src/tribler/core/components/restapi/rest/rest_manager.py", line 53, in error_middleware
    response = await handler(request)
  File "/home/user/tribler/pyenv39/lib/python3.9/site-packages/aiohttp/web_middlewares.py", line 114, in impl
    return await handler(request)
  File "/home/user/tribler/src/tribler/core/components/libtorrent/restapi/torrentinfo_endpoint.py", line 131, in get_torrent_info
    metainfo = await self.download_manager.get_metainfo(infohash, timeout=60, hops=hops, url=uri)
  File "/home/user/tribler/src/tribler/core/components/libtorrent/download_manager/download_manager.py", line 520, in get_metainfo
    download = await self.start_download(tdef=tdef, config=dcfg, hidden=True, checkpoint_disabled=True)
  File "/home/user/tribler/src/tribler/core/components/libtorrent/download_manager/download_manager.py", line 653, in start_download
    atp = download.get_atp()
  File "/home/user/tribler/src/tribler/core/components/libtorrent/download_manager/download.py", line 200, in get_atp
    atp["name"] = self.tdef.get_name_as_unicode()
  File "/home/user/tribler/src/tribler/core/components/libtorrent/torrentdef.py", line 558, in get_name_as_unicode
    return self.get_name_utf8()
  File "/home/user/tribler/src/tribler/core/components/libtorrent/torrentdef.py", line 326, in get_name_utf8
    return escape_as_utf8(self.get_name(), self.get_encoding())
  File "/home/user/tribler/src/tribler/core/components/libtorrent/torrentdef.py", line 38, in escape_as_utf8
    return string.decode(encoding).encode('utf8').decode('utf8')
AttributeError: 'str' object has no attribute 'decode'
```
This PR addresses the issue.