### PR TITLE
Immediately show all downloads on Tribler start

### DIFF
--- a/src/tribler/core/components/libtorrent/restapi/downloads_endpoint.py
+++ b/src/tribler/core/components/libtorrent/restapi/downloads_endpoint.py
@@ -254,9 +254,6 @@ class DownloadsEndpoint(RESTEndpoint):
             ALL_LOADED: self.download_manager.all_checkpoints_are_loaded,
         }
 
-        if not self.download_manager.all_checkpoints_are_loaded:
-            return RESTResponse({"downloads": [], "checkpoints": checkpoints})
-
         result = []
         downloads = (d for d in self.download_manager.get_downloads() if not d.hidden)
         if infohash:

--- a/src/tribler/core/components/libtorrent/tests/test_download_manager.py
+++ b/src/tribler/core/components/libtorrent/tests/test_download_manager.py
@@ -246,7 +246,10 @@ async def test_start_download(fake_dlmgr):
     mock_download.get_def().get_infohash = MagicMock(return_value=b"1" * 20)
     mock_download.future_added = succeed(True)
     mock_ltsession.async_add_torrent = MagicMock()
+
     await fake_dlmgr.start_handle(mock_download, {})
+    await asyncio.sleep(0.1)
+
     check_was_run.assert_called()
     fake_dlmgr.downloads.clear()
 

--- a/src/tribler/gui/widgets/downloadspage.py
+++ b/src/tribler/gui/widgets/downloadspage.py
@@ -229,19 +229,6 @@ class DownloadsPage(AddBreadcrumbOnShowMixin, QWidget):
         The result could consists of multiple downloads.
         Only downloads from the result will be processed.
         """
-        checkpoints = result.get('checkpoints', {})
-        if checkpoints and self.loading_message_widget:
-            # If not all checkpoints are loaded, display the number of the loaded checkpoints
-            total = checkpoints['total']
-            loaded = checkpoints['loaded']
-            if not checkpoints['all_loaded']:
-                # The column is too narrow for a long message, probably we should redesign this UI element later
-                message = f'{loaded}/{total} checkpoints'
-                self._logger.info(f'Loading checkpoints: {message}')
-                self.loading_list_item.textlabel.setText(message)
-                self.schedule_downloads_refresh()
-                return
-
         loading_widget_index = self.window().downloads_list.indexOfTopLevelItem(self.loading_message_widget)
         if loading_widget_index > -1:
             self.window().downloads_list.takeTopLevelItem(loading_widget_index)


### PR DESCRIPTION
This PR fixes #7770. Now, all downloads are displayed immediately without any artificial delay.

The PR extracts the potentially blocking part of `DownloadManager.start_handle` into a separate method, `DownloadManager._async_add_torrent`, and runs the potentially blocking second method as a separate task. As a result, now all checkpoints load almost instantly and can be immediately presented to a user.