### PR TITLE
Fix flaky test `test_patched_db_session_default_duration_threshold`

### DIFF
--- a/src/tribler/core/utilities/pony_utils.py
+++ b/src/tribler/core/utilities/pony_utils.py
@@ -226,7 +226,7 @@ class TriblerDbSession(core.DBSessionContextManager):
         db_session_duration = time.time() - start_time
 
         threshold = SLOW_DB_SESSION_DURATION_THRESHOLD if self.duration_threshold is None else self.duration_threshold
-        if db_session_duration > threshold:
+        if db_session_duration >= threshold:
             self._log_warning(db_session_duration, info)
 
     @staticmethod


### PR DESCRIPTION
This PR fixes #7675. When the specified threshold is zero, not TriblerDbSession should issue a warning every time.