### PR TITLE
Update dependencies and use the latest PyInstaller version

### DIFF
--- a/build/mac/makedist_macos.sh
+++ b/build/mac/makedist_macos.sh
@@ -21,8 +21,8 @@ export RESOURCES=build/mac/resources
 
 python3 -m venv build-env
 . ./build-env/bin/activate
-python3 -m pip install pip==23.0.1 # pin pip version to avoid "--no-use-pep517" issues with the latest version
-python3 -m pip install PyInstaller==4.2 --no-use-pep517
+python3 -m pip install --upgrade pip
+python3 -m pip install PyInstaller==6.5.0
 python3 -m pip install --upgrade -r requirements-build.txt
 
 # ----- Build

--- a/build/win/makedist_win.bat
+++ b/build/win/makedist_win.bat
@@ -13,6 +13,7 @@ IF NOT EXIST build\win (
 REM locate Python directory and set up Python environment
 python3 build\win\locate-python.py > tmp_pythonhome.txt
 SET /p PYTHONHOME= < tmp_pythonhome.txt
+ECHO PYTHONHOME SET TO %PYTHONHOME%
 DEL /f /q tmp_pythonhome.txt
 REM Arno: Add . to find our core
 SET PYTHONPATH=.;%PYTHONHOME%
@@ -36,7 +37,7 @@ call build\win\clean.bat
 REM ----- Prepare venv & install dependencies before the build
 
 python3 -m venv build-env
-./build-env/Scripts/activate.bat
+build-env/Scripts/activate.bat
 python3 -m pip install --upgrade pip
 python3 -m pip install --upgrade -r requirements-build.txt
 

--- a/build/win/resources/tribler.nsi
+++ b/build/win/resources/tribler.nsi
@@ -68,7 +68,7 @@ BrandingText "${PRODUCT}"
 ;--------------------------------
 ;Modern UI Configuration
 
-!define MUI_ICON "tribler_source\resources\tribler.ico"
+!define MUI_ICON "_internal\tribler_source\resources\tribler.ico"
 !define MUI_COMPONENTSPAGE_SMALLDESC
 !define MUI_ABORTWARNING
 

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 
-PyInstaller==5.1; sys_platform != 'darwin'
+PyInstaller==6.5.0; sys_platform != 'darwin'
 
 setuptools==65.5.1; sys_platform == 'darwin'
 text-unidecode==1.3; sys_platform == 'darwin'
@@ -9,4 +9,4 @@ defusedxml==0.7.1; sys_platform == 'linux2' or sys_platform == 'linux'
 markupsafe==2.0.1; sys_platform == 'linux2' or sys_platform == 'linux'
 PyGObject==3.44.1; sys_platform == 'linux2' or sys_platform == 'linux'
 
-requests==2.25.1
+requests==2.31.0

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -1,30 +1,30 @@
-aiohttp==3.8.3
+aiohttp==3.9.3
 aiohttp-apispec==2.2.3 # keep this higher or equal to 2.2.3 https://githubhot.com/repo/maximdanilchenko/aiohttp-apispec/issues/122
-anyio==3.6.2
+anyio==3.7.1
 chardet==4.0.0
-configobj==5.0.6
-cryptography==39.0.1
+configobj==5.0.8
+cryptography==42.0.5
 decorator==5.1.0
-Faker==14.1.0
-libnacl==1.8.0
-lz4==3.1.3
-marshmallow==3.14.1
+Faker==18.11.2
+libnacl==2.1.0
+lz4==4.3.3
+marshmallow==3.21.1
 netifaces==0.11.0
-networkx==2.6.3
-pony==0.7.16
-psutil==5.8.0
-pyasn1==0.4.8
-pydantic==1.9.0
-PyOpenSSL==21.0.0
-pyyaml==6.0
-sentry-sdk==1.5.0
+networkx==3.1
+pony==0.7.17
+psutil==5.9.8
+pyasn1==0.6.0
+pydantic==1.10.15
+PyOpenSSL==24.1.0
+pyyaml==6.0.1
+sentry-sdk==1.44.1
 service-identity==21.1.0
-yappi==1.4.0
-yarl==1.7.2 # keep this dependency higher than 1.6.3. See: https://github.com/aio-libs/yarl/issues/517
-bitarray==2.5.1
+yappi==1.6.0
+yarl==1.9.4 # keep this dependency higher than 1.6.3. See: https://github.com/aio-libs/yarl/issues/517
+bitarray==2.9.2
 pyipv8==2.10.0
-libtorrent==1.2.15
-file-read-backwards==2.0.0
+libtorrent==1.2.19
+file-read-backwards==3.0.0
 Brotli==1.0.9 # to prevent AttributeError on macOs: module 'brotli' has no attribute 'error' (in urllib3.response)
-human-readable==1.3.2
+human-readable==1.3.4
 filelock==3.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 -r requirements-core.txt
 
-Pillow==9.3.0
-PyQt5==5.15.1
-PyQt5-sip==12.8.1
-pyqtgraph==0.12.3
-PyQtWebEngine==5.15.2
+Pillow==10.3.0
+PyQt5==5.15.10
+PyQt5-sip==12.13.0
+pyqtgraph==0.13.3  # The latest version that supports Python 3.8
+PyQtWebEngine==5.15.6

--- a/tribler.spec
+++ b/tribler.spec
@@ -174,5 +174,5 @@ if sys.platform == 'darwin':
 
 # On Windows 10, we have to make sure that qwindows.dll is in the right path
 if sys.platform == 'win32':
-    shutil.copytree(os.path.join('dist', 'tribler', 'PyQt5', 'Qt', 'plugins', 'platforms'),
-                    os.path.join('dist', 'tribler', 'platforms'))
+    shutil.copytree(os.path.join('dist', 'tribler', '_internal', 'PyQt5', 'Qt5', 'plugins', 'platforms'),
+                    os.path.join('dist', 'tribler', '_internal', 'platforms'))


### PR DESCRIPTION
This PR attempts to fix MacOS segfaulting by upgrading Qt-related dependencies and updating PyInstaller to the latest version.

After the installation on MacOS, it is necessary to open the terminal and perform the following command:
```
xattr -c /Applications/Tribler.app
```
Or, alternatively:
```
xattr -d com.apple.quarantine /Applications/Tribler.app
```

Without it, MacOS falsely reports that the application is corrupted, but it just means that it is not signed.