### PR TITLE
Fix binary build

### DIFF
--- a/build.py
+++ b/build.py
@@ -68,7 +68,9 @@ else:
         "requests",
         "tribler.core",
         "tribler.gui",
-        "faker"
+        "faker",
+        "libtorrent",
+        "ssl",
     ]
 
     # These files will be included in the build

--- a/build.py
+++ b/build.py
@@ -1,6 +1,16 @@
 """
-This file includes the build configuration for the Tribler executable using CX Freeze.
-The exports of this file are used in setup.py to build the executable.
+This file includes the build configuration for the Tribler.
+The exports of this file are used in setup.py to build the executable or wheel package.
+
+Building executable depends on cx_Freeze.
+
+1) If cx_Freeze is not installed,
+setuptools is used to build the wheel package.
+
+To create a wheel package:
+python setup.py bdist_wheel
+
+2) If cx_Freeze is installed,
 
 To create a build:
 python setup.py build
@@ -19,64 +29,77 @@ import sys
 from pathlib import Path
 
 from setuptools import find_packages
-from cx_Freeze import setup, Executable
 
-app_name = "Tribler" if sys.platform != "linux" else "tribler"
-app_script = "src/tribler/run.py"
-app_icon_path = "build/win/resources/tribler.ico" if sys.platform == "win32" else "build/mac/resources/tribler.icns"
-app_executable = Executable(
-    target_name=app_name,
-    script=app_script,
-    base="Win32GUI" if sys.platform == "win32" else None,
-    icon=app_icon_path,
-)
+try:
+    import cx_Freeze
+except ImportError:
+    cx_Freeze = None
 
-# These packages will be included in the build
-sys.path.insert(0, 'src')
-included_packages = [
-    "aiohttp_apispec",
-    "sentry_sdk",
-    "ipv8",
-    "PIL",
-    "pkg_resources",
-    "pydantic",
-    "pyqtgraph",
-    "PyQt5.QtTest",
-    "requests",
-    "tribler.core",
-    "tribler.gui",
-    "faker"
-]
+if cx_Freeze is None:
+    # If cx_Freeze is not installed, use setuptools to build the wheel package
+    from setuptools import setup
+    app_executable = None
+    build_exe_options = {}
 
-# These files will be included in the build
-included_files = [
-    ("src/tribler/gui/qt_resources", "qt_resources"),
-    ("src/tribler/gui/images", "images"),
-    ("src/tribler/gui/i18n", "i18n"),
-    ("src/tribler/core", "tribler_source/tribler/core"),
-    ("src/tribler/gui", "tribler_source/tribler/gui"),
-    ("build/win/resources", "tribler_source/resources"),
-]
+else:
+    from cx_Freeze import setup, Executable
 
-# These packages will be excluded from the build
-excluded_packages = [
-    'wx',
-    'PyQt4',
-    'FixTk',
-    'tcl',
-    'tk',
-    '_tkinter',
-    'tkinter',
-    'Tkinter',
-    'matplotlib'
-]
+    app_name = "Tribler" if sys.platform != "linux" else "tribler"
+    app_script = "src/tribler/run.py"
+    app_icon_path = "build/win/resources/tribler.ico" if sys.platform == "win32" else "build/mac/resources/tribler.icns"
+    app_executable = Executable(
+        target_name=app_name,
+        script=app_script,
+        base="Win32GUI" if sys.platform == "win32" else None,
+        icon=app_icon_path,
+    )
 
-build_exe_options = {
-    "packages": included_packages,
-    "excludes": excluded_packages,
-    "include_files": included_files,
-    "include_msvcr": True,
-    'build_exe': 'dist/tribler'
-}
+    # These packages will be included in the build
+    sys.path.insert(0, 'src')
+    included_packages = [
+        "aiohttp_apispec",
+        "sentry_sdk",
+        "ipv8",
+        "PIL",
+        "pkg_resources",
+        "pydantic",
+        "pyqtgraph",
+        "PyQt5.QtTest",
+        "requests",
+        "tribler.core",
+        "tribler.gui",
+        "faker"
+    ]
+
+    # These files will be included in the build
+    included_files = [
+        ("src/tribler/gui/qt_resources", "qt_resources"),
+        ("src/tribler/gui/images", "images"),
+        ("src/tribler/gui/i18n", "i18n"),
+        ("src/tribler/core", "tribler_source/tribler/core"),
+        ("src/tribler/gui", "tribler_source/tribler/gui"),
+        ("build/win/resources", "tribler_source/resources"),
+    ]
+
+    # These packages will be excluded from the build
+    excluded_packages = [
+        'wx',
+        'PyQt4',
+        'FixTk',
+        'tcl',
+        'tk',
+        '_tkinter',
+        'tkinter',
+        'Tkinter',
+        'matplotlib'
+    ]
+
+    build_exe_options = {
+        "packages": included_packages,
+        "excludes": excluded_packages,
+        "include_files": included_files,
+        "include_msvcr": True,
+        'build_exe': 'dist/tribler'
+    }
 
 __all__ = ["setup", "app_executable", "build_exe_options"]

--- a/build/win/makedist_win.bat
+++ b/build/win/makedist_win.bat
@@ -67,9 +67,9 @@ REM copy C:\build\vc_redist_110.exe dist\tribler
 copy C:\build\vc_redist_140.exe dist\tribler
 
 REM Copy various libraries required on runtime (libsodium and openssl)
-copy C:\build\libsodium.dll dist\tribler
-REM Sandip, 2019-10-24: No need to copy openssl dlls separately
-REM copy C:\build\openssl\*.dll dist\tribler
+copy C:\build\libsodium.dll dist\tribler\lib
+REM Sandip, 2024-03-26: Some openssl dlls are missing so need to be copied manually.
+copy C:\build\openssl\*.dll dist\tribler\lib
 
 
 @echo Running NSIS

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from setuptools import find_packages
 
-from build import app_executable, build_exe_options, setup
+from build import setup, setup_options, setup_executables
 
 
 def read_version_from_file(file_path):
@@ -86,6 +86,6 @@ setup(
         "Topic :: Security :: Cryptography",
         "Operating System :: OS Independent",
     ],
-    options={"build_exe": build_exe_options},
-    executables=[app_executable]
+    options=setup_options,
+    executables=setup_executables
 )


### PR DESCRIPTION
- cx_Freeze build is missing openssl DLLs on windows. This PR adds these DLLs during the build process.
- It fixes the issue with building binaries and wheel using the setup.py script. Cx_Freeze does not support building wheels so build script is made conditional.