### PR TITLE
Show Tribler source lines in traceback when running Tribler binary

### DIFF
--- a/src/run_tribler.py
+++ b/src/run_tribler.py
@@ -11,6 +11,7 @@ import encodings.idna  # pylint: disable=unused-import
 
 from tribler.core.sentry_reporter.sentry_reporter import SentryReporter, SentryStrategy
 from tribler.core.sentry_reporter.sentry_scrubber import SentryScrubber
+from tribler.core.utilities import linecache_patch
 from tribler.core.utilities.asyncio_fixes.finish_accept_patch import apply_finish_accept_patch
 from tribler.core.utilities.slow_coro_detection.main_thread_stack_tracking import start_main_thread_stack_tracing
 from tribler.core.utilities.osutils import get_root_state_directory
@@ -77,6 +78,7 @@ def init_boot_logger():
 
 
 def main():
+    linecache_patch.patch()
     init_boot_logger()
 
     parsed_args = RunTriblerArgsParser().parse_args()

--- a/src/tribler/core/utilities/linecache_patch.py
+++ b/src/tribler/core/utilities/linecache_patch.py
@@ -1,0 +1,25 @@
+import linecache
+import sys
+
+original_updatecache = linecache.updatecache
+
+
+def patched_updatecache(filename, *args, **kwargs):
+    if getattr(sys, 'frozen', False):
+        # When Tribler runs from a bundle, Tribler sources are available inside the `tribler_source` subfolder
+        if filename.startswith('src\\tribler'):  # Relative path with cx_freeze on Windows
+            filename = 'tribler_source' + filename[3:]  # Replacing `src\\` -> `tribler_source\\`
+        elif filename.startswith('tribler/'):  # Relative path with PyInstaller on Mac/Linux:
+            filename = 'tribler_source/' + filename  # Appending `tribler_source/` to the relative path
+    result = original_updatecache(filename, *args, **kwargs)
+    return result
+
+
+patched_updatecache.patched = True
+
+
+def patch():
+    if getattr(linecache.updatecache, 'patched', False):
+        return
+
+    linecache.updatecache = patched_updatecache

--- a/src/tribler/core/utilities/tests/test_linecache_patch.py
+++ b/src/tribler/core/utilities/tests/test_linecache_patch.py
@@ -1,0 +1,36 @@
+from unittest.mock import Mock, patch
+
+from tribler.core.utilities import linecache_patch
+
+
+def original_updatecache_mock(filename, *args, **kwargs):
+    return [filename]  # as if file consist of a single line that equal to the filename
+
+
+@patch('tribler.core.utilities.linecache_patch.original_updatecache', original_updatecache_mock)
+@patch('sys.frozen', False, create=True)
+def test_not_frozen():
+    assert linecache_patch.patched_updatecache('src\\tribler\\path') == ['src\\tribler\\path']
+    assert linecache_patch.patched_updatecache('tribler/path') == ['tribler/path']
+    assert linecache_patch.patched_updatecache('other/path') == ['other/path']
+
+
+@patch('tribler.core.utilities.linecache_patch.original_updatecache', original_updatecache_mock)
+@patch('sys.frozen', True, create=True)
+def test_frozen():
+    assert linecache_patch.patched_updatecache('src\\tribler\\path') == ['tribler_source\\tribler\\path']
+    assert linecache_patch.patched_updatecache('tribler/path') == ['tribler_source/tribler/path']
+    assert linecache_patch.patched_updatecache('other/path') == ['other/path']
+
+
+@patch('tribler.core.utilities.linecache_patch.linecache')
+def test_patch(linecache_mock):
+    _original_updatecache_mock = Mock(patched=True)
+    linecache_mock.updatecache = _original_updatecache_mock
+
+    linecache_patch.patch()
+    assert linecache_mock.updatecache is _original_updatecache_mock  # already patched, no second time patch
+
+    _original_updatecache_mock.patched = False
+    linecache_patch.patch()
+    assert linecache_mock.updatecache is linecache_patch.patched_updatecache


### PR DESCRIPTION
When Tribler binary encounters an error, it currently displays traceback with file names and line numbers only, without the actual source lines, like that:
```
  File "C:\dev\tribler\src\run_tribler.py", line 124, in <module>
  File "C:\dev\tribler\src\run_tribler.py", line 120, in main
  File "C:\dev\tribler\src\tribler\gui\start_gui.py", line 77, in run_gui
  File "C:\dev\tribler\src\tribler\gui\tribler_window.py", line 236, in __init__

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "C:\dev\tribler\src\tribler\gui\utilities.py", line 455, in trackback_wrapper
  File "C:\dev\tribler\src\tribler\gui\utilities.py", line 452, in trackback_wrapper
  File "C:\dev\tribler\src\tribler\gui\tribler_window.py", line 361, in on_test_tribler_gui_exception
tribler.gui.exceptions.TriblerGuiTestException: Tribler GUI Test Exception
```

The traceback misses source lines because the `linecache` module cannot find source files to display the actual source lines. Usually, a binary compiled with `PyInstaller` or `cx_freeze` includes only `.pyc` files, so finding corresponding source lines is impossible. However, Tribler includes Python files inside the `tribler_source` subfolder. This allows source lines to be displayed for files in the `tribler_source` subfolder. For that, we need a small patch for the `linecache` module that fixes relative file names so it becomes possible to find the corresponding file.

With this patch applied, tracebacks in Sentry reports show actual source lines, which makes it easier to understand the reason for the error:
```
  File "C:\dev\tribler\src\run_tribler.py", line 124, in <module>
    main()
  File "C:\dev\tribler\src\run_tribler.py", line 120, in main
    run_gui(api_port, api_key, root_state_dir, parsed_args)
  File "C:\dev\tribler\src\tribler\gui\start_gui.py", line 77, in run_gui
    window = TriblerWindow(process_manager, app_manager, settings, root_state_dir,
  File "C:\dev\tribler\src\tribler\gui\tribler_window.py", line 236, in __init__
    connect(self.tribler_gui_test_exception_shortcut.activated, self.on_test_tribler_gui_exception)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "C:\dev\tribler\src\tribler\gui\utilities.py", line 455, in trackback_wrapper
    raise exc from CreationTraceback(traceback_str)
  File "C:\dev\tribler\src\tribler\gui\utilities.py", line 452, in trackback_wrapper
    callback(*args, **kwargs)
  File "C:\dev\tribler\src\tribler\gui\tribler_window.py", line 361, in on_test_tribler_gui_exception
    raise TriblerGuiTestException("Tribler GUI Test Exception")
tribler.gui.exceptions.TriblerGuiTestException: Tribler GUI Test Exception
```

This patch is not necessary, but it makes analyzing tracebacks easier.