### PR TITLE
Fix for incorrect tunnel settings

### DIFF
--- a/src/tribler/core/components/tunnel/tunnel_component.py
+++ b/src/tribler/core/components/tunnel/tunnel_component.py
@@ -51,7 +51,7 @@ class TunnelsComponent(Component):
                                     dlmgr=download_manager,
                                     dht_provider=provider,
                                     exitnode_cache=exitnode_cache,
-                                    settings=settings)
+                                    **settings.__dict__)
 
         self._ipv8_component.initialise_community_by_default(self.community)
         self._ipv8_component.ipv8.add_strategy(self.community, GoldenRatioStrategy(self.community), INFINITE)


### PR DESCRIPTION
The minimum number of circuits is currently not being respected, and is always set to 1. That means if you lose that one circuit (e.g. because you only have 1 download), the download will stop completely.