### PR TITLE
Sentry: Disable parse code output

### DIFF
--- a/src/tribler/core/sentry_reporter/sentry_reporter.py
+++ b/src/tribler/core/sentry_reporter/sentry_reporter.py
@@ -16,8 +16,7 @@ from sentry_sdk.integrations.threading import ThreadingIntegration
 from tribler.core import version
 from tribler.core.sentry_reporter.sentry_tools import (
     get_first_item,
-    get_value,
-    parse_last_core_output
+    get_value
 )
 
 VALUE = 'value'
@@ -206,17 +205,6 @@ class SentryReporter:
         # try to retrieve an error from the last_core_output
         if last_core_output:
             info[LAST_CORE_OUTPUT] = last_core_output.split('\n')  # split for better representation in the web view
-
-            # check is it necessary to parse the last core output
-            exceptions = event.get(EXCEPTION, {}).get(VALUES, [])
-            exception_types = (e.get(TYPE) for e in exceptions)
-            need_to_parse_core_output = any(t in self._types_that_requires_core_output_parse for t in exception_types)
-
-            if need_to_parse_core_output:
-                if last_core_exception := parse_last_core_output(last_core_output):
-                    # create a core exception extracted from the last core output
-                    core_exception = {TYPE: last_core_exception.type, VALUE: last_core_exception.message}
-                    exceptions.append(core_exception)
 
         event[CONTEXTS][REPORTER] = info
         event[CONTEXTS][BROWSER] = {VERSION: tribler_version, NAME: TRIBLER}

--- a/src/tribler/core/sentry_reporter/sentry_tools.py
+++ b/src/tribler/core/sentry_reporter/sentry_tools.py
@@ -7,10 +7,6 @@ from typing import Optional
 
 from faker import Faker
 
-# Find an exception in the string like: "OverflowError: bind(): port must be 0-65535"
-_re_search_exception = re.compile(r'^([A-Za-z0-9_.]+):\s+(.+)')
-_re_search_exception_exclusions = re.compile(r'(?:warning)', re.RegexFlag.IGNORECASE)
-
 # Remove the substring like "Sentry is attempting to send 1 pending error messages"
 _re_remove_sentry = re.compile(r'Sentry is attempting.*')
 
@@ -19,24 +15,6 @@ _re_remove_sentry = re.compile(r'Sentry is attempting.*')
 class LastCoreException:
     type: str
     message: str
-
-
-def parse_last_core_output(text: str) -> Optional[LastCoreException]:
-    """ This function tries to find an Exception type and the Exception message in the raw core output
-    """
-
-    def _clean_up(s: str):
-        return _re_remove_sentry.sub('', s).strip()
-
-    for line in reversed(text.split('\n')):
-        if m := _re_search_exception.match(line):
-            exception_type = m.group(1)
-            if _re_search_exception_exclusions.search(exception_type):
-                continue  # find an exclusion
-
-            return LastCoreException(type=_clean_up(exception_type),
-                                     message=_clean_up(m.group(2)))
-    return None
 
 
 def get_first_item(items, default=None):

--- a/src/tribler/core/sentry_reporter/tests/test_sentry_tools.py
+++ b/src/tribler/core/sentry_reporter/tests/test_sentry_tools.py
@@ -1,7 +1,7 @@
 import pytest
 
 from tribler.core.sentry_reporter.sentry_tools import (
-    _re_search_exception, _re_search_exception_exclusions, delete_item,
+    delete_item,
     distinct_by,
     extract_dict,
     format_version,
@@ -9,8 +9,7 @@ from tribler.core.sentry_reporter.sentry_tools import (
     get_last_item,
     get_value,
     modify_value,
-    obfuscate_string, parse_last_core_output,
-)
+    obfuscate_string, )
 
 
 def test_first():
@@ -109,93 +108,7 @@ OBFUSCATED_STRINGS = [
     ('string', 'quality'),
 ]
 
-EXCEPTION_STRINGS = [
-    (
-        'OverflowError: bind(): port must be 0-65535',
-        (
-            'OverflowError',
-            'bind(): port must be 0-65535'
-        ),
-    ),
-
-    (
-        "pony_orm.core.TransactionIntegrityError: MiscData['db_version'] cannot be stored. IntegrityError: UNIQUE",
-        (
-            'pony_orm.core.TransactionIntegrityError',
-            "MiscData['db_version'] cannot be stored. IntegrityError: UNIQUE"
-        ),
-    ),
-
-    # Strings thst should not be matched
-    ('ERROR <exception_handler:100>', None),
-    ('PyInstaller\loader\pyimod03_importers.py:495', None),
-    ('foo:bar: baz', None),
-    ('foo<bar>: baz', None),
-]
-
 
 @pytest.mark.parametrize('given, expected', OBFUSCATED_STRINGS)
 def test_obfuscate_string(given, expected):
     assert obfuscate_string(given) == expected
-
-
-@pytest.mark.parametrize('given, expected', EXCEPTION_STRINGS)
-def test_parse_last_core_output_re(given, expected):
-    # Test that `_re_search_exception` matches with the expected values from the `EXCEPTION_STRINGS`
-    if m := _re_search_exception.match(given):
-        exception_type, exception_text = expected
-
-        assert m.group(1) == exception_type
-        assert m.group(2) == exception_text
-    else:  # no match
-        assert m == expected
-
-
-EXCEPTION_EXCLUSIONS_STRINGS = [
-    'UserWarning',
-]
-
-
-@pytest.mark.parametrize('given', EXCEPTION_EXCLUSIONS_STRINGS)
-def test_re_search_exception_exclusions(given):
-    # Test that `_re_search_exception_exclusions` matches with the expected values from the
-    # `EXCEPTION_EXCLUSIONS_STRINGS`
-    assert _re_search_exception_exclusions.search(given)
-
-
-def test_parse_last_core_output():
-    # Test that `parse_last_core_output` correctly extract the last core exception from the real raw core output
-
-    last_core_output = '''
-pony.orm.core.TransactionIntegrityError: Object MiscData['db_version'] cannot be stored in the database. IntegrityError
-ERROR <exception_handler:100> CoreExceptionHandler.unhandled_error_observer(): Unhandled exception occurred! bind(): 
-Traceback (most recent call last):
-  File "/Users/<user>/Projects/github.com/Tribler/tribler/src/tribler/core/components/component.py", line 61, in start
-    await self.run()
-  File "/Users/<user>/Projects/github.com/Tribler/tribler/src/tribler/core/components/restapi/restapi_component.py", 
-    await rest_manager.start()
-  File "/Users/<user>/Projects/github.com/Tribler/tribler/src/tribler/core/components/restapi/rest/rest_manager.py", 
-    await self.site.start()
-  File "/Users/<user>/Projects/github.com/Tribler/tribler/venv/lib/python3.8/site-packages/aiohttp/web_runner.py", 
-    self._server = await loop.create_server(
-  File "/Applications/Xcode.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/
-    sock.bind(sa)
-OverflowError: bind(): port must be 0-65535.Sentry is attempting to send 1 pending error messages
-Waiting up to 2 seconds
-Press Ctrl-C to quit
-    '''
-    last_core_exception = parse_last_core_output(last_core_output)
-    assert last_core_exception.type == 'OverflowError'
-    assert last_core_exception.message == 'bind(): port must be 0-65535.'
-
-
-def test_parse_last_core_output_no_match():
-    # Test that `parse_last_core_output` returns None in the case there is no exceptions in the raw core output
-
-    last_core_exception = parse_last_core_output('last core output without exceptions')
-    assert not last_core_exception
-
-
-def test_parse_last_core_output_exclusion():
-    last_core_exception = parse_last_core_output('UserWarning: You are using cryptography on a 32-bit Python on a...')
-    assert not last_core_exception


### PR DESCRIPTION
This PR disables (and removes) the parse code output logic introduced in 
- #7066

The reason for this change is that we now have an error code returned along with the CoreCrashedError, making the parsing of core output unnecessary. `CoreCrashedError` can now be grouped by the error code, which was previously impossible.

While the feature for parsing code output could be improved, it requires more stringent logging rules, which were not supported by team members (see discussion in #7861).  