### PR TITLE
Fix network name is no longer available error

### DIFF
--- a/src/tribler/core/components/socks_servers/socks5/connection.py
+++ b/src/tribler/core/components/socks_servers/socks5/connection.py
@@ -215,3 +215,4 @@ class Socks5Connection(Protocol):
 
         if self.transport:
             self.transport.close()
+            self.transport = None

--- a/src/tribler/core/components/socks_servers/socks5/tests/test_connection.py
+++ b/src/tribler/core/components/socks_servers/socks5/tests/test_connection.py
@@ -50,7 +50,7 @@ def test_invalid_version(connection):
     Test passing an invalid version to the socks5 server
     """
     connection.data_received(unhexlify('040100'))
-    assert not connection.transport.connected
+    assert not connection.transport
 
 
 def test_method_request(connection):

--- a/src/tribler/core/components/tunnel/community/dispatcher.py
+++ b/src/tribler/core/components/tunnel/community/dispatcher.py
@@ -93,9 +93,13 @@ class TunnelDispatcher(TaskManager):
             self._logger.info('Failed to get HTTP response using tunnels: %s', e)
             return
 
+        transport = tcp_connection.transport
+        if not transport:
+            return
+
         if response:
-            tcp_connection.transport.write(response)
-        tcp_connection.transport.close()
+            transport.write(response)
+        transport.close()
 
     def select_circuit(self, connection, request):
         def add_data_if_result(result_func, connection=connection.udp_connection, request=request):

--- a/src/tribler/core/components/tunnel/tests/test_dispatcher.py
+++ b/src/tribler/core/components/tunnel/tests/test_dispatcher.py
@@ -96,6 +96,14 @@ async def test_on_socks_in_tcp(dispatcher):
     tcp_connection.transport.write.assert_called_once_with(b'test')
 
 
+async def test_on_socks5_tcp_data_with_transport_none(dispatcher):
+    tcp_connection = Mock(transport=None)
+    dispatcher.set_socks_servers([tcp_connection.socksserver])
+
+    dispatcher.tunnels.perform_http_request = Mock(return_value=succeed(b'test'))
+    await dispatcher.on_socks5_tcp_data(tcp_connection, ("0.0.0.0", 1024), b'')
+
+
 def test_circuit_dead(dispatcher, mock_circuit):
     """
     Test whether the correct peers are removed when a circuit breaks


### PR DESCRIPTION
Fixes #7759 

On Windows, calling self.transport.close() can raise a CancelledError. This is because the transport is still in the event loop's transport map, and the event loop will call the transport's connection_lost method, which will call self.close() again.
This time, the transport is None, so the method will return immediately.