### PR TITLE
Improved tunnel circuit management

### DIFF
--- a/src/tribler/core/components/libtorrent/download_manager/download.py
+++ b/src/tribler/core/components/libtorrent/download_manager/download.py
@@ -81,6 +81,7 @@ class Download(TaskManager):
         self.pause_after_next_hashcheck = False
         self.checkpoint_after_next_hashcheck = False
         self.tracker_status = {}  # {url: [num_peers, status_str]}
+        self.shutting_down = False
 
         self.futures: Dict[str, list[tuple[Future, Callable, Optional[Getter]]]] = defaultdict(list)
         self.alert_handlers = defaultdict(list)

--- a/src/tribler/core/components/libtorrent/download_manager/download_manager.py
+++ b/src/tribler/core/components/libtorrent/download_manager/download_manager.py
@@ -307,10 +307,7 @@ class DownloadManager(TaskManager):
             settings['anonymous_mode'] = True
             settings['force_proxy'] = True
 
-            # Anon listen port is never used anywhere, so we let Libtorrent set it
-            # settings["listen_interfaces"] = f"0.0.0.0:{anon_port}"
-
-            # By default block all IPs except 1.1.1.1 (which is used to ensure libtorrent makes a connection to us)
+            # By default, block all IPs except 1.1.1.1 (which is used to ensure libtorrent makes a connection to us)
             self.update_ip_filter(ltsession, ['1.1.1.1'])
 
         self.set_session_settings(ltsession, settings)
@@ -340,8 +337,6 @@ class DownloadManager(TaskManager):
             except Exception as exc:
                 self._logger.info(f"could not load libtorrent state, got exception: {exc!r}. starting from scratch")
         else:
-            # ltsession.listen_on(anon_port, anon_port + 20)
-
             rate = DownloadManager.get_libtorrent_max_upload_rate(self.config)
             download_rate = DownloadManager.get_libtorrent_max_download_rate(self.config)
             settings = {'upload_rate_limit': rate,
@@ -758,6 +753,7 @@ class DownloadManager(TaskManager):
     async def remove_download(self, download, remove_content=False, remove_checkpoint=True):
         infohash = download.get_def().get_infohash()
         handle = download.handle
+        download.shutting_down = True
 
         # Note that the following block of code needs to be able to deal with multiple simultaneous
         # calls using the same download object. We need to make sure that we don't return without

--- a/src/tribler/core/components/socks_servers/socks5/udp_connection.py
+++ b/src/tribler/core/components/socks_servers/socks5/udp_connection.py
@@ -16,7 +16,7 @@ class SocksUDPConnection(DatagramProtocol):
 
     async def open(self):
         self.transport, _ = await get_event_loop().create_datagram_endpoint(lambda: self,
-                                                                            local_addr=('0.0.0.0', 0))
+                                                                            local_addr=('127.0.0.1', 0))
 
     def get_listen_port(self):
         _, port = self.transport.get_extra_info('sockname')

--- a/src/tribler/core/components/tunnel/community/tunnel_community.py
+++ b/src/tribler/core/components/tunnel/community/tunnel_community.py
@@ -333,8 +333,9 @@ class TriblerTunnelCommunity(HiddenTunnelCommunity):
                 lt_listen_port = self.download_manager.listen_ports.get(hops)
                 lt_listen_port = lt_listen_port or self.download_manager.get_session(hops).listen_port()
                 for session in self.socks_servers[hops - 1].sessions:
-                    if session.udp_connection and lt_listen_port:
-                        session.udp_connection.remote_udp_address = ("127.0.0.1", lt_listen_port)
+                    connection = session.udp_connection
+                    if connection and lt_listen_port and connection.remote_udp_address is None:
+                        connection.remote_udp_address = ("127.0.0.1", lt_listen_port)
         await super().create_introduction_point(info_hash, required_ip=required_ip)
 
     async def unload(self):

--- a/src/tribler/core/components/tunnel/community/tunnel_community.py
+++ b/src/tribler/core/components/tunnel/community/tunnel_community.py
@@ -260,6 +260,10 @@ class TriblerTunnelCommunity(HiddenTunnelCommunity):
                                                self.settings.max_circuits)
                                 for hop_count, download_count in active_downloads_per_hop.items()}
 
+        self.monitor_hidden_swarms(new_states, hops)
+        self.download_states = new_states
+
+    def monitor_hidden_swarms(self, new_states, hops):
         ip_counter = Counter([c.info_hash for c in list(self.circuits.values()) if c.ctype == CIRCUIT_TYPE_IP_SEEDER])
         for info_hash in set(list(new_states) + list(self.download_states)):
             new_state = new_states.get(info_hash, None)
@@ -280,8 +284,6 @@ class TriblerTunnelCommunity(HiddenTunnelCommunity):
                 for _ in range(1 - ip_counter.get(info_hash, 0)):
                     self.logger.info('Create introducing circuit for %s', hexlify(info_hash))
                     self.create_introduction_point(info_hash)
-
-        self.download_states = new_states
 
     def on_e2e_finished(self, address, info_hash):
         dl = self.get_download(info_hash)

--- a/src/tribler/gui/debug_window.py
+++ b/src/tribler/gui/debug_window.py
@@ -519,7 +519,7 @@ class DebugWindow(QMainWindow):
             return
 
         for c in circuits["circuits"]:
-            c["hops"] = f"{c['goal_hops']} / {c['goal_hops']}"
+            c["hops"] = f"{c['actual_hops']} / {c['goal_hops']}"
             c["exit_flags"] = c["exit_flags"] if c["state"] == "READY" else ""
 
         self.add_items_to_tree(


### PR DESCRIPTION
This PR fixes various small tunnel related issues, including a couple of things related to circuit management:
* Metainfo downloads aren't being filtered out in `monitor_downloads`. This can lead to having too many circuits. Additionally, hidden services is currently joining hidden swarms for metainfo downloads, firing off a whole bunch of logic for a download that's going to disappear in a couple of minutes.
* Often (depending on the timing of `monitor_downloads`) when removing a download, it first announces itself to the DHT.
* Ensure we always have at least `min_circuits` for the default hop count. This avoids last minute circuit creation, and also makes more sense since the `TorrentChecker` will be constantly needing circuits anyway.

Other than fixing an issue with the tunnel debug panel, it also fixes a few SOCKS5 related issues:
* It currently binds the UDP associate socket to `0.0.0.0`, potentially allowing remote peers to send us SOCKS5 packets directly.
* The `remote_udp_address` can be set to the wrong address in case the circuit is being used by `TorrentChecker`. In this case, it will send responses that are meant for `TorrentChecker` to libtorrent instead.