### PR TITLE
Remove code related to `num_entries`

### DIFF
--- a/src/tribler/core/components/database/db/tests/test_serialization.py
+++ b/src/tribler/core/components/database/db/tests/test_serialization.py
@@ -1,6 +1,10 @@
 from datetime import datetime
+from unittest.mock import Mock, patch
 
-from tribler.core.components.database.db.serialization import TorrentMetadataPayload
+import pytest
+
+from tribler.core.components.database.db.serialization import TorrentMetadataPayload, UnknownBlobTypeException, \
+    read_payload_with_offset
 
 
 def test_fix_torrent_metadata_payload():
@@ -24,3 +28,10 @@ def test_torrent_metadata_payload_magnet():
     expected = "magnet:?xt=urn:btih:000102030405060708090a0b0c0d0e0f10111213&dn=b'title'&tr=b'tracker_info'"
 
     assert expected == payload.get_magnet()
+
+
+@patch('struct.unpack_from', Mock(return_value=(301,)))
+def test_read_payload_with_offset_exception():
+    # Test that an exception is raised when metadata_type != REGULAR_TORRENT
+    with pytest.raises(UnknownBlobTypeException):
+        read_payload_with_offset(b'')

--- a/src/tribler/core/components/database/restapi/database_endpoint.py
+++ b/src/tribler/core/components/database/restapi/database_endpoint.py
@@ -39,7 +39,6 @@ json2pony_columns = {
     'date': "torrent_date",
     'created': "torrent_date",
     'status': 'status',
-    'torrents': 'num_entries',
     'votes': 'votes',
     'subscribed': 'subscribed',
     'health': 'HEALTH',


### PR DESCRIPTION
This PR closes #7808 by removing code related to `num_entries`, which are leftovers from #7669.

The PR involves refactoring, specifically the removal of unused code.