### PR TITLE
Conversion of error codes to hex for error message formatting.

### DIFF
--- a/src/tribler/gui/core_manager.py
+++ b/src/tribler/gui/core_manager.py
@@ -275,8 +275,16 @@ class CoreManager(QObject):
         return output
 
     @staticmethod
+    def error_code_to_hex(error_code: int) -> str:
+        """Convert a signed integer error code to a hexadecimal string."""
+        v = error_code & (2 ** 32 - 1)
+        return hex(v)
+
+    @staticmethod
     def format_error_message(exit_code: int, exit_status: int) -> str:
-        message = f"The Tribler core has unexpectedly finished with exit code {exit_code} and status: {exit_status}."
+        hex_error_code = CoreManager.error_code_to_hex(exit_code)
+        message = f"The Tribler core has unexpectedly finished with exit code {exit_code} ({hex_error_code}) " \
+                  f"and status: {exit_status}."
         if exit_code == 1:
             string_error = "Application error"
         else:

--- a/src/tribler/gui/tests/test_core_manager.py
+++ b/src/tribler/gui/tests/test_core_manager.py
@@ -142,8 +142,22 @@ def test_decode_raw_core_output(core_manager):
 
 def test_format_error_message():
     actual = CoreManager.format_error_message(exit_code=errno.ENOENT, exit_status=1)
-    expected = '''The Tribler core has unexpectedly finished with exit code 2 and status: 1.
+    expected = '''The Tribler core has unexpectedly finished with exit code 2 (0x2) and status: 1.
 
 Error message: No such file or directory'''
+
+    assert actual == expected
+
+
+def test_error_code_to_hex_negative():
+    actual = CoreManager.error_code_to_hex(-1073741819)
+    expected = '0xc0000005'
+
+    assert actual == expected
+
+
+def test_error_code_to_hex_positive():
+    actual = CoreManager.error_code_to_hex(2)
+    expected = '0x2'
 
     assert actual == expected


### PR DESCRIPTION
This PR adds conversion to hex for the error codes.

It will help in investigating issues like #7855, as we will see the hex representation of the error code. This makes it easier to search for the error, especially in the case of Windows. For *nix systems, this change is harmless.

Related issue: #7863