### PR TITLE
Rendezvous redesign

### DIFF
--- a/src/tribler/core/components/ipv8/rendezvous/db/database.py
+++ b/src/tribler/core/components/ipv8/rendezvous/db/database.py
@@ -1,39 +1,72 @@
 from __future__ import annotations
 
+import logging
+import math
+import time
 from pathlib import Path
-from typing import TYPE_CHECKING, Union
-
-from pony.orm import Database, db_session, select
+from typing import TYPE_CHECKING, Union, Optional
 
 from ipv8.peer import Peer
+from pony.orm import Database, db_session, select
+
 from tribler.core.components.ipv8.rendezvous.db.orm_bindings import certificate
 from tribler.core.utilities.utilities import MEMORY_DB
 
 if TYPE_CHECKING:
-    from tribler.core.components.ipv8.rendezvous.db.orm_bindings.certificate import RendezvousCertificate
+    from tribler.core.components.ipv8.rendezvous.db.orm_bindings.certificate import PeerScore
 
 
 class RendezvousDatabase:
 
-    def __init__(self, db_path: Union[Path, type(MEMORY_DB)]) -> None:
+    @property
+    def current_time(self) -> float:
+        return time.time()
+
+    def __init__(self, db_path: Union[Path, type(MEMORY_DB)], decay_coefficient: float,
+                 decay_granularity: float, stale_timeout: float) -> None:
         create_db = db_path is MEMORY_DB or not db_path.is_file()
         db_path_string = ":memory:" if db_path is MEMORY_DB else str(db_path)
 
+        self.decay_coefficient = decay_coefficient
+        self.decay_granularity = decay_granularity
+        self.stale_timeout = stale_timeout
+
         self.database = Database()
-        self.Certificate = certificate.define_binding(self.database)
+        self.PeerScore = certificate.define_binding(self.database)
         self.database.bind(provider='sqlite', filename=db_path_string, create_db=create_db, timeout=120.0)
         self.database.generate_mapping(create_tables=create_db)
 
-    def add(self, peer: Peer, start_timestamp: float, stop_timestamp: float) -> None:
-        with db_session(immediate=True):
-            self.Certificate(public_key=peer.public_key.key_to_bin(),
-                             start=start_timestamp,
-                             stop=stop_timestamp)
+    def calculate_decay(self, last_updated_time: float) -> float:
+        if last_updated_time > self.current_time:
+            logging.exception("RendezvousDatabase corrupted. Clock is set to the past.")
+            return 0
+        time_passed = (self.current_time - last_updated_time) / self.decay_granularity
+        return math.exp(- time_passed * self.decay_coefficient)
 
-    def get(self, peer: Peer) -> list[RendezvousCertificate]:
-        with db_session():
-            return select(certificate for certificate in self.Certificate
-                          if certificate.public_key == peer.public_key.key_to_bin()).fetch()
+    def add(self, peer: Peer, start_timestamp: float, stop_timestamp: float) -> None:
+        with (db_session(immediate=True)):
+            peer_score = self.PeerScore.get(public_key=peer.public_key.key_to_bin())
+            duration = stop_timestamp - start_timestamp
+            if peer_score:
+                decay_coef = self.calculate_decay(peer_score.last_updated)
+                peer_score.total = decay_coef * peer_score.total + duration
+                peer_score.count = 1 if decay_coef == 0 else peer_score.count + 1
+                peer_score.last_updated = self.current_time
+            else:
+                self.PeerScore(public_key=peer.public_key.key_to_bin(), total=duration, count=1,
+                               last_updated=self.current_time)
+
+    def get(self, peer: Peer) -> Optional[PeerScore]:
+        with db_session(immediate=True):
+            peer_score = self.PeerScore.get(public_key=peer.public_key.key_to_bin())
+            if peer_score:
+                if self.current_time - peer_score.last_updated > self.stale_timeout:
+                    # Decay and update the peer_score
+                    decay_coef = self.calculate_decay(peer_score.last_updated)
+                    peer_score.total *= decay_coef
+                    peer_score.count = 1 if decay_coef == 0 else peer_score.count
+                    peer_score.last_updated = self.current_time
+            return peer_score
 
     def shutdown(self) -> None:
         self.database.disconnect()

--- a/src/tribler/core/components/ipv8/rendezvous/db/orm_bindings/certificate.py
+++ b/src/tribler/core/components/ipv8/rendezvous/db/orm_bindings/certificate.py
@@ -17,6 +17,6 @@ def define_binding(db):
         public_key = Required(bytes, index=True)
         total = Required(float)
         count = Required(int)
-        last_updated = Required(int)
+        last_updated = Required(float)
 
     return PeerScore

--- a/src/tribler/core/components/ipv8/rendezvous/db/orm_bindings/certificate.py
+++ b/src/tribler/core/components/ipv8/rendezvous/db/orm_bindings/certificate.py
@@ -5,16 +5,18 @@ from pony.orm import Required
 
 if TYPE_CHECKING:
     @dataclasses.dataclass
-    class RendezvousCertificate:
+    class PeerScore:
         public_key: bytes
-        start: float
-        stop: float
+        total: float
+        count: int
+        last_updated: int
 
 
 def define_binding(db):
-    class RendezvousCertificate(db.Entity):
+    class PeerScore(db.Entity):
         public_key = Required(bytes, index=True)
-        start = Required(float)
-        stop = Required(float)
+        total = Required(float)
+        count = Required(int)
+        last_updated = Required(int)
 
-    return RendezvousCertificate
+    return PeerScore

--- a/src/tribler/core/components/ipv8/rendezvous/rendezvous_hook.py
+++ b/src/tribler/core/components/ipv8/rendezvous/rendezvous_hook.py
@@ -4,6 +4,7 @@ import time
 from ipv8.peerdiscovery.network import Network, PeerObserver
 from ipv8.types import Peer
 from tribler.core.components.ipv8.rendezvous.db.database import RendezvousDatabase
+from tribler.core.components.ipv8.settings import RendezvousSettings
 
 
 class RendezvousHook(PeerObserver):

--- a/src/tribler/core/components/ipv8/settings.py
+++ b/src/tribler/core/components/ipv8/settings.py
@@ -15,13 +15,19 @@ class BootstrapSettings(TriblerConfigSection):
     infohash: str = 'b496932f32daad964e1b63188faabf74d22b45ea'
 
 
+class RendezvousSettings(TriblerConfigSection):
+    enabled: bool = False
+    decay_coefficient: float = 1 / 2000
+    decay_granularity: float = 3600  # 1 hour
+    stale_timeout: float = 3600 * 24 * 7  # 1 week
+
+
 class Ipv8Settings(TriblerConfigSection):
     enabled: bool = True
     port: int = 7759
     address: str = '0.0.0.0'
     bootstrap_override: Optional[str] = None
     statistics: bool = False
-    rendezvous_stats: bool = False
     walk_interval: float = 0.5
     walk_scaling_enabled: bool = True
     walk_scaling_upper_limit: float = 3.0

--- a/src/tribler/core/components/ipv8/tests/test_ipv8_component.py
+++ b/src/tribler/core/components/ipv8/tests/test_ipv8_component.py
@@ -43,8 +43,8 @@ async def test_ipv8_component_statistics_enabled(tribler_config):
 
 
 async def test_ipv8_rendezvous_enabled(tribler_config):
-    tribler_config.ipv8.rendezvous_stats = True
+    tribler_config.rendezvous.enabled = True
     async with Session(tribler_config, [KeyComponent(), Ipv8Component()]) as session:
         comp = session.get_instance(Ipv8Component)
         assert comp.rendezvous_db is not None
-        assert comp.rendevous_hook is not None
+        assert comp.rendezvous_hook is not None

--- a/src/tribler/core/config/tribler_config.py
+++ b/src/tribler/core/config/tribler_config.py
@@ -13,7 +13,7 @@ from tribler.core.components.ipv8.settings import (
     BootstrapSettings,
     DHTSettings,
     DiscoveryCommunitySettings,
-    Ipv8Settings,
+    Ipv8Settings, RendezvousSettings,
 )
 from tribler.core.components.key.settings import TrustchainSettings
 from tribler.core.components.libtorrent.settings import DownloadDefaultsSettings, LibtorrentSettings
@@ -41,6 +41,7 @@ class TriblerConfig(BaseSettings):
     tunnel_community: TunnelCommunitySettings = TunnelCommunitySettings()
     bootstrap: BootstrapSettings = BootstrapSettings()
     ipv8: Ipv8Settings = Ipv8Settings()
+    rendezvous: RendezvousSettings = RendezvousSettings()
     discovery_community: DiscoveryCommunitySettings = DiscoveryCommunitySettings()
     dht: DHTSettings = DHTSettings()
     trustchain: TrustchainSettings = TrustchainSettings()


### PR DESCRIPTION
A redesign of rendezvous certificates based on sketch https://github.com/Tribler/tribler/issues/6519#issuecomment-1929458867

Compared to the previous iteration this version does not store all certificates, but rather a `peer_score`. 

For the score we store the running total multiplied each time with an exponential decay.  