### PR TITLE
Update ipv8-rust-tunnels to 0.1.17

### DIFF
--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -25,4 +25,4 @@ Brotli==1.0.9 # to prevent AttributeError on macOs: module 'brotli' has no attri
 human-readable==1.3.2
 colorlog==6.7.0
 filelock==3.13.0
-ipv8-rust-tunnels==0.1.16
+ipv8-rust-tunnels==0.1.17


### PR DESCRIPTION
Fixes an issue when the IPv8 port is already occupied, in which case it now retries using port+1 until successful.