### PR TITLE
Fix flaky test by expecting both ClientOSError and ServerDisconnectedError when server disconnects

### DIFF
--- a/src/tribler/core/components/restapi/rest/tests/test_rest_manager.py
+++ b/src/tribler/core/components/restapi/rest/tests/test_rest_manager.py
@@ -3,7 +3,7 @@ from asyncio import CancelledError
 from unittest.mock import Mock, patch
 
 import pytest
-from aiohttp import ServerDisconnectedError
+from aiohttp import ClientOSError, ServerDisconnectedError
 from aiohttp.web_protocol import RequestHandler
 
 from tribler.core.components.restapi.rest.aiohttp_patch import get_transport_is_none_counter, patch_make_request
@@ -144,7 +144,7 @@ async def test_aiohttp_assertion_patched(rest_manager, api_port):
     # the main monkey-patch should handle the closed transport and increment the counter during the request handling
     counter_before = get_transport_is_none_counter()
 
-    with pytest.raises(ServerDisconnectedError):
+    with pytest.raises((ClientOSError, ServerDisconnectedError)):
         # The server is disconnected, because the transport is closed and the start() coroutine is canceled
         with patch('aiohttp.web_protocol.RequestHandler.start', new=new_start):
             await do_real_request(api_port, 'settings')


### PR DESCRIPTION
This PR fixes #7725 by expecting ClientOSError in addition to ServerDisconnectedError when aiohttp server disconnects. It looks like there are some internal indeterminism in aiohttp regarding what error will be raised here.