### PR TITLE
Fix GUI test GitHub action on Windows by replacing wget with curl

### DIFF
--- a/.github/actions/windows_dependencies/action.yml
+++ b/.github/actions/windows_dependencies/action.yml
@@ -33,7 +33,7 @@ runs:
         RELEASE_FOLDER: .\libsodium\x64\Release
       shell: cmd
       run: |
-        C:\msys64\usr\bin\wget.exe -q https://download.libsodium.org/libsodium/releases/libsodium-${{inputs.libsodium-version}}-msvc.zip
+        curl -L https://download.libsodium.org/libsodium/releases/libsodium-${{inputs.libsodium-version}}-msvc.zip -o libsodium-${{inputs.libsodium-version}}-msvc.zip
         7z x libsodium-${{inputs.libsodium-version}}-msvc.zip
         dir %RELEASE_FOLDER% /ad /b /o-n > latest_release_file
         set /p latest_release= < latest_release_file


### PR DESCRIPTION
Currently, GUI tests GitHub action refuses to work due to the following error:
```
These files don't exist: cached-bin/libsodium-1.0.18/libsodium.dll
Run C:\msys64\usr\bin\wget.exe -q https://download.libsodium.org/libsodium/releases/libsodium-1.0.18-msvc.zip
  C:\msys64\usr\bin\wget.exe -q https://download.libsodium.org/libsodium/releases/libsodium-1.0.18-msvc.zip
  7z x libsodium-1.0.18-msvc.zip
  dir %RELEASE_FOLDER% /ad /b /o-n > latest_release_file
  set /p latest_release= < latest_release_file
  echo Latest release: %latest_release%
  if not exist "cached-bin\libsodium-1.0.18" mkdir "cached-bin\libsodium-1.0.18"
  copy %RELEASE_FOLDER%\%latest_release%\dynamic\libsodium.dll .\cached-bin\libsodium-1.0.18\libsodium.dll
  shell: C:\Windows\system32\cmd.EXE /D /E:ON /V:OFF /S /C "CALL "{0}""
  env:
    PYTEST_SENTRY_DSN: ***
    pythonLocation: C:\hostedtoolcache\windows\Python\3.8.10\x64
    PKG_CONFIG_PATH: C:\hostedtoolcache\windows\Python\3.8.10\x64/lib/pkgconfig
    Python_ROOT_DIR: C:\hostedtoolcache\windows\Python\3.8.10\x64
    Python2_ROOT_DIR: C:\hostedtoolcache\windows\Python\3.8.10\x64
    Python3_ROOT_DIR: C:\hostedtoolcache\windows\Python\3.8.10\x64
    VIRTUAL_ENV: C:\Users\runneradmin\.virtualenvs\.venv
    RELEASE_FOLDER: .\libsodium\x64\Release

7-Zip 23.01 (x64) : Copyright (c) 1999-2023 Igor Pavlov : 2023-06-20

Scanning the drive for archives:

ERROR: The system cannot find the file specified.
libsodium-1.0.18-msvc.zip
```

Examples:
* https://github.com/Tribler/tribler/actions/runs/8327533783/job/22785427033#step:4:96
* https://github.com/Tribler/tribler/actions/runs/8326898779/job/22783469947#step:4:96

It looks like `wget` has some problems with certificates that prevent downloading the `libsodium` library.

This PR fixes the problem by replacing the `wget` call with the `curl` call. Windows dependencies build successfully with this fix.

`wget` is linked to OpenSSL whereas `curl` is linked to the NSS cryptographic libraries, and this can explain the difference:
https://serverfault.com/questions/922222/why-does-curl-work-with-a-specific-https-site-but-wget-has-problems-with-certif