### PR TITLE
Fix CoreConnectTimeoutError

### DIFF
--- a/src/tribler/gui/event_request_manager.py
+++ b/src/tribler/gui/event_request_manager.py
@@ -131,7 +131,7 @@ class EventRequestManager(QNetworkAccessManager):
 
         should_retry = reschedule_on_err and time.time() < self.start_time + CORE_CONNECTION_TIMEOUT
         error_name = self.network_errors.get(error, error)
-        self._logger.info(f"Error {error_name} while trying to connect to Tribler Core"
+        self._logger.info(f"Error {error_name} while trying to connect to Tribler Core at port[{self.api_port}]"
                           + (', will retry' if should_retry else ', will not retry'))
 
         if reschedule_on_err:
@@ -139,7 +139,8 @@ class EventRequestManager(QNetworkAccessManager):
                 self.connect_timer.start(RECONNECT_INTERVAL_MS)  # Reschedule an attempt
             else:
                 raise CoreConnectTimeoutError(
-                    f"Could not connect with the Tribler Core within {CORE_CONNECTION_TIMEOUT} seconds: "
+                    f"Could not connect with the Tribler Core at port[{self.api_port}] "
+                    f"within {CORE_CONNECTION_TIMEOUT} seconds: "
                     f"{error_name} (code {error})"
                 )
 


### PR DESCRIPTION
Under the current assumption that the GUI process spawns the Core process, the core process is selected from the process database with rowid higher than the rowid of the GUI process. This avoid GUI to select any previous core process (given the same PID as in the case of Flatpak) that did not finish properly (ie. exit_code or finished is None).

The CoreConnectTimeoutError was raised by GUI trying to connect to the previous instance of Core Port which is likely not available at the time of checking which esults in failure to connect to the Core within the timeout period.

Fixes https://github.com/Tribler/tribler/issues/7137