### PR TITLE
Fix coroutine stack tracking

### DIFF
--- a/src/tribler/core/utilities/slow_coro_detection/tests/test_slow_coro_detection.py
+++ b/src/tribler/core/utilities/slow_coro_detection/tests/test_slow_coro_detection.py
@@ -86,7 +86,7 @@ def test__report_freeze_first_report(logger, format_info):
     _report_freeze(handle, duration, first_report=True)
     format_info.assert_called_with(handle, include_stack=True, stack_cut_duration=pytest.approx(8.0))
     logger.error.assert_called_with(
-        'Slow coroutine is occupying the loop for 10.000 seconds already: <formatted handle>')
+        'A slow coroutine step is occupying the loop for 10.000 seconds already: <formatted handle>')
 
 
 @patch('tribler.core.utilities.slow_coro_detection.watching_thread.format_info', return_value='<formatted handle>')
@@ -98,4 +98,5 @@ def test__report_freeze_not_first_report(logger, format_info):
     _report_freeze(handle, duration, first_report=False)
     format_info.assert_called_with(handle, include_stack=True, stack_cut_duration=pytest.approx(8.0),
                                    limit=2, enable_profiling_tip=False)
-    logger.error.assert_called_with('Still executing <formatted handle>')
+    logger.error.assert_called_with(
+        'Still executing the slow coroutine step for 10.000 seconds already: <formatted handle>')

--- a/src/tribler/core/utilities/slow_coro_detection/watching_thread.py
+++ b/src/tribler/core/utilities/slow_coro_detection/watching_thread.py
@@ -88,9 +88,9 @@ def _report_freeze(handle: Handle, duration: float, first_report: bool):
 
     if first_report:
         info_str = format_info(handle, include_stack=True, stack_cut_duration=stack_cut_duration)
-        logger.error(f'Slow coroutine is occupying the loop for {duration:.3f} seconds already: {info_str}')
+        logger.error(f'A slow coroutine step is occupying the loop for {duration:.3f} seconds already: {info_str}')
         return
 
     info_str = format_info(handle, include_stack=True, stack_cut_duration=stack_cut_duration, limit=2,
                            enable_profiling_tip=False)
-    logger.error(f"Still executing {info_str}")
+    logger.error(f"Still executing the slow coroutine step for {duration:.3f} seconds already: {info_str}")


### PR DESCRIPTION
This PR fixes the logic of stack tracing for coroutines.

Python asyncio logic uses some optimizations when handling tasks and replaces the reference to the `Task._wakeup()` method with instances of C classes `TaskWakeupMethWrapper` or `task_wakeup`, depending on the Python version. It should be taken into account when determining whether the current handle relates to a task.

Also, the PR shows the exact duration for long coroutine steps.