### PR TITLE
Do not show resume_data on logging Download ATP

### DIFF
--- a/src/tribler/core/components/libtorrent/download_manager/download_manager.py
+++ b/src/tribler/core/components/libtorrent/download_manager/download_manager.py
@@ -648,7 +648,7 @@ class DownloadManager(TaskManager):
                             dummy=self.dummy_mode)
         self._logger.info(f'Download created: {download}')
         atp = download.get_atp()
-        self._logger.info(f'ATP: {atp}')
+        self._logger.info(f"ATP: { {k: v for k, v in atp.items() if k not in ['resume_data']} }")
         # Keep metainfo downloads in self.downloads for now because we will need to remove it later,
         # and removing the download at this point will stop us from receiving any further alerts.
         if infohash not in self.metainfo_requests or self.metainfo_requests[infohash][0] == download:


### PR DESCRIPTION
Logging Download ATP outputs huge `resume_data` which is not much useful. This PR keeps the log line with same log level (info) but without `resume_data`.