### PR TITLE
Optimize requests for downloads

### DIFF
--- a/scripts/application_tester/tribler_apptester/actions/change_anonymity_action.py
+++ b/scripts/application_tester/tribler_apptester/actions/change_anonymity_action.py
@@ -15,7 +15,7 @@ class ChangeAnonymityAction(ActionSequence):
 
         self.add_action(PageAction('downloads'))
         self.add_action(WaitAction(1000))
-        self.add_action(CustomAction("""if not window.downloads_page.downloads or len(window.downloads_page.downloads['downloads']) == 0:
+        self.add_action(CustomAction("""if len(window.downloads_page.download_widgets) == 0:
     exit_script()
         """))
         self.add_action(ClickAction('window.downloads_list.topLevelItem(randint(0, len(window.downloads_page.download_widgets.keys()) - 1)).progress_slider'))

--- a/scripts/application_tester/tribler_apptester/actions/change_download_files_action.py
+++ b/scripts/application_tester/tribler_apptester/actions/change_download_files_action.py
@@ -15,7 +15,7 @@ class ChangeDownloadFilesAction(ActionSequence):
 
         self.add_action(PageAction('downloads'))
         self.add_action(WaitAction(1000))
-        self.add_action(CustomAction("""if not window.downloads_page.downloads or len(window.downloads_page.downloads['downloads']) == 0:
+        self.add_action(CustomAction("""if len(window.downloads_page.download_widgets) == 0:
     exit_script()
         """))
         self.add_action(ClickAction('window.downloads_list.topLevelItem(randint(0, len(window.downloads_page.download_widgets.keys()) - 1)).progress_slider'))

--- a/scripts/application_tester/tribler_apptester/actions/explore_download_action.py
+++ b/scripts/application_tester/tribler_apptester/actions/explore_download_action.py
@@ -16,7 +16,7 @@ class ExploreDownloadAction(ActionSequence):
 
         self.add_action(PageAction('downloads'))
         self.add_action(WaitAction(1000))
-        self.add_action(CustomAction("""if not window.downloads_page.downloads or len(window.downloads_page.downloads['downloads']) == 0:
+        self.add_action(CustomAction("""if len(window.downloads_page.download_widgets) == 0:
     exit_script()
         """))
         self.add_action(ClickAction('window.downloads_list.topLevelItem(randint(0, len(window.downloads_page.download_widgets.keys()) - 1)).progress_slider'))

--- a/scripts/application_tester/tribler_apptester/actions/remove_download_action.py
+++ b/scripts/application_tester/tribler_apptester/actions/remove_download_action.py
@@ -15,7 +15,7 @@ class RemoveRandomDownloadAction(ActionSequence):
 
         self.add_action(PageAction('downloads'))
         self.add_action(WaitAction(1000))
-        self.add_action(CustomAction("""if not window.downloads_page.downloads or len(window.downloads_page.downloads['downloads']) == 0:
+        self.add_action(CustomAction("""if len(window.downloads_page.download_widgets) == 0:
     exit_script()
         """))
         self.add_action(ClickAction('window.downloads_list.topLevelItem(randint(0, len(window.downloads_page.download_widgets.keys()) - 1)).progress_slider'))

--- a/src/tribler/core/components/libtorrent/restapi/downloads_endpoint.py
+++ b/src/tribler/core/components/libtorrent/restapi/downloads_endpoint.py
@@ -194,13 +194,14 @@ class DownloadsEndpoint(RESTEndpoint):
     @docs(
         tags=["Libtorrent"],
         summary="Return all downloads, both active and inactive",
-        parameters=[{
-            'in': 'query',
-            'name': 'get_peers',
-            'description': 'Flag indicating whether or not to include peers',
-            'type': 'boolean',
-            'required': False
-        },
+        parameters=[
+            {
+                'in': 'query',
+                'name': 'get_peers',
+                'description': 'Flag indicating whether or not to include peers',
+                'type': 'boolean',
+                'required': False
+            },
             {
                 'in': 'query',
                 'name': 'get_pieces',
@@ -210,18 +211,19 @@ class DownloadsEndpoint(RESTEndpoint):
             },
             {
                 'in': 'query',
-                'name': 'get_files',
-                'description': 'Flag indicating whether or not to include files',
-                'type': 'boolean',
+                'name': 'infohash',
+                'description': 'If specified only return the download with the given infohash',
+                'type': 'str',
                 'required': False
             },
             {
                 'in': 'query',
-                'name': 'infohash',
-                'description': 'Limit fetching of files, peers, and pieces to a specific infohash',
-                'type': 'boolean',
+                'name': 'excluded',
+                'description': 'If specified, only return downloads excluding this one',
+                'type': 'str',
                 'required': False
-            }],
+            },
+        ],
         responses={
             200: {
                 "schema": schema(DownloadsResponse={
@@ -278,6 +280,7 @@ class DownloadsEndpoint(RESTEndpoint):
         get_peers = params.get('get_peers')
         get_pieces = params.get('get_pieces')
         infohash = params.get('infohash')
+        excluded = params.get('excluded')
 
         checkpoints = {
             TOTAL: self.download_manager.checkpoints_count,
@@ -292,6 +295,8 @@ class DownloadsEndpoint(RESTEndpoint):
         downloads = (d for d in self.download_manager.get_downloads() if not d.hidden)
         if infohash:
             downloads = (d for d in downloads if d.tdef.get_infohash_hex() == infohash)
+        if excluded:
+            downloads = (d for d in downloads if d.tdef.get_infohash_hex() != excluded)
 
         for download in downloads:
             state = download.get_state()

--- a/src/tribler/core/components/libtorrent/restapi/downloads_endpoint.py
+++ b/src/tribler/core/components/libtorrent/restapi/downloads_endpoint.py
@@ -277,7 +277,6 @@ class DownloadsEndpoint(RESTEndpoint):
         params = request.query
         get_peers = params.get('get_peers', '0') == '1'
         get_pieces = params.get('get_pieces', '0') == '1'
-        get_files = params.get('get_files', '0') == '1'
         unfiltered = not params.get('infohash')
 
         checkpoints = {
@@ -367,10 +366,6 @@ class DownloadsEndpoint(RESTEndpoint):
                 # Add piece information if requested
                 if get_pieces:
                     download_json["pieces"] = download.get_pieces_base64().decode('utf-8')
-
-                # Add files if requested
-                if get_files:
-                    download_json["files"] = self.get_files_info_json(download)
 
             downloads_json.append(download_json)
         return RESTResponse({"downloads": downloads_json, "checkpoints": checkpoints})

--- a/src/tribler/core/components/libtorrent/restapi/tests/test_downloads_endpoint.py
+++ b/src/tribler/core/components/libtorrent/restapi/tests/test_downloads_endpoint.py
@@ -196,11 +196,10 @@ async def test_get_downloads(mock_dlmgr, test_download, rest_api):
     mock_dlmgr.checkpoints_loaded = 1
     mock_dlmgr.all_checkpoints_are_loaded = True
 
-    downloads = await do_request(rest_api, 'downloads?get_peers=1&get_files=1', expected_code=200)
+    downloads = await do_request(rest_api, 'downloads?get_peers=1', expected_code=200)
     assert len(downloads["downloads"]) == 1
     assert "peers" in downloads["downloads"][0]  # Unfiltered with get_peers=1
     assert "pieces" not in downloads["downloads"][0]  # Unfiltered with get_pieces=0
-    assert "files" in downloads["downloads"][0]  # Unfiltered with get_files=1
     assert downloads["checkpoints"] == {"total": 1, "loaded": 1, "all_loaded": True}
 
 

--- a/src/tribler/core/components/libtorrent/restapi/tests/test_downloads_endpoint.py
+++ b/src/tribler/core/components/libtorrent/restapi/tests/test_downloads_endpoint.py
@@ -19,6 +19,7 @@ from tribler.core.utilities.rest_utils import HTTP_SCHEME, path_to_url
 from tribler.core.utilities.simpledefs import DownloadStatus
 from tribler.core.utilities.unicode import hexlify
 
+
 # pylint: disable=redefined-outer-name
 
 @pytest.fixture
@@ -246,25 +247,6 @@ async def test_get_downloads_with_passing_filter(mock_dlmgr, test_download, rest
     assert "peers" in downloads["downloads"][0]  # Filter passes with get_peers=1
     assert "pieces" in downloads["downloads"][0]  # Filter passes with get_pieces=1
     assert "files" not in downloads["downloads"][0]  # Filter passes with get_files=0
-    assert downloads["checkpoints"] == {"total": 1, "loaded": 1, "all_loaded": True}
-
-
-async def test_get_downloads_with_unpassing_filter(mock_dlmgr, test_download, rest_api):
-    """
-    Testing whether the API returns all downloads even if the infohash filter does not pass.
-    """
-    mock_dlmgr.get_downloads = lambda: [test_download]
-    mock_dlmgr.checkpoints_count = 1
-    mock_dlmgr.checkpoints_loaded = 1
-    mock_dlmgr.all_checkpoints_are_loaded = True
-
-    downloads = await do_request(rest_api, 'downloads?get_peers=1&get_pieces=1&infohash=' + '00' * 20,
-                                 expected_code=200)
-
-    assert len(downloads["downloads"]) == 1
-    assert "peers" not in downloads["downloads"][0]  # Filter does not pass, ignore get_peers
-    assert "pieces" not in downloads["downloads"][0]  # Filter does not pass, ignore get_pieces
-    assert "files" not in downloads["downloads"][0]  # Filter does not pass, ignore get_files
     assert downloads["checkpoints"] == {"total": 1, "loaded": 1, "all_loaded": True}
 
 

--- a/src/tribler/core/components/libtorrent/restapi/tests/test_downloads_endpoint.py
+++ b/src/tribler/core/components/libtorrent/restapi/tests/test_downloads_endpoint.py
@@ -1,4 +1,5 @@
 import collections
+import copy
 import os
 import unittest.mock
 from pathlib import Path
@@ -9,7 +10,7 @@ from ipv8.messaging.anonymization.tunnel import CIRCUIT_ID_PORT
 from ipv8.util import fail, succeed
 
 import tribler.core.components.libtorrent.restapi.downloads_endpoint as download_endpoint
-from tribler.core.components.libtorrent.download_manager.download import IllegalFileIndex
+from tribler.core.components.libtorrent.download_manager.download import Download, IllegalFileIndex
 from tribler.core.components.libtorrent.download_manager.download_state import DownloadState
 from tribler.core.components.libtorrent.restapi.downloads_endpoint import DownloadsEndpoint, get_extended_status
 from tribler.core.components.libtorrent.torrent_file_tree import TorrentFileTree
@@ -193,9 +194,6 @@ async def test_get_downloads(mock_dlmgr, test_download, rest_api):
     Testing whether the API returns the right download when a download is added
     """
     mock_dlmgr.get_downloads = lambda: [test_download]
-    mock_dlmgr.checkpoints_count = 1
-    mock_dlmgr.checkpoints_loaded = 1
-    mock_dlmgr.all_checkpoints_are_loaded = True
 
     downloads = await do_request(rest_api, 'downloads?get_peers=1', expected_code=200)
     assert len(downloads["downloads"]) == 1
@@ -209,9 +207,6 @@ async def test_get_downloads_circuit_peer(mock_dlmgr, test_download, rest_api, e
     Testing whether circuit peers are correctly returned from downloads.
     """
     mock_dlmgr.get_downloads = lambda: [test_download]
-    mock_dlmgr.checkpoints_count = 1
-    mock_dlmgr.checkpoints_loaded = 1
-    mock_dlmgr.all_checkpoints_are_loaded = True
     endpoint.tunnel_community = Mock()
     endpoint.tunnel_community.ip_to_circuit_id = lambda _: 42
     test_download.get_peerlist = lambda: [{
@@ -225,7 +220,6 @@ async def test_get_downloads_circuit_peer(mock_dlmgr, test_download, rest_api, e
     assert len(downloads["downloads"]) == 1
     assert "peers" in downloads["downloads"][0]  # Unfiltered with get_peers=1
     assert "pieces" not in downloads["downloads"][0]  # Unfiltered with get_pieces=0
-    assert "files" not in downloads["downloads"][0]  # Unfiltered with get_files=0
     assert downloads["checkpoints"] == {"total": 1, "loaded": 1, "all_loaded": True}
     assert downloads["downloads"][0]["peers"][0]["port"] == CIRCUIT_ID_PORT
     assert downloads["downloads"][0]["peers"][0]["circuit"] == 42
@@ -236,9 +230,6 @@ async def test_get_downloads_with_passing_filter(mock_dlmgr, test_download, rest
     Testing whether the API returns all downloads even if the infohash filter passes.
     """
     mock_dlmgr.get_downloads = lambda: [test_download]
-    mock_dlmgr.checkpoints_count = 1
-    mock_dlmgr.checkpoints_loaded = 1
-    mock_dlmgr.all_checkpoints_are_loaded = True
 
     downloads = await do_request(rest_api, 'downloads?get_peers=1&get_pieces=1&infohash=' + test_download.infohash,
                                  expected_code=200)
@@ -246,8 +237,34 @@ async def test_get_downloads_with_passing_filter(mock_dlmgr, test_download, rest
     assert len(downloads["downloads"]) == 1
     assert "peers" in downloads["downloads"][0]  # Filter passes with get_peers=1
     assert "pieces" in downloads["downloads"][0]  # Filter passes with get_pieces=1
-    assert "files" not in downloads["downloads"][0]  # Filter passes with get_files=0
     assert downloads["checkpoints"] == {"total": 1, "loaded": 1, "all_loaded": True}
+
+
+async def test_get_downloads_with_excluding_filter(mock_dlmgr, test_download, test_tdef, rest_api):
+    # In this test, we will create two downloads (test_download and another_download ) and we will exclude
+    # another_download from the list of downloads returned by the API.
+
+    def create_another_download():
+        another_tdef = copy.deepcopy(test_tdef)
+        another_tdef.infohash = b'2' * 20
+        another_tdef._infohash_hex = hexlify(another_tdef.infohash)
+
+        return Download(
+            tdef=another_tdef,
+            download_manager=mock_dlmgr,
+            config=test_download.config
+        )
+
+    another_download = create_another_download()
+    mock_dlmgr.get_downloads = Mock(return_value=[test_download, another_download])
+
+    # test that without the filter, both downloads are returned
+    result = await do_request(rest_api, 'downloads')
+    assert len(result['downloads']) == 2
+
+    # test that with the filter, only one download is returned
+    result = await do_request(rest_api, 'downloads', params={'excluded': another_download.tdef.get_infohash_hex()})
+    assert len(result['downloads']) == 1
 
 
 async def test_start_download_no_uri(rest_api):
@@ -522,8 +539,8 @@ async def test_export_download(mock_dlmgr, mock_handle, test_download, rest_api)
     """
     test_download.get_torrent_data = lambda: 'a' * 20
     mock_dlmgr.get_download = lambda _: test_download
-    await do_request(rest_api, f'downloads/{test_download.infohash}/torrent',
-                     expected_code=200, request_type='GET', json_response=False)
+    await do_request(rest_api, f'downloads/{test_download.infohash}/torrent', expected_code=200, request_type='GET',
+                     json_response=False)
 
 
 async def test_get_files_unknown_download(mock_dlmgr, rest_api):
@@ -542,8 +559,7 @@ async def test_get_files_from_view_start_loading(mock_dlmgr, test_download, rest
     expected_file = {'index': IllegalFileIndex.unloaded.value, 'name': 'loading...', 'size': 0, 'included': False,
                      'progress': 0.0}
 
-    result = await do_request(rest_api, f'downloads/{test_download.infohash}/files',
-                              params={"view_start_path": "."})
+    result = await do_request(rest_api, f'downloads/{test_download.infohash}/files', params={"view_start_path": "."})
 
     assert 'infohash' in result
     assert result['infohash'] == test_download.infohash
@@ -560,8 +576,7 @@ async def test_get_files_from_view_start(mock_dlmgr, test_download, rest_api):
     test_download.tdef.load_torrent_info()
     expected_file = {'index': 0, 'name': 'video.avi', 'size': 1942100, 'included': True, 'progress': 0.0}
 
-    result = await do_request(rest_api, f'downloads/{test_download.infohash}/files',
-                              params={"view_start_path": "."})
+    result = await do_request(rest_api, f'downloads/{test_download.infohash}/files', params={"view_start_path": "."})
 
     assert 'infohash' in result
     assert result['infohash'] == test_download.infohash
@@ -587,8 +602,8 @@ async def test_stream_unknown_download(mock_dlmgr, rest_api):
     Testing whether the API returns error 404 if we stream a non-existent download
     """
     mock_dlmgr.get_download = lambda _: None
-    await do_request(rest_api, 'downloads/abcd/stream/0',
-                     headers={'range': 'bytes=0-'}, expected_code=404, request_type='GET')
+    await do_request(rest_api, 'downloads/abcd/stream/0', headers={'range': 'bytes=0-'}, expected_code=404,
+                     request_type='GET')
 
 
 async def test_stream_download_out_of_bounds_file(mock_dlmgr, mock_handle, test_download, rest_api):

--- a/src/tribler/core/components/libtorrent/torrentdef.py
+++ b/src/tribler/core/components/libtorrent/torrentdef.py
@@ -301,13 +301,13 @@ class TorrentDef:
             return []
         return self.metainfo[b'info'][b'pieces'][:]
 
-    def get_infohash(self) -> bytes:
+    def get_infohash(self) -> Optional[bytes]:
         """
         Returns the infohash of the torrent, if metainfo is provided. Might be None if no metainfo is provided.
         """
         return self.infohash
 
-    def get_infohash_hex(self) -> str:
+    def get_infohash_hex(self) -> Optional[str]:
         if not self._infohash_hex and self.infohash:
             self._infohash_hex = hexlify(self.infohash)
 
@@ -394,8 +394,6 @@ class TorrentDef:
         self.metainfo = bdecode_compat(torrent_dict['metainfo'])
         self.copy_metainfo_to_torrent_parameters()
         self.infohash = torrent_dict['infohash']
-        if self.infohash:
-            self.infohash_hex = hexlify(self.infohash)
 
     def _get_all_files_as_unicode_with_length(self) -> Iterator[Path, int]:
         """ Get a generator for files in the torrent def. No filtering

--- a/src/tribler/core/components/libtorrent/torrentdef.py
+++ b/src/tribler/core/components/libtorrent/torrentdef.py
@@ -19,7 +19,7 @@ from tribler.core.components.libtorrent.utils import torrent_utils
 from tribler.core.components.libtorrent.utils.libtorrent_helper import libtorrent as lt
 from tribler.core.utilities import maketorrent, path_util
 from tribler.core.utilities.path_util import Path
-from tribler.core.utilities.unicode import ensure_unicode
+from tribler.core.utilities.unicode import ensure_unicode, hexlify
 from tribler.core.utilities.utilities import bdecode_compat, is_valid_url
 
 
@@ -64,7 +64,8 @@ class TorrentDef:
         self.torrent_parameters = {}
         self.metainfo = metainfo
         self.files_list = []
-        self.infohash = None
+        self.infohash: Optional[bytes] = None
+        self._infohash_hex: Optional[str] = None
         self._torrent_info = None
 
         if metainfo is not None:
@@ -83,7 +84,6 @@ class TorrentDef:
                 except (KeyError, RuntimeError) as exc:
                     raise ValueError from exc
             self.copy_metainfo_to_torrent_parameters()
-
         elif torrent_parameters:
             self.torrent_parameters.update(torrent_parameters)
 
@@ -307,6 +307,12 @@ class TorrentDef:
         """
         return self.infohash
 
+    def get_infohash_hex(self) -> str:
+        if not self._infohash_hex and self.infohash:
+            self._infohash_hex = hexlify(self.infohash)
+
+        return self._infohash_hex
+
     def get_metainfo(self) -> Dict:
         """
         Returns the metainfo of the torrent. Might be None if no metainfo is provided.
@@ -388,6 +394,8 @@ class TorrentDef:
         self.metainfo = bdecode_compat(torrent_dict['metainfo'])
         self.copy_metainfo_to_torrent_parameters()
         self.infohash = torrent_dict['infohash']
+        if self.infohash:
+            self.infohash_hex = hexlify(self.infohash)
 
     def _get_all_files_as_unicode_with_length(self) -> Iterator[Path, int]:
         """ Get a generator for files in the torrent def. No filtering

--- a/src/tribler/gui/tests/test_downloadspage.py
+++ b/src/tribler/gui/tests/test_downloadspage.py
@@ -21,15 +21,15 @@ def test_accept_requests():
     # Test that the page accepts requests with the greater request id
     page = downloads_page()
 
-    page.on_received_downloads(result={REQUEST_ID: 1, 'downloads': MagicMock()})
+    page.process_refresh_result(result={REQUEST_ID: 1, 'downloads': MagicMock()})
     assert page.received_downloads.emit.called
 
     page.received_downloads.emit.reset_mock()
-    page.on_received_downloads(result={REQUEST_ID: 2, 'downloads': MagicMock()})
+    page.process_refresh_result(result={REQUEST_ID: 2, 'downloads': MagicMock()})
     assert page.received_downloads.emit.called
 
     page.received_downloads.emit.reset_mock()
-    page.on_received_downloads(result={REQUEST_ID: 10, 'downloads': MagicMock()})
+    page.process_refresh_result(result={REQUEST_ID: 10, 'downloads': MagicMock()})
     assert page.received_downloads.emit.called
 
 
@@ -38,13 +38,13 @@ def test_ignore_request():
     # Test that the page ignores requests with a lower or equal request id
     page = downloads_page()
 
-    page.on_received_downloads(result={REQUEST_ID: 10, 'downloads': MagicMock()})
+    page.on_received_non_selected_downloads(result={REQUEST_ID: 10, 'downloads': MagicMock()})
     assert page.received_downloads.emit.called
 
     page.received_downloads.emit.reset_mock()
-    page.on_received_downloads(result={REQUEST_ID: 10, 'downloads': MagicMock()})
+    page.on_received_non_selected_downloads(result={REQUEST_ID: 10, 'downloads': MagicMock()})
     assert not page.received_downloads.emit.called
 
     page.received_downloads.emit.reset_mock()
-    page.on_received_downloads(result={REQUEST_ID: 9, 'downloads': MagicMock()})
+    page.on_received_non_selected_downloads(result={REQUEST_ID: 9, 'downloads': MagicMock()})
     assert not page.received_downloads.emit.called

--- a/src/tribler/gui/tests/test_gui.py
+++ b/src/tribler/gui/tests/test_gui.py
@@ -178,7 +178,7 @@ def screenshot(widget, name=None):
 def go_to_and_wait_for_downloads(window):
     QTest.mouseClick(window.left_menu_button_downloads, Qt.LeftButton)
     QTest.mouseClick(window.downloads_all_button, Qt.LeftButton)
-    wait_for_variable(window, "downloads_page.downloads")
+    wait_for_variable(window, "downloads_page.last_processed_request_id")
 
 
 def wait_for_list_populated(llist, num_items=1, timeout=DEFAULT_TIMEOUT_SEC):


### PR DESCRIPTION
This PR fixes #7360

The list of optimizations includes:
1. Backend: Removal of the `get_files` parameter (as it is no longer used).
2. Backend: Optimization of querying for a specific infohash.
3. Frontend: Splitting the requests for downloads into two categories: one for selected downloads and another for non-selected downloads. Extended information like pieces and files is requested only for selected downloads.
4. Frontend: The logic for receiving data was conceptually rewritten to allow for partial updates of downloads. Now, it is possible to update just a single download, whereas previously, updating all downloads was mandatory. This opens up possibilities for further improvements.