### PR TITLE
Fix remote search

### DIFF
--- a/src/tribler/core/components/content_discovery/community/content_discovery_community.py
+++ b/src/tribler/core/components/content_discovery/community/content_discovery_community.py
@@ -105,9 +105,9 @@ class ContentDiscoveryCommunity(Community):
 
     def convert_to_json(self, parameters):
         sanitized = dict(parameters)
-        # Convert frozenset to string
-        if "metadata_type" in sanitized:
-            sanitized["metadata_type"] = [int(mt) for mt in sanitized["metadata_type"] if mt]
+        # Convert metadata_type to an int list if it is a string
+        if "metadata_type" in sanitized and isinstance(sanitized["metadata_type"], str):
+            sanitized["metadata_type"] = [int(sanitized["metadata_type"])]
 
         self.sanitize_dict(sanitized, decode=False)
 
@@ -310,6 +310,9 @@ class ContentDiscoveryCommunity(Community):
             infohash_set = await run_threaded(self.composition.tribler_db.instance, self.search_for_tags, tags)
             if infohash_set:
                 sanitized_parameters['infohash_set'] = {bytes.fromhex(s) for s in infohash_set}
+
+            # exclude_deleted should be extracted because `get_entries_threaded` doesn't expect it as a parameter
+            sanitized_parameters.pop('exclude_deleted', None)
 
         return await self.composition.metadata_store.get_entries_threaded(**sanitized_parameters)
 

--- a/src/tribler/core/components/content_discovery/community/tests/test_content_discovery_community.py
+++ b/src/tribler/core/components/content_discovery/community/tests/test_content_discovery_community.py
@@ -306,7 +306,7 @@ class TestContentDiscoveryCommunity(TestBase[ContentDiscoveryCommunity]):
         query1 = {"txt_filter": "ubuntu*"}
         await assert_response_received_on_search(query1)
 
-        # Query with unexpected parameters like 'exclude_deleted'
+        # Query with deprecated parameters like 'exclude_deleted'
         query2 = {'txt_filter': '"ubuntu*"', 'hide_xxx': '1', 'metadata_type': REGULAR_TORRENT, 'exclude_deleted': '1'}
         await assert_response_received_on_search(query2)
 

--- a/src/tribler/core/components/content_discovery/community/tests/test_content_discovery_community.py
+++ b/src/tribler/core/components/content_discovery/community/tests/test_content_discovery_community.py
@@ -300,6 +300,15 @@ class TestContentDiscoveryCommunity(TestBase[ContentDiscoveryCommunity]):
         await self.deliver_messages()
 
         notifier.assert_called()
+        notifier.reset_mock()
+
+        # Test that the search still works with unexpected parameters like 'exclude_deleted'
+        query = {'txt_filter': '"ubuntu*"', 'hide_xxx': '1', 'metadata_type': REGULAR_TORRENT, 'exclude_deleted': '1'}
+        self.overlay(0).send_search_request(**query)
+
+        await self.deliver_messages()
+
+        notifier.assert_called()
 
     def test_version_response_payload(self):
         """


### PR DESCRIPTION
There are two issues addressed in this PR:
1. The request parameters included a deprecated parameter `exclude_deleted`. This parameter is popped out when doing the actual search on the metadata store now.
2. The `metadata_type` in the request parameter is received as string `'300'` which on conversion to json was turning it to list `[3, 0, 0]`. Since channels are removed, there is only one metadata type which is a single string, a simple integer conversion should be sufficient if the value is of string type.

Out of scope of this PR:
1. This PR does not address removing the deprecated parameter `exclude_deleted` from the remote search endpoint call from the GUI side.
2. Still the search query processing logic checks if the metadata_type is either an integer or list of integers. Since there is only one metadata type available, this logic should be changed. This change is out of scope for this PR.

Fixes #7893 
