### PR TITLE
Add SOCKS5 ports to sentry reporter

### DIFF
--- a/src/tribler/core/components/socks_servers/socks_servers_component.py
+++ b/src/tribler/core/components/socks_servers/socks_servers_component.py
@@ -6,6 +6,7 @@ from tribler.core.components.socks_servers.socks5.server import Socks5Server
 from tribler.core.utilities.network_utils import default_network_utils
 
 NUM_SOCKS_PROXIES = 5
+SOCKS5_SERVER_PORTS = 'socks5_server_ports'
 
 
 class SocksServersComponent(Component):
@@ -30,6 +31,9 @@ class SocksServersComponent(Component):
             default_network_utils.remember(socks_port)
 
         self.logger.info(f'Socks listen port: {self.socks_ports}')
+
+        # Set the SOCKS5 server ports in the reporter for debugging Network errors
+        self.reporter.additional_information[SOCKS5_SERVER_PORTS] = self.socks_ports
 
     async def shutdown(self):
         for socks_server in self.socks_servers:

--- a/src/tribler/core/components/socks_servers/tests/test_socks_servers_component.py
+++ b/src/tribler/core/components/socks_servers/tests/test_socks_servers_component.py
@@ -1,5 +1,5 @@
 from tribler.core.components.session import Session
-from tribler.core.components.socks_servers.socks_servers_component import SocksServersComponent
+from tribler.core.components.socks_servers.socks_servers_component import SocksServersComponent, SOCKS5_SERVER_PORTS
 
 
 # pylint: disable=protected-access
@@ -10,3 +10,4 @@ async def test_socks_servers_component(tribler_config):
         assert comp.started_event.is_set() and not comp.failed
         assert comp.socks_ports
         assert comp.socks_servers
+        assert comp.reporter.additional_information[SOCKS5_SERVER_PORTS] == comp.socks_ports


### PR DESCRIPTION
This PR adds socks5 server ports to the reporter. Having this information will help to recognize the Network errors like [this](https://github.com/Tribler/tribler/issues/7759) by comparing the ports.

Here is how it looks on the report:
![sentry-reporter-sock5-ports](https://github.com/Tribler/tribler/assets/1442867/52e4cc60-9930-45c2-9821-4e7a310a6bfc)
