### PR TITLE
Update pytest arguments and remove forced garbage collection

### DIFF
--- a/.github/workflows/vars/pytest.env
+++ b/.github/workflows/vars/pytest.env
@@ -1,6 +1,6 @@
 PYTEST_ARGUMENTS='--randomly-seed=1 --disable-warnings --verbose --durations=3 --showlocals'
 
-PYTEST_CORE_ARGUMENTS='./src/tribler/core ${PYTEST_ARGUMENTS} --forced-gc'
+PYTEST_CORE_ARGUMENTS='./src/tribler/core ${PYTEST_ARGUMENTS}'
 PYTEST_CORE_ARGUMENTS_WIN='${PYTEST_CORE_ARGUMENTS}'
 PYTEST_CORE_ARGUMENTS_LINUX='${PYTEST_CORE_ARGUMENTS} --looptime'
 PYTEST_CORE_ARGUMENTS_MAC='${PYTEST_CORE_ARGUMENTS} --looptime'

--- a/src/tribler/core/conftest.py
+++ b/src/tribler/core/conftest.py
@@ -1,5 +1,4 @@
 import asyncio
-import gc
 import logging
 import platform
 import sys
@@ -37,10 +36,6 @@ def pytest_configure(config):
     logging.getLogger('faker.factory').propagate = False
 
 
-def pytest_addoption(parser):
-    parser.addoption("--forced-gc", action="store_true", help="Enable forced garbage collection")
-
-
 @pytest.hookimpl
 def pytest_cmdline_main(config: Config):
     """ Enable extended logging if the verbose option is used """
@@ -71,28 +66,6 @@ def pytest_runtest_protocol(item: Function, log=True, nextitem=None):
         print(f' in {duration:.3f}s ({human_readable.time_delta(total)} in total)', end='')
     else:
         yield
-
-
-@pytest.fixture(autouse=True)
-def ensure_gc(request):
-    """ Ensure that the garbage collector runs after each test.
-    This is critical for test stability as we use Libtorrent and need to ensure all its destructors are called. """
-    # For this fixture, it is necessary for it to be called as late as possible within the current test's scope.
-    # Therefore it should be placed at the first place in the "function" scope.
-    # If there are two or more autouse fixtures within this scope, the order should be explicitly set through using
-    # this fixture as a dependency.
-    # See the discussion in https://github.com/Tribler/tribler/pull/7542 for more information.
-
-    yield
-    # Without "yield" the fixture triggers the garbage collection at the beginning of the (next) test.
-    # For that reason, the errors triggered during the garbage collection phase will take place not in the erroneous
-    # test but in the randomly scheduled next test. Usually, these errors are silently suppressed, as any exception in
-    # __del__ methods is silently suppressed, but they still can somehow affect the test.
-    #
-    # By adding the yield we move the garbage collection phase to the end of the current test, to not affect the next
-    # test.
-    if request.config.getoption("--forced-gc"):
-        gc.collect()
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR fixes #7880 by disabling forced garbage collection for all core tests. Instead, forced garbage collection is applied only to the libtorrent component.