### PR TITLE
Build windows binary using Cx_Freeze

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,9 +48,9 @@ We support development on Linux, macOS and Windows. We have written
 documentation that guides you through installing the required packages when
 setting up a Tribler development environment.
 
-* `Linux <http://tribler.readthedocs.io/en/latest/development/development_on_linux.html>`_
-* `Windows <http://tribler.readthedocs.io/en/latest/development/development_on_windows.html>`_
-* `macOS <http://tribler.readthedocs.io/en/latest/development/development_on_osx.html>`_
+* `Linux <http://tribler.readthedocs.io/en/latest/development/development_on_linux.html>`__
+* `Windows <http://tribler.readthedocs.io/en/latest/development/development_on_windows.html>`__
+* `macOS <http://tribler.readthedocs.io/en/latest/development/development_on_osx.html>`__
 
 
 
@@ -59,9 +59,9 @@ Packaging Tribler
 
 We have written guides on how to package Tribler for distribution on various systems.
 
-* `Linux <http://tribler.readthedocs.io/en/latest/building/building.html>`_
-* `Windows <http://tribler.readthedocs.io/en/latest/building/building_on_windows.html>`_
-* `macOS <http://tribler.readthedocs.io/en/latest/building/building_on_osx.html>`_
+* `Linux <http://tribler.readthedocs.io/en/latest/building/building.html>`__
+* `Windows <http://tribler.readthedocs.io/en/latest/building/building_on_windows.html>`__
+* `macOS <http://tribler.readthedocs.io/en/latest/building/building_on_osx.html>`__
 
 
 Docker support

--- a/build.py
+++ b/build.py
@@ -1,0 +1,82 @@
+"""
+This file includes the build configuration for the Tribler executable using CX Freeze.
+The exports of this file are used in setup.py to build the executable.
+
+To create a build:
+python setup.py build
+
+To create a distributable package:
+python setup.py bdist
+
+To create a distributable package for a specific platform:
+python setup.py bdist_mac
+python setup.py bdist_win
+"""
+import os
+import re
+import shutil
+import sys
+from pathlib import Path
+
+from setuptools import find_packages
+from cx_Freeze import setup, Executable
+
+app_name = "Tribler" if sys.platform != "linux" else "tribler"
+app_script = "src/tribler/run.py"
+app_icon_path = "build/win/resources/tribler.ico" if sys.platform == "win32" else "build/mac/resources/tribler.icns"
+app_executable = Executable(
+    target_name=app_name,
+    script=app_script,
+    base="Win32GUI" if sys.platform == "win32" else None,
+    icon=app_icon_path,
+)
+
+# These packages will be included in the build
+sys.path.insert(0, 'src')
+included_packages = [
+    "aiohttp_apispec",
+    "sentry_sdk",
+    "ipv8",
+    "PIL",
+    "pkg_resources",
+    "pydantic",
+    "pyqtgraph",
+    "PyQt5.QtTest",
+    "requests",
+    "tribler.core",
+    "tribler.gui",
+    "faker"
+]
+
+# These files will be included in the build
+included_files = [
+    ("src/tribler/gui/qt_resources", "qt_resources"),
+    ("src/tribler/gui/images", "images"),
+    ("src/tribler/gui/i18n", "i18n"),
+    ("src/tribler/core", "tribler_source/tribler/core"),
+    ("src/tribler/gui", "tribler_source/tribler/gui"),
+    ("build/win/resources", "tribler_source/resources"),
+]
+
+# These packages will be excluded from the build
+excluded_packages = [
+    'wx',
+    'PyQt4',
+    'FixTk',
+    'tcl',
+    'tk',
+    '_tkinter',
+    'tkinter',
+    'Tkinter',
+    'matplotlib'
+]
+
+build_exe_options = {
+    "packages": included_packages,
+    "excludes": excluded_packages,
+    "include_files": included_files,
+    "include_msvcr": True,
+    'build_exe': 'dist/tribler'
+}
+
+__all__ = ["setup", "app_executable", "build_exe_options"]

--- a/build/win/makedist_win.bat
+++ b/build/win/makedist_win.bat
@@ -48,7 +48,10 @@ REM packs them in the installer .EXE
 ECHO Install pip dependencies for correct py-installer's work
 python3 -m pip install --upgrade -r build\win\requirements.txt
 
-%PYTHONHOME%\Scripts\pyinstaller.exe tribler.spec --log-level=%LOG_LEVEL% || exit /b
+REM Sandip 2024-03-22: Deprecated, we are not using PyInstaller anymore because of issue with False Malware detections.
+REM %PYTHONHOME%\Scripts\pyinstaller.exe tribler.spec --log-level=%LOG_LEVEL% || exit /b
+ECHO Building Tribler using Cx_Freeze
+python3 setup.py build
 
 copy build\win\resources\tribler*.nsi dist\tribler
 

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,6 +1,7 @@
 -r requirements.txt
 
-PyInstaller==5.13.1; sys_platform != 'darwin'
+PyInstaller==5.13.1; sys_platform == 'linux2' or sys_platform == 'linux'
+cx_Freeze==6.15.16; sys_platform == 'win32'
 
 setuptools==65.5.1; sys_platform == 'darwin'
 text-unidecode==1.3; sys_platform == 'darwin'

--- a/setup.py
+++ b/setup.py
@@ -3,10 +3,9 @@ import re
 import shutil
 from pathlib import Path
 
-from setuptools import setup, find_packages
+from setuptools import find_packages
 
-# Copy src/run_tribler.py --> src/tribler/run.py to make it accessible in entry_points scripts.
-shutil.copy("src/run_tribler.py", "src/tribler/run.py")
+from build import app_executable, build_exe_options, setup
 
 
 def read_version_from_file(file_path):
@@ -18,10 +17,6 @@ def read_version_from_file(file_path):
         version_str = version_match.group(1)
         return version_str.split("-")[0]
     raise RuntimeError("Unable to find version string.")
-
-
-version_file = os.path.join('src', 'tribler', 'core', 'version.py')
-version = read_version_from_file(version_file)
 
 
 def read_requirements(file_name, directory='.'):
@@ -39,22 +34,36 @@ def read_requirements(file_name, directory='.'):
 
 
 base_dir = os.path.dirname(os.path.abspath(__file__))
-
 install_requires = read_requirements('requirements-build.txt', base_dir)
 extras_require = {
     'dev': read_requirements('requirements-test.txt', base_dir),
 }
 
+# Copy src/run_tribler.py --> src/tribler/run.py to make it accessible in entry_points scripts.
+# See: entry_points={"gui_scripts": ["tribler=tribler.run:main"]} in setup() below.
+shutil.copy("src/run_tribler.py", "src/tribler/run.py")
+
+# Read the version from the version file: src/tribler/core/version.py
+# Note that, for version.py to include the correct version, it should be generated first using git commands.
+# For example:
+#    git describe --tags | python -c "import sys; print(next(sys.stdin).lstrip('v'))" > .TriblerVersion
+#    git rev-parse HEAD > .TriblerCommit
+# Then, the version.py file can be generated using the following command:
+#    python build/update_version.py
+version_file = os.path.join('src', 'tribler', 'core', 'version.py')
+version = read_version_from_file(version_file)
 
 setup(
-    name="Tribler",
+    name="tribler",
     version=version,
     description="Privacy enhanced BitTorrent client with P2P content discovery",
     long_description=Path('README.rst').read_text(encoding="utf-8"),
     long_description_content_type="text/x-rst",
     author="Tribler Team",
     author_email="info@tribler.org",
-    url="https://www.tribler.org",
+    url="https://github.com/Tribler/tribler",
+    keywords='BitTorrent client, file sharing, peer-to-peer, P2P, TOR-like network',
+    python_requires='>=3.8',
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     include_package_data=True,
@@ -68,12 +77,15 @@ setup(
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
-        "License :: OSI Approved :: GPL-3.0 license",
+        "Intended Audience :: End Users/Desktop",
+        "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
-        "Topic :: Internet :: File Sharing",
+        "Topic :: Communications :: File Sharing",
         "Topic :: Security :: Cryptography",
         "Operating System :: OS Independent",
     ],
+    options={"build_exe": build_exe_options},
+    executables=[app_executable]
 )


### PR DESCRIPTION
This PR aims to transition from PyInstaller to Cx_Freeze for generating Windows binaries. The motivation for this change is detailed [here](https://github.com/Tribler/tribler/issues/5979).

Although Cx_Freeze supports MSI installer generation (refer to the build.py documentation in the PR), this feature is not utilized. Instead, the existing NSIS-based installation process is maintained, with the switch only affecting the executable creation, previously managed by PyInstaller.

It's important to note that this PR exclusively alters the Windows build process. For Linux and MacOS, PyInstaller remains the tool of choice for binary creation. This decision stems from the absence of malware misidentification issues and the significantly smaller binary size produced by PyInstaller compared to Cx_Freeze on these platforms, prompting no changes there for the time being.