### PR TITLE
Use default python version

### DIFF
--- a/.github/workflows/!main.yml
+++ b/.github/workflows/!main.yml
@@ -5,9 +5,6 @@ on:
     branches:
       - main
 
-env:
-  PYTHON_VERSION: 3.9
-
 jobs:
   docker:
     uses: ./.github/workflows/docker-image.yml
@@ -17,20 +14,14 @@ jobs:
 
   coverage:
     uses: ./.github/workflows/coverage.yml
-    with:
-      python-version: ${{ env.PYTHON_VERSION }}
     secrets:
       CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   pytest:
     uses: ./.github/workflows/pytest.yml
-    with:
-      python-version: ${{ env.PYTHON_VERSION }}
 
   ubuntu:
     uses: ./.github/workflows/build_ubuntu.yml
-    with:
-      python-version: ${{ env.PYTHON_VERSION }}
     secrets:
       SENTRY_URL: ${{ secrets.SENTRY_URL }}


### PR DESCRIPTION
This PR fixes the following error:

```
[Invalid workflow file: .github/workflows/!main.yml#L21](https://github.com/Tribler/tribler/actions/runs/7722749231/workflow)
The workflow is not valid. .github/workflows/!main.yml (Line: 21, Col: 23): Unrecognized named-value: 'env'. Located at position 1 within expression: env.PYTHON_VERSION .github/workflows/!main.yml (Line: 29, Col: 23): Unrecognized named-value: 'env'. Located at position 1 within expression: env.PYTHON_VERSION
```

https://github.com/Tribler/tribler/actions/runs/7722749231