### PR TITLE
Modify `future_setter` to not keep an alert object

### DIFF
--- a/src/tribler/core/components/libtorrent/download_manager/download.py
+++ b/src/tribler/core/components/libtorrent/download_manager/download.py
@@ -270,7 +270,7 @@ class Download(TaskManager):
 
             for future, future_setter, getter in self.futures.pop(alert_type, []):
                 if not future.done():
-                    future_setter(getter(alert) if getter else alert)
+                    future_setter(getter(alert) if getter else None)
         except Exception as e:
             self._logger.exception(f'process_alert failed with {e.__class__.__name__}: {e} '
                                    f'for alert {safe_repr(alert)}')


### PR DESCRIPTION
This PR addresses potentially dangerous behavior where an alert object is stored in the `future`, which could exceed its time to live since it is valid only until the next `pop_alerts` call.

Refs: 
 - https://libtorrent.org/reference-Session.html#pop-alerts-wait-for-alert-set-alert-notify

Related to 
- #7886