### PR TITLE
Remove state information from REST API documentation

### DIFF
--- a/doc/restapi/state.rst
+++ b/doc/restapi/state.rst
@@ -1,8 +1,0 @@
-==========
-State info
-==========
-
-.. openapi:: swagger.yaml
-   :include:
-      /state.*
-   :encoding: utf-8


### PR DESCRIPTION
This PR fixes #7916 by removing the `state.rst` file.