### PR TITLE
Removed random slot logic from TunnelCommunity

### DIFF
--- a/scripts/exit_node/run_exit_node.py
+++ b/scripts/exit_node/run_exit_node.py
@@ -47,7 +47,6 @@ def make_config(options) -> TriblerConfig:
 
     statedir = Path(os.path.join(get_root_state_directory(create=True), "tunnel-%d") % ipv8_port)
     config = TriblerConfig.load(state_dir=statedir)
-    config.tunnel_community.random_slots = options.random_slots
     config.torrent_checking.enabled = False
     config.ipv8.enabled = True
     config.libtorrent.enabled = False
@@ -199,7 +198,6 @@ async def main():
                         help='Use an alternate port for the REST API', action=PortAction, metavar='{0..65535}')
     parser.add_argument('--cert-file', '-e', help='Path to combined certificate/key file. If not given HTTP is used.')
     parser.add_argument('--api-key', '-k', help='API key to use. If not given API key protection is disabled.')
-    parser.add_argument('--random_slots', '-r', default=10, type=int, help='Specifies the number of random slots')
     parser.add_argument('--exit', '-x', action='store_const', default=False, const=True,
                         help='Allow being an exit-node')
     parser.add_argument('--testnet', '-t', action='store_const', default=False, const=True, help='Join the testnet')

--- a/src/tribler/core/components/restapi/rest/debug_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/debug_endpoint.py
@@ -60,8 +60,7 @@ class DebugEndpoint(RESTEndpoint):
         self.core_exception_handler = core_exception_handler
 
     def setup_routes(self):
-        self.app.add_routes([web.get('/circuits/slots', self.get_circuit_slots),
-                             web.get('/open_files', self.get_open_files),
+        self.app.add_routes([web.get('/open_files', self.get_open_files),
                              web.get('/open_sockets', self.get_open_sockets),
                              web.get('/threads', self.get_threads),
                              web.get('/cpu/history', self.get_cpu_history),
@@ -74,27 +73,6 @@ class DebugEndpoint(RESTEndpoint):
                              ])
         if HAS_MELIAE:
             self.app.add_routes([web.get('/memory/dump', self.get_memory_dump)])
-
-    @docs(
-        tags=['Debug'],
-        summary="Return information about the slots in the tunnel overlay.",
-        responses={
-            200: {
-                'schema': schema(CircuitSlotsResponse={'slots': [
-                    schema(CircuitSlot={
-                        'random': Integer,
-                    })
-                ]})
-            }
-        }
-    )
-    async def get_circuit_slots(self, request):
-        random_slots = self.tunnel_community.random_slots if self.tunnel_community else []
-        return RESTResponse({
-            "slots": {
-                "random": random_slots,
-            }
-        })
 
     @docs(
         tags=['Debug'],

--- a/src/tribler/core/components/restapi/rest/tests/test_debug_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/tests/test_debug_endpoint.py
@@ -35,16 +35,6 @@ def endpoint(mock_tunnel_community, tmp_path, core_resource_monitor):
                          resource_monitor=core_resource_monitor)
 
 
-async def test_get_slots(rest_api, mock_tunnel_community):
-    """
-    Test whether we can get slot information from the API
-    """
-
-    mock_tunnel_community.random_slots = [None, None, None, 12345]
-    response_json = await do_request(rest_api, 'debug/circuits/slots', expected_code=200)
-    assert len(response_json["slots"]["random"]) == 4
-
-
 async def test_get_open_files(rest_api, tmp_path):
     """
     Test whether the API returns open files

--- a/src/tribler/core/components/tunnel/settings.py
+++ b/src/tribler/core/components/tunnel/settings.py
@@ -6,7 +6,6 @@ from tribler.core.config.tribler_config_section import TriblerConfigSection
 class TunnelCommunitySettings(TriblerConfigSection):
     enabled: bool = True
     exitnode_enabled: bool = False
-    random_slots: int = 20
     testnet: bool = Field(default=False, env='TUNNEL_TESTNET')
     min_circuits: int = 3
     max_circuits: int = 10

--- a/src/tribler/core/components/tunnel/tests/test_triblertunnel_community.py
+++ b/src/tribler/core/components/tunnel/tests/test_triblertunnel_community.py
@@ -308,25 +308,6 @@ class TestTriblerTunnelCommunity(TestBase):  # pylint: disable=too-many-public-m
 
         self.assertEqual(self.nodes[0].overlay.tunnels_ready(1), 0.0)
 
-    async def test_intro_point_slot(self):
-        """
-        Test whether a introduction point occupies a slot
-        """
-        self.add_node_to_experiment(self.create_node())
-        self.nodes[1].overlay.settings.peer_flags.add(PEER_FLAG_EXIT_BT)
-        await self.introduce_nodes()
-
-        circuit = self.nodes[0].overlay.create_circuit(1)
-        await circuit.ready
-
-        exit_socket = list(self.nodes[1].overlay.exit_sockets.values())[0]
-        self.assertTrue(exit_socket.circuit_id in self.nodes[1].overlay.random_slots)
-
-        self.nodes[0].overlay.send_cell(circuit.peer,
-                                        EstablishIntroPayload(circuit.circuit_id, int(random() * 2 ** 16), b'', b''))
-        await self.deliver_messages()
-        self.assertFalse(exit_socket.circuit_id in self.nodes[1].overlay.random_slots)
-
     async def test_perform_http_request(self):
         """
         Test whether we can make a http request through a circuit
@@ -429,9 +410,3 @@ class TestTriblerTunnelCommunity(TestBase):  # pylint: disable=too-many-public-m
         """ Test whether we can join a circuit"""
         community: TriblerTunnelCommunity = self.overlay(0)
         assert await community.should_join_circuit(create_payload=Mock(), previous_node_address=Mock())
-
-    async def test_should_join_circuit_no_slots(self):
-        """ Test whether we can not join a circuit when we have no slots"""
-        community: TriblerTunnelCommunity = self.overlay(0)
-        community.random_slots = []
-        assert not await community.should_join_circuit(create_payload=Mock(), previous_node_address=Mock())


### PR DESCRIPTION
With the removal of the `BandwidthCommunity` (https://github.com/Tribler/tribler/pull/7798), the random slots logic in the `TunnelCommunity` serves no purpose.  Additionally, it causes unnecessary delays because `create` messages can get rejected for no reason. Therefore, I suggest we remove it.