### PR TITLE
Update PR merging policy to use "merge –no–ff" instead of "rebase + merge –no–ff"

### DIFF
--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -62,7 +62,7 @@ When creating a new Pull request, please take note of the following:
 
 PR policies
 ===========
-* We use `rebase + merge –no–ff <https://www.endoflineblog.com/oneflow-a-git-branching-model-and-workflow#option-3-rebase-merge-no-ff>`_ for merging a branch
+* We use `merge –no–ff <https://www.endoflineblog.com/oneflow-a-git-branching-model-and-workflow#option-2-merge-no-ff>`_ for merging a branch
 * Responsibility for merging the PR is on the creator of PR
 * In the case where you cannot reach a consensus with the reviewer, you can request a second reviewer to act as a `Tie Breaker <https://github.com/Tribler/tribler/issues/7807>`_.
 


### PR DESCRIPTION
This PR closes #7895