### PR TITLE
Add dev mode to enable running multiple Tribler instances

### DIFF
--- a/src/tribler.sh
+++ b/src/tribler.sh
@@ -15,6 +15,24 @@ script_path() {
 
 UNAME="$(uname -s)"
 
+# Allow multiple instances of Tribler to run in development mode.
+is_dev_mode=$(echo "$DEV_MODE" | tr '[:upper:]' '[:lower:]') # Convert to lowercase using tr
+if [ "$is_dev_mode" = "true" ]; then
+  echo "Running Tribler in development mode"
+  # Set the state directory
+  TSTATEDIR="$HOME/.Tribler"
+
+  # If there are multiple instances of the script running, append a number to the state directory
+  script_name=$(basename "$0")  # Get the name of the script
+  # Count the instances of the script running, excluding the pgrep command itself
+  instance_count=$(pgrep -f "$script_name" | grep -v "$$" | wc -l)
+  if [ "$instance_count" -gt 1 ]; then
+      TSTATEDIR="$TSTATEDIR-$((instance_count-1))"
+  fi
+  export TSTATEDIR
+  echo "Running Tribler from state directory $TSTATEDIR"
+fi
+
 # Add all required modules to PYTHONPATH
 SRC_DIR="$(dirname "$(script_path "$0")")/src"
 PYTHONPATH="$PYTHONPATH:$SRC_DIR"


### PR DESCRIPTION
Sometimes it is desirable to run multiple instances of Tribler while developing or testing community logic. Running multiple instances of Tribler with a custom community ID helps to test your community logic in isolation while still ensuring there are no runtime errors.

The PR introduces an environment variable called `DEV_MODE` which if set to `True` (case-insensitive), allows running multiple instances of Tribler on *nix environment. If the environment variable is not set, there is no change on the normal Tribler execution and prevents multiple instances of Tribler as expected.

When this feature is enabled (by setting DEV_MODE=True), the state directory for each subsequent Tribler is organized in this manner:
- First instance: `$HOME/.Tribler`  <-- default instance
- Second instance: `$HOME/.Tribler-1`
- Third instance: `$HOME/.Tribler-2`

Here is a screenshot of running three different local instances of Tribler.
![multiple-tribler-instances](https://github.com/Tribler/tribler/assets/1442867/219ca131-134a-46b6-8e68-9016c7a1c2e6)


This script was initially developed to test https://github.com/Tribler/tribler/pull/7896

**Out of Scope:**
- Windows `run_tribler.bat` script is not updated
- The script only works if Tribler is run using the same script command and does not account for any Tribler instances running using installed binary. Thus, this feature is for dev mode only.