### PR TITLE
Suppress ValueError on EventsEndpoint at shutdown

### DIFF
--- a/src/tribler/core/components/restapi/rest/events_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/events_endpoint.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import time
 from asyncio import CancelledError, Queue
+from contextlib import suppress
 from dataclasses import asdict
 from typing import Any, Dict, List, Optional
 
@@ -215,6 +216,7 @@ class EventsEndpoint(RESTEndpoint):
         else:
             self._logger.info('Event stream was closed due to shutdown')
         finally:
-            self.events_responses.remove(response)
+            with suppress(ValueError):
+                self.events_responses.remove(response)
 
         return response

--- a/src/tribler/core/components/restapi/rest/events_endpoint.py
+++ b/src/tribler/core/components/restapi/rest/events_endpoint.py
@@ -215,8 +215,9 @@ class EventsEndpoint(RESTEndpoint):
             self._logger.warning('Event stream was canceled')
         else:
             self._logger.info('Event stream was closed due to shutdown')
-        finally:
-            with suppress(ValueError):
-                self.events_responses.remove(response)
+
+        # See: https://github.com/Tribler/tribler/pull/7906
+        with suppress(ValueError):
+            self.events_responses.remove(response)
 
         return response


### PR DESCRIPTION
This ValueError is raised at the shutdown stage so suppressing the error is acceptable.
Fixes #7905 