### PR TITLE
Fix corrupted "add torrent" layout

### DIFF
--- a/src/tribler/gui/qt_resources/mainwindow.ui
+++ b/src/tribler/gui/qt_resources/mainwindow.ui
@@ -273,34 +273,27 @@ color: #eee;</string>
 									<bool>false</bool>
 								</property>
 								<property name="styleSheet">
-									<string notr="true">QWidget {
-background-color: #202020;
+									<string notr="true">
+QWidget {
+	background-color: #202020;
+	font-size: 14px;
+	color: white;
+	text-align: left;
 }
 
 QPushButton {
-color: #B5B5B5;
-border: none;
-background: none;
-text-align: left;
-font-size: 14px;
-padding-left: 20px;
-border-left: 4px solid transparent;
-}
-
-QPushButton::hover {
-color: white;
+	color: #B5B5B5;
+	border: none;
+	background: none;
+	padding-left: 20px;
+	border-left: 4px solid transparent;
 }
 
 QPushButton::checked {
-border-left: 4px solid #e67300;
-color: white;
+	border-left: 4px solid #e67300;
+	color: white;
 }
-
-QLabel{
-padding-left:20px;
-color: #B5B5B5;
-}
-</string>
+									</string>
 								</property>
 								<layout class="QVBoxLayout" name="verticalLayout_2">
 									<property name="spacing">
@@ -310,7 +303,7 @@ color: #B5B5B5;
 										<number>0</number>
 									</property>
 									<item>
-										<widget class="QPushButton" name="add_torrent_button">
+										<widget class="QToolButton" name="add_torrent_button">
 											<property name="sizePolicy">
 												<sizepolicy hsizetype="Preferred" vsizetype="Fixed">
 													<horstretch>0</horstretch>
@@ -327,17 +320,21 @@ color: #B5B5B5;
 												<cursorShape>PointingHandCursor</cursorShape>
 											</property>
 											<property name="styleSheet">
-												<string notr="true">QPushButton#add_torrent_button {
+												<string notr="true">
+QToolButton#add_torrent_button {
     border-style: outset;
-    border-width: 2px;
+    border-width: 1px;
     border-radius: 15px;
     border-color: grey;
-    padding-left: 5px;
-    margin-left: 17px;
-    margin-right: 30px;
-    font: bold;
+    margin-left: 15px;
+    padding-left: 10px;
+    margin-right: 10px;
 }
-QPushButton::menu-indicator{width:0px;}</string>
+QToolButton::menu-indicator {
+    image: none;
+	width: 0px;
+}
+                                                </string>
 											</property>
 											<property name="text">
 												<string>Add torrent</string>
@@ -349,12 +346,15 @@ QPushButton::menu-indicator{width:0px;}</string>
 											</property>
 											<property name="iconSize">
 												<size>
-													<width>16</width>
-													<height>16</height>
+													<width>15</width>
+													<height>15</height>
 												</size>
 											</property>
-											<property name="flat">
-												<bool>true</bool>
+											<property name="toolButtonStyle">
+												<enum>Qt::ToolButtonTextBesideIcon</enum>
+											</property>
+											<property name="popupMode">
+												<enum>QToolButton::InstantPopup</enum>
 											</property>
 										</widget>
 									</item>
@@ -425,7 +425,7 @@ QPushButton::menu-indicator{width:0px;}</string>
 											<property name="sizeHint" stdset="0">
 												<size>
 													<width>20</width>
-													<height>14</height>
+													<height>5</height>
 												</size>
 											</property>
 										</spacer>

--- a/src/tribler/gui/qt_resources/mainwindow.ui
+++ b/src/tribler/gui/qt_resources/mainwindow.ui
@@ -1,26 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>MainWindow</class>
- <widget class="QMainWindow" name="MainWindow">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>1058</width>
-    <height>867</height>
-   </rect>
-  </property>
-  <property name="sizePolicy">
-   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-    <horstretch>0</horstretch>
-    <verstretch>0</verstretch>
-   </sizepolicy>
-  </property>
-  <property name="windowTitle">
-   <string notr="true">MainWindow</string>
-  </property>
-  <property name="styleSheet">
-   <string notr="true">QWidget{
+	<class>MainWindow</class>
+	<widget class="QMainWindow" name="MainWindow">
+		<property name="geometry">
+			<rect>
+				<x>0</x>
+				<y>0</y>
+				<width>1058</width>
+				<height>867</height>
+			</rect>
+		</property>
+		<property name="sizePolicy">
+			<sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+				<horstretch>0</horstretch>
+				<verstretch>0</verstretch>
+			</sizepolicy>
+		</property>
+		<property name="windowTitle">
+			<string notr="true">MainWindow</string>
+		</property>
+		<property name="styleSheet">
+			<string notr="true">QWidget{
 color:white;
 }
 
@@ -107,10 +107,10 @@ padding: 4px;
 
 
 </string>
-  </property>
-  <widget class="QWidget" name="central_widget">
-   <property name="styleSheet">
-    <string notr="true">QWidget {
+		</property>
+		<widget class="QWidget" name="central_widget">
+			<property name="styleSheet">
+				<string notr="true">QWidget {
 background-color: #282828;}
 
 TabButtonPanel UnderlineTabButton{
@@ -159,121 +159,121 @@ padding: 4px;
 
 
 </string>
-   </property>
-   <layout class="QGridLayout" name="gridLayout">
-    <property name="leftMargin">
-     <number>0</number>
-    </property>
-    <property name="topMargin">
-     <number>0</number>
-    </property>
-    <property name="rightMargin">
-     <number>0</number>
-    </property>
-    <property name="bottomMargin">
-     <number>0</number>
-    </property>
-    <property name="verticalSpacing">
-     <number>0</number>
-    </property>
-    <item row="1" column="0">
-     <widget class="QWidget" name="tribler_status_bar" native="true">
-      <property name="styleSheet">
-       <string notr="true">background-color: #cc6600;
+			</property>
+			<layout class="QGridLayout" name="gridLayout">
+				<property name="leftMargin">
+					<number>0</number>
+				</property>
+				<property name="topMargin">
+					<number>0</number>
+				</property>
+				<property name="rightMargin">
+					<number>0</number>
+				</property>
+				<property name="bottomMargin">
+					<number>0</number>
+				</property>
+				<property name="verticalSpacing">
+					<number>0</number>
+				</property>
+				<item row="1" column="0">
+					<widget class="QWidget" name="tribler_status_bar" native="true">
+						<property name="styleSheet">
+							<string notr="true">background-color: #cc6600;
 color: #eee;</string>
-      </property>
-      <layout class="QHBoxLayout" name="horizontalLayout_55">
-       <property name="spacing">
-        <number>0</number>
-       </property>
-       <property name="leftMargin">
-        <number>0</number>
-       </property>
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <property name="rightMargin">
-        <number>0</number>
-       </property>
-       <property name="bottomMargin">
-        <number>0</number>
-       </property>
-       <item>
-        <widget class="QLabel" name="tribler_status_bar_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>30</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>16777215</width>
-           <height>30</height>
-          </size>
-         </property>
-         <property name="styleSheet">
-          <string notr="true">font-size: 14px;</string>
-         </property>
-         <property name="text">
-          <string>Transaction in progress, Please don't close Tribler.</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-    </item>
-    <item row="2" column="0">
-     <layout class="QHBoxLayout" name="central_h_layout">
-      <property name="spacing">
-       <number>0</number>
-      </property>
-      <property name="leftMargin">
-       <number>0</number>
-      </property>
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>0</number>
-      </property>
-      <item>
-       <widget class="QWidget" name="left_menu" native="true">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>200</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>180</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="autoFillBackground">
-         <bool>false</bool>
-        </property>
-        <property name="styleSheet">
-         <string notr="true">QWidget {
+						</property>
+						<layout class="QHBoxLayout" name="horizontalLayout_55">
+							<property name="spacing">
+								<number>0</number>
+							</property>
+							<property name="leftMargin">
+								<number>0</number>
+							</property>
+							<property name="topMargin">
+								<number>0</number>
+							</property>
+							<property name="rightMargin">
+								<number>0</number>
+							</property>
+							<property name="bottomMargin">
+								<number>0</number>
+							</property>
+							<item>
+								<widget class="QLabel" name="tribler_status_bar_label">
+									<property name="sizePolicy">
+										<sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+											<horstretch>0</horstretch>
+											<verstretch>0</verstretch>
+										</sizepolicy>
+									</property>
+									<property name="minimumSize">
+										<size>
+											<width>0</width>
+											<height>30</height>
+										</size>
+									</property>
+									<property name="maximumSize">
+										<size>
+											<width>16777215</width>
+											<height>30</height>
+										</size>
+									</property>
+									<property name="styleSheet">
+										<string notr="true">font-size: 14px;</string>
+									</property>
+									<property name="text">
+										<string>Transaction in progress, Please don't close Tribler.</string>
+									</property>
+									<property name="alignment">
+										<set>Qt::AlignCenter</set>
+									</property>
+								</widget>
+							</item>
+						</layout>
+					</widget>
+				</item>
+				<item row="2" column="0">
+					<layout class="QHBoxLayout" name="central_h_layout">
+						<property name="spacing">
+							<number>0</number>
+						</property>
+						<property name="leftMargin">
+							<number>0</number>
+						</property>
+						<property name="topMargin">
+							<number>0</number>
+						</property>
+						<property name="rightMargin">
+							<number>0</number>
+						</property>
+						<property name="bottomMargin">
+							<number>0</number>
+						</property>
+						<item>
+							<widget class="QWidget" name="left_menu" native="true">
+								<property name="sizePolicy">
+									<sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+										<horstretch>0</horstretch>
+										<verstretch>0</verstretch>
+									</sizepolicy>
+								</property>
+								<property name="minimumSize">
+									<size>
+										<width>200</width>
+										<height>0</height>
+									</size>
+								</property>
+								<property name="maximumSize">
+									<size>
+										<width>180</width>
+										<height>16777215</height>
+									</size>
+								</property>
+								<property name="autoFillBackground">
+									<bool>false</bool>
+								</property>
+								<property name="styleSheet">
+									<string notr="true">QWidget {
 background-color: #202020;
 }
 
@@ -301,33 +301,33 @@ padding-left:20px;
 color: #B5B5B5;
 }
 </string>
-        </property>
-        <layout class="QVBoxLayout" name="verticalLayout_2">
-         <property name="spacing">
-          <number>10</number>
-         </property>
-         <property name="leftMargin">
-          <number>0</number>
-         </property>
-         <item>
-          <widget class="QPushButton" name="add_torrent_button">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>0</width>
-             <height>38</height>
-            </size>
-           </property>
-           <property name="cursor">
-            <cursorShape>PointingHandCursor</cursorShape>
-           </property>
-           <property name="styleSheet">
-            <string notr="true">QPushButton#add_torrent_button {
+								</property>
+								<layout class="QVBoxLayout" name="verticalLayout_2">
+									<property name="spacing">
+										<number>10</number>
+									</property>
+									<property name="leftMargin">
+										<number>0</number>
+									</property>
+									<item>
+										<widget class="QPushButton" name="add_torrent_button">
+											<property name="sizePolicy">
+												<sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+													<horstretch>0</horstretch>
+													<verstretch>0</verstretch>
+												</sizepolicy>
+											</property>
+											<property name="minimumSize">
+												<size>
+													<width>0</width>
+													<height>38</height>
+												</size>
+											</property>
+											<property name="cursor">
+												<cursorShape>PointingHandCursor</cursorShape>
+											</property>
+											<property name="styleSheet">
+												<string notr="true">QPushButton#add_torrent_button {
     border-style: outset;
     border-width: 2px;
     border-radius: 15px;
@@ -338,635 +338,638 @@ color: #B5B5B5;
     font: bold;
 }
 QPushButton::menu-indicator{width:0px;}</string>
-           </property>
-           <property name="text">
-            <string>Add torrent</string>
-           </property>
-           <property name="icon">
-            <iconset>
-             <normaloff>../images/add.png</normaloff>../images/add.png</iconset>
-           </property>
-           <property name="iconSize">
-            <size>
-             <width>16</width>
-             <height>16</height>
-            </size>
-           </property>
-           <property name="flat">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <spacer name="downloads_button_spacer">
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
-           </property>
-           <property name="sizeType">
-            <enum>QSizePolicy::Fixed</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>14</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
-          <widget class="QPushButton" name="left_menu_button_downloads">
-           <property name="minimumSize">
-            <size>
-             <width>0</width>
-             <height>26</height>
-            </size>
-           </property>
-           <property name="cursor">
-            <cursorShape>PointingHandCursor</cursorShape>
-           </property>
-           <property name="focusPolicy">
-            <enum>Qt::NoFocus</enum>
-           </property>
-           <property name="styleSheet">
-            <string notr="true"/>
-           </property>
-           <property name="text">
-            <string> Downloads</string>
-           </property>
-           <property name="icon">
-            <iconset>
-             <normaloff>../images/downloads.png</normaloff>
-             <disabledon>../images/downloads.png</disabledon>../images/downloads.png</iconset>
-           </property>
-           <property name="iconSize">
-            <size>
-             <width>16</width>
-             <height>16</height>
-            </size>
-           </property>
-           <property name="checkable">
-            <bool>true</bool>
-           </property>
-           <property name="flat">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <spacer name="torrents_buttons_spacer">
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
-           </property>
-           <property name="sizeType">
-            <enum>QSizePolicy::Fixed</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>14</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
-          <widget class="QPushButton" name="left_menu_button_popular">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>0</width>
-             <height>26</height>
-            </size>
-           </property>
-           <property name="cursor">
-            <cursorShape>PointingHandCursor</cursorShape>
-           </property>
-           <property name="focusPolicy">
-            <enum>Qt::NoFocus</enum>
-           </property>
-           <property name="text">
-            <string> Popular</string>
-           </property>
-           <property name="icon">
-            <iconset>
-             <normaloff>../images/fire.png</normaloff>
-             <disabledoff>../images/fire.png</disabledoff>
-             <disabledon>../images/fire.png</disabledon>../images/fire.png</iconset>
-           </property>
-           <property name="iconSize">
-            <size>
-             <width>16</width>
-             <height>16</height>
-            </size>
-           </property>
-           <property name="checkable">
-            <bool>true</bool>
-           </property>
-           <property name="flat">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <spacer name="verticalSpacer">
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
-           </property>
-           <property name="sizeType">
-            <enum>QSizePolicy::Expanding</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>40</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item>
-       <widget class="QStackedWidget" name="stackedWidget">
-        <property name="currentIndex">
-         <number>2</number>
-        </property>
-        <widget class="SearchResultsWidget" name="search_results_page"/>
-        <widget class="SettingsPage" name="settings_page">
-         <layout class="QVBoxLayout" name="verticalLayout">
-          <property name="spacing">
-           <number>0</number>
-          </property>
-          <property name="leftMargin">
-           <number>0</number>
-          </property>
-          <property name="topMargin">
-           <number>0</number>
-          </property>
-          <property name="rightMargin">
-           <number>0</number>
-          </property>
-          <property name="bottomMargin">
-           <number>0</number>
-          </property>
-          <item>
-           <widget class="QWidget" name="settings_header_label" native="true">
-            <layout class="QHBoxLayout" name="horizontalLayout_2">
-             <property name="spacing">
-              <number>0</number>
-             </property>
-             <property name="leftMargin">
-              <number>0</number>
-             </property>
-             <property name="topMargin">
-              <number>0</number>
-             </property>
-             <property name="rightMargin">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
-              <number>0</number>
-             </property>
-             <item>
-              <widget class="QLabel" name="label">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="minimumSize">
-                <size>
-                 <width>0</width>
-                 <height>50</height>
-                </size>
-               </property>
-               <property name="maximumSize">
-                <size>
-                 <width>16777215</width>
-                 <height>50</height>
-                </size>
-               </property>
-               <property name="styleSheet">
-                <string notr="true">color: #eee;
+											</property>
+											<property name="text">
+												<string>Add torrent</string>
+											</property>
+											<property name="icon">
+												<iconset>
+													<normaloff>../images/add.png</normaloff>../images/add.png
+												</iconset>
+											</property>
+											<property name="iconSize">
+												<size>
+													<width>16</width>
+													<height>16</height>
+												</size>
+											</property>
+											<property name="flat">
+												<bool>true</bool>
+											</property>
+										</widget>
+									</item>
+									<item>
+										<spacer name="downloads_button_spacer">
+											<property name="orientation">
+												<enum>Qt::Vertical</enum>
+											</property>
+											<property name="sizeType">
+												<enum>QSizePolicy::Fixed</enum>
+											</property>
+											<property name="sizeHint" stdset="0">
+												<size>
+													<width>20</width>
+													<height>14</height>
+												</size>
+											</property>
+										</spacer>
+									</item>
+									<item>
+										<widget class="QPushButton" name="left_menu_button_downloads">
+											<property name="minimumSize">
+												<size>
+													<width>0</width>
+													<height>26</height>
+												</size>
+											</property>
+											<property name="cursor">
+												<cursorShape>PointingHandCursor</cursorShape>
+											</property>
+											<property name="focusPolicy">
+												<enum>Qt::NoFocus</enum>
+											</property>
+											<property name="styleSheet">
+												<string notr="true"/>
+											</property>
+											<property name="text">
+												<string> Downloads</string>
+											</property>
+											<property name="icon">
+												<iconset>
+													<normaloff>../images/downloads.png</normaloff>
+													<disabledon>../images/downloads.png</disabledon>../images/downloads.png
+												</iconset>
+											</property>
+											<property name="iconSize">
+												<size>
+													<width>16</width>
+													<height>16</height>
+												</size>
+											</property>
+											<property name="checkable">
+												<bool>true</bool>
+											</property>
+											<property name="flat">
+												<bool>true</bool>
+											</property>
+										</widget>
+									</item>
+									<item>
+										<spacer name="torrents_buttons_spacer">
+											<property name="orientation">
+												<enum>Qt::Vertical</enum>
+											</property>
+											<property name="sizeType">
+												<enum>QSizePolicy::Fixed</enum>
+											</property>
+											<property name="sizeHint" stdset="0">
+												<size>
+													<width>20</width>
+													<height>14</height>
+												</size>
+											</property>
+										</spacer>
+									</item>
+									<item>
+										<widget class="QPushButton" name="left_menu_button_popular">
+											<property name="sizePolicy">
+												<sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+													<horstretch>0</horstretch>
+													<verstretch>0</verstretch>
+												</sizepolicy>
+											</property>
+											<property name="minimumSize">
+												<size>
+													<width>0</width>
+													<height>26</height>
+												</size>
+											</property>
+											<property name="cursor">
+												<cursorShape>PointingHandCursor</cursorShape>
+											</property>
+											<property name="focusPolicy">
+												<enum>Qt::NoFocus</enum>
+											</property>
+											<property name="text">
+												<string> Popular</string>
+											</property>
+											<property name="icon">
+												<iconset>
+													<normaloff>../images/fire.png</normaloff>
+													<disabledoff>../images/fire.png</disabledoff>
+													<disabledon>../images/fire.png</disabledon>../images/fire.png
+												</iconset>
+											</property>
+											<property name="iconSize">
+												<size>
+													<width>16</width>
+													<height>16</height>
+												</size>
+											</property>
+											<property name="checkable">
+												<bool>true</bool>
+											</property>
+											<property name="flat">
+												<bool>true</bool>
+											</property>
+										</widget>
+									</item>
+									<item>
+										<spacer name="verticalSpacer">
+											<property name="orientation">
+												<enum>Qt::Vertical</enum>
+											</property>
+											<property name="sizeType">
+												<enum>QSizePolicy::Expanding</enum>
+											</property>
+											<property name="sizeHint" stdset="0">
+												<size>
+													<width>20</width>
+													<height>40</height>
+												</size>
+											</property>
+										</spacer>
+									</item>
+								</layout>
+							</widget>
+						</item>
+						<item>
+							<widget class="QStackedWidget" name="stackedWidget">
+								<property name="currentIndex">
+									<number>2</number>
+								</property>
+								<widget class="SearchResultsWidget" name="search_results_page"/>
+								<widget class="SettingsPage" name="settings_page">
+									<layout class="QVBoxLayout" name="verticalLayout">
+										<property name="spacing">
+											<number>0</number>
+										</property>
+										<property name="leftMargin">
+											<number>0</number>
+										</property>
+										<property name="topMargin">
+											<number>0</number>
+										</property>
+										<property name="rightMargin">
+											<number>0</number>
+										</property>
+										<property name="bottomMargin">
+											<number>0</number>
+										</property>
+										<item>
+											<widget class="QWidget" name="settings_header_label" native="true">
+												<layout class="QHBoxLayout" name="horizontalLayout_2">
+													<property name="spacing">
+														<number>0</number>
+													</property>
+													<property name="leftMargin">
+														<number>0</number>
+													</property>
+													<property name="topMargin">
+														<number>0</number>
+													</property>
+													<property name="rightMargin">
+														<number>0</number>
+													</property>
+													<property name="bottomMargin">
+														<number>0</number>
+													</property>
+													<item>
+														<widget class="QLabel" name="label">
+															<property name="sizePolicy">
+																<sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+																	<horstretch>0</horstretch>
+																	<verstretch>0</verstretch>
+																</sizepolicy>
+															</property>
+															<property name="minimumSize">
+																<size>
+																	<width>0</width>
+																	<height>50</height>
+																</size>
+															</property>
+															<property name="maximumSize">
+																<size>
+																	<width>16777215</width>
+																	<height>50</height>
+																</size>
+															</property>
+															<property name="styleSheet">
+																<string notr="true">color: #eee;
 background-color: transparent;
 font-size: 20px;
 font-weight: bold;
 margin: 10px;</string>
-               </property>
-               <property name="text">
-                <string>Settings</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="EllipseButton" name="settings_save_button">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="minimumSize">
-                <size>
-                 <width>42</width>
-                 <height>24</height>
-                </size>
-               </property>
-               <property name="cursor">
-                <cursorShape>PointingHandCursor</cursorShape>
-               </property>
-               <property name="styleSheet">
-                <string notr="true"/>
-               </property>
-               <property name="text">
-                <string>SAVE</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <spacer name="horizontalSpacer_42">
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-               <property name="sizeType">
-                <enum>QSizePolicy::Fixed</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>10</width>
-                 <height>20</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item>
-           <widget class="TabButtonPanel" name="settings_tab" native="true">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>0</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="styleSheet">
-             <string notr="true"/>
-            </property>
-            <layout class="QHBoxLayout" name="horizontalLayout_9">
-             <property name="spacing">
-              <number>0</number>
-             </property>
-             <property name="leftMargin">
-              <number>0</number>
-             </property>
-             <property name="topMargin">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
-              <number>0</number>
-             </property>
-             <item>
-              <spacer name="horizontalSpacer_11">
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-               <property name="sizeType">
-                <enum>QSizePolicy::Fixed</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>10</width>
-                 <height>20</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-             <item>
-              <widget class="UnderlineTabButton" name="settings_general_button">
-               <property name="enabled">
-                <bool>false</bool>
-               </property>
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="minimumSize">
-                <size>
-                 <width>0</width>
-                 <height>36</height>
-                </size>
-               </property>
-               <property name="maximumSize">
-                <size>
-                 <width>16777215</width>
-                 <height>36</height>
-                </size>
-               </property>
-               <property name="cursor">
-                <cursorShape>PointingHandCursor</cursorShape>
-               </property>
-               <property name="styleSheet">
-                <string notr="true"/>
-               </property>
-               <property name="text">
-                <string>GENERAL</string>
-               </property>
-               <property name="checkable">
-                <bool>true</bool>
-               </property>
-               <property name="checked">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="UnderlineTabButton" name="settings_connection_button">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="minimumSize">
-                <size>
-                 <width>0</width>
-                 <height>36</height>
-                </size>
-               </property>
-               <property name="maximumSize">
-                <size>
-                 <width>16777215</width>
-                 <height>36</height>
-                </size>
-               </property>
-               <property name="cursor">
-                <cursorShape>PointingHandCursor</cursorShape>
-               </property>
-               <property name="styleSheet">
-                <string notr="true"/>
-               </property>
-               <property name="text">
-                <string>CONNECTION</string>
-               </property>
-               <property name="checkable">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="UnderlineTabButton" name="settings_bandwidth_button">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="minimumSize">
-                <size>
-                 <width>0</width>
-                 <height>36</height>
-                </size>
-               </property>
-               <property name="maximumSize">
-                <size>
-                 <width>16777215</width>
-                 <height>36</height>
-                </size>
-               </property>
-               <property name="cursor">
-                <cursorShape>PointingHandCursor</cursorShape>
-               </property>
-               <property name="styleSheet">
-                <string notr="true"/>
-               </property>
-               <property name="text">
-                <string>BANDWIDTH</string>
-               </property>
-               <property name="checkable">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="UnderlineTabButton" name="settings_seeding_button">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="minimumSize">
-                <size>
-                 <width>0</width>
-                 <height>36</height>
-                </size>
-               </property>
-               <property name="cursor">
-                <cursorShape>PointingHandCursor</cursorShape>
-               </property>
-               <property name="styleSheet">
-                <string notr="true"/>
-               </property>
-               <property name="text">
-                <string>SEEDING</string>
-               </property>
-               <property name="checkable">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="UnderlineTabButton" name="settings_anonymity_button">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="minimumSize">
-                <size>
-                 <width>0</width>
-                 <height>36</height>
-                </size>
-               </property>
-               <property name="maximumSize">
-                <size>
-                 <width>16777215</width>
-                 <height>36</height>
-                </size>
-               </property>
-               <property name="cursor">
-                <cursorShape>PointingHandCursor</cursorShape>
-               </property>
-               <property name="styleSheet">
-                <string notr="true"/>
-               </property>
-               <property name="text">
-                <string>ANONYMITY</string>
-               </property>
-               <property name="checkable">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="UnderlineTabButton" name="settings_data_button">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="minimumSize">
-                <size>
-                 <width>0</width>
-                 <height>36</height>
-                </size>
-               </property>
-               <property name="maximumSize">
-                <size>
-                 <width>16777215</width>
-                 <height>36</height>
-                </size>
-               </property>
-               <property name="cursor">
-                <cursorShape>PointingHandCursor</cursorShape>
-               </property>
-               <property name="styleSheet">
-                <string notr="true"/>
-               </property>
-               <property name="text">
-                <string>DATA</string>
-               </property>
-               <property name="checkable">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="UnderlineTabButton" name="settings_debug_button">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="minimumSize">
-                <size>
-                 <width>0</width>
-                 <height>36</height>
-                </size>
-               </property>
-               <property name="maximumSize">
-                <size>
-                 <width>16777215</width>
-                 <height>36</height>
-                </size>
-               </property>
-               <property name="cursor">
-                <cursorShape>PointingHandCursor</cursorShape>
-               </property>
-               <property name="styleSheet">
-                <string notr="true"/>
-               </property>
-               <property name="text">
-                <string>DEBUG</string>
-               </property>
-               <property name="checkable">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <spacer name="horizontalSpacer_10">
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>40</width>
-                 <height>20</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item>
-           <widget class="QScrollArea" name="scrollArea">
-            <property name="styleSheet">
-             <string notr="true">QScrollArea {
+															</property>
+															<property name="text">
+																<string>Settings</string>
+															</property>
+														</widget>
+													</item>
+													<item>
+														<widget class="EllipseButton" name="settings_save_button">
+															<property name="sizePolicy">
+																<sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+																	<horstretch>0</horstretch>
+																	<verstretch>0</verstretch>
+																</sizepolicy>
+															</property>
+															<property name="minimumSize">
+																<size>
+																	<width>42</width>
+																	<height>24</height>
+																</size>
+															</property>
+															<property name="cursor">
+																<cursorShape>PointingHandCursor</cursorShape>
+															</property>
+															<property name="styleSheet">
+																<string notr="true"/>
+															</property>
+															<property name="text">
+																<string>SAVE</string>
+															</property>
+														</widget>
+													</item>
+													<item>
+														<spacer name="horizontalSpacer_42">
+															<property name="orientation">
+																<enum>Qt::Horizontal</enum>
+															</property>
+															<property name="sizeType">
+																<enum>QSizePolicy::Fixed</enum>
+															</property>
+															<property name="sizeHint" stdset="0">
+																<size>
+																	<width>10</width>
+																	<height>20</height>
+																</size>
+															</property>
+														</spacer>
+													</item>
+												</layout>
+											</widget>
+										</item>
+										<item>
+											<widget class="TabButtonPanel" name="settings_tab" native="true">
+												<property name="sizePolicy">
+													<sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+														<horstretch>0</horstretch>
+														<verstretch>0</verstretch>
+													</sizepolicy>
+												</property>
+												<property name="minimumSize">
+													<size>
+														<width>0</width>
+														<height>0</height>
+													</size>
+												</property>
+												<property name="styleSheet">
+													<string notr="true"/>
+												</property>
+												<layout class="QHBoxLayout" name="horizontalLayout_9">
+													<property name="spacing">
+														<number>0</number>
+													</property>
+													<property name="leftMargin">
+														<number>0</number>
+													</property>
+													<property name="topMargin">
+														<number>0</number>
+													</property>
+													<property name="bottomMargin">
+														<number>0</number>
+													</property>
+													<item>
+														<spacer name="horizontalSpacer_11">
+															<property name="orientation">
+																<enum>Qt::Horizontal</enum>
+															</property>
+															<property name="sizeType">
+																<enum>QSizePolicy::Fixed</enum>
+															</property>
+															<property name="sizeHint" stdset="0">
+																<size>
+																	<width>10</width>
+																	<height>20</height>
+																</size>
+															</property>
+														</spacer>
+													</item>
+													<item>
+														<widget class="UnderlineTabButton" name="settings_general_button">
+															<property name="enabled">
+																<bool>false</bool>
+															</property>
+															<property name="sizePolicy">
+																<sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+																	<horstretch>0</horstretch>
+																	<verstretch>0</verstretch>
+																</sizepolicy>
+															</property>
+															<property name="minimumSize">
+																<size>
+																	<width>0</width>
+																	<height>36</height>
+																</size>
+															</property>
+															<property name="maximumSize">
+																<size>
+																	<width>16777215</width>
+																	<height>36</height>
+																</size>
+															</property>
+															<property name="cursor">
+																<cursorShape>PointingHandCursor</cursorShape>
+															</property>
+															<property name="styleSheet">
+																<string notr="true"/>
+															</property>
+															<property name="text">
+																<string>GENERAL</string>
+															</property>
+															<property name="checkable">
+																<bool>true</bool>
+															</property>
+															<property name="checked">
+																<bool>true</bool>
+															</property>
+														</widget>
+													</item>
+													<item>
+														<widget class="UnderlineTabButton" name="settings_connection_button">
+															<property name="sizePolicy">
+																<sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+																	<horstretch>0</horstretch>
+																	<verstretch>0</verstretch>
+																</sizepolicy>
+															</property>
+															<property name="minimumSize">
+																<size>
+																	<width>0</width>
+																	<height>36</height>
+																</size>
+															</property>
+															<property name="maximumSize">
+																<size>
+																	<width>16777215</width>
+																	<height>36</height>
+																</size>
+															</property>
+															<property name="cursor">
+																<cursorShape>PointingHandCursor</cursorShape>
+															</property>
+															<property name="styleSheet">
+																<string notr="true"/>
+															</property>
+															<property name="text">
+																<string>CONNECTION</string>
+															</property>
+															<property name="checkable">
+																<bool>true</bool>
+															</property>
+														</widget>
+													</item>
+													<item>
+														<widget class="UnderlineTabButton" name="settings_bandwidth_button">
+															<property name="sizePolicy">
+																<sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+																	<horstretch>0</horstretch>
+																	<verstretch>0</verstretch>
+																</sizepolicy>
+															</property>
+															<property name="minimumSize">
+																<size>
+																	<width>0</width>
+																	<height>36</height>
+																</size>
+															</property>
+															<property name="maximumSize">
+																<size>
+																	<width>16777215</width>
+																	<height>36</height>
+																</size>
+															</property>
+															<property name="cursor">
+																<cursorShape>PointingHandCursor</cursorShape>
+															</property>
+															<property name="styleSheet">
+																<string notr="true"/>
+															</property>
+															<property name="text">
+																<string>BANDWIDTH</string>
+															</property>
+															<property name="checkable">
+																<bool>true</bool>
+															</property>
+														</widget>
+													</item>
+													<item>
+														<widget class="UnderlineTabButton" name="settings_seeding_button">
+															<property name="sizePolicy">
+																<sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+																	<horstretch>0</horstretch>
+																	<verstretch>0</verstretch>
+																</sizepolicy>
+															</property>
+															<property name="minimumSize">
+																<size>
+																	<width>0</width>
+																	<height>36</height>
+																</size>
+															</property>
+															<property name="cursor">
+																<cursorShape>PointingHandCursor</cursorShape>
+															</property>
+															<property name="styleSheet">
+																<string notr="true"/>
+															</property>
+															<property name="text">
+																<string>SEEDING</string>
+															</property>
+															<property name="checkable">
+																<bool>true</bool>
+															</property>
+														</widget>
+													</item>
+													<item>
+														<widget class="UnderlineTabButton" name="settings_anonymity_button">
+															<property name="sizePolicy">
+																<sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+																	<horstretch>0</horstretch>
+																	<verstretch>0</verstretch>
+																</sizepolicy>
+															</property>
+															<property name="minimumSize">
+																<size>
+																	<width>0</width>
+																	<height>36</height>
+																</size>
+															</property>
+															<property name="maximumSize">
+																<size>
+																	<width>16777215</width>
+																	<height>36</height>
+																</size>
+															</property>
+															<property name="cursor">
+																<cursorShape>PointingHandCursor</cursorShape>
+															</property>
+															<property name="styleSheet">
+																<string notr="true"/>
+															</property>
+															<property name="text">
+																<string>ANONYMITY</string>
+															</property>
+															<property name="checkable">
+																<bool>true</bool>
+															</property>
+														</widget>
+													</item>
+													<item>
+														<widget class="UnderlineTabButton" name="settings_data_button">
+															<property name="sizePolicy">
+																<sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+																	<horstretch>0</horstretch>
+																	<verstretch>0</verstretch>
+																</sizepolicy>
+															</property>
+															<property name="minimumSize">
+																<size>
+																	<width>0</width>
+																	<height>36</height>
+																</size>
+															</property>
+															<property name="maximumSize">
+																<size>
+																	<width>16777215</width>
+																	<height>36</height>
+																</size>
+															</property>
+															<property name="cursor">
+																<cursorShape>PointingHandCursor</cursorShape>
+															</property>
+															<property name="styleSheet">
+																<string notr="true"/>
+															</property>
+															<property name="text">
+																<string>DATA</string>
+															</property>
+															<property name="checkable">
+																<bool>true</bool>
+															</property>
+														</widget>
+													</item>
+													<item>
+														<widget class="UnderlineTabButton" name="settings_debug_button">
+															<property name="sizePolicy">
+																<sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+																	<horstretch>0</horstretch>
+																	<verstretch>0</verstretch>
+																</sizepolicy>
+															</property>
+															<property name="minimumSize">
+																<size>
+																	<width>0</width>
+																	<height>36</height>
+																</size>
+															</property>
+															<property name="maximumSize">
+																<size>
+																	<width>16777215</width>
+																	<height>36</height>
+																</size>
+															</property>
+															<property name="cursor">
+																<cursorShape>PointingHandCursor</cursorShape>
+															</property>
+															<property name="styleSheet">
+																<string notr="true"/>
+															</property>
+															<property name="text">
+																<string>DEBUG</string>
+															</property>
+															<property name="checkable">
+																<bool>true</bool>
+															</property>
+														</widget>
+													</item>
+													<item>
+														<spacer name="horizontalSpacer_10">
+															<property name="orientation">
+																<enum>Qt::Horizontal</enum>
+															</property>
+															<property name="sizeHint" stdset="0">
+																<size>
+																	<width>40</width>
+																	<height>20</height>
+																</size>
+															</property>
+														</spacer>
+													</item>
+												</layout>
+											</widget>
+										</item>
+										<item>
+											<widget class="QScrollArea" name="scrollArea">
+												<property name="styleSheet">
+													<string notr="true">QScrollArea {
 border-top: 1px solid #555;
 }</string>
-            </property>
-            <property name="sizeAdjustPolicy">
-             <enum>QAbstractScrollArea::AdjustToContents</enum>
-            </property>
-            <property name="widgetResizable">
-             <bool>true</bool>
-            </property>
-            <widget class="QWidget" name="scrollAreaWidgetContents">
-             <property name="geometry">
-              <rect>
-               <x>0</x>
-               <y>0</y>
-               <width>300</width>
-               <height>506</height>
-              </rect>
-             </property>
-             <layout class="QVBoxLayout" name="verticalLayout_22">
-              <property name="spacing">
-               <number>0</number>
-              </property>
-              <property name="leftMargin">
-               <number>0</number>
-              </property>
-              <property name="topMargin">
-               <number>0</number>
-              </property>
-              <property name="rightMargin">
-               <number>0</number>
-              </property>
-              <property name="bottomMargin">
-               <number>0</number>
-              </property>
-              <item>
-               <widget class="QStackedWidget" name="settings_stacked_widget">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="minimumSize">
-                 <size>
-                  <width>300</width>
-                  <height>0</height>
-                 </size>
-                </property>
-                <property name="maximumSize">
-                 <size>
-                  <width>16777215</width>
-                  <height>16777215</height>
-                 </size>
-                </property>
-                <property name="styleSheet">
-                 <string notr="true">QStackedWidget QLabel, QStackedWidget QRadioButton, QStackedWidget {
+												</property>
+												<property name="sizeAdjustPolicy">
+													<enum>QAbstractScrollArea::AdjustToContents</enum>
+												</property>
+												<property name="widgetResizable">
+													<bool>true</bool>
+												</property>
+												<widget class="QWidget" name="scrollAreaWidgetContents">
+													<property name="geometry">
+														<rect>
+															<x>0</x>
+															<y>0</y>
+															<width>300</width>
+															<height>506</height>
+														</rect>
+													</property>
+													<layout class="QVBoxLayout" name="verticalLayout_22">
+														<property name="spacing">
+															<number>0</number>
+														</property>
+														<property name="leftMargin">
+															<number>0</number>
+														</property>
+														<property name="topMargin">
+															<number>0</number>
+														</property>
+														<property name="rightMargin">
+															<number>0</number>
+														</property>
+														<property name="bottomMargin">
+															<number>0</number>
+														</property>
+														<item>
+															<widget class="QStackedWidget" name="settings_stacked_widget">
+																<property name="sizePolicy">
+																	<sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+																		<horstretch>0</horstretch>
+																		<verstretch>0</verstretch>
+																	</sizepolicy>
+																</property>
+																<property name="minimumSize">
+																	<size>
+																		<width>300</width>
+																		<height>0</height>
+																	</size>
+																</property>
+																<property name="maximumSize">
+																	<size>
+																		<width>16777215</width>
+																		<height>16777215</height>
+																	</size>
+																</property>
+																<property name="styleSheet">
+																	<string notr="true">QStackedWidget QLabel, QStackedWidget QRadioButton, QStackedWidget {
 color: #B5B5B5;
 }
 QComboBox {
@@ -981,2096 +984,2102 @@ border: 0px;
 QCheckBox{margin-left: 10px;}
 QCheckBox::indicator { margin: 4px; }
 </string>
-                </property>
-                <property name="currentIndex">
-                 <number>6</number>
-                </property>
-                <widget class="QWidget" name="settings_general_tab">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <layout class="QFormLayout" name="formLayout">
-                  <property name="fieldGrowthPolicy">
-                   <enum>QFormLayout::ExpandingFieldsGrow</enum>
-                  </property>
-                  <property name="labelAlignment">
-                   <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-                  </property>
-                  <property name="formAlignment">
-                   <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-                  </property>
-                  <item row="1" column="0">
-                   <widget class="QLabel" name="label_35">
-                    <property name="styleSheet">
-                     <string notr="true">font-weight: bold;
+																</property>
+																<property name="currentIndex">
+																	<number>6</number>
+																</property>
+																<widget class="QWidget" name="settings_general_tab">
+																	<property name="sizePolicy">
+																		<sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+																			<horstretch>0</horstretch>
+																			<verstretch>0</verstretch>
+																		</sizepolicy>
+																	</property>
+																	<layout class="QFormLayout" name="formLayout">
+																		<property name="fieldGrowthPolicy">
+																			<enum>QFormLayout::ExpandingFieldsGrow</enum>
+																		</property>
+																		<property name="labelAlignment">
+																			<set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+																		</property>
+																		<property name="formAlignment">
+																			<set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+																		</property>
+																		<item row="1" column="0">
+																			<widget class="QLabel" name="label_35">
+																				<property name="styleSheet">
+																					<string notr="true">font-weight: bold;
 color: white;</string>
-                    </property>
-                    <property name="text">
-                     <string>Family filter</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="2" column="0">
-                   <widget class="QCheckBox" name="family_filter_checkbox">
-                    <property name="text">
-                     <string>Family filter enabled? (requires Tribler restart)</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="3" column="0">
-                   <widget class="QLabel" name="label_4">
-                    <property name="styleSheet">
-                     <string notr="true">font-weight: bold;
+																				</property>
+																				<property name="text">
+																					<string>Family filter</string>
+																				</property>
+																			</widget>
+																		</item>
+																		<item row="2" column="0">
+																			<widget class="QCheckBox" name="family_filter_checkbox">
+																				<property name="text">
+																					<string>Family filter enabled? (requires Tribler restart)</string>
+																				</property>
+																			</widget>
+																		</item>
+																		<item row="3" column="0">
+																			<widget class="QLabel" name="label_4">
+																				<property name="styleSheet">
+																					<string notr="true">font-weight: bold;
 color: white;margin-top:10px;</string>
-                    </property>
-                    <property name="text">
-                     <string>Download location</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="4" column="0">
-                   <widget class="QWidget" name="settings_download_location_widget" native="true">
-                    <layout class="QHBoxLayout" name="horizontalLayout_8">
-                     <property name="spacing">
-                      <number>0</number>
-                     </property>
-                     <property name="leftMargin">
-                      <number>0</number>
-                     </property>
-                     <property name="topMargin">
-                      <number>0</number>
-                     </property>
-                     <property name="rightMargin">
-                      <number>0</number>
-                     </property>
-                     <property name="bottomMargin">
-                      <number>0</number>
-                     </property>
-                     <item>
-                      <widget class="QLabel" name="label_5">
-                       <property name="text">
-                        <string>Save files to:</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item>
-                      <spacer name="horizontalSpacer">
-                       <property name="orientation">
-                        <enum>Qt::Horizontal</enum>
-                       </property>
-                       <property name="sizeHint" stdset="0">
-                        <size>
-                         <width>15</width>
-                         <height>20</height>
-                        </size>
-                       </property>
-                      </spacer>
-                     </item>
-                     <item>
-                      <widget class="QLineEdit" name="download_location_input">
-                       <property name="sizePolicy">
-                        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                         <horstretch>0</horstretch>
-                         <verstretch>0</verstretch>
-                        </sizepolicy>
-                       </property>
-                       <property name="minimumSize">
-                        <size>
-                         <width>250</width>
-                         <height>28</height>
-                        </size>
-                       </property>
-                       <property name="maximumSize">
-                        <size>
-                         <width>250</width>
-                         <height>28</height>
-                        </size>
-                       </property>
-                       <property name="styleSheet">
-                        <string notr="true"/>
-                       </property>
-                       <property name="placeholderText">
-                        <string>File location</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item>
-                      <widget class="QToolButton" name="download_location_chooser_button">
-                       <property name="minimumSize">
-                        <size>
-                         <width>50</width>
-                         <height>30</height>
-                        </size>
-                       </property>
-                       <property name="baseSize">
-                        <size>
-                         <width>50</width>
-                         <height>30</height>
-                        </size>
-                       </property>
-                       <property name="cursor">
-                        <cursorShape>PointingHandCursor</cursorShape>
-                       </property>
-                       <property name="toolTip">
-                        <string>Browse download location</string>
-                       </property>
-                       <property name="text">
-                        <string notr="true">Browse</string>
-                       </property>
-                       <property name="icon">
-                        <iconset>
-                         <normaloff>../images/browse_folder.svg</normaloff>../images/browse_folder.svg</iconset>
-                       </property>
-                       <property name="toolButtonStyle">
-                        <enum>Qt::ToolButtonIconOnly</enum>
-                       </property>
-                       <property name="autoRaise">
-                        <bool>false</bool>
-                       </property>
-                       <property name="arrowType">
-                        <enum>Qt::NoArrow</enum>
-                       </property>
-                      </widget>
-                     </item>
-                    </layout>
-                   </widget>
-                  </item>
-                  <item row="5" column="0">
-                   <widget class="QCheckBox" name="always_ask_location_checkbox">
-                    <property name="text">
-                     <string>Always ask download settings?</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="6" column="0">
-                   <widget class="QLabel" name="default_download_settings_header">
-                    <property name="styleSheet">
-                     <string notr="true">font-weight: bold;
+																				</property>
+																				<property name="text">
+																					<string>Download location</string>
+																				</property>
+																			</widget>
+																		</item>
+																		<item row="4" column="0">
+																			<widget class="QWidget" name="settings_download_location_widget" native="true">
+																				<layout class="QHBoxLayout" name="horizontalLayout_8">
+																					<property name="spacing">
+																						<number>0</number>
+																					</property>
+																					<property name="leftMargin">
+																						<number>0</number>
+																					</property>
+																					<property name="topMargin">
+																						<number>0</number>
+																					</property>
+																					<property name="rightMargin">
+																						<number>0</number>
+																					</property>
+																					<property name="bottomMargin">
+																						<number>0</number>
+																					</property>
+																					<item>
+																						<widget class="QLabel" name="label_5">
+																							<property name="text">
+																								<string>Save files to:</string>
+																							</property>
+																						</widget>
+																					</item>
+																					<item>
+																						<spacer name="horizontalSpacer">
+																							<property name="orientation">
+																								<enum>Qt::Horizontal</enum>
+																							</property>
+																							<property name="sizeHint" stdset="0">
+																								<size>
+																									<width>15</width>
+																									<height>20</height>
+																								</size>
+																							</property>
+																						</spacer>
+																					</item>
+																					<item>
+																						<widget class="QLineEdit" name="download_location_input">
+																							<property name="sizePolicy">
+																								<sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+																									<horstretch>0</horstretch>
+																									<verstretch>0</verstretch>
+																								</sizepolicy>
+																							</property>
+																							<property name="minimumSize">
+																								<size>
+																									<width>250</width>
+																									<height>28</height>
+																								</size>
+																							</property>
+																							<property name="maximumSize">
+																								<size>
+																									<width>250</width>
+																									<height>28</height>
+																								</size>
+																							</property>
+																							<property name="styleSheet">
+																								<string notr="true"/>
+																							</property>
+																							<property name="placeholderText">
+																								<string>File location</string>
+																							</property>
+																						</widget>
+																					</item>
+																					<item>
+																						<widget class="QToolButton" name="download_location_chooser_button">
+																							<property name="minimumSize">
+																								<size>
+																									<width>50</width>
+																									<height>30</height>
+																								</size>
+																							</property>
+																							<property name="baseSize">
+																								<size>
+																									<width>50</width>
+																									<height>30</height>
+																								</size>
+																							</property>
+																							<property name="cursor">
+																								<cursorShape>PointingHandCursor</cursorShape>
+																							</property>
+																							<property name="toolTip">
+																								<string>Browse download location</string>
+																							</property>
+																							<property name="text">
+																								<string notr="true">Browse</string>
+																							</property>
+																							<property name="icon">
+																								<iconset>
+																									<normaloff>../images/browse_folder.svg</normaloff>../images/browse_folder.svg
+																								</iconset>
+																							</property>
+																							<property name="toolButtonStyle">
+																								<enum>Qt::ToolButtonIconOnly</enum>
+																							</property>
+																							<property name="autoRaise">
+																								<bool>false</bool>
+																							</property>
+																							<property name="arrowType">
+																								<enum>Qt::NoArrow</enum>
+																							</property>
+																						</widget>
+																					</item>
+																				</layout>
+																			</widget>
+																		</item>
+																		<item row="5" column="0">
+																			<widget class="QCheckBox" name="always_ask_location_checkbox">
+																				<property name="text">
+																					<string>Always ask download settings?</string>
+																				</property>
+																			</widget>
+																		</item>
+																		<item row="6" column="0">
+																			<widget class="QLabel" name="default_download_settings_header">
+																				<property name="styleSheet">
+																					<string notr="true">font-weight: bold;
 color: white;margin-top:10px;</string>
-                    </property>
-                    <property name="text">
-                     <string>Default download settings</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="7" column="0">
-                   <widget class="QCheckBox" name="download_settings_anon_checkbox">
-                    <property name="text">
-                     <string>Download anonymously using proxies</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="8" column="0">
-                   <widget class="QCheckBox" name="download_settings_anon_seeding_checkbox">
-                    <property name="text">
-                     <string>Encrypted anonymous seeding using proxies</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="9" column="0">
-                   <widget class="QLabel" name="label_22">
-                    <property name="styleSheet">
-                     <string notr="true">font-weight: bold;
+																				</property>
+																				<property name="text">
+																					<string>Default download settings</string>
+																				</property>
+																			</widget>
+																		</item>
+																		<item row="7" column="0">
+																			<widget class="QCheckBox" name="download_settings_anon_checkbox">
+																				<property name="text">
+																					<string>Download anonymously using proxies</string>
+																				</property>
+																			</widget>
+																		</item>
+																		<item row="8" column="0">
+																			<widget class="QCheckBox" name="download_settings_anon_seeding_checkbox">
+																				<property name="text">
+																					<string>Encrypted anonymous seeding using proxies</string>
+																				</property>
+																			</widget>
+																		</item>
+																		<item row="9" column="0">
+																			<widget class="QLabel" name="label_22">
+																				<property name="styleSheet">
+																					<string notr="true">font-weight: bold;
 color: white;margin-top:10px;</string>
-                    </property>
-                    <property name="text">
-                     <string>Watch Folder</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="10" column="0">
-                   <widget class="QWidget" name="settings_watch_folder_widget" native="true">
-                    <layout class="QHBoxLayout" name="horizontalLayout_watchfolder">
-                     <property name="spacing">
-                      <number>0</number>
-                     </property>
-                     <property name="leftMargin">
-                      <number>0</number>
-                     </property>
-                     <property name="topMargin">
-                      <number>0</number>
-                     </property>
-                     <property name="rightMargin">
-                      <number>0</number>
-                     </property>
-                     <property name="bottomMargin">
-                      <number>0</number>
-                     </property>
-                     <item>
-                      <widget class="QCheckBox" name="watchfolder_enabled_checkbox">
-                       <property name="text">
-                        <string>Torrent watch folder</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item>
-                      <spacer name="horizontalSpacer_5">
-                       <property name="orientation">
-                        <enum>Qt::Horizontal</enum>
-                       </property>
-                       <property name="sizeHint" stdset="0">
-                        <size>
-                         <width>15</width>
-                         <height>20</height>
-                        </size>
-                       </property>
-                      </spacer>
-                     </item>
-                     <item>
-                      <widget class="QLineEdit" name="watchfolder_location_input">
-                       <property name="sizePolicy">
-                        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                         <horstretch>0</horstretch>
-                         <verstretch>0</verstretch>
-                        </sizepolicy>
-                       </property>
-                       <property name="minimumSize">
-                        <size>
-                         <width>250</width>
-                         <height>28</height>
-                        </size>
-                       </property>
-                       <property name="maximumSize">
-                        <size>
-                         <width>250</width>
-                         <height>28</height>
-                        </size>
-                       </property>
-                       <property name="styleSheet">
-                        <string notr="true"/>
-                       </property>
-                       <property name="placeholderText">
-                        <string>Location</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item>
-                      <widget class="QToolButton" name="watch_folder_chooser_button">
-                       <property name="minimumSize">
-                        <size>
-                         <width>50</width>
-                         <height>30</height>
-                        </size>
-                       </property>
-                       <property name="baseSize">
-                        <size>
-                         <width>50</width>
-                         <height>30</height>
-                        </size>
-                       </property>
-                       <property name="cursor">
-                        <cursorShape>PointingHandCursor</cursorShape>
-                       </property>
-                       <property name="toolTip">
-                        <string>Browse watch folder</string>
-                       </property>
-                       <property name="text">
-                        <string notr="true">Browse</string>
-                       </property>
-                       <property name="icon">
-                        <iconset>
-                         <normaloff>../images/browse_folder.svg</normaloff>../images/browse_folder.svg</iconset>
-                       </property>
-                       <property name="toolButtonStyle">
-                        <enum>Qt::ToolButtonIconOnly</enum>
-                       </property>
-                       <property name="autoRaise">
-                        <bool>false</bool>
-                       </property>
-                       <property name="arrowType">
-                        <enum>Qt::NoArrow</enum>
-                       </property>
-                      </widget>
-                     </item>
-                    </layout>
-                   </widget>
-                  </item>
-                  <item row="11" column="0">
-                   <widget class="QLabel" name="label_31">
-                    <property name="styleSheet">
-                     <string notr="true">font-weight: bold;
+																				</property>
+																				<property name="text">
+																					<string>Watch Folder</string>
+																				</property>
+																			</widget>
+																		</item>
+																		<item row="10" column="0">
+																			<widget class="QWidget" name="settings_watch_folder_widget" native="true">
+																				<layout class="QHBoxLayout" name="horizontalLayout_watchfolder">
+																					<property name="spacing">
+																						<number>0</number>
+																					</property>
+																					<property name="leftMargin">
+																						<number>0</number>
+																					</property>
+																					<property name="topMargin">
+																						<number>0</number>
+																					</property>
+																					<property name="rightMargin">
+																						<number>0</number>
+																					</property>
+																					<property name="bottomMargin">
+																						<number>0</number>
+																					</property>
+																					<item>
+																						<widget class="QCheckBox" name="watchfolder_enabled_checkbox">
+																							<property name="text">
+																								<string>Torrent watch folder</string>
+																							</property>
+																						</widget>
+																					</item>
+																					<item>
+																						<spacer name="horizontalSpacer_5">
+																							<property name="orientation">
+																								<enum>Qt::Horizontal</enum>
+																							</property>
+																							<property name="sizeHint" stdset="0">
+																								<size>
+																									<width>15</width>
+																									<height>20</height>
+																								</size>
+																							</property>
+																						</spacer>
+																					</item>
+																					<item>
+																						<widget class="QLineEdit" name="watchfolder_location_input">
+																							<property name="sizePolicy">
+																								<sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+																									<horstretch>0</horstretch>
+																									<verstretch>0</verstretch>
+																								</sizepolicy>
+																							</property>
+																							<property name="minimumSize">
+																								<size>
+																									<width>250</width>
+																									<height>28</height>
+																								</size>
+																							</property>
+																							<property name="maximumSize">
+																								<size>
+																									<width>250</width>
+																									<height>28</height>
+																								</size>
+																							</property>
+																							<property name="styleSheet">
+																								<string notr="true"/>
+																							</property>
+																							<property name="placeholderText">
+																								<string>Location</string>
+																							</property>
+																						</widget>
+																					</item>
+																					<item>
+																						<widget class="QToolButton" name="watch_folder_chooser_button">
+																							<property name="minimumSize">
+																								<size>
+																									<width>50</width>
+																									<height>30</height>
+																								</size>
+																							</property>
+																							<property name="baseSize">
+																								<size>
+																									<width>50</width>
+																									<height>30</height>
+																								</size>
+																							</property>
+																							<property name="cursor">
+																								<cursorShape>PointingHandCursor</cursorShape>
+																							</property>
+																							<property name="toolTip">
+																								<string>Browse watch folder</string>
+																							</property>
+																							<property name="text">
+																								<string notr="true">Browse</string>
+																							</property>
+																							<property name="icon">
+																								<iconset>
+																									<normaloff>../images/browse_folder.svg</normaloff>../images/browse_folder.svg
+																								</iconset>
+																							</property>
+																							<property name="toolButtonStyle">
+																								<enum>Qt::ToolButtonIconOnly</enum>
+																							</property>
+																							<property name="autoRaise">
+																								<bool>false</bool>
+																							</property>
+																							<property name="arrowType">
+																								<enum>Qt::NoArrow</enum>
+																							</property>
+																						</widget>
+																					</item>
+																				</layout>
+																			</widget>
+																		</item>
+																		<item row="11" column="0">
+																			<widget class="QLabel" name="label_31">
+																				<property name="styleSheet">
+																					<string notr="true">font-weight: bold;
 color: white;margin-top:10px</string>
-                    </property>
-                    <property name="text">
-                     <string>Tray Icon</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="12" column="0">
-                   <widget class="QCheckBox" name="minimize_to_tray_checkbox">
-                    <property name="text">
-                     <string>Minimize to system tray?</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="13" column="0">
-                   <widget class="QCheckBox" name="use_monochrome_icon_checkbox">
-                    <property name="text">
-                     <string>Use monochrome icon?</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="14" column="0">
-                   <widget class="QCheckBox" name="channel_autocommit_checkbox">
-                    <property name="text">
-                     <string>Commit changes automatically (requires Tribler restart)</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="0">
-                   <layout class="QFormLayout" name="formLayout_2">
-                    <property name="formAlignment">
-                     <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-                    </property>
-                    <property name="topMargin">
-                     <number>0</number>
-                    </property>
-                    <property name="rightMargin">
-                     <number>0</number>
-                    </property>
-                    <item row="0" column="0">
-                     <widget class="QLabel" name="language_selector_label">
-                      <property name="text">
-                       <string>Select interface language
+																				</property>
+																				<property name="text">
+																					<string>Tray Icon</string>
+																				</property>
+																			</widget>
+																		</item>
+																		<item row="12" column="0">
+																			<widget class="QCheckBox" name="minimize_to_tray_checkbox">
+																				<property name="text">
+																					<string>Minimize to system tray?</string>
+																				</property>
+																			</widget>
+																		</item>
+																		<item row="13" column="0">
+																			<widget class="QCheckBox" name="use_monochrome_icon_checkbox">
+																				<property name="text">
+																					<string>Use monochrome icon?</string>
+																				</property>
+																			</widget>
+																		</item>
+																		<item row="14" column="0">
+																			<widget class="QCheckBox" name="channel_autocommit_checkbox">
+																				<property name="text">
+																					<string>Commit changes automatically (requires Tribler restart)</string>
+																				</property>
+																			</widget>
+																		</item>
+																		<item row="0" column="0">
+																			<layout class="QFormLayout" name="formLayout_2">
+																				<property name="formAlignment">
+																					<set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+																				</property>
+																				<property name="topMargin">
+																					<number>0</number>
+																				</property>
+																				<property name="rightMargin">
+																					<number>0</number>
+																				</property>
+																				<item row="0" column="0">
+																					<widget class="QLabel" name="language_selector_label">
+																						<property name="text">
+																							<string>Select interface language
 (requires Tribler restart)</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="0" column="1">
-                     <widget class="QComboBox" name="language_selector">
-                      <property name="minimumSize">
-                       <size>
-                        <width>200</width>
-                        <height>20</height>
-                       </size>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
-                  </item>
-                  <item row="15" column="0">
-                   <widget class="QLabel" name="label_7">
-                    <property name="font">
-                     <font>
-                      <weight>75</weight>
-                      <bold>true</bold>
-                     </font>
-                    </property>
-                    <property name="styleSheet">
-                     <string notr="true">font-weight: bold;
+																						</property>
+																					</widget>
+																				</item>
+																				<item row="0" column="1">
+																					<widget class="QComboBox" name="language_selector">
+																						<property name="minimumSize">
+																							<size>
+																								<width>200</width>
+																								<height>20</height>
+																							</size>
+																						</property>
+																					</widget>
+																				</item>
+																			</layout>
+																		</item>
+																		<item row="15" column="0">
+																			<widget class="QLabel" name="label_7">
+																				<property name="font">
+																					<font>
+																						<weight>75</weight>
+																						<bold>true</bold>
+																					</font>
+																				</property>
+																				<property name="styleSheet">
+																					<string notr="true">font-weight: bold;
 color: white;margin-top:10px;</string>
-                    </property>
-                    <property name="text">
-                     <string>Tags</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="16" column="0">
-                   <widget class="QCheckBox" name="disable_tags_checkbox">
-                    <property name="text">
-                     <string>Hide tags from content items</string>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-                <widget class="QWidget" name="settings_connection_tab">
-                 <layout class="QFormLayout" name="formLayout">
-                  <property name="fieldGrowthPolicy">
-                   <enum>QFormLayout::ExpandingFieldsGrow</enum>
-                  </property>
-                  <property name="labelAlignment">
-                   <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-                  </property>
-                  <property name="formAlignment">
-                   <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-                  </property>
-                  <item row="2" column="0">
-                   <widget class="QLabel" name="label_4">
-                    <property name="styleSheet">
-                     <string notr="true">font-weight: bold;
+																				</property>
+																				<property name="text">
+																					<string>Tags</string>
+																				</property>
+																			</widget>
+																		</item>
+																		<item row="16" column="0">
+																			<widget class="QCheckBox" name="disable_tags_checkbox">
+																				<property name="text">
+																					<string>Hide tags from content items</string>
+																				</property>
+																			</widget>
+																		</item>
+																	</layout>
+																</widget>
+																<widget class="QWidget" name="settings_connection_tab">
+																	<layout class="QFormLayout" name="formLayout">
+																		<property name="fieldGrowthPolicy">
+																			<enum>QFormLayout::ExpandingFieldsGrow</enum>
+																		</property>
+																		<property name="labelAlignment">
+																			<set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+																		</property>
+																		<property name="formAlignment">
+																			<set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+																		</property>
+																		<item row="2" column="0">
+																			<widget class="QLabel" name="label_4">
+																				<property name="styleSheet">
+																					<string notr="true">font-weight: bold;
 color: white;</string>
-                    </property>
-                    <property name="text">
-                     <string>Torrent proxy settings</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="3" column="0">
-                   <widget class="QLabel" name="label_11">
-                    <property name="styleSheet">
-                     <string notr="true"/>
-                    </property>
-                    <property name="text">
-                     <string>Type</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="3" column="1">
-                   <widget class="QComboBox" name="lt_proxy_type_combobox">
-                    <property name="minimumSize">
-                     <size>
-                      <width>250</width>
-                      <height>28</height>
-                     </size>
-                    </property>
-                    <property name="maximumSize">
-                     <size>
-                      <width>250</width>
-                      <height>28</height>
-                     </size>
-                    </property>
-                    <item>
-                     <property name="text">
-                      <string>None</string>
-                     </property>
-                    </item>
-                    <item>
-                     <property name="text">
-                      <string>Socks4</string>
-                     </property>
-                    </item>
-                    <item>
-                     <property name="text">
-                      <string>Socks5</string>
-                     </property>
-                    </item>
-                    <item>
-                     <property name="text">
-                      <string>Socks5 with authentication</string>
-                     </property>
-                    </item>
-                    <item>
-                     <property name="text">
-                      <string>HTTP</string>
-                     </property>
-                    </item>
-                    <item>
-                     <property name="text">
-                      <string>HTTP with authentication</string>
-                     </property>
-                    </item>
-                   </widget>
-                  </item>
-                  <item row="4" column="0">
-                   <widget class="QLabel" name="label_5">
-                    <property name="styleSheet">
-                     <string notr="true"/>
-                    </property>
-                    <property name="text">
-                     <string>Server</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="4" column="1">
-                   <widget class="QLineEdit" name="lt_proxy_server_input">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="minimumSize">
-                     <size>
-                      <width>250</width>
-                      <height>0</height>
-                     </size>
-                    </property>
-                    <property name="maximumSize">
-                     <size>
-                      <width>250</width>
-                      <height>16777215</height>
-                     </size>
-                    </property>
-                    <property name="styleSheet">
-                     <string notr="true"/>
-                    </property>
-                    <property name="placeholderText">
-                     <string>Server</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="5" column="0">
-                   <widget class="QLabel" name="label_12">
-                    <property name="styleSheet">
-                     <string notr="true"/>
-                    </property>
-                    <property name="text">
-                     <string>Port</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="5" column="1">
-                   <widget class="QLineEdit" name="lt_proxy_port_input">
-                    <property name="minimumSize">
-                     <size>
-                      <width>250</width>
-                      <height>0</height>
-                     </size>
-                    </property>
-                    <property name="maximumSize">
-                     <size>
-                      <width>250</width>
-                      <height>16777215</height>
-                     </size>
-                    </property>
-                    <property name="styleSheet">
-                     <string notr="true"/>
-                    </property>
-                    <property name="placeholderText">
-                     <string>Port</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="6" column="0">
-                   <widget class="QLabel" name="label_13">
-                    <property name="styleSheet">
-                     <string notr="true"/>
-                    </property>
-                    <property name="text">
-                     <string>Username</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="6" column="1">
-                   <widget class="QLineEdit" name="lt_proxy_username_input">
-                    <property name="minimumSize">
-                     <size>
-                      <width>250</width>
-                      <height>0</height>
-                     </size>
-                    </property>
-                    <property name="maximumSize">
-                     <size>
-                      <width>250</width>
-                      <height>16777215</height>
-                     </size>
-                    </property>
-                    <property name="styleSheet">
-                     <string notr="true"/>
-                    </property>
-                    <property name="placeholderText">
-                     <string>Username</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="7" column="0">
-                   <widget class="QLabel" name="label_14">
-                    <property name="styleSheet">
-                     <string notr="true"/>
-                    </property>
-                    <property name="text">
-                     <string>Password</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="7" column="1">
-                   <widget class="QLineEdit" name="lt_proxy_password_input">
-                    <property name="minimumSize">
-                     <size>
-                      <width>250</width>
-                      <height>0</height>
-                     </size>
-                    </property>
-                    <property name="maximumSize">
-                     <size>
-                      <width>250</width>
-                      <height>16777215</height>
-                     </size>
-                    </property>
-                    <property name="styleSheet">
-                     <string notr="true"/>
-                    </property>
-                    <property name="echoMode">
-                     <enum>QLineEdit::Password</enum>
-                    </property>
-                    <property name="placeholderText">
-                     <string>Password</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="8" column="0">
-                   <widget class="QLabel" name="label_15">
-                    <property name="styleSheet">
-                     <string notr="true">font-weight: bold;
+																				</property>
+																				<property name="text">
+																					<string>Torrent proxy settings</string>
+																				</property>
+																			</widget>
+																		</item>
+																		<item row="3" column="0">
+																			<widget class="QLabel" name="label_11">
+																				<property name="styleSheet">
+																					<string notr="true"/>
+																				</property>
+																				<property name="text">
+																					<string>Type</string>
+																				</property>
+																			</widget>
+																		</item>
+																		<item row="3" column="1">
+																			<widget class="QComboBox" name="lt_proxy_type_combobox">
+																				<property name="minimumSize">
+																					<size>
+																						<width>250</width>
+																						<height>28</height>
+																					</size>
+																				</property>
+																				<property name="maximumSize">
+																					<size>
+																						<width>250</width>
+																						<height>28</height>
+																					</size>
+																				</property>
+																				<item>
+																					<property name="text">
+																						<string>None</string>
+																					</property>
+																				</item>
+																				<item>
+																					<property name="text">
+																						<string>Socks4</string>
+																					</property>
+																				</item>
+																				<item>
+																					<property name="text">
+																						<string>Socks5</string>
+																					</property>
+																				</item>
+																				<item>
+																					<property name="text">
+																						<string>Socks5 with authentication</string>
+																					</property>
+																				</item>
+																				<item>
+																					<property name="text">
+																						<string>HTTP</string>
+																					</property>
+																				</item>
+																				<item>
+																					<property name="text">
+																						<string>HTTP with authentication</string>
+																					</property>
+																				</item>
+																			</widget>
+																		</item>
+																		<item row="4" column="0">
+																			<widget class="QLabel" name="label_5">
+																				<property name="styleSheet">
+																					<string notr="true"/>
+																				</property>
+																				<property name="text">
+																					<string>Server</string>
+																				</property>
+																			</widget>
+																		</item>
+																		<item row="4" column="1">
+																			<widget class="QLineEdit" name="lt_proxy_server_input">
+																				<property name="sizePolicy">
+																					<sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+																						<horstretch>0</horstretch>
+																						<verstretch>0</verstretch>
+																					</sizepolicy>
+																				</property>
+																				<property name="minimumSize">
+																					<size>
+																						<width>250</width>
+																						<height>0</height>
+																					</size>
+																				</property>
+																				<property name="maximumSize">
+																					<size>
+																						<width>250</width>
+																						<height>16777215</height>
+																					</size>
+																				</property>
+																				<property name="styleSheet">
+																					<string notr="true"/>
+																				</property>
+																				<property name="placeholderText">
+																					<string>Server</string>
+																				</property>
+																			</widget>
+																		</item>
+																		<item row="5" column="0">
+																			<widget class="QLabel" name="label_12">
+																				<property name="styleSheet">
+																					<string notr="true"/>
+																				</property>
+																				<property name="text">
+																					<string>Port</string>
+																				</property>
+																			</widget>
+																		</item>
+																		<item row="5" column="1">
+																			<widget class="QLineEdit" name="lt_proxy_port_input">
+																				<property name="minimumSize">
+																					<size>
+																						<width>250</width>
+																						<height>0</height>
+																					</size>
+																				</property>
+																				<property name="maximumSize">
+																					<size>
+																						<width>250</width>
+																						<height>16777215</height>
+																					</size>
+																				</property>
+																				<property name="styleSheet">
+																					<string notr="true"/>
+																				</property>
+																				<property name="placeholderText">
+																					<string>Port</string>
+																				</property>
+																			</widget>
+																		</item>
+																		<item row="6" column="0">
+																			<widget class="QLabel" name="label_13">
+																				<property name="styleSheet">
+																					<string notr="true"/>
+																				</property>
+																				<property name="text">
+																					<string>Username</string>
+																				</property>
+																			</widget>
+																		</item>
+																		<item row="6" column="1">
+																			<widget class="QLineEdit" name="lt_proxy_username_input">
+																				<property name="minimumSize">
+																					<size>
+																						<width>250</width>
+																						<height>0</height>
+																					</size>
+																				</property>
+																				<property name="maximumSize">
+																					<size>
+																						<width>250</width>
+																						<height>16777215</height>
+																					</size>
+																				</property>
+																				<property name="styleSheet">
+																					<string notr="true"/>
+																				</property>
+																				<property name="placeholderText">
+																					<string>Username</string>
+																				</property>
+																			</widget>
+																		</item>
+																		<item row="7" column="0">
+																			<widget class="QLabel" name="label_14">
+																				<property name="styleSheet">
+																					<string notr="true"/>
+																				</property>
+																				<property name="text">
+																					<string>Password</string>
+																				</property>
+																			</widget>
+																		</item>
+																		<item row="7" column="1">
+																			<widget class="QLineEdit" name="lt_proxy_password_input">
+																				<property name="minimumSize">
+																					<size>
+																						<width>250</width>
+																						<height>0</height>
+																					</size>
+																				</property>
+																				<property name="maximumSize">
+																					<size>
+																						<width>250</width>
+																						<height>16777215</height>
+																					</size>
+																				</property>
+																				<property name="styleSheet">
+																					<string notr="true"/>
+																				</property>
+																				<property name="echoMode">
+																					<enum>QLineEdit::Password</enum>
+																				</property>
+																				<property name="placeholderText">
+																					<string>Password</string>
+																				</property>
+																			</widget>
+																		</item>
+																		<item row="8" column="0">
+																			<widget class="QLabel" name="label_15">
+																				<property name="styleSheet">
+																					<string notr="true">font-weight: bold;
 color: white;</string>
-                    </property>
-                    <property name="text">
-                     <string>BitTorrent features</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="9" column="0">
-                   <widget class="QLabel" name="label_6">
-                    <property name="styleSheet">
-                     <string notr="true"/>
-                    </property>
-                    <property name="text">
-                     <string>Enabled bandwidth
+																				</property>
+																				<property name="text">
+																					<string>BitTorrent features</string>
+																				</property>
+																			</widget>
+																		</item>
+																		<item row="9" column="0">
+																			<widget class="QLabel" name="label_6">
+																				<property name="styleSheet">
+																					<string notr="true"/>
+																				</property>
+																				<property name="text">
+																					<string>Enabled bandwidth
 Management (uTP)</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="9" column="1">
-                   <widget class="QCheckBox" name="lt_utp_checkbox">
-                    <property name="styleSheet">
-                     <string notr="true">margin-top: 2px;</string>
-                    </property>
-                    <property name="text">
-                     <string/>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="10" column="0">
-                   <widget class="QLabel" name="label_41">
-                    <property name="text">
-                     <string>Max connections
+																				</property>
+																			</widget>
+																		</item>
+																		<item row="9" column="1">
+																			<widget class="QCheckBox" name="lt_utp_checkbox">
+																				<property name="styleSheet">
+																					<string notr="true">margin-top: 2px;</string>
+																				</property>
+																				<property name="text">
+																					<string/>
+																				</property>
+																			</widget>
+																		</item>
+																		<item row="10" column="0">
+																			<widget class="QLabel" name="label_41">
+																				<property name="text">
+																					<string>Max connections
 per download</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="10" column="1">
-                   <widget class="QLineEdit" name="max_connections_download_input">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="minimumSize">
-                     <size>
-                      <width>250</width>
-                      <height>0</height>
-                     </size>
-                    </property>
-                    <property name="maximumSize">
-                     <size>
-                      <width>250</width>
-                      <height>16777215</height>
-                     </size>
-                    </property>
-                    <property name="placeholderText">
-                     <string>Max connections per download</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="11" column="1">
-                   <widget class="QLabel" name="label_43">
-                    <property name="text">
-                     <string>0 = unlimited</string>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-                <widget class="QWidget" name="settings_bandwidth_tab">
-                 <layout class="QFormLayout" name="formLayout">
-                  <property name="fieldGrowthPolicy">
-                   <enum>QFormLayout::ExpandingFieldsGrow</enum>
-                  </property>
-                  <property name="labelAlignment">
-                   <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-                  </property>
-                  <property name="formAlignment">
-                   <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-                  </property>
-                  <item row="0" column="0">
-                   <widget class="QLabel" name="tribler_profile_header_label">
-                    <property name="styleSheet">
-                     <string notr="true">font-weight: bold;
+																				</property>
+																			</widget>
+																		</item>
+																		<item row="10" column="1">
+																			<widget class="QLineEdit" name="max_connections_download_input">
+																				<property name="sizePolicy">
+																					<sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+																						<horstretch>0</horstretch>
+																						<verstretch>0</verstretch>
+																					</sizepolicy>
+																				</property>
+																				<property name="minimumSize">
+																					<size>
+																						<width>250</width>
+																						<height>0</height>
+																					</size>
+																				</property>
+																				<property name="maximumSize">
+																					<size>
+																						<width>250</width>
+																						<height>16777215</height>
+																					</size>
+																				</property>
+																				<property name="placeholderText">
+																					<string>Max connections per download</string>
+																				</property>
+																			</widget>
+																		</item>
+																		<item row="11" column="1">
+																			<widget class="QLabel" name="label_43">
+																				<property name="text">
+																					<string>0 = unlimited</string>
+																				</property>
+																			</widget>
+																		</item>
+																	</layout>
+																</widget>
+																<widget class="QWidget" name="settings_bandwidth_tab">
+																	<layout class="QFormLayout" name="formLayout">
+																		<property name="fieldGrowthPolicy">
+																			<enum>QFormLayout::ExpandingFieldsGrow</enum>
+																		</property>
+																		<property name="labelAlignment">
+																			<set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+																		</property>
+																		<property name="formAlignment">
+																			<set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+																		</property>
+																		<item row="0" column="0">
+																			<widget class="QLabel" name="tribler_profile_header_label">
+																				<property name="styleSheet">
+																					<string notr="true">font-weight: bold;
 color: white;</string>
-                    </property>
-                    <property name="text">
-                     <string>Bandwidth limits</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="2" column="0">
-                   <widget class="QLabel" name="label_2">
-                    <property name="styleSheet">
-                     <string notr="true"/>
-                    </property>
-                    <property name="text">
-                     <string>Upload rate limit</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="2" column="1">
-                   <widget class="QWidget" name="widget_4" native="true">
-                    <property name="minimumSize">
-                     <size>
-                      <width>0</width>
-                      <height>0</height>
-                     </size>
-                    </property>
-                    <layout class="QHBoxLayout" name="horizontalLayout_24">
-                     <property name="spacing">
-                      <number>3</number>
-                     </property>
-                     <property name="leftMargin">
-                      <number>0</number>
-                     </property>
-                     <property name="topMargin">
-                      <number>0</number>
-                     </property>
-                     <property name="rightMargin">
-                      <number>0</number>
-                     </property>
-                     <property name="bottomMargin">
-                      <number>0</number>
-                     </property>
-                     <item>
-                      <widget class="QLineEdit" name="upload_rate_limit_input">
-                       <property name="sizePolicy">
-                        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                         <horstretch>0</horstretch>
-                         <verstretch>0</verstretch>
-                        </sizepolicy>
-                       </property>
-                       <property name="minimumSize">
-                        <size>
-                         <width>100</width>
-                         <height>0</height>
-                        </size>
-                       </property>
-                       <property name="maximumSize">
-                        <size>
-                         <width>100</width>
-                         <height>16777215</height>
-                        </size>
-                       </property>
-                       <property name="styleSheet">
-                        <string notr="true"/>
-                       </property>
-                       <property name="placeholderText">
-                        <string>Upload</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item>
-                      <widget class="QLabel" name="label_16">
-                       <property name="styleSheet">
-                        <string notr="true"/>
-                       </property>
-                       <property name="text">
-                        <string>KB/s   (0 = unlimited)</string>
-                       </property>
-                      </widget>
-                     </item>
-                    </layout>
-                   </widget>
-                  </item>
-                  <item row="3" column="0">
-                   <widget class="QLabel" name="label_17">
-                    <property name="styleSheet">
-                     <string notr="true"/>
-                    </property>
-                    <property name="text">
-                     <string>Download rate limit</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="5" column="1">
-                   <widget class="QLabel" name="label_6">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="styleSheet">
-                     <string notr="true"/>
-                    </property>
-                    <property name="text">
-                     <string>Note that these settings apply to anonymous and plain downloads.</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="3" column="1">
-                   <widget class="QWidget" name="widget_5" native="true">
-                    <property name="minimumSize">
-                     <size>
-                      <width>0</width>
-                      <height>0</height>
-                     </size>
-                    </property>
-                    <layout class="QHBoxLayout" name="horizontalLayout_25">
-                     <property name="spacing">
-                      <number>3</number>
-                     </property>
-                     <property name="leftMargin">
-                      <number>0</number>
-                     </property>
-                     <property name="topMargin">
-                      <number>0</number>
-                     </property>
-                     <property name="rightMargin">
-                      <number>0</number>
-                     </property>
-                     <property name="bottomMargin">
-                      <number>0</number>
-                     </property>
-                     <item>
-                      <widget class="QLineEdit" name="download_rate_limit_input">
-                       <property name="sizePolicy">
-                        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                         <horstretch>0</horstretch>
-                         <verstretch>0</verstretch>
-                        </sizepolicy>
-                       </property>
-                       <property name="minimumSize">
-                        <size>
-                         <width>100</width>
-                         <height>0</height>
-                        </size>
-                       </property>
-                       <property name="maximumSize">
-                        <size>
-                         <width>100</width>
-                         <height>16777215</height>
-                        </size>
-                       </property>
-                       <property name="styleSheet">
-                        <string notr="true"/>
-                       </property>
-                       <property name="placeholderText">
-                        <string>Download</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item>
-                      <widget class="QLabel" name="label_18">
-                       <property name="styleSheet">
-                        <string notr="true"/>
-                       </property>
-                       <property name="text">
-                        <string>KB/s   (0 = unlimited)</string>
-                       </property>
-                      </widget>
-                     </item>
-                    </layout>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-                <widget class="QWidget" name="settings_seeding_tab">
-                 <layout class="QFormLayout" name="formLayout">
-                  <property name="fieldGrowthPolicy">
-                   <enum>QFormLayout::ExpandingFieldsGrow</enum>
-                  </property>
-                  <property name="labelAlignment">
-                   <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-                  </property>
-                  <property name="formAlignment">
-                   <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-                  </property>
-                  <item row="0" column="0">
-                   <widget class="QLabel" name="tribler_profile_header_label">
-                    <property name="styleSheet">
-                     <string notr="true">font-weight: bold;
+																				</property>
+																				<property name="text">
+																					<string>Bandwidth limits</string>
+																				</property>
+																			</widget>
+																		</item>
+																		<item row="2" column="0">
+																			<widget class="QLabel" name="label_2">
+																				<property name="styleSheet">
+																					<string notr="true"/>
+																				</property>
+																				<property name="text">
+																					<string>Upload rate limit</string>
+																				</property>
+																			</widget>
+																		</item>
+																		<item row="2" column="1">
+																			<widget class="QWidget" name="widget_4" native="true">
+																				<property name="minimumSize">
+																					<size>
+																						<width>0</width>
+																						<height>0</height>
+																					</size>
+																				</property>
+																				<layout class="QHBoxLayout" name="horizontalLayout_24">
+																					<property name="spacing">
+																						<number>3</number>
+																					</property>
+																					<property name="leftMargin">
+																						<number>0</number>
+																					</property>
+																					<property name="topMargin">
+																						<number>0</number>
+																					</property>
+																					<property name="rightMargin">
+																						<number>0</number>
+																					</property>
+																					<property name="bottomMargin">
+																						<number>0</number>
+																					</property>
+																					<item>
+																						<widget class="QLineEdit" name="upload_rate_limit_input">
+																							<property name="sizePolicy">
+																								<sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+																									<horstretch>0</horstretch>
+																									<verstretch>0</verstretch>
+																								</sizepolicy>
+																							</property>
+																							<property name="minimumSize">
+																								<size>
+																									<width>100</width>
+																									<height>0</height>
+																								</size>
+																							</property>
+																							<property name="maximumSize">
+																								<size>
+																									<width>100</width>
+																									<height>16777215</height>
+																								</size>
+																							</property>
+																							<property name="styleSheet">
+																								<string notr="true"/>
+																							</property>
+																							<property name="placeholderText">
+																								<string>Upload</string>
+																							</property>
+																						</widget>
+																					</item>
+																					<item>
+																						<widget class="QLabel" name="label_16">
+																							<property name="styleSheet">
+																								<string notr="true"/>
+																							</property>
+																							<property name="text">
+																								<string>KB/s   (0 = unlimited)</string>
+																							</property>
+																						</widget>
+																					</item>
+																				</layout>
+																			</widget>
+																		</item>
+																		<item row="3" column="0">
+																			<widget class="QLabel" name="label_17">
+																				<property name="styleSheet">
+																					<string notr="true"/>
+																				</property>
+																				<property name="text">
+																					<string>Download rate limit</string>
+																				</property>
+																			</widget>
+																		</item>
+																		<item row="5" column="1">
+																			<widget class="QLabel" name="label_6">
+																				<property name="sizePolicy">
+																					<sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+																						<horstretch>0</horstretch>
+																						<verstretch>0</verstretch>
+																					</sizepolicy>
+																				</property>
+																				<property name="styleSheet">
+																					<string notr="true"/>
+																				</property>
+																				<property name="text">
+																					<string>Note that these settings apply to anonymous and plain downloads.</string>
+																				</property>
+																			</widget>
+																		</item>
+																		<item row="3" column="1">
+																			<widget class="QWidget" name="widget_5" native="true">
+																				<property name="minimumSize">
+																					<size>
+																						<width>0</width>
+																						<height>0</height>
+																					</size>
+																				</property>
+																				<layout class="QHBoxLayout" name="horizontalLayout_25">
+																					<property name="spacing">
+																						<number>3</number>
+																					</property>
+																					<property name="leftMargin">
+																						<number>0</number>
+																					</property>
+																					<property name="topMargin">
+																						<number>0</number>
+																					</property>
+																					<property name="rightMargin">
+																						<number>0</number>
+																					</property>
+																					<property name="bottomMargin">
+																						<number>0</number>
+																					</property>
+																					<item>
+																						<widget class="QLineEdit" name="download_rate_limit_input">
+																							<property name="sizePolicy">
+																								<sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+																									<horstretch>0</horstretch>
+																									<verstretch>0</verstretch>
+																								</sizepolicy>
+																							</property>
+																							<property name="minimumSize">
+																								<size>
+																									<width>100</width>
+																									<height>0</height>
+																								</size>
+																							</property>
+																							<property name="maximumSize">
+																								<size>
+																									<width>100</width>
+																									<height>16777215</height>
+																								</size>
+																							</property>
+																							<property name="styleSheet">
+																								<string notr="true"/>
+																							</property>
+																							<property name="placeholderText">
+																								<string>Download</string>
+																							</property>
+																						</widget>
+																					</item>
+																					<item>
+																						<widget class="QLabel" name="label_18">
+																							<property name="styleSheet">
+																								<string notr="true"/>
+																							</property>
+																							<property name="text">
+																								<string>KB/s   (0 = unlimited)</string>
+																							</property>
+																						</widget>
+																					</item>
+																				</layout>
+																			</widget>
+																		</item>
+																	</layout>
+																</widget>
+																<widget class="QWidget" name="settings_seeding_tab">
+																	<layout class="QFormLayout" name="formLayout">
+																		<property name="fieldGrowthPolicy">
+																			<enum>QFormLayout::ExpandingFieldsGrow</enum>
+																		</property>
+																		<property name="labelAlignment">
+																			<set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+																		</property>
+																		<property name="formAlignment">
+																			<set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+																		</property>
+																		<item row="0" column="0">
+																			<widget class="QLabel" name="tribler_profile_header_label">
+																				<property name="styleSheet">
+																					<string notr="true">font-weight: bold;
 color: white;</string>
-                    </property>
-                    <property name="text">
-                     <string>Seeding options</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="4" column="1">
-                   <widget class="QLineEdit" name="seeding_time_input">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="minimumSize">
-                     <size>
-                      <width>60</width>
-                      <height>28</height>
-                     </size>
-                    </property>
-                    <property name="maximumSize">
-                     <size>
-                      <width>60</width>
-                      <height>28</height>
-                     </size>
-                    </property>
-                    <property name="styleSheet">
-                     <string notr="true"/>
-                    </property>
-                    <property name="text">
-                     <string>hh:mm</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="2" column="1">
-                   <widget class="QComboBox" name="seeding_ratio_combobox">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="minimumSize">
-                     <size>
-                      <width>70</width>
-                      <height>24</height>
-                     </size>
-                    </property>
-                    <property name="maximumSize">
-                     <size>
-                      <width>70</width>
-                      <height>24</height>
-                     </size>
-                    </property>
-                    <item>
-                     <property name="text">
-                      <string notr="true">0.5</string>
-                     </property>
-                    </item>
-                    <item>
-                     <property name="text">
-                      <string notr="true">0.75</string>
-                     </property>
-                    </item>
-                    <item>
-                     <property name="text">
-                      <string notr="true">1.0</string>
-                     </property>
-                    </item>
-                    <item>
-                     <property name="text">
-                      <string notr="true">1.5</string>
-                     </property>
-                    </item>
-                    <item>
-                     <property name="text">
-                      <string notr="true">2.0</string>
-                     </property>
-                    </item>
-                    <item>
-                     <property name="text">
-                      <string notr="true">3.0</string>
-                     </property>
-                    </item>
-                    <item>
-                     <property name="text">
-                      <string notr="true">5.0</string>
-                     </property>
-                    </item>
-                   </widget>
-                  </item>
-                  <item row="5" column="0">
-                   <widget class="QRadioButton" name="seeding_never_radio">
-                    <property name="styleSheet">
-                     <string notr="true"/>
-                    </property>
-                    <property name="text">
-                     <string>No seeding</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="4" column="0">
-                   <widget class="QRadioButton" name="seeding_time_radio">
-                    <property name="styleSheet">
-                     <string notr="true"/>
-                    </property>
-                    <property name="text">
-                     <string>Seeding for (hours:minutes)</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="3" column="0">
-                   <widget class="QRadioButton" name="seeding_forever_radio">
-                    <property name="styleSheet">
-                     <string notr="true"/>
-                    </property>
-                    <property name="text">
-                     <string>Unlimited seeding</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="2" column="0">
-                   <widget class="QRadioButton" name="seeding_ratio_radio">
-                    <property name="styleSheet">
-                     <string notr="true"/>
-                    </property>
-                    <property name="text">
-                     <string>Seed until up/down ratio is bigger than</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="6" column="0" colspan="2">
-                   <widget class="QLabel" name="label_45">
-                    <property name="text">
-                     <string>Note that these settings also apply to existing downloads.</string>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-                <widget class="QWidget" name="settings_anonymity_tab">
-                 <layout class="QVBoxLayout" name="formLayout">
-                  <property name="spacing">
-                   <number>10</number>
-                  </property>
-                  <property name="leftMargin">
-                   <number>12</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>12</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>12</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>12</number>
-                  </property>
-                  <item>
-                   <spacer name="verticalSpacer_6">
-                    <property name="orientation">
-                     <enum>Qt::Vertical</enum>
-                    </property>
-                    <property name="sizeType">
-                     <enum>QSizePolicy::Minimum</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>20</width>
-                      <height>10</height>
-                     </size>
-                    </property>
-                   </spacer>
-                  </item>
-                  <item>
-                   <widget class="QLabel" name="label_17">
-                    <property name="styleSheet">
-                     <string notr="true">font-weight: bold;
+																				</property>
+																				<property name="text">
+																					<string>Seeding options</string>
+																				</property>
+																			</widget>
+																		</item>
+																		<item row="4" column="1">
+																			<widget class="QLineEdit" name="seeding_time_input">
+																				<property name="sizePolicy">
+																					<sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+																						<horstretch>0</horstretch>
+																						<verstretch>0</verstretch>
+																					</sizepolicy>
+																				</property>
+																				<property name="minimumSize">
+																					<size>
+																						<width>60</width>
+																						<height>28</height>
+																					</size>
+																				</property>
+																				<property name="maximumSize">
+																					<size>
+																						<width>60</width>
+																						<height>28</height>
+																					</size>
+																				</property>
+																				<property name="styleSheet">
+																					<string notr="true"/>
+																				</property>
+																				<property name="text">
+																					<string>hh:mm</string>
+																				</property>
+																			</widget>
+																		</item>
+																		<item row="2" column="1">
+																			<widget class="QComboBox" name="seeding_ratio_combobox">
+																				<property name="sizePolicy">
+																					<sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+																						<horstretch>0</horstretch>
+																						<verstretch>0</verstretch>
+																					</sizepolicy>
+																				</property>
+																				<property name="minimumSize">
+																					<size>
+																						<width>70</width>
+																						<height>24</height>
+																					</size>
+																				</property>
+																				<property name="maximumSize">
+																					<size>
+																						<width>70</width>
+																						<height>24</height>
+																					</size>
+																				</property>
+																				<item>
+																					<property name="text">
+																						<string notr="true">0.5</string>
+																					</property>
+																				</item>
+																				<item>
+																					<property name="text">
+																						<string notr="true">0.75</string>
+																					</property>
+																				</item>
+																				<item>
+																					<property name="text">
+																						<string notr="true">1.0</string>
+																					</property>
+																				</item>
+																				<item>
+																					<property name="text">
+																						<string notr="true">1.5</string>
+																					</property>
+																				</item>
+																				<item>
+																					<property name="text">
+																						<string notr="true">2.0</string>
+																					</property>
+																				</item>
+																				<item>
+																					<property name="text">
+																						<string notr="true">3.0</string>
+																					</property>
+																				</item>
+																				<item>
+																					<property name="text">
+																						<string notr="true">5.0</string>
+																					</property>
+																				</item>
+																			</widget>
+																		</item>
+																		<item row="5" column="0">
+																			<widget class="QRadioButton" name="seeding_never_radio">
+																				<property name="styleSheet">
+																					<string notr="true"/>
+																				</property>
+																				<property name="text">
+																					<string>No seeding</string>
+																				</property>
+																			</widget>
+																		</item>
+																		<item row="4" column="0">
+																			<widget class="QRadioButton" name="seeding_time_radio">
+																				<property name="styleSheet">
+																					<string notr="true"/>
+																				</property>
+																				<property name="text">
+																					<string>Seeding for (hours:minutes)</string>
+																				</property>
+																			</widget>
+																		</item>
+																		<item row="3" column="0">
+																			<widget class="QRadioButton" name="seeding_forever_radio">
+																				<property name="styleSheet">
+																					<string notr="true"/>
+																				</property>
+																				<property name="text">
+																					<string>Unlimited seeding</string>
+																				</property>
+																			</widget>
+																		</item>
+																		<item row="2" column="0">
+																			<widget class="QRadioButton" name="seeding_ratio_radio">
+																				<property name="styleSheet">
+																					<string notr="true"/>
+																				</property>
+																				<property name="text">
+																					<string>Seed until up/down ratio is bigger than</string>
+																				</property>
+																			</widget>
+																		</item>
+																		<item row="6" column="0" colspan="2">
+																			<widget class="QLabel" name="label_45">
+																				<property name="text">
+																					<string>Note that these settings also apply to existing downloads.</string>
+																				</property>
+																			</widget>
+																		</item>
+																	</layout>
+																</widget>
+																<widget class="QWidget" name="settings_anonymity_tab">
+																	<layout class="QVBoxLayout" name="formLayout">
+																		<property name="spacing">
+																			<number>10</number>
+																		</property>
+																		<property name="leftMargin">
+																			<number>12</number>
+																		</property>
+																		<property name="topMargin">
+																			<number>12</number>
+																		</property>
+																		<property name="rightMargin">
+																			<number>12</number>
+																		</property>
+																		<property name="bottomMargin">
+																			<number>12</number>
+																		</property>
+																		<item>
+																			<spacer name="verticalSpacer_6">
+																				<property name="orientation">
+																					<enum>Qt::Vertical</enum>
+																				</property>
+																				<property name="sizeType">
+																					<enum>QSizePolicy::Minimum</enum>
+																				</property>
+																				<property name="sizeHint" stdset="0">
+																					<size>
+																						<width>20</width>
+																						<height>10</height>
+																					</size>
+																				</property>
+																			</spacer>
+																		</item>
+																		<item>
+																			<widget class="QLabel" name="label_17">
+																				<property name="styleSheet">
+																					<string notr="true">font-weight: bold;
 color: white;</string>
-                    </property>
-                    <property name="text">
-                     <string>Proxy downloading</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QWidget" name="widget_6" native="true">
-                    <property name="styleSheet">
-                     <string notr="true">color: white;</string>
-                    </property>
-                    <layout class="QHBoxLayout" name="horizontalLayout_26">
-                     <property name="leftMargin">
-                      <number>0</number>
-                     </property>
-                     <property name="topMargin">
-                      <number>0</number>
-                     </property>
-                     <property name="rightMargin">
-                      <number>0</number>
-                     </property>
-                     <property name="bottomMargin">
-                      <number>0</number>
-                     </property>
-                     <item>
-                      <widget class="QLabel" name="label_20">
-                       <property name="text">
-                        <string>High speed
+																				</property>
+																				<property name="text">
+																					<string>Proxy downloading</string>
+																				</property>
+																			</widget>
+																		</item>
+																		<item>
+																			<widget class="QWidget" name="widget_6" native="true">
+																				<property name="styleSheet">
+																					<string notr="true">color: white;</string>
+																				</property>
+																				<layout class="QHBoxLayout" name="horizontalLayout_26">
+																					<property name="leftMargin">
+																						<number>0</number>
+																					</property>
+																					<property name="topMargin">
+																						<number>0</number>
+																					</property>
+																					<property name="rightMargin">
+																						<number>0</number>
+																					</property>
+																					<property name="bottomMargin">
+																						<number>0</number>
+																					</property>
+																					<item>
+																						<widget class="QLabel" name="label_20">
+																							<property name="text">
+																								<string>High speed
 Minimum anonymity</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item>
-                      <widget class="QLabel" name="label_21">
-                       <property name="text">
-                        <string>Low speed
+																							</property>
+																						</widget>
+																					</item>
+																					<item>
+																						<widget class="QLabel" name="label_21">
+																							<property name="text">
+																								<string>Low speed
 High anonymity</string>
-                       </property>
-                       <property name="alignment">
-                        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                       </property>
-                      </widget>
-                     </item>
-                    </layout>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QSlider" name="number_hops_slider">
-                    <property name="styleSheet">
-                     <string notr="true"/>
-                    </property>
-                    <property name="minimum">
-                     <number>1</number>
-                    </property>
-                    <property name="maximum">
-                     <number>3</number>
-                    </property>
-                    <property name="value">
-                     <number>1</number>
-                    </property>
-                    <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
-                    </property>
-                    <property name="tickPosition">
-                     <enum>QSlider::TicksBelow</enum>
-                    </property>
-                    <property name="tickInterval">
-                     <number>1</number>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <spacer name="verticalSpacer_5">
-                    <property name="orientation">
-                     <enum>Qt::Vertical</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>20</width>
-                      <height>40</height>
-                     </size>
-                    </property>
-                   </spacer>
-                  </item>
-                 </layout>
-                </widget>
-                <widget class="QWidget" name="settings_data_tab">
-                 <layout class="QFormLayout" name="formLayout">
-                  <property name="fieldGrowthPolicy">
-                   <enum>QFormLayout::ExpandingFieldsGrow</enum>
-                  </property>
-                  <property name="labelAlignment">
-                   <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-                  </property>
-                  <property name="formAlignment">
-                   <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-                  </property>
-                  <item row="0" column="0">
-                   <widget class="QLabel" name="tribler_data_setting_heading">
-                    <property name="styleSheet">
-                     <string notr="true">font-weight: bold; color: white;</string>
-                    </property>
-                    <property name="text">
-                     <string>Tribler state directory</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="1" column="0" colspan="2">
-                   <widget class="QLabel" name="tribler_data_setting_brief">
-                    <property name="styleSheet">
-                     <string notr="true">color: white;</string>
-                    </property>
-                    <property name="text">
-                     <string>This is where Tribler stores housekeeping data which includes databases and config files. Note that, your torrent data is not stored here.</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="2" column="0" colspan="2">
-                   <widget class="QWidget" name="state_dir_current" native="true">
-                    <layout class="QVBoxLayout" name="state_dir_current_layout">
-                     <item>
-                      <widget class="QLabel" name="sd_current_version">
-                       <property name="styleSheet">
-                        <string notr="true">font-weight: bold; color: white;</string>
-                       </property>
-                       <property name="text">
-                        <string>Current version</string>
-                       </property>
-                      </widget>
-                     </item>
-                    </layout>
-                   </widget>
-                  </item>
-                  <item row="3" column="0" colspan="2">
-                   <widget class="QWidget" name="state_dir_list" native="true">
-                    <layout class="QVBoxLayout" name="state_dir_list_layout">
-                     <item>
-                      <widget class="QLabel" name="sd_old_version">
-                       <property name="styleSheet">
-                        <string notr="true">font-weight: bold; color: white;</string>
-                       </property>
-                       <property name="text">
-                        <string>Older versions</string>
-                       </property>
-                      </widget>
-                     </item>
-                    </layout>
-                   </widget>
-                  </item>
-                  <item row="4" column="0" colspan="2">
-                   <widget class="QPushButton" name="btn_remove_old_state_dir">
-                    <property name="enabled">
-                     <bool>true</bool>
-                    </property>
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="minimumSize">
-                     <size>
-                      <width>250</width>
-                      <height>32</height>
-                     </size>
-                    </property>
-                    <property name="maximumSize">
-                     <size>
-                      <width>250</width>
-                      <height>32</height>
-                     </size>
-                    </property>
-                    <property name="cursor">
-                     <cursorShape>PointingHandCursor</cursorShape>
-                    </property>
-                    <property name="layoutDirection">
-                     <enum>Qt::LeftToRight</enum>
-                    </property>
-                    <property name="autoFillBackground">
-                     <bool>false</bool>
-                    </property>
-                    <property name="styleSheet">
-                     <string notr="true">border-radius:16px; margin-left:16px; background-color:#e67300; color:#fff;</string>
-                    </property>
-                    <property name="text">
-                     <string>Remove selected versions</string>
-                    </property>
-                    <property name="autoDefault">
-                     <bool>false</bool>
-                    </property>
-                    <property name="default">
-                     <bool>false</bool>
-                    </property>
-                    <property name="flat">
-                     <bool>false</bool>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-                <widget class="QWidget" name="settings_debug_tab">
-                 <layout class="QFormLayout" name="settigsDebugFormLayout">
-                  <property name="fieldGrowthPolicy">
-                   <enum>QFormLayout::ExpandingFieldsGrow</enum>
-                  </property>
-                  <property name="labelAlignment">
-                   <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-                  </property>
-                  <property name="formAlignment">
-                   <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-                  </property>
-                  <item row="0" column="0">
-                   <widget class="QLabel" name="tribler_profile_header_label">
-                    <property name="styleSheet">
-                     <string notr="true">font-weight: bold;
+																							</property>
+																							<property name="alignment">
+																								<set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+																							</property>
+																						</widget>
+																					</item>
+																				</layout>
+																			</widget>
+																		</item>
+																		<item>
+																			<widget class="QSlider" name="number_hops_slider">
+																				<property name="styleSheet">
+																					<string notr="true"/>
+																				</property>
+																				<property name="minimum">
+																					<number>1</number>
+																				</property>
+																				<property name="maximum">
+																					<number>3</number>
+																				</property>
+																				<property name="value">
+																					<number>1</number>
+																				</property>
+																				<property name="orientation">
+																					<enum>Qt::Horizontal</enum>
+																				</property>
+																				<property name="tickPosition">
+																					<enum>QSlider::TicksBelow</enum>
+																				</property>
+																				<property name="tickInterval">
+																					<number>1</number>
+																				</property>
+																			</widget>
+																		</item>
+																		<item>
+																			<spacer name="verticalSpacer_5">
+																				<property name="orientation">
+																					<enum>Qt::Vertical</enum>
+																				</property>
+																				<property name="sizeHint" stdset="0">
+																					<size>
+																						<width>20</width>
+																						<height>40</height>
+																					</size>
+																				</property>
+																			</spacer>
+																		</item>
+																	</layout>
+																</widget>
+																<widget class="QWidget" name="settings_data_tab">
+																	<layout class="QFormLayout" name="formLayout">
+																		<property name="fieldGrowthPolicy">
+																			<enum>QFormLayout::ExpandingFieldsGrow</enum>
+																		</property>
+																		<property name="labelAlignment">
+																			<set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+																		</property>
+																		<property name="formAlignment">
+																			<set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+																		</property>
+																		<item row="0" column="0">
+																			<widget class="QLabel" name="tribler_data_setting_heading">
+																				<property name="styleSheet">
+																					<string notr="true">font-weight: bold; color: white;</string>
+																				</property>
+																				<property name="text">
+																					<string>Tribler state directory</string>
+																				</property>
+																			</widget>
+																		</item>
+																		<item row="1" column="0" colspan="2">
+																			<widget class="QLabel" name="tribler_data_setting_brief">
+																				<property name="styleSheet">
+																					<string notr="true">color: white;</string>
+																				</property>
+																				<property name="text">
+																					<string>This is where Tribler stores housekeeping data which includes databases and config files. Note that, your torrent data is not stored here.</string>
+																				</property>
+																			</widget>
+																		</item>
+																		<item row="2" column="0" colspan="2">
+																			<widget class="QWidget" name="state_dir_current" native="true">
+																				<layout class="QVBoxLayout" name="state_dir_current_layout">
+																					<item>
+																						<widget class="QLabel" name="sd_current_version">
+																							<property name="styleSheet">
+																								<string notr="true">font-weight: bold; color: white;</string>
+																							</property>
+																							<property name="text">
+																								<string>Current version</string>
+																							</property>
+																						</widget>
+																					</item>
+																				</layout>
+																			</widget>
+																		</item>
+																		<item row="3" column="0" colspan="2">
+																			<widget class="QWidget" name="state_dir_list" native="true">
+																				<layout class="QVBoxLayout" name="state_dir_list_layout">
+																					<item>
+																						<widget class="QLabel" name="sd_old_version">
+																							<property name="styleSheet">
+																								<string notr="true">font-weight: bold; color: white;</string>
+																							</property>
+																							<property name="text">
+																								<string>Older versions</string>
+																							</property>
+																						</widget>
+																					</item>
+																				</layout>
+																			</widget>
+																		</item>
+																		<item row="4" column="0" colspan="2">
+																			<widget class="QPushButton" name="btn_remove_old_state_dir">
+																				<property name="enabled">
+																					<bool>true</bool>
+																				</property>
+																				<property name="sizePolicy">
+																					<sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+																						<horstretch>0</horstretch>
+																						<verstretch>0</verstretch>
+																					</sizepolicy>
+																				</property>
+																				<property name="minimumSize">
+																					<size>
+																						<width>250</width>
+																						<height>32</height>
+																					</size>
+																				</property>
+																				<property name="maximumSize">
+																					<size>
+																						<width>250</width>
+																						<height>32</height>
+																					</size>
+																				</property>
+																				<property name="cursor">
+																					<cursorShape>PointingHandCursor</cursorShape>
+																				</property>
+																				<property name="layoutDirection">
+																					<enum>Qt::LeftToRight</enum>
+																				</property>
+																				<property name="autoFillBackground">
+																					<bool>false</bool>
+																				</property>
+																				<property name="styleSheet">
+																					<string notr="true">border-radius:16px; margin-left:16px; background-color:#e67300; color:#fff;</string>
+																				</property>
+																				<property name="text">
+																					<string>Remove selected versions</string>
+																				</property>
+																				<property name="autoDefault">
+																					<bool>false</bool>
+																				</property>
+																				<property name="default">
+																					<bool>false</bool>
+																				</property>
+																				<property name="flat">
+																					<bool>false</bool>
+																				</property>
+																			</widget>
+																		</item>
+																	</layout>
+																</widget>
+																<widget class="QWidget" name="settings_debug_tab">
+																	<layout class="QFormLayout" name="settigsDebugFormLayout">
+																		<property name="fieldGrowthPolicy">
+																			<enum>QFormLayout::ExpandingFieldsGrow</enum>
+																		</property>
+																		<property name="labelAlignment">
+																			<set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+																		</property>
+																		<property name="formAlignment">
+																			<set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+																		</property>
+																		<item row="0" column="0">
+																			<widget class="QLabel" name="tribler_profile_header_label">
+																				<property name="styleSheet">
+																					<string notr="true">font-weight: bold;
 color: white;</string>
-                    </property>
-                    <property name="text">
-                     <string>Developer mode</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="1" column="0">
-                   <widget class="QCheckBox" name="developer_mode_enabled_checkbox">
-                    <property name="text">
-                     <string>Enable developer mode </string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="2" column="0">
-                   <widget class="QLabel" name="tribler_profile_header_label">
-                    <property name="styleSheet">
-                     <string notr="true">font-weight: bold;
+																				</property>
+																				<property name="text">
+																					<string>Developer mode</string>
+																				</property>
+																			</widget>
+																		</item>
+																		<item row="1" column="0">
+																			<widget class="QCheckBox" name="developer_mode_enabled_checkbox">
+																				<property name="text">
+																					<string>Enable developer mode </string>
+																				</property>
+																			</widget>
+																		</item>
+																		<item row="2" column="0">
+																			<widget class="QLabel" name="tribler_profile_header_label">
+																				<property name="styleSheet">
+																					<string notr="true">font-weight: bold;
 color: white;</string>
-                    </property>
-                    <property name="text">
-                     <string>Log Directory</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="3" column="0">
-                   <widget class="QLabel" name="label_log_location">
-                    <property name="styleSheet">
-                     <string notr="true"/>
-                    </property>
-                    <property name="text">
-                     <string>Log directory </string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="3" column="1">
-                   <widget class="QWidget" name="log_location_widget" native="true">
-                    <layout class="QHBoxLayout" name="log_location_layout">
-                     <property name="spacing">
-                      <number>0</number>
-                     </property>
-                     <property name="leftMargin">
-                      <number>0</number>
-                     </property>
-                     <property name="topMargin">
-                      <number>0</number>
-                     </property>
-                     <property name="rightMargin">
-                      <number>0</number>
-                     </property>
-                     <property name="bottomMargin">
-                      <number>0</number>
-                     </property>
-                     <item>
-                      <widget class="QLineEdit" name="log_location_input">
-                       <property name="sizePolicy">
-                        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                         <horstretch>0</horstretch>
-                         <verstretch>0</verstretch>
-                        </sizepolicy>
-                       </property>
-                       <property name="minimumSize">
-                        <size>
-                         <width>250</width>
-                         <height>28</height>
-                        </size>
-                       </property>
-                       <property name="maximumSize">
-                        <size>
-                         <width>250</width>
-                         <height>28</height>
-                        </size>
-                       </property>
-                       <property name="styleSheet">
-                        <string notr="true"/>
-                       </property>
-                       <property name="placeholderText">
-                        <string>Log directory</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item>
-                      <widget class="QToolButton" name="log_location_chooser_button">
-                       <property name="minimumSize">
-                        <size>
-                         <width>50</width>
-                         <height>30</height>
-                        </size>
-                       </property>
-                       <property name="baseSize">
-                        <size>
-                         <width>50</width>
-                         <height>30</height>
-                        </size>
-                       </property>
-                       <property name="toolTip">
-                        <string>Browse directory</string>
-                       </property>
-                       <property name="text">
-                        <string>Browse</string>
-                       </property>
-                       <property name="icon">
-                        <iconset>
-                         <normaloff>../images/browse_folder.svg</normaloff>../images/browse_folder.svg</iconset>
-                       </property>
-                       <property name="toolButtonStyle">
-                        <enum>Qt::ToolButtonIconOnly</enum>
-                       </property>
-                       <property name="autoRaise">
-                        <bool>false</bool>
-                       </property>
-                       <property name="arrowType">
-                        <enum>Qt::NoArrow</enum>
-                       </property>
-                      </widget>
-                     </item>
-                    </layout>
-                   </widget>
-                  </item>
-                  <item row="4" column="0">
-                   <widget class="QLabel" name="label_68">
-                    <property name="styleSheet">
-                     <string notr="true">font-weight: bold;color: white;</string>
-                    </property>
-                    <property name="text">
-                     <string>Resource Monitoring</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="5" column="0">
-                   <widget class="QCheckBox" name="checkbox_enable_resource_log">
-                    <property name="text">
-                     <string>Enable resource monitoring</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="6" column="0">
-                   <widget class="QLabel" name="label_66">
-                    <property name="styleSheet">
-                     <string notr="true">font-weight: bold;color: white;</string>
-                    </property>
-                    <property name="text">
-                     <string>CPU Priority [0-5]</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="7" column="0" colspan="2">
-                   <widget class="QSlider" name="slider_cpu_level">
-                    <property name="maximum">
-                     <number>5</number>
-                    </property>
-                    <property name="pageStep">
-                     <number>1</number>
-                    </property>
-                    <property name="value">
-                     <number>1</number>
-                    </property>
-                    <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="8" column="0">
-                   <widget class="QLabel" name="cpu_priority_value">
-                    <property name="text">
-                     <string>Current priority = 1</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="9" column="0">
-                   <widget class="QLabel" name="label_90">
-                    <property name="styleSheet">
-                     <string notr="true">font-weight: bold;color: white;</string>
-                    </property>
-                    <property name="text">
-                     <string>Network (IPv8) Statistics</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="10" column="0" colspan="2">
-                   <widget class="QCheckBox" name="checkbox_enable_network_statistics">
-                    <property name="text">
-                     <string>Enable network statistics (requires restart)</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="11" column="0">
-                   <widget class="QLabel" name="network_statistics_warning">
-                    <property name="text">
-                     <string>Note: Enabling statistics slightly slows down Tribler</string>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-        <widget class="DownloadsPage" name="downloads_page">
-         <layout class="QVBoxLayout" name="verticalLayout">
-          <property name="spacing">
-           <number>0</number>
-          </property>
-          <property name="leftMargin">
-           <number>0</number>
-          </property>
-          <property name="topMargin">
-           <number>0</number>
-          </property>
-          <property name="rightMargin">
-           <number>0</number>
-          </property>
-          <property name="bottomMargin">
-           <number>0</number>
-          </property>
-          <item>
-           <widget class="QWidget" name="widget_2" native="true">
-            <layout class="QHBoxLayout" name="horizontalLayout_21">
-             <property name="spacing">
-              <number>0</number>
-             </property>
-             <property name="leftMargin">
-              <number>0</number>
-             </property>
-             <property name="topMargin">
-              <number>0</number>
-             </property>
-             <property name="rightMargin">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
-              <number>0</number>
-             </property>
-             <item>
-              <widget class="QLabel" name="downloads_header_label">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="minimumSize">
-                <size>
-                 <width>0</width>
-                 <height>44</height>
-                </size>
-               </property>
-               <property name="maximumSize">
-                <size>
-                 <width>16777215</width>
-                 <height>44</height>
-                </size>
-               </property>
-               <property name="styleSheet">
-                <string notr="true">margin: 10px;
+																				</property>
+																				<property name="text">
+																					<string>Log Directory</string>
+																				</property>
+																			</widget>
+																		</item>
+																		<item row="3" column="0">
+																			<widget class="QLabel" name="label_log_location">
+																				<property name="styleSheet">
+																					<string notr="true"/>
+																				</property>
+																				<property name="text">
+																					<string>Log directory </string>
+																				</property>
+																			</widget>
+																		</item>
+																		<item row="3" column="1">
+																			<widget class="QWidget" name="log_location_widget" native="true">
+																				<layout class="QHBoxLayout" name="log_location_layout">
+																					<property name="spacing">
+																						<number>0</number>
+																					</property>
+																					<property name="leftMargin">
+																						<number>0</number>
+																					</property>
+																					<property name="topMargin">
+																						<number>0</number>
+																					</property>
+																					<property name="rightMargin">
+																						<number>0</number>
+																					</property>
+																					<property name="bottomMargin">
+																						<number>0</number>
+																					</property>
+																					<item>
+																						<widget class="QLineEdit" name="log_location_input">
+																							<property name="sizePolicy">
+																								<sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+																									<horstretch>0</horstretch>
+																									<verstretch>0</verstretch>
+																								</sizepolicy>
+																							</property>
+																							<property name="minimumSize">
+																								<size>
+																									<width>250</width>
+																									<height>28</height>
+																								</size>
+																							</property>
+																							<property name="maximumSize">
+																								<size>
+																									<width>250</width>
+																									<height>28</height>
+																								</size>
+																							</property>
+																							<property name="styleSheet">
+																								<string notr="true"/>
+																							</property>
+																							<property name="placeholderText">
+																								<string>Log directory</string>
+																							</property>
+																						</widget>
+																					</item>
+																					<item>
+																						<widget class="QToolButton" name="log_location_chooser_button">
+																							<property name="minimumSize">
+																								<size>
+																									<width>50</width>
+																									<height>30</height>
+																								</size>
+																							</property>
+																							<property name="baseSize">
+																								<size>
+																									<width>50</width>
+																									<height>30</height>
+																								</size>
+																							</property>
+																							<property name="toolTip">
+																								<string>Browse directory</string>
+																							</property>
+																							<property name="text">
+																								<string>Browse</string>
+																							</property>
+																							<property name="icon">
+																								<iconset>
+																									<normaloff>../images/browse_folder.svg</normaloff>../images/browse_folder.svg
+																								</iconset>
+																							</property>
+																							<property name="toolButtonStyle">
+																								<enum>Qt::ToolButtonIconOnly</enum>
+																							</property>
+																							<property name="autoRaise">
+																								<bool>false</bool>
+																							</property>
+																							<property name="arrowType">
+																								<enum>Qt::NoArrow</enum>
+																							</property>
+																						</widget>
+																					</item>
+																				</layout>
+																			</widget>
+																		</item>
+																		<item row="4" column="0">
+																			<widget class="QLabel" name="label_68">
+																				<property name="styleSheet">
+																					<string notr="true">font-weight: bold;color: white;</string>
+																				</property>
+																				<property name="text">
+																					<string>Resource Monitoring</string>
+																				</property>
+																			</widget>
+																		</item>
+																		<item row="5" column="0">
+																			<widget class="QCheckBox" name="checkbox_enable_resource_log">
+																				<property name="text">
+																					<string>Enable resource monitoring</string>
+																				</property>
+																			</widget>
+																		</item>
+																		<item row="6" column="0">
+																			<widget class="QLabel" name="label_66">
+																				<property name="styleSheet">
+																					<string notr="true">font-weight: bold;color: white;</string>
+																				</property>
+																				<property name="text">
+																					<string>CPU Priority [0-5]</string>
+																				</property>
+																			</widget>
+																		</item>
+																		<item row="7" column="0" colspan="2">
+																			<widget class="QSlider" name="slider_cpu_level">
+																				<property name="maximum">
+																					<number>5</number>
+																				</property>
+																				<property name="pageStep">
+																					<number>1</number>
+																				</property>
+																				<property name="value">
+																					<number>1</number>
+																				</property>
+																				<property name="orientation">
+																					<enum>Qt::Horizontal</enum>
+																				</property>
+																			</widget>
+																		</item>
+																		<item row="8" column="0">
+																			<widget class="QLabel" name="cpu_priority_value">
+																				<property name="text">
+																					<string>Current priority = 1</string>
+																				</property>
+																			</widget>
+																		</item>
+																		<item row="9" column="0">
+																			<widget class="QLabel" name="label_90">
+																				<property name="styleSheet">
+																					<string notr="true">font-weight: bold;color: white;</string>
+																				</property>
+																				<property name="text">
+																					<string>Network (IPv8) Statistics</string>
+																				</property>
+																			</widget>
+																		</item>
+																		<item row="10" column="0" colspan="2">
+																			<widget class="QCheckBox" name="checkbox_enable_network_statistics">
+																				<property name="text">
+																					<string>Enable network statistics (requires restart)</string>
+																				</property>
+																			</widget>
+																		</item>
+																		<item row="11" column="0">
+																			<widget class="QLabel" name="network_statistics_warning">
+																				<property name="text">
+																					<string>Note: Enabling statistics slightly slows down Tribler</string>
+																				</property>
+																			</widget>
+																		</item>
+																	</layout>
+																</widget>
+															</widget>
+														</item>
+													</layout>
+												</widget>
+											</widget>
+										</item>
+									</layout>
+								</widget>
+								<widget class="DownloadsPage" name="downloads_page">
+									<layout class="QVBoxLayout" name="verticalLayout">
+										<property name="spacing">
+											<number>0</number>
+										</property>
+										<property name="leftMargin">
+											<number>0</number>
+										</property>
+										<property name="topMargin">
+											<number>0</number>
+										</property>
+										<property name="rightMargin">
+											<number>0</number>
+										</property>
+										<property name="bottomMargin">
+											<number>0</number>
+										</property>
+										<item>
+											<widget class="QWidget" name="widget_2" native="true">
+												<layout class="QHBoxLayout" name="horizontalLayout_21">
+													<property name="spacing">
+														<number>0</number>
+													</property>
+													<property name="leftMargin">
+														<number>0</number>
+													</property>
+													<property name="topMargin">
+														<number>0</number>
+													</property>
+													<property name="rightMargin">
+														<number>0</number>
+													</property>
+													<property name="bottomMargin">
+														<number>0</number>
+													</property>
+													<item>
+														<widget class="QLabel" name="downloads_header_label">
+															<property name="sizePolicy">
+																<sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+																	<horstretch>0</horstretch>
+																	<verstretch>0</verstretch>
+																</sizepolicy>
+															</property>
+															<property name="minimumSize">
+																<size>
+																	<width>0</width>
+																	<height>44</height>
+																</size>
+															</property>
+															<property name="maximumSize">
+																<size>
+																	<width>16777215</width>
+																	<height>44</height>
+																</size>
+															</property>
+															<property name="styleSheet">
+																<string notr="true">margin: 10px;
 font-size: 20px;
 font-weight: bold;
 color: white;</string>
-               </property>
-               <property name="text">
-                <string>Downloads</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <spacer name="horizontalSpacer_49">
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>40</width>
-                 <height>20</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-             <item>
-              <widget class="QLineEdit" name="downloads_filter_input">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="minimumSize">
-                <size>
-                 <width>180</width>
-                 <height>28</height>
-                </size>
-               </property>
-               <property name="maximumSize">
-                <size>
-                 <width>180</width>
-                 <height>28</height>
-                </size>
-               </property>
-               <property name="styleSheet">
-                <string notr="true">QLineEdit {
+															</property>
+															<property name="text">
+																<string>Downloads</string>
+															</property>
+														</widget>
+													</item>
+													<item>
+														<spacer name="horizontalSpacer_49">
+															<property name="orientation">
+																<enum>Qt::Horizontal</enum>
+															</property>
+															<property name="sizeHint" stdset="0">
+																<size>
+																	<width>40</width>
+																	<height>20</height>
+																</size>
+															</property>
+														</spacer>
+													</item>
+													<item>
+														<widget class="QLineEdit" name="downloads_filter_input">
+															<property name="sizePolicy">
+																<sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+																	<horstretch>0</horstretch>
+																	<verstretch>0</verstretch>
+																</sizepolicy>
+															</property>
+															<property name="minimumSize">
+																<size>
+																	<width>180</width>
+																	<height>28</height>
+																</size>
+															</property>
+															<property name="maximumSize">
+																<size>
+																	<width>180</width>
+																	<height>28</height>
+																</size>
+															</property>
+															<property name="styleSheet">
+																<string notr="true">QLineEdit {
 border-radius: 3px;
 }
 QLineEdit:focus, QLineEdit::hover {
 background-color: #404040;
 color: white;
 }</string>
-               </property>
-               <property name="placeholderText">
-                <string>Filter</string>
-               </property>
-               <property name="clearButtonEnabled">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <spacer name="horizontalSpacer_64">
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-               <property name="sizeType">
-                <enum>QSizePolicy::Fixed</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>12</width>
-                 <height>20</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-             <item>
-              <spacer name="horizontalSpacer_69">
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-               <property name="sizeType">
-                <enum>QSizePolicy::Minimum</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>6</width>
-                 <height>20</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-             <item>
-              <widget class="CircleButton" name="start_download_button">
-               <property name="enabled">
-                <bool>false</bool>
-               </property>
-               <property name="minimumSize">
-                <size>
-                 <width>28</width>
-                 <height>28</height>
-                </size>
-               </property>
-               <property name="maximumSize">
-                <size>
-                 <width>28</width>
-                 <height>28</height>
-                </size>
-               </property>
-               <property name="cursor">
-                <cursorShape>PointingHandCursor</cursorShape>
-               </property>
-               <property name="styleSheet">
-                <string notr="true">border-radius: 14px;
+															</property>
+															<property name="placeholderText">
+																<string>Filter</string>
+															</property>
+															<property name="clearButtonEnabled">
+																<bool>true</bool>
+															</property>
+														</widget>
+													</item>
+													<item>
+														<spacer name="horizontalSpacer_64">
+															<property name="orientation">
+																<enum>Qt::Horizontal</enum>
+															</property>
+															<property name="sizeType">
+																<enum>QSizePolicy::Fixed</enum>
+															</property>
+															<property name="sizeHint" stdset="0">
+																<size>
+																	<width>12</width>
+																	<height>20</height>
+																</size>
+															</property>
+														</spacer>
+													</item>
+													<item>
+														<spacer name="horizontalSpacer_69">
+															<property name="orientation">
+																<enum>Qt::Horizontal</enum>
+															</property>
+															<property name="sizeType">
+																<enum>QSizePolicy::Minimum</enum>
+															</property>
+															<property name="sizeHint" stdset="0">
+																<size>
+																	<width>6</width>
+																	<height>20</height>
+																</size>
+															</property>
+														</spacer>
+													</item>
+													<item>
+														<widget class="CircleButton" name="start_download_button">
+															<property name="enabled">
+																<bool>false</bool>
+															</property>
+															<property name="minimumSize">
+																<size>
+																	<width>28</width>
+																	<height>28</height>
+																</size>
+															</property>
+															<property name="maximumSize">
+																<size>
+																	<width>28</width>
+																	<height>28</height>
+																</size>
+															</property>
+															<property name="cursor">
+																<cursorShape>PointingHandCursor</cursorShape>
+															</property>
+															<property name="styleSheet">
+																<string notr="true">border-radius: 14px;
 padding-left: 2px;</string>
-               </property>
-               <property name="text">
-                <string/>
-               </property>
-               <property name="icon">
-                <iconset>
-                 <normaloff>../images/play.png</normaloff>../images/play.png</iconset>
-               </property>
-               <property name="iconSize">
-                <size>
-                 <width>14</width>
-                 <height>14</height>
-                </size>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <spacer name="horizontalSpacer_41">
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-               <property name="sizeType">
-                <enum>QSizePolicy::Fixed</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>6</width>
-                 <height>20</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-             <item>
-              <widget class="CircleButton" name="stop_download_button">
-               <property name="enabled">
-                <bool>false</bool>
-               </property>
-               <property name="minimumSize">
-                <size>
-                 <width>28</width>
-                 <height>28</height>
-                </size>
-               </property>
-               <property name="maximumSize">
-                <size>
-                 <width>28</width>
-                 <height>28</height>
-                </size>
-               </property>
-               <property name="cursor">
-                <cursorShape>PointingHandCursor</cursorShape>
-               </property>
-               <property name="styleSheet">
-                <string notr="true">border-radius: 14px;</string>
-               </property>
-               <property name="text">
-                <string/>
-               </property>
-               <property name="icon">
-                <iconset>
-                 <normaloff>../images/stop.png</normaloff>../images/stop.png</iconset>
-               </property>
-               <property name="iconSize">
-                <size>
-                 <width>12</width>
-                 <height>12</height>
-                </size>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <spacer name="horizontalSpacer_40">
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-               <property name="sizeType">
-                <enum>QSizePolicy::Fixed</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>6</width>
-                 <height>20</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-             <item>
-              <widget class="CircleButton" name="remove_download_button">
-               <property name="enabled">
-                <bool>false</bool>
-               </property>
-               <property name="minimumSize">
-                <size>
-                 <width>28</width>
-                 <height>28</height>
-                </size>
-               </property>
-               <property name="maximumSize">
-                <size>
-                 <width>28</width>
-                 <height>28</height>
-                </size>
-               </property>
-               <property name="cursor">
-                <cursorShape>PointingHandCursor</cursorShape>
-               </property>
-               <property name="styleSheet">
-                <string notr="true">border-radius: 14px;</string>
-               </property>
-               <property name="text">
-                <string/>
-               </property>
-               <property name="icon">
-                <iconset>
-                 <normaloff>../images/delete.png</normaloff>../images/delete.png</iconset>
-               </property>
-               <property name="iconSize">
-                <size>
-                 <width>12</width>
-                 <height>12</height>
-                </size>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <spacer name="horizontalSpacer_39">
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-               <property name="sizeType">
-                <enum>QSizePolicy::Fixed</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>12</width>
-                 <height>20</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item>
-           <widget class="TabButtonPanel" name="downloads_tab" native="true">
-            <layout class="QHBoxLayout" name="horizontalLayout_20">
-             <property name="spacing">
-              <number>0</number>
-             </property>
-             <property name="leftMargin">
-              <number>0</number>
-             </property>
-             <property name="topMargin">
-              <number>0</number>
-             </property>
-             <property name="rightMargin">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
-              <number>0</number>
-             </property>
-             <item>
-              <spacer name="horizontalSpacer_29">
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-               <property name="sizeType">
-                <enum>QSizePolicy::Fixed</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>10</width>
-                 <height>20</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-             <item>
-              <widget class="UnderlineTabButton" name="downloads_all_button">
-               <property name="enabled">
-                <bool>false</bool>
-               </property>
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="minimumSize">
-                <size>
-                 <width>0</width>
-                 <height>36</height>
-                </size>
-               </property>
-               <property name="maximumSize">
-                <size>
-                 <width>16777215</width>
-                 <height>36</height>
-                </size>
-               </property>
-               <property name="cursor">
-                <cursorShape>PointingHandCursor</cursorShape>
-               </property>
-               <property name="styleSheet">
-                <string notr="true"/>
-               </property>
-               <property name="text">
-                <string>ALL</string>
-               </property>
-               <property name="checkable">
-                <bool>true</bool>
-               </property>
-               <property name="checked">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="UnderlineTabButton" name="downloads_downloading_button">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="minimumSize">
-                <size>
-                 <width>0</width>
-                 <height>36</height>
-                </size>
-               </property>
-               <property name="maximumSize">
-                <size>
-                 <width>16777215</width>
-                 <height>36</height>
-                </size>
-               </property>
-               <property name="cursor">
-                <cursorShape>PointingHandCursor</cursorShape>
-               </property>
-               <property name="styleSheet">
-                <string notr="true"/>
-               </property>
-               <property name="text">
-                <string>DOWNLOADING</string>
-               </property>
-               <property name="checkable">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="UnderlineTabButton" name="downloads_completed_button">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="minimumSize">
-                <size>
-                 <width>0</width>
-                 <height>36</height>
-                </size>
-               </property>
-               <property name="maximumSize">
-                <size>
-                 <width>16777215</width>
-                 <height>36</height>
-                </size>
-               </property>
-               <property name="cursor">
-                <cursorShape>PointingHandCursor</cursorShape>
-               </property>
-               <property name="styleSheet">
-                <string notr="true"/>
-               </property>
-               <property name="text">
-                <string>COMPLETED</string>
-               </property>
-               <property name="checkable">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="UnderlineTabButton" name="downloads_active_button">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="minimumSize">
-                <size>
-                 <width>0</width>
-                 <height>36</height>
-                </size>
-               </property>
-               <property name="maximumSize">
-                <size>
-                 <width>16777215</width>
-                 <height>36</height>
-                </size>
-               </property>
-               <property name="cursor">
-                <cursorShape>PointingHandCursor</cursorShape>
-               </property>
-               <property name="styleSheet">
-                <string notr="true"/>
-               </property>
-               <property name="text">
-                <string>ACTIVE</string>
-               </property>
-               <property name="checkable">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="UnderlineTabButton" name="downloads_inactive_button">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="minimumSize">
-                <size>
-                 <width>0</width>
-                 <height>36</height>
-                </size>
-               </property>
-               <property name="maximumSize">
-                <size>
-                 <width>16777215</width>
-                 <height>36</height>
-                </size>
-               </property>
-               <property name="cursor">
-                <cursorShape>PointingHandCursor</cursorShape>
-               </property>
-               <property name="styleSheet">
-                <string notr="true"/>
-               </property>
-               <property name="text">
-                <string>INACTIVE</string>
-               </property>
-               <property name="checkable">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <spacer name="horizontalSpacer_28">
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>40</width>
-                 <height>20</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item>
-           <widget class="QWidget" name="downloads_splitter_container" native="true">
-            <layout class="QGridLayout" name="gridLayout_3">
-             <property name="leftMargin">
-              <number>0</number>
-             </property>
-             <property name="topMargin">
-              <number>0</number>
-             </property>
-             <property name="rightMargin">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
-              <number>0</number>
-             </property>
-             <property name="verticalSpacing">
-              <number>6</number>
-             </property>
-             <item row="0" column="0">
-              <widget class="QSplitter" name="downloads_splitter">
-               <property name="styleSheet">
-                <string notr="true">QSplitter::handle { background-color: #555; }</string>
-               </property>
-               <property name="orientation">
-                <enum>Qt::Vertical</enum>
-               </property>
-               <property name="handleWidth">
-                <number>5</number>
-               </property>
-               <widget class="QWidget" name="download_list_container" native="true">
-                <layout class="QVBoxLayout" name="veritcalLayout">
-                 <property name="spacing">
-                  <number>0</number>
-                 </property>
-                 <property name="leftMargin">
-                  <number>0</number>
-                 </property>
-                 <property name="topMargin">
-                  <number>0</number>
-                 </property>
-                 <property name="rightMargin">
-                  <number>0</number>
-                 </property>
-                 <property name="bottomMargin">
-                  <number>0</number>
-                 </property>
-                 <item>
-                  <widget class="QLabel" name="diskspace_usage">
-                   <property name="styleSheet">
-                    <string notr="true">color: #B5B5B5; margin-left: 6px;</string>
-                   </property>
-                   <property name="text">
-                    <string/>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QTreeWidget" name="downloads_list">
-                   <property name="contextMenuPolicy">
-                    <enum>Qt::CustomContextMenu</enum>
-                   </property>
-                   <property name="styleSheet">
-                    <string notr="true">QTreeWidget {
+															</property>
+															<property name="text">
+																<string/>
+															</property>
+															<property name="icon">
+																<iconset>
+																	<normaloff>../images/play.png</normaloff>../images/play.png
+																</iconset>
+															</property>
+															<property name="iconSize">
+																<size>
+																	<width>14</width>
+																	<height>14</height>
+																</size>
+															</property>
+														</widget>
+													</item>
+													<item>
+														<spacer name="horizontalSpacer_41">
+															<property name="orientation">
+																<enum>Qt::Horizontal</enum>
+															</property>
+															<property name="sizeType">
+																<enum>QSizePolicy::Fixed</enum>
+															</property>
+															<property name="sizeHint" stdset="0">
+																<size>
+																	<width>6</width>
+																	<height>20</height>
+																</size>
+															</property>
+														</spacer>
+													</item>
+													<item>
+														<widget class="CircleButton" name="stop_download_button">
+															<property name="enabled">
+																<bool>false</bool>
+															</property>
+															<property name="minimumSize">
+																<size>
+																	<width>28</width>
+																	<height>28</height>
+																</size>
+															</property>
+															<property name="maximumSize">
+																<size>
+																	<width>28</width>
+																	<height>28</height>
+																</size>
+															</property>
+															<property name="cursor">
+																<cursorShape>PointingHandCursor</cursorShape>
+															</property>
+															<property name="styleSheet">
+																<string notr="true">border-radius: 14px;</string>
+															</property>
+															<property name="text">
+																<string/>
+															</property>
+															<property name="icon">
+																<iconset>
+																	<normaloff>../images/stop.png</normaloff>../images/stop.png
+																</iconset>
+															</property>
+															<property name="iconSize">
+																<size>
+																	<width>12</width>
+																	<height>12</height>
+																</size>
+															</property>
+														</widget>
+													</item>
+													<item>
+														<spacer name="horizontalSpacer_40">
+															<property name="orientation">
+																<enum>Qt::Horizontal</enum>
+															</property>
+															<property name="sizeType">
+																<enum>QSizePolicy::Fixed</enum>
+															</property>
+															<property name="sizeHint" stdset="0">
+																<size>
+																	<width>6</width>
+																	<height>20</height>
+																</size>
+															</property>
+														</spacer>
+													</item>
+													<item>
+														<widget class="CircleButton" name="remove_download_button">
+															<property name="enabled">
+																<bool>false</bool>
+															</property>
+															<property name="minimumSize">
+																<size>
+																	<width>28</width>
+																	<height>28</height>
+																</size>
+															</property>
+															<property name="maximumSize">
+																<size>
+																	<width>28</width>
+																	<height>28</height>
+																</size>
+															</property>
+															<property name="cursor">
+																<cursorShape>PointingHandCursor</cursorShape>
+															</property>
+															<property name="styleSheet">
+																<string notr="true">border-radius: 14px;</string>
+															</property>
+															<property name="text">
+																<string/>
+															</property>
+															<property name="icon">
+																<iconset>
+																	<normaloff>../images/delete.png</normaloff>../images/delete.png
+																</iconset>
+															</property>
+															<property name="iconSize">
+																<size>
+																	<width>12</width>
+																	<height>12</height>
+																</size>
+															</property>
+														</widget>
+													</item>
+													<item>
+														<spacer name="horizontalSpacer_39">
+															<property name="orientation">
+																<enum>Qt::Horizontal</enum>
+															</property>
+															<property name="sizeType">
+																<enum>QSizePolicy::Fixed</enum>
+															</property>
+															<property name="sizeHint" stdset="0">
+																<size>
+																	<width>12</width>
+																	<height>20</height>
+																</size>
+															</property>
+														</spacer>
+													</item>
+												</layout>
+											</widget>
+										</item>
+										<item>
+											<widget class="TabButtonPanel" name="downloads_tab" native="true">
+												<layout class="QHBoxLayout" name="horizontalLayout_20">
+													<property name="spacing">
+														<number>0</number>
+													</property>
+													<property name="leftMargin">
+														<number>0</number>
+													</property>
+													<property name="topMargin">
+														<number>0</number>
+													</property>
+													<property name="rightMargin">
+														<number>0</number>
+													</property>
+													<property name="bottomMargin">
+														<number>0</number>
+													</property>
+													<item>
+														<spacer name="horizontalSpacer_29">
+															<property name="orientation">
+																<enum>Qt::Horizontal</enum>
+															</property>
+															<property name="sizeType">
+																<enum>QSizePolicy::Fixed</enum>
+															</property>
+															<property name="sizeHint" stdset="0">
+																<size>
+																	<width>10</width>
+																	<height>20</height>
+																</size>
+															</property>
+														</spacer>
+													</item>
+													<item>
+														<widget class="UnderlineTabButton" name="downloads_all_button">
+															<property name="enabled">
+																<bool>false</bool>
+															</property>
+															<property name="sizePolicy">
+																<sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+																	<horstretch>0</horstretch>
+																	<verstretch>0</verstretch>
+																</sizepolicy>
+															</property>
+															<property name="minimumSize">
+																<size>
+																	<width>0</width>
+																	<height>36</height>
+																</size>
+															</property>
+															<property name="maximumSize">
+																<size>
+																	<width>16777215</width>
+																	<height>36</height>
+																</size>
+															</property>
+															<property name="cursor">
+																<cursorShape>PointingHandCursor</cursorShape>
+															</property>
+															<property name="styleSheet">
+																<string notr="true"/>
+															</property>
+															<property name="text">
+																<string>ALL</string>
+															</property>
+															<property name="checkable">
+																<bool>true</bool>
+															</property>
+															<property name="checked">
+																<bool>true</bool>
+															</property>
+														</widget>
+													</item>
+													<item>
+														<widget class="UnderlineTabButton" name="downloads_downloading_button">
+															<property name="sizePolicy">
+																<sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+																	<horstretch>0</horstretch>
+																	<verstretch>0</verstretch>
+																</sizepolicy>
+															</property>
+															<property name="minimumSize">
+																<size>
+																	<width>0</width>
+																	<height>36</height>
+																</size>
+															</property>
+															<property name="maximumSize">
+																<size>
+																	<width>16777215</width>
+																	<height>36</height>
+																</size>
+															</property>
+															<property name="cursor">
+																<cursorShape>PointingHandCursor</cursorShape>
+															</property>
+															<property name="styleSheet">
+																<string notr="true"/>
+															</property>
+															<property name="text">
+																<string>DOWNLOADING</string>
+															</property>
+															<property name="checkable">
+																<bool>true</bool>
+															</property>
+														</widget>
+													</item>
+													<item>
+														<widget class="UnderlineTabButton" name="downloads_completed_button">
+															<property name="sizePolicy">
+																<sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+																	<horstretch>0</horstretch>
+																	<verstretch>0</verstretch>
+																</sizepolicy>
+															</property>
+															<property name="minimumSize">
+																<size>
+																	<width>0</width>
+																	<height>36</height>
+																</size>
+															</property>
+															<property name="maximumSize">
+																<size>
+																	<width>16777215</width>
+																	<height>36</height>
+																</size>
+															</property>
+															<property name="cursor">
+																<cursorShape>PointingHandCursor</cursorShape>
+															</property>
+															<property name="styleSheet">
+																<string notr="true"/>
+															</property>
+															<property name="text">
+																<string>COMPLETED</string>
+															</property>
+															<property name="checkable">
+																<bool>true</bool>
+															</property>
+														</widget>
+													</item>
+													<item>
+														<widget class="UnderlineTabButton" name="downloads_active_button">
+															<property name="sizePolicy">
+																<sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+																	<horstretch>0</horstretch>
+																	<verstretch>0</verstretch>
+																</sizepolicy>
+															</property>
+															<property name="minimumSize">
+																<size>
+																	<width>0</width>
+																	<height>36</height>
+																</size>
+															</property>
+															<property name="maximumSize">
+																<size>
+																	<width>16777215</width>
+																	<height>36</height>
+																</size>
+															</property>
+															<property name="cursor">
+																<cursorShape>PointingHandCursor</cursorShape>
+															</property>
+															<property name="styleSheet">
+																<string notr="true"/>
+															</property>
+															<property name="text">
+																<string>ACTIVE</string>
+															</property>
+															<property name="checkable">
+																<bool>true</bool>
+															</property>
+														</widget>
+													</item>
+													<item>
+														<widget class="UnderlineTabButton" name="downloads_inactive_button">
+															<property name="sizePolicy">
+																<sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+																	<horstretch>0</horstretch>
+																	<verstretch>0</verstretch>
+																</sizepolicy>
+															</property>
+															<property name="minimumSize">
+																<size>
+																	<width>0</width>
+																	<height>36</height>
+																</size>
+															</property>
+															<property name="maximumSize">
+																<size>
+																	<width>16777215</width>
+																	<height>36</height>
+																</size>
+															</property>
+															<property name="cursor">
+																<cursorShape>PointingHandCursor</cursorShape>
+															</property>
+															<property name="styleSheet">
+																<string notr="true"/>
+															</property>
+															<property name="text">
+																<string>INACTIVE</string>
+															</property>
+															<property name="checkable">
+																<bool>true</bool>
+															</property>
+														</widget>
+													</item>
+													<item>
+														<spacer name="horizontalSpacer_28">
+															<property name="orientation">
+																<enum>Qt::Horizontal</enum>
+															</property>
+															<property name="sizeHint" stdset="0">
+																<size>
+																	<width>40</width>
+																	<height>20</height>
+																</size>
+															</property>
+														</spacer>
+													</item>
+												</layout>
+											</widget>
+										</item>
+										<item>
+											<widget class="QWidget" name="downloads_splitter_container" native="true">
+												<layout class="QGridLayout" name="gridLayout_3">
+													<property name="leftMargin">
+														<number>0</number>
+													</property>
+													<property name="topMargin">
+														<number>0</number>
+													</property>
+													<property name="rightMargin">
+														<number>0</number>
+													</property>
+													<property name="bottomMargin">
+														<number>0</number>
+													</property>
+													<property name="verticalSpacing">
+														<number>6</number>
+													</property>
+													<item row="0" column="0">
+														<widget class="QSplitter" name="downloads_splitter">
+															<property name="styleSheet">
+																<string notr="true">QSplitter::handle { background-color: #555; }</string>
+															</property>
+															<property name="orientation">
+																<enum>Qt::Vertical</enum>
+															</property>
+															<property name="handleWidth">
+																<number>5</number>
+															</property>
+															<widget class="QWidget" name="download_list_container" native="true">
+																<layout class="QVBoxLayout" name="veritcalLayout">
+																	<property name="spacing">
+																		<number>0</number>
+																	</property>
+																	<property name="leftMargin">
+																		<number>0</number>
+																	</property>
+																	<property name="topMargin">
+																		<number>0</number>
+																	</property>
+																	<property name="rightMargin">
+																		<number>0</number>
+																	</property>
+																	<property name="bottomMargin">
+																		<number>0</number>
+																	</property>
+																	<item>
+																		<widget class="QLabel" name="diskspace_usage">
+																			<property name="styleSheet">
+																				<string notr="true">color: #B5B5B5; margin-left: 6px;</string>
+																			</property>
+																			<property name="text">
+																				<string/>
+																			</property>
+																		</widget>
+																	</item>
+																	<item>
+																		<widget class="QTreeWidget" name="downloads_list">
+																			<property name="contextMenuPolicy">
+																				<enum>Qt::CustomContextMenu</enum>
+																			</property>
+																			<property name="styleSheet">
+																				<string notr="true">QTreeWidget {
     border: none;
     font-size: 13px;
     outline: 0;
@@ -3103,97 +3112,97 @@ padding-left: 2px;</string>
     QTableCornerButton::section {
     background-color: transparent;
     }</string>
-                   </property>
-                   <property name="alternatingRowColors">
-                    <bool>false</bool>
-                   </property>
-                   <property name="selectionMode">
-                    <enum>QAbstractItemView::ExtendedSelection</enum>
-                   </property>
-                   <property name="verticalScrollMode">
-                    <enum>QAbstractItemView::ScrollPerPixel</enum>
-                   </property>
-                   <property name="indentation">
-                    <number>0</number>
-                   </property>
-                   <property name="uniformRowHeights">
-                    <bool>true</bool>
-                   </property>
-                   <property name="sortingEnabled">
-                    <bool>true</bool>
-                   </property>
-                   <column>
-                    <property name="text">
-                     <string>NAME</string>
-                    </property>
-                   </column>
-                   <column>
-                    <property name="text">
-                     <string>SIZE</string>
-                    </property>
-                   </column>
-                   <column>
-                    <property name="text">
-                     <string>PROGRESS</string>
-                    </property>
-                   </column>
-                   <column>
-                    <property name="text">
-                     <string>STATUS</string>
-                    </property>
-                   </column>
-                   <column>
-                    <property name="text">
-                     <string>SEEDS</string>
-                    </property>
-                   </column>
-                   <column>
-                    <property name="text">
-                     <string>PEERS</string>
-                    </property>
-                   </column>
-                   <column>
-                    <property name="text">
-                     <string>SPEED (DOWN)</string>
-                    </property>
-                   </column>
-                   <column>
-                    <property name="text">
-                     <string>SPEED (UP)</string>
-                    </property>
-                   </column>
-                   <column>
-                    <property name="text">
-                     <string>RATIO</string>
-                    </property>
-                   </column>
-                   <column>
-                    <property name="text">
-                     <string>ANONYMOUS?</string>
-                    </property>
-                   </column>
-                   <column>
-                    <property name="text">
-                     <string>HOPS</string>
-                    </property>
-                   </column>
-                   <column>
-                    <property name="text">
-                     <string>ETA</string>
-                    </property>
-                   </column>
-                   <column>
-                    <property name="text">
-                     <string>ADDED ON</string>
-                    </property>
-                   </column>
-                  </widget>
-                 </item>
-                </layout>
-               </widget>
-               <widget class="DownloadsDetailsTabWidget" name="download_details_widget">
-                <property name="styleSheet">
-                 <string notr="true">QLabel {
+																			</property>
+																			<property name="alternatingRowColors">
+																				<bool>false</bool>
+																			</property>
+																			<property name="selectionMode">
+																				<enum>QAbstractItemView::ExtendedSelection</enum>
+																			</property>
+																			<property name="verticalScrollMode">
+																				<enum>QAbstractItemView::ScrollPerPixel</enum>
+																			</property>
+																			<property name="indentation">
+																				<number>0</number>
+																			</property>
+																			<property name="uniformRowHeights">
+																				<bool>true</bool>
+																			</property>
+																			<property name="sortingEnabled">
+																				<bool>true</bool>
+																			</property>
+																			<column>
+																				<property name="text">
+																					<string>NAME</string>
+																				</property>
+																			</column>
+																			<column>
+																				<property name="text">
+																					<string>SIZE</string>
+																				</property>
+																			</column>
+																			<column>
+																				<property name="text">
+																					<string>PROGRESS</string>
+																				</property>
+																			</column>
+																			<column>
+																				<property name="text">
+																					<string>STATUS</string>
+																				</property>
+																			</column>
+																			<column>
+																				<property name="text">
+																					<string>SEEDS</string>
+																				</property>
+																			</column>
+																			<column>
+																				<property name="text">
+																					<string>PEERS</string>
+																				</property>
+																			</column>
+																			<column>
+																				<property name="text">
+																					<string>SPEED (DOWN)</string>
+																				</property>
+																			</column>
+																			<column>
+																				<property name="text">
+																					<string>SPEED (UP)</string>
+																				</property>
+																			</column>
+																			<column>
+																				<property name="text">
+																					<string>RATIO</string>
+																				</property>
+																			</column>
+																			<column>
+																				<property name="text">
+																					<string>ANONYMOUS?</string>
+																				</property>
+																			</column>
+																			<column>
+																				<property name="text">
+																					<string>HOPS</string>
+																				</property>
+																			</column>
+																			<column>
+																				<property name="text">
+																					<string>ETA</string>
+																				</property>
+																			</column>
+																			<column>
+																				<property name="text">
+																					<string>ADDED ON</string>
+																				</property>
+																			</column>
+																		</widget>
+																	</item>
+																</layout>
+															</widget>
+															<widget class="DownloadsDetailsTabWidget" name="download_details_widget">
+																<property name="styleSheet">
+																	<string notr="true">QLabel {
 color: white;
 }
 QTabWidget {
@@ -3207,358 +3216,359 @@ QTabBar::tab:selected {
     color: #555;
     background-color: #777;
 }</string>
-                </property>
-                <property name="currentIndex">
-                 <number>1</number>
-                </property>
-                <property name="movable">
-                 <bool>false</bool>
-                </property>
-                <widget class="QWidget" name="tab">
-                 <attribute name="title">
-                  <string>Details</string>
-                 </attribute>
-                 <layout class="QVBoxLayout" name="verticalLayout_8">
-                  <property name="spacing">
-                   <number>0</number>
-                  </property>
-                  <property name="leftMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>0</number>
-                  </property>
-                  <item>
-                   <widget class="QScrollArea" name="scrollArea_2">
-                    <property name="styleSheet">
-                     <string notr="true"/>
-                    </property>
-                    <property name="widgetResizable">
-                     <bool>true</bool>
-                    </property>
-                    <widget class="QWidget" name="scrollAreaWidgetContents_2">
-                     <property name="geometry">
-                      <rect>
-                       <x>0</x>
-                       <y>0</y>
-                       <width>854</width>
-                       <height>378</height>
-                      </rect>
-                     </property>
-                     <layout class="QFormLayout" name="formLayout_4">
-                      <property name="fieldGrowthPolicy">
-                       <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
-                      </property>
-                      <property name="labelAlignment">
-                       <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-                      </property>
-                      <property name="formAlignment">
-                       <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-                      </property>
-                      <property name="leftMargin">
-                       <number>12</number>
-                      </property>
-                      <property name="topMargin">
-                       <number>12</number>
-                      </property>
-                      <property name="rightMargin">
-                       <number>12</number>
-                      </property>
-                      <property name="bottomMargin">
-                       <number>12</number>
-                      </property>
-                      <item row="0" column="0">
-                       <widget class="QLabel" name="label_39">
-                        <property name="styleSheet">
-                         <string notr="true">font-weight: bold;</string>
-                        </property>
-                        <property name="text">
-                         <string>Progress</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="0" column="1">
-                       <widget class="DownloadProgressBar" name="download_progress_bar" native="true">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
-                        </property>
-                        <property name="minimumSize">
-                         <size>
-                          <width>0</width>
-                          <height>26</height>
-                         </size>
-                        </property>
-                        <property name="maximumSize">
-                         <size>
-                          <width>600000</width>
-                          <height>26</height>
-                         </size>
-                        </property>
-                        <property name="styleSheet">
-                         <string notr="true">background-color: white;
+																</property>
+																<property name="currentIndex">
+																	<number>1</number>
+																</property>
+																<property name="movable">
+																	<bool>false</bool>
+																</property>
+																<widget class="QWidget" name="tab">
+																	<attribute name="title">
+																		<string>Details</string>
+																	</attribute>
+																	<layout class="QVBoxLayout" name="verticalLayout_8">
+																		<property name="spacing">
+																			<number>0</number>
+																		</property>
+																		<property name="leftMargin">
+																			<number>0</number>
+																		</property>
+																		<property name="topMargin">
+																			<number>0</number>
+																		</property>
+																		<property name="rightMargin">
+																			<number>0</number>
+																		</property>
+																		<property name="bottomMargin">
+																			<number>0</number>
+																		</property>
+																		<item>
+																			<widget class="QScrollArea" name="scrollArea_2">
+																				<property name="styleSheet">
+																					<string notr="true"/>
+																				</property>
+																				<property name="widgetResizable">
+																					<bool>true</bool>
+																				</property>
+																				<widget class="QWidget" name="scrollAreaWidgetContents_2">
+																					<property name="geometry">
+																						<rect>
+																							<x>0</x>
+																							<y>0</y>
+																							<width>854</width>
+																							<height>378</height>
+																						</rect>
+																					</property>
+																					<layout class="QFormLayout" name="formLayout_4">
+																						<property name="fieldGrowthPolicy">
+																							<enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+																						</property>
+																						<property name="labelAlignment">
+																							<set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+																						</property>
+																						<property name="formAlignment">
+																							<set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+																						</property>
+																						<property name="leftMargin">
+																							<number>12</number>
+																						</property>
+																						<property name="topMargin">
+																							<number>12</number>
+																						</property>
+																						<property name="rightMargin">
+																							<number>12</number>
+																						</property>
+																						<property name="bottomMargin">
+																							<number>12</number>
+																						</property>
+																						<item row="0" column="0">
+																							<widget class="QLabel" name="label_39">
+																								<property name="styleSheet">
+																									<string notr="true">font-weight: bold;</string>
+																								</property>
+																								<property name="text">
+																									<string>Progress</string>
+																								</property>
+																							</widget>
+																						</item>
+																						<item row="0" column="1">
+																							<widget class="DownloadProgressBar" name="download_progress_bar" native="true">
+																								<property name="sizePolicy">
+																									<sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+																										<horstretch>0</horstretch>
+																										<verstretch>0</verstretch>
+																									</sizepolicy>
+																								</property>
+																								<property name="minimumSize">
+																									<size>
+																										<width>0</width>
+																										<height>26</height>
+																									</size>
+																								</property>
+																								<property name="maximumSize">
+																									<size>
+																										<width>600000</width>
+																										<height>26</height>
+																									</size>
+																								</property>
+																								<property name="styleSheet">
+																									<string notr="true">background-color: white;
 margin-right: 10px;</string>
-                        </property>
-                        <layout class="QHBoxLayout" name="horizontalLayout_36"/>
-                       </widget>
-                      </item>
-                      <item row="1" column="0">
-                       <spacer name="verticalSpacer_14">
-                        <property name="orientation">
-                         <enum>Qt::Vertical</enum>
-                        </property>
-                        <property name="sizeType">
-                         <enum>QSizePolicy::Fixed</enum>
-                        </property>
-                        <property name="sizeHint" stdset="0">
-                         <size>
-                          <width>20</width>
-                          <height>6</height>
-                         </size>
-                        </property>
-                       </spacer>
-                      </item>
-                      <item row="2" column="0">
-                       <widget class="QLabel" name="label_28">
-                        <property name="styleSheet">
-                         <string notr="true">font-weight: bold;</string>
-                        </property>
-                        <property name="text">
-                         <string>Name</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="2" column="1">
-                       <widget class="QLabel" name="download_detail_name_label">
-                        <property name="text">
-                         <string/>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="3" column="0">
-                       <widget class="QLabel" name="label_30">
-                        <property name="styleSheet">
-                         <string notr="true">font-weight: bold;</string>
-                        </property>
-                        <property name="text">
-                         <string>Status</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="3" column="1">
-                       <widget class="QLabel" name="download_detail_status_label">
-                        <property name="text">
-                         <string/>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="4" column="0">
-                       <widget class="QLabel" name="label_36">
-                        <property name="styleSheet">
-                         <string notr="true">font-weight: bold;</string>
-                        </property>
-                        <property name="text">
-                         <string>Filesize</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="4" column="1">
-                       <widget class="QLabel" name="download_detail_filesize_label">
-                        <property name="text">
-                         <string/>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="5" column="0">
-                       <widget class="QLabel" name="label_38">
-                        <property name="styleSheet">
-                         <string notr="true">font-weight: bold;</string>
-                        </property>
-                        <property name="text">
-                         <string>Health</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="5" column="1">
-                       <widget class="QLabel" name="download_detail_health_label">
-                        <property name="text">
-                         <string/>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="6" column="0">
-                       <widget class="QLabel" name="label_40">
-                        <property name="styleSheet">
-                         <string notr="true">font-weight: bold;</string>
-                        </property>
-                        <property name="text">
-                         <string>Infohash</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="6" column="1">
-                       <layout class="QFormLayout" name="infohash_layout">
-                        <property name="labelAlignment">
-                         <set>Qt::AlignCenter</set>
-                        </property>
-                        <property name="formAlignment">
-                         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-                        </property>
-                        <item row="0" column="0">
-                         <widget class="QLabel" name="download_detail_infohash_label">
-                          <property name="text">
-                           <string notr="true">00000000000000000000</string>
-                          </property>
-                         </widget>
-                        </item>
-                        <item row="0" column="1">
-                         <widget class="QToolButton" name="download_detail_copy_magnet_button">
-                          <property name="minimumSize">
-                           <size>
-                            <width>28</width>
-                            <height>28</height>
-                           </size>
-                          </property>
-                          <property name="maximumSize">
-                           <size>
-                            <width>28</width>
-                            <height>28</height>
-                           </size>
-                          </property>
-                          <property name="cursor">
-                           <cursorShape>PointingHandCursor</cursorShape>
-                          </property>
-                          <property name="toolTip">
-                           <string>Click to copy magnet link</string>
-                          </property>
-                          <property name="styleSheet">
-                           <string notr="true">border: none;</string>
-                          </property>
-                          <property name="text">
-                           <string/>
-                          </property>
-                          <property name="icon">
-                           <iconset>
-                            <normaloff>../images/magnet.png</normaloff>../images/magnet.png</iconset>
-                          </property>
-                          <property name="iconSize">
-                           <size>
-                            <width>25</width>
-                            <height>25</height>
-                           </size>
-                          </property>
-                         </widget>
-                        </item>
-                       </layout>
-                      </item>
-                      <item row="7" column="0">
-                       <widget class="QLabel" name="label_44">
-                        <property name="styleSheet">
-                         <string notr="true">font-weight: bold;</string>
-                        </property>
-                        <property name="text">
-                         <string>Destination</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="7" column="1">
-                       <widget class="QLabel" name="download_detail_destination_label">
-                        <property name="text">
-                         <string/>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="8" column="0">
-                       <widget class="QLabel" name="label_46">
-                        <property name="styleSheet">
-                         <string notr="true">font-weight: bold;</string>
-                        </property>
-                        <property name="text">
-                         <string>Ratio</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="8" column="1">
-                       <widget class="QLabel" name="download_detail_ratio_label">
-                        <property name="text">
-                         <string/>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="11" column="0">
-                       <widget class="QLabel" name="label_26">
-                        <property name="styleSheet">
-                         <string notr="true">font-weight: bold;</string>
-                        </property>
-                        <property name="text">
-                         <string>Availability</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="11" column="1">
-                       <widget class="QLabel" name="download_detail_availability_label">
-                        <property name="text">
-                         <string/>
-                        </property>
-                       </widget>
-                      </item>
-                     </layout>
-                    </widget>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-                <widget class="QWidget" name="download_files_tab">
-                 <attribute name="title">
-                  <string>Files</string>
-                 </attribute>
-                 <layout class="QVBoxLayout" name="verticalLayout_7">
-                  <property name="spacing">
-                   <number>0</number>
-                  </property>
-                  <property name="leftMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>0</number>
-                  </property>
-                 </layout>
-                </widget>
-                <widget class="QWidget" name="tab_2">
-                 <attribute name="title">
-                  <string>Trackers</string>
-                 </attribute>
-                 <layout class="QVBoxLayout" name="verticalLayout_9">
-                  <property name="leftMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>0</number>
-                  </property>
-                  <item>
-                   <widget class="QTreeWidget" name="download_trackers_list">
-                    <property name="styleSheet">
-                     <string notr="true">QTreeWidget {
+																								</property>
+																								<layout class="QHBoxLayout" name="horizontalLayout_36"/>
+																							</widget>
+																						</item>
+																						<item row="1" column="0">
+																							<spacer name="verticalSpacer_14">
+																								<property name="orientation">
+																									<enum>Qt::Vertical</enum>
+																								</property>
+																								<property name="sizeType">
+																									<enum>QSizePolicy::Fixed</enum>
+																								</property>
+																								<property name="sizeHint" stdset="0">
+																									<size>
+																										<width>20</width>
+																										<height>6</height>
+																									</size>
+																								</property>
+																							</spacer>
+																						</item>
+																						<item row="2" column="0">
+																							<widget class="QLabel" name="label_28">
+																								<property name="styleSheet">
+																									<string notr="true">font-weight: bold;</string>
+																								</property>
+																								<property name="text">
+																									<string>Name</string>
+																								</property>
+																							</widget>
+																						</item>
+																						<item row="2" column="1">
+																							<widget class="QLabel" name="download_detail_name_label">
+																								<property name="text">
+																									<string/>
+																								</property>
+																							</widget>
+																						</item>
+																						<item row="3" column="0">
+																							<widget class="QLabel" name="label_30">
+																								<property name="styleSheet">
+																									<string notr="true">font-weight: bold;</string>
+																								</property>
+																								<property name="text">
+																									<string>Status</string>
+																								</property>
+																							</widget>
+																						</item>
+																						<item row="3" column="1">
+																							<widget class="QLabel" name="download_detail_status_label">
+																								<property name="text">
+																									<string/>
+																								</property>
+																							</widget>
+																						</item>
+																						<item row="4" column="0">
+																							<widget class="QLabel" name="label_36">
+																								<property name="styleSheet">
+																									<string notr="true">font-weight: bold;</string>
+																								</property>
+																								<property name="text">
+																									<string>Filesize</string>
+																								</property>
+																							</widget>
+																						</item>
+																						<item row="4" column="1">
+																							<widget class="QLabel" name="download_detail_filesize_label">
+																								<property name="text">
+																									<string/>
+																								</property>
+																							</widget>
+																						</item>
+																						<item row="5" column="0">
+																							<widget class="QLabel" name="label_38">
+																								<property name="styleSheet">
+																									<string notr="true">font-weight: bold;</string>
+																								</property>
+																								<property name="text">
+																									<string>Health</string>
+																								</property>
+																							</widget>
+																						</item>
+																						<item row="5" column="1">
+																							<widget class="QLabel" name="download_detail_health_label">
+																								<property name="text">
+																									<string/>
+																								</property>
+																							</widget>
+																						</item>
+																						<item row="6" column="0">
+																							<widget class="QLabel" name="label_40">
+																								<property name="styleSheet">
+																									<string notr="true">font-weight: bold;</string>
+																								</property>
+																								<property name="text">
+																									<string>Infohash</string>
+																								</property>
+																							</widget>
+																						</item>
+																						<item row="6" column="1">
+																							<layout class="QFormLayout" name="infohash_layout">
+																								<property name="labelAlignment">
+																									<set>Qt::AlignCenter</set>
+																								</property>
+																								<property name="formAlignment">
+																									<set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+																								</property>
+																								<item row="0" column="0">
+																									<widget class="QLabel" name="download_detail_infohash_label">
+																										<property name="text">
+																											<string notr="true">00000000000000000000</string>
+																										</property>
+																									</widget>
+																								</item>
+																								<item row="0" column="1">
+																									<widget class="QToolButton" name="download_detail_copy_magnet_button">
+																										<property name="minimumSize">
+																											<size>
+																												<width>28</width>
+																												<height>28</height>
+																											</size>
+																										</property>
+																										<property name="maximumSize">
+																											<size>
+																												<width>28</width>
+																												<height>28</height>
+																											</size>
+																										</property>
+																										<property name="cursor">
+																											<cursorShape>PointingHandCursor</cursorShape>
+																										</property>
+																										<property name="toolTip">
+																											<string>Click to copy magnet link</string>
+																										</property>
+																										<property name="styleSheet">
+																											<string notr="true">border: none;</string>
+																										</property>
+																										<property name="text">
+																											<string/>
+																										</property>
+																										<property name="icon">
+																											<iconset>
+																												<normaloff>../images/magnet.png</normaloff>../images/magnet.png
+																											</iconset>
+																										</property>
+																										<property name="iconSize">
+																											<size>
+																												<width>25</width>
+																												<height>25</height>
+																											</size>
+																										</property>
+																									</widget>
+																								</item>
+																							</layout>
+																						</item>
+																						<item row="7" column="0">
+																							<widget class="QLabel" name="label_44">
+																								<property name="styleSheet">
+																									<string notr="true">font-weight: bold;</string>
+																								</property>
+																								<property name="text">
+																									<string>Destination</string>
+																								</property>
+																							</widget>
+																						</item>
+																						<item row="7" column="1">
+																							<widget class="QLabel" name="download_detail_destination_label">
+																								<property name="text">
+																									<string/>
+																								</property>
+																							</widget>
+																						</item>
+																						<item row="8" column="0">
+																							<widget class="QLabel" name="label_46">
+																								<property name="styleSheet">
+																									<string notr="true">font-weight: bold;</string>
+																								</property>
+																								<property name="text">
+																									<string>Ratio</string>
+																								</property>
+																							</widget>
+																						</item>
+																						<item row="8" column="1">
+																							<widget class="QLabel" name="download_detail_ratio_label">
+																								<property name="text">
+																									<string/>
+																								</property>
+																							</widget>
+																						</item>
+																						<item row="11" column="0">
+																							<widget class="QLabel" name="label_26">
+																								<property name="styleSheet">
+																									<string notr="true">font-weight: bold;</string>
+																								</property>
+																								<property name="text">
+																									<string>Availability</string>
+																								</property>
+																							</widget>
+																						</item>
+																						<item row="11" column="1">
+																							<widget class="QLabel" name="download_detail_availability_label">
+																								<property name="text">
+																									<string/>
+																								</property>
+																							</widget>
+																						</item>
+																					</layout>
+																				</widget>
+																			</widget>
+																		</item>
+																	</layout>
+																</widget>
+																<widget class="QWidget" name="download_files_tab">
+																	<attribute name="title">
+																		<string>Files</string>
+																	</attribute>
+																	<layout class="QVBoxLayout" name="verticalLayout_7">
+																		<property name="spacing">
+																			<number>0</number>
+																		</property>
+																		<property name="leftMargin">
+																			<number>0</number>
+																		</property>
+																		<property name="topMargin">
+																			<number>0</number>
+																		</property>
+																		<property name="rightMargin">
+																			<number>0</number>
+																		</property>
+																		<property name="bottomMargin">
+																			<number>0</number>
+																		</property>
+																	</layout>
+																</widget>
+																<widget class="QWidget" name="tab_2">
+																	<attribute name="title">
+																		<string>Trackers</string>
+																	</attribute>
+																	<layout class="QVBoxLayout" name="verticalLayout_9">
+																		<property name="leftMargin">
+																			<number>0</number>
+																		</property>
+																		<property name="topMargin">
+																			<number>0</number>
+																		</property>
+																		<property name="rightMargin">
+																			<number>0</number>
+																		</property>
+																		<property name="bottomMargin">
+																			<number>0</number>
+																		</property>
+																		<item>
+																			<widget class="QTreeWidget" name="download_trackers_list">
+																				<property name="styleSheet">
+																					<string notr="true">QTreeWidget {
 border: none;
 font-size: 13px;
 }
@@ -3592,56 +3602,56 @@ color: white;
 QTableCornerButton::section {
 background-color: transparent;
 }</string>
-                    </property>
-                    <property name="alternatingRowColors">
-                     <bool>false</bool>
-                    </property>
-                    <property name="selectionMode">
-                     <enum>QAbstractItemView::NoSelection</enum>
-                    </property>
-                    <property name="indentation">
-                     <number>0</number>
-                    </property>
-                    <column>
-                     <property name="text">
-                      <string>NAME</string>
-                     </property>
-                    </column>
-                    <column>
-                     <property name="text">
-                      <string>STATUS</string>
-                     </property>
-                    </column>
-                    <column>
-                     <property name="text">
-                      <string>PEERS</string>
-                     </property>
-                    </column>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-                <widget class="QWidget" name="tab_3">
-                 <attribute name="title">
-                  <string>Peers</string>
-                 </attribute>
-                 <layout class="QVBoxLayout" name="verticalLayout_9">
-                  <property name="leftMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>0</number>
-                  </property>
-                  <item>
-                   <widget class="QTreeWidget" name="download_peers_list">
-                    <property name="styleSheet">
-                     <string notr="true">QTreeWidget {
+																				</property>
+																				<property name="alternatingRowColors">
+																					<bool>false</bool>
+																				</property>
+																				<property name="selectionMode">
+																					<enum>QAbstractItemView::NoSelection</enum>
+																				</property>
+																				<property name="indentation">
+																					<number>0</number>
+																				</property>
+																				<column>
+																					<property name="text">
+																						<string>NAME</string>
+																					</property>
+																				</column>
+																				<column>
+																					<property name="text">
+																						<string>STATUS</string>
+																					</property>
+																				</column>
+																				<column>
+																					<property name="text">
+																						<string>PEERS</string>
+																					</property>
+																				</column>
+																			</widget>
+																		</item>
+																	</layout>
+																</widget>
+																<widget class="QWidget" name="tab_3">
+																	<attribute name="title">
+																		<string>Peers</string>
+																	</attribute>
+																	<layout class="QVBoxLayout" name="verticalLayout_9">
+																		<property name="leftMargin">
+																			<number>0</number>
+																		</property>
+																		<property name="topMargin">
+																			<number>0</number>
+																		</property>
+																		<property name="rightMargin">
+																			<number>0</number>
+																		</property>
+																		<property name="bottomMargin">
+																			<number>0</number>
+																		</property>
+																		<item>
+																			<widget class="QTreeWidget" name="download_peers_list">
+																				<property name="styleSheet">
+																					<string notr="true">QTreeWidget {
 border: none;
 font-size: 13px;
 }
@@ -3675,264 +3685,263 @@ background-color: #303030;
                                      QTableCornerButton::section {
                                      background-color: transparent;
                                      }</string>
-                    </property>
-                    <property name="alternatingRowColors">
-                     <bool>false</bool>
-                    </property>
-                    <property name="selectionMode">
-                     <enum>QAbstractItemView::NoSelection</enum>
-                    </property>
-                    <property name="indentation">
-                     <number>0</number>
-                    </property>
-                    <attribute name="headerStretchLastSection">
-                     <bool>true</bool>
-                    </attribute>
-                    <column>
-                     <property name="text">
-                      <string>PEER (IP/PORT)</string>
-                     </property>
-                    </column>
-                    <column>
-                     <property name="text">
-                      <string>COMPLETED</string>
-                     </property>
-                    </column>
-                    <column>
-                     <property name="text">
-                      <string>SPEED (DOWN)</string>
-                     </property>
-                    </column>
-                    <column>
-                     <property name="text">
-                      <string>SPEED (UP)</string>
-                     </property>
-                    </column>
-                    <column>
-                     <property name="text">
-                      <string>FLAGS</string>
-                     </property>
-                    </column>
-                    <column>
-                     <property name="text">
-                      <string>CLIENT</string>
-                     </property>
-                    </column>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </widget>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-        <widget class="LoadingPage" name="loading_page">
-         <layout class="QVBoxLayout" name="verticalLayout">
-          <property name="spacing">
-           <number>0</number>
-          </property>
-          <property name="leftMargin">
-           <number>0</number>
-          </property>
-          <property name="topMargin">
-           <number>0</number>
-          </property>
-          <property name="rightMargin">
-           <number>0</number>
-          </property>
-          <property name="bottomMargin">
-           <number>0</number>
-          </property>
-          <item>
-           <widget class="QGraphicsView" name="loading_svg_view">
-            <property name="styleSheet">
-             <string notr="true">border: none;</string>
-            </property>
-            <property name="renderHints">
-             <set>QPainter::Antialiasing|QPainter::HighQualityAntialiasing|QPainter::TextAntialiasing</set>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLabel" name="loading_text_label">
-            <property name="minimumSize">
-             <size>
-              <width>0</width>
-              <height>160</height>
-             </size>
-            </property>
-            <property name="styleSheet">
-             <string notr="true">color: white; font-size: 18px;
+																				</property>
+																				<property name="alternatingRowColors">
+																					<bool>false</bool>
+																				</property>
+																				<property name="selectionMode">
+																					<enum>QAbstractItemView::NoSelection</enum>
+																				</property>
+																				<property name="indentation">
+																					<number>0</number>
+																				</property>
+																				<attribute name="headerStretchLastSection">
+																					<bool>true</bool>
+																				</attribute>
+																				<column>
+																					<property name="text">
+																						<string>PEER (IP/PORT)</string>
+																					</property>
+																				</column>
+																				<column>
+																					<property name="text">
+																						<string>COMPLETED</string>
+																					</property>
+																				</column>
+																				<column>
+																					<property name="text">
+																						<string>SPEED (DOWN)</string>
+																					</property>
+																				</column>
+																				<column>
+																					<property name="text">
+																						<string>SPEED (UP)</string>
+																					</property>
+																				</column>
+																				<column>
+																					<property name="text">
+																						<string>FLAGS</string>
+																					</property>
+																				</column>
+																				<column>
+																					<property name="text">
+																						<string>CLIENT</string>
+																					</property>
+																				</column>
+																			</widget>
+																		</item>
+																	</layout>
+																</widget>
+															</widget>
+														</widget>
+													</item>
+												</layout>
+											</widget>
+										</item>
+									</layout>
+								</widget>
+								<widget class="LoadingPage" name="loading_page">
+									<layout class="QVBoxLayout" name="verticalLayout">
+										<property name="spacing">
+											<number>0</number>
+										</property>
+										<property name="leftMargin">
+											<number>0</number>
+										</property>
+										<property name="topMargin">
+											<number>0</number>
+										</property>
+										<property name="rightMargin">
+											<number>0</number>
+										</property>
+										<property name="bottomMargin">
+											<number>0</number>
+										</property>
+										<item>
+											<widget class="QGraphicsView" name="loading_svg_view">
+												<property name="styleSheet">
+													<string notr="true">border: none;</string>
+												</property>
+												<property name="renderHints">
+													<set>QPainter::Antialiasing|QPainter::HighQualityAntialiasing|QPainter::TextAntialiasing</set>
+												</property>
+											</widget>
+										</item>
+										<item>
+											<widget class="QLabel" name="loading_text_label">
+												<property name="minimumSize">
+													<size>
+														<width>0</width>
+														<height>160</height>
+													</size>
+												</property>
+												<property name="styleSheet">
+													<string notr="true">color: white; font-size: 18px;
 padding:0 15px;</string>
-            </property>
-            <property name="text">
-             <string>Loading...</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignCenter</set>
-            </property>
-            <property name="wordWrap">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QWidget" name="widget_9" native="true">
-            <layout class="QHBoxLayout" name="force_btn_layout">
-             <item>
-              <widget class="QPushButton" name="force_shutdown_btn">
-               <property name="enabled">
-                <bool>true</bool>
-               </property>
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="minimumSize">
-                <size>
-                 <width>180</width>
-                 <height>32</height>
-                </size>
-               </property>
-               <property name="maximumSize">
-                <size>
-                 <width>180</width>
-                 <height>32</height>
-                </size>
-               </property>
-               <property name="layoutDirection">
-                <enum>Qt::LeftToRight</enum>
-               </property>
-               <property name="autoFillBackground">
-                <bool>false</bool>
-               </property>
-               <property name="styleSheet">
-                <string notr="true">border-radius:16px;
+												</property>
+												<property name="text">
+													<string>Loading...</string>
+												</property>
+												<property name="alignment">
+													<set>Qt::AlignCenter</set>
+												</property>
+												<property name="wordWrap">
+													<bool>true</bool>
+												</property>
+											</widget>
+										</item>
+										<item>
+											<widget class="QWidget" name="widget_9" native="true">
+												<layout class="QHBoxLayout" name="force_btn_layout">
+													<item>
+														<widget class="QPushButton" name="force_shutdown_btn">
+															<property name="enabled">
+																<bool>true</bool>
+															</property>
+															<property name="sizePolicy">
+																<sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+																	<horstretch>0</horstretch>
+																	<verstretch>0</verstretch>
+																</sizepolicy>
+															</property>
+															<property name="minimumSize">
+																<size>
+																	<width>180</width>
+																	<height>32</height>
+																</size>
+															</property>
+															<property name="maximumSize">
+																<size>
+																	<width>180</width>
+																	<height>32</height>
+																</size>
+															</property>
+															<property name="layoutDirection">
+																<enum>Qt::LeftToRight</enum>
+															</property>
+															<property name="autoFillBackground">
+																<bool>false</bool>
+															</property>
+															<property name="styleSheet">
+																<string notr="true">border-radius:16px;
 background-color:#e67300;
 color:#fff;
 padding:0 10px;
 text-transform:  uppercase;
 font-weight:bold;</string>
-               </property>
-               <property name="text">
-                <string>Force Shutdown</string>
-               </property>
-               <property name="autoDefault">
-                <bool>false</bool>
-               </property>
-               <property name="default">
-                <bool>false</bool>
-               </property>
-               <property name="flat">
-                <bool>false</bool>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QPushButton" name="skip_conversion_btn">
-               <property name="enabled">
-                <bool>true</bool>
-               </property>
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="minimumSize">
-                <size>
-                 <width>180</width>
-                 <height>32</height>
-                </size>
-               </property>
-               <property name="maximumSize">
-                <size>
-                 <width>180</width>
-                 <height>32</height>
-                </size>
-               </property>
-               <property name="layoutDirection">
-                <enum>Qt::LeftToRight</enum>
-               </property>
-               <property name="autoFillBackground">
-                <bool>false</bool>
-               </property>
-               <property name="styleSheet">
-                <string notr="true">border-radius:16px;
+															</property>
+															<property name="text">
+																<string>Force Shutdown</string>
+															</property>
+															<property name="autoDefault">
+																<bool>false</bool>
+															</property>
+															<property name="default">
+																<bool>false</bool>
+															</property>
+															<property name="flat">
+																<bool>false</bool>
+															</property>
+														</widget>
+													</item>
+													<item>
+														<widget class="QPushButton" name="skip_conversion_btn">
+															<property name="enabled">
+																<bool>true</bool>
+															</property>
+															<property name="sizePolicy">
+																<sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+																	<horstretch>0</horstretch>
+																	<verstretch>0</verstretch>
+																</sizepolicy>
+															</property>
+															<property name="minimumSize">
+																<size>
+																	<width>180</width>
+																	<height>32</height>
+																</size>
+															</property>
+															<property name="maximumSize">
+																<size>
+																	<width>180</width>
+																	<height>32</height>
+																</size>
+															</property>
+															<property name="layoutDirection">
+																<enum>Qt::LeftToRight</enum>
+															</property>
+															<property name="autoFillBackground">
+																<bool>false</bool>
+															</property>
+															<property name="styleSheet">
+																<string notr="true">border-radius:16px;
 background-color:#e67300;
 color:#fff;
 padding:0 10px;
 text-transform:  uppercase;
 font-weight:bold;</string>
-               </property>
-               <property name="text">
-                <string>Skip</string>
-               </property>
-               <property name="autoDefault">
-                <bool>false</bool>
-               </property>
-               <property name="default">
-                <bool>false</bool>
-               </property>
-               <property name="flat">
-                <bool>false</bool>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item>
-           <spacer name="force_shutdown_vspacer">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeType">
-             <enum>QSizePolicy::Fixed</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>60</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-         </layout>
-        </widget>
-        <widget class="ChannelContentsWidget" name="popular_page"/>
-       </widget>
-      </item>
-     </layout>
-    </item>
-    <item row="0" column="0">
-     <widget class="QWidget" name="top_bar" native="true">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>0</width>
-        <height>50</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>16777215</width>
-        <height>50</height>
-       </size>
-      </property>
-      <property name="styleSheet">
-       <string notr="true">QWidget {
+															</property>
+															<property name="text">
+																<string>Skip</string>
+															</property>
+															<property name="autoDefault">
+																<bool>false</bool>
+															</property>
+															<property name="default">
+																<bool>false</bool>
+															</property>
+															<property name="flat">
+																<bool>false</bool>
+															</property>
+														</widget>
+													</item>
+												</layout>
+											</widget>
+										</item>
+										<item>
+											<spacer name="force_shutdown_vspacer">
+												<property name="orientation">
+													<enum>Qt::Vertical</enum>
+												</property>
+												<property name="sizeType">
+													<enum>QSizePolicy::Fixed</enum>
+												</property>
+												<property name="sizeHint" stdset="0">
+													<size>
+														<width>20</width>
+														<height>60</height>
+													</size>
+												</property>
+											</spacer>
+										</item>
+									</layout>
+								</widget>
+								<widget class="ChannelContentsWidget" name="popular_page"/></widget>
+						</item>
+					</layout>
+				</item>
+				<item row="0" column="0">
+					<widget class="QWidget" name="top_bar" native="true">
+						<property name="sizePolicy">
+							<sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+								<horstretch>0</horstretch>
+								<verstretch>0</verstretch>
+							</sizepolicy>
+						</property>
+						<property name="minimumSize">
+							<size>
+								<width>0</width>
+								<height>50</height>
+							</size>
+						</property>
+						<property name="maximumSize">
+							<size>
+								<width>16777215</width>
+								<height>50</height>
+							</size>
+						</property>
+						<property name="styleSheet">
+							<string notr="true">QWidget {
 background-color: #202020;
 border-bottom: 1px solid #242424;
 }
@@ -3940,135 +3949,135 @@ border-bottom: 1px solid #242424;
 CircleButton {
 border: 2px solid white;
 }</string>
-      </property>
-      <layout class="QHBoxLayout" name="horizontalLayout">
-       <property name="spacing">
-        <number>0</number>
-       </property>
-       <property name="leftMargin">
-        <number>0</number>
-       </property>
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <property name="rightMargin">
-        <number>0</number>
-       </property>
-       <property name="bottomMargin">
-        <number>0</number>
-       </property>
-       <item>
-        <spacer name="horizontalSpacer_3">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>10</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <widget class="QToolButton" name="top_menu_button">
-         <property name="minimumSize">
-          <size>
-           <width>16</width>
-           <height>18</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>16</width>
-           <height>18</height>
-          </size>
-         </property>
-         <property name="cursor">
-          <cursorShape>PointingHandCursor</cursorShape>
-         </property>
-         <property name="styleSheet">
-          <string notr="true">border: none; 
+						</property>
+						<layout class="QHBoxLayout" name="horizontalLayout">
+							<property name="spacing">
+								<number>0</number>
+							</property>
+							<property name="leftMargin">
+								<number>0</number>
+							</property>
+							<property name="topMargin">
+								<number>0</number>
+							</property>
+							<property name="rightMargin">
+								<number>0</number>
+							</property>
+							<property name="bottomMargin">
+								<number>0</number>
+							</property>
+							<item>
+								<spacer name="horizontalSpacer_3">
+									<property name="orientation">
+										<enum>Qt::Horizontal</enum>
+									</property>
+									<property name="sizeType">
+										<enum>QSizePolicy::Fixed</enum>
+									</property>
+									<property name="sizeHint" stdset="0">
+										<size>
+											<width>10</width>
+											<height>20</height>
+										</size>
+									</property>
+								</spacer>
+							</item>
+							<item>
+								<widget class="QToolButton" name="top_menu_button">
+									<property name="minimumSize">
+										<size>
+											<width>16</width>
+											<height>18</height>
+										</size>
+									</property>
+									<property name="maximumSize">
+										<size>
+											<width>16</width>
+											<height>18</height>
+										</size>
+									</property>
+									<property name="cursor">
+										<cursorShape>PointingHandCursor</cursorShape>
+									</property>
+									<property name="styleSheet">
+										<string notr="true">border: none;
 </string>
-         </property>
-         <property name="text">
-          <string notr="true"/>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="horizontalSpacer_7">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>10</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <widget class="QLabel" name="tribler_name">
-         <property name="styleSheet">
-          <string notr="true">color: #e67300;
+									</property>
+									<property name="text">
+										<string notr="true"/>
+									</property>
+								</widget>
+							</item>
+							<item>
+								<spacer name="horizontalSpacer_7">
+									<property name="orientation">
+										<enum>Qt::Horizontal</enum>
+									</property>
+									<property name="sizeType">
+										<enum>QSizePolicy::Fixed</enum>
+									</property>
+									<property name="sizeHint" stdset="0">
+										<size>
+											<width>10</width>
+											<height>20</height>
+										</size>
+									</property>
+								</spacer>
+							</item>
+							<item>
+								<widget class="QLabel" name="tribler_name">
+									<property name="styleSheet">
+										<string notr="true">color: #e67300;
 font-size: 28px;
 font-weight: bold;
 font-family: &quot;Arial&quot;;</string>
-         </property>
-         <property name="text">
-          <string notr="true">Tribler</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="horizontalSpacer_4">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>12</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <widget class="ClickableLineEdit" name="top_search_bar">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>350</width>
-           <height>28</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>350</width>
-           <height>28</height>
-          </size>
-         </property>
-         <property name="styleSheet">
-          <string notr="true">QLineEdit {
+									</property>
+									<property name="text">
+										<string notr="true">Tribler</string>
+									</property>
+									<property name="alignment">
+										<set>Qt::AlignCenter</set>
+									</property>
+								</widget>
+							</item>
+							<item>
+								<spacer name="horizontalSpacer_4">
+									<property name="orientation">
+										<enum>Qt::Horizontal</enum>
+									</property>
+									<property name="sizeType">
+										<enum>QSizePolicy::Fixed</enum>
+									</property>
+									<property name="sizeHint" stdset="0">
+										<size>
+											<width>12</width>
+											<height>20</height>
+										</size>
+									</property>
+								</spacer>
+							</item>
+							<item>
+								<widget class="ClickableLineEdit" name="top_search_bar">
+									<property name="sizePolicy">
+										<sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+											<horstretch>0</horstretch>
+											<verstretch>0</verstretch>
+										</sizepolicy>
+									</property>
+									<property name="minimumSize">
+										<size>
+											<width>350</width>
+											<height>28</height>
+										</size>
+									</property>
+									<property name="maximumSize">
+										<size>
+											<width>350</width>
+											<height>28</height>
+										</size>
+									</property>
+									<property name="styleSheet">
+										<string notr="true">QLineEdit {
 background-color: #eee;
 border: none;
 padding-left: 5px;
@@ -4079,365 +4088,367 @@ color: black;
 QLineEdit:focus {
 border: 1px solid #FF924F;
 }</string>
-         </property>
-         <property name="placeholderText">
-          <string>Search for your favorite content</string>
-         </property>
-         <property name="clearButtonEnabled">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="horizontalSpacer_2">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Expanding</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <widget class="QPushButton" name="debug_panel_button">
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>26</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>16777215</width>
-           <height>30</height>
-          </size>
-         </property>
-         <property name="cursor">
-          <cursorShape>PointingHandCursor</cursorShape>
-         </property>
-         <property name="focusPolicy">
-          <enum>Qt::NoFocus</enum>
-         </property>
-         <property name="styleSheet">
-          <string notr="true"/>
-         </property>
-         <property name="text">
-          <string> Debug</string>
-         </property>
-         <property name="icon">
-          <iconset>
-           <normaloff>../images/debug.png</normaloff>
-           <disabledon>../images/debug.png</disabledon>../images/debug.png</iconset>
-         </property>
-         <property name="iconSize">
-          <size>
-           <width>16</width>
-           <height>16</height>
-          </size>
-         </property>
-         <property name="checkable">
-          <bool>false</bool>
-         </property>
-         <property name="flat">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="horizontalSpacer_68">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>10</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <widget class="QToolButton" name="settings_button">
-         <property name="minimumSize">
-          <size>
-           <width>22</width>
-           <height>22</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>22</width>
-           <height>22</height>
-          </size>
-         </property>
-         <property name="cursor">
-          <cursorShape>PointingHandCursor</cursorShape>
-         </property>
-         <property name="toolTip">
-          <string>Settings</string>
-         </property>
-         <property name="styleSheet">
-          <string notr="true">border: none;
+									</property>
+									<property name="placeholderText">
+										<string>Search for your favorite content</string>
+									</property>
+									<property name="clearButtonEnabled">
+										<bool>true</bool>
+									</property>
+								</widget>
+							</item>
+							<item>
+								<spacer name="horizontalSpacer_2">
+									<property name="orientation">
+										<enum>Qt::Horizontal</enum>
+									</property>
+									<property name="sizeType">
+										<enum>QSizePolicy::Expanding</enum>
+									</property>
+									<property name="sizeHint" stdset="0">
+										<size>
+											<width>40</width>
+											<height>20</height>
+										</size>
+									</property>
+								</spacer>
+							</item>
+							<item>
+								<widget class="QPushButton" name="debug_panel_button">
+									<property name="minimumSize">
+										<size>
+											<width>0</width>
+											<height>26</height>
+										</size>
+									</property>
+									<property name="maximumSize">
+										<size>
+											<width>16777215</width>
+											<height>30</height>
+										</size>
+									</property>
+									<property name="cursor">
+										<cursorShape>PointingHandCursor</cursorShape>
+									</property>
+									<property name="focusPolicy">
+										<enum>Qt::NoFocus</enum>
+									</property>
+									<property name="styleSheet">
+										<string notr="true"/>
+									</property>
+									<property name="text">
+										<string> Debug</string>
+									</property>
+									<property name="icon">
+										<iconset>
+											<normaloff>../images/debug.png</normaloff>
+											<disabledon>../images/debug.png</disabledon>../images/debug.png
+										</iconset>
+									</property>
+									<property name="iconSize">
+										<size>
+											<width>16</width>
+											<height>16</height>
+										</size>
+									</property>
+									<property name="checkable">
+										<bool>false</bool>
+									</property>
+									<property name="flat">
+										<bool>true</bool>
+									</property>
+								</widget>
+							</item>
+							<item>
+								<spacer name="horizontalSpacer_68">
+									<property name="orientation">
+										<enum>Qt::Horizontal</enum>
+									</property>
+									<property name="sizeType">
+										<enum>QSizePolicy::Fixed</enum>
+									</property>
+									<property name="sizeHint" stdset="0">
+										<size>
+											<width>10</width>
+											<height>20</height>
+										</size>
+									</property>
+								</spacer>
+							</item>
+							<item>
+								<widget class="QToolButton" name="settings_button">
+									<property name="minimumSize">
+										<size>
+											<width>22</width>
+											<height>22</height>
+										</size>
+									</property>
+									<property name="maximumSize">
+										<size>
+											<width>22</width>
+											<height>22</height>
+										</size>
+									</property>
+									<property name="cursor">
+										<cursorShape>PointingHandCursor</cursorShape>
+									</property>
+									<property name="toolTip">
+										<string>Settings</string>
+									</property>
+									<property name="styleSheet">
+										<string notr="true">border: none;
 background: none;</string>
-         </property>
-         <property name="text">
-          <string notr="true"/>
-         </property>
-         <property name="icon">
-          <iconset>
-           <normaloff>../images/gear.png</normaloff>../images/gear.png</iconset>
-         </property>
-         <property name="iconSize">
-          <size>
-           <width>20</width>
-           <height>20</height>
-          </size>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="horizontalSpacer_67">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>10</width>
-           <height>10</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </widget>
-    </item>
-   </layout>
-  </widget>
- </widget>
- <layoutdefault spacing="6" margin="11"/>
- <customwidgets>
-  <customwidget>
-   <class>TorrentFileTreeWidget</class>
-   <extends>QTreeWidget</extends>
-   <header>tribler.gui.widgets.torrentfiletreewidget.h</header>
-  </customwidget>
-  <customwidget>
-   <class>PreformattedTorrentFileTreeWidget</class>
-   <extends>QTableWidget</extends>
-   <header>tribler.gui.widgets.torrentfiletreewidget.h</header>
-  </customwidget>
-  <customwidget>
-   <class>EllipseButton</class>
-   <extends>QToolButton</extends>
-   <header>tribler.gui.widgets.ellipsebutton.h</header>
-  </customwidget>
-  <customwidget>
-   <class>UnderlineTabButton</class>
-   <extends>QToolButton</extends>
-   <header>tribler.gui.widgets.underlinetabbutton.h</header>
-  </customwidget>
-  <customwidget>
-   <class>TabButtonPanel</class>
-   <extends>QWidget</extends>
-   <header>tribler.gui.widgets.tabbuttonpanel.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>SettingsPage</class>
-   <extends>QWidget</extends>
-   <header>tribler.gui.widgets.settingspage.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>DownloadsPage</class>
-   <extends>QWidget</extends>
-   <header>tribler.gui.widgets.downloadspage.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>DownloadsDetailsTabWidget</class>
-   <extends>QTabWidget</extends>
-   <header>tribler.gui.widgets.downloadsdetailstabwidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>LoadingPage</class>
-   <extends>QWidget</extends>
-   <header>tribler.gui.widgets.loadingpage.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>DiscoveringPage</class>
-   <extends>QWidget</extends>
-   <header>tribler.gui.widgets.discoveringpage.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>CircleButton</class>
-   <extends>QToolButton</extends>
-   <header>tribler.gui.widgets.circlebutton.h</header>
-  </customwidget>
-  <customwidget>
-   <class>DownloadProgressBar</class>
-   <extends>QWidget</extends>
-   <header>tribler.gui.widgets.downloadprogressbar.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>ChannelContentsWidget</class>
-   <extends>QWidget</extends>
-   <header>tribler.gui.widgets.channelcontentswidget.h</header>
-  </customwidget>
-  <customwidget>
-   <class>ClickableLineEdit</class>
-   <extends>QLineEdit</extends>
-   <header>tribler.gui.widgets.clickable_line_edit.h</header>
-  </customwidget>
-  <customwidget>
-   <class>SearchResultsWidget</class>
-   <extends>QWidget</extends>
-   <header>tribler.gui.widgets.searchresultswidget.h</header>
-  </customwidget>
- </customwidgets>
- <resources/>
- <connections>
-  <connection>
-   <sender>top_search_bar</sender>
-   <signal>textChanged(QString)</signal>
-   <receiver>MainWindow</receiver>
-   <slot>on_search_text_change()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>308</x>
-     <y>24</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>427</x>
-     <y>317</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>top_menu_button</sender>
-   <signal>clicked()</signal>
-   <receiver>MainWindow</receiver>
-   <slot>on_top_menu_button_click()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>17</x>
-     <y>24</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>427</x>
-     <y>317</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>settings_button</sender>
-   <signal>clicked()</signal>
-   <receiver>MainWindow</receiver>
-   <slot>on_settings_button_click()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>1003</x>
-     <y>35</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>427</x>
-     <y>327</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>force_shutdown_btn</sender>
-   <signal>clicked()</signal>
-   <receiver>MainWindow</receiver>
-   <slot>clicked_force_shutdown()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>221</x>
-     <y>101</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>skip_conversion_btn</sender>
-   <signal>clicked()</signal>
-   <receiver>MainWindow</receiver>
-   <slot>clicked_skip_conversion()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>221</x>
-     <y>101</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>left_menu_button_downloads</sender>
-   <signal>clicked()</signal>
-   <receiver>MainWindow</receiver>
-   <slot>clicked_menu_button_downloads()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>101</x>
-     <y>295</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>427</x>
-     <y>317</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>left_menu_button_popular</sender>
-   <signal>clicked()</signal>
-   <receiver>MainWindow</receiver>
-   <slot>clicked_menu_button_popular()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
- <slots>
-  <slot>on_top_search_button_click()</slot>
-  <slot>on_add_torrent_button_click()</slot>
-  <slot>on_top_menu_button_click()</slot>
-  <slot>clicked_menu_button_downloads()</slot>
-  <slot>clicked_menu_button_subscriptions()</slot>
-  <slot>on_search_text_change()</slot>
-  <slot>clicked_menu_button_discovered()</slot>
-  <slot>on_settings_button_click()</slot>
-  <slot>clicked_menu_button_search()</slot>
-  <slot>clicked_force_shutdown()</slot>
-  <slot>clicked_skip_conversion()</slot>
-  <slot>clicked_menu_button_popular()</slot>
- </slots>
+									</property>
+									<property name="text">
+										<string notr="true"/>
+									</property>
+									<property name="icon">
+										<iconset>
+											<normaloff>../images/gear.png</normaloff>../images/gear.png
+										</iconset>
+									</property>
+									<property name="iconSize">
+										<size>
+											<width>20</width>
+											<height>20</height>
+										</size>
+									</property>
+								</widget>
+							</item>
+							<item>
+								<spacer name="horizontalSpacer_67">
+									<property name="orientation">
+										<enum>Qt::Horizontal</enum>
+									</property>
+									<property name="sizeType">
+										<enum>QSizePolicy::Fixed</enum>
+									</property>
+									<property name="sizeHint" stdset="0">
+										<size>
+											<width>10</width>
+											<height>10</height>
+										</size>
+									</property>
+								</spacer>
+							</item>
+						</layout>
+					</widget>
+				</item>
+			</layout>
+		</widget>
+	</widget>
+	<layoutdefault spacing="6" margin="11"/>
+	<customwidgets>
+		<customwidget>
+			<class>TorrentFileTreeWidget</class>
+			<extends>QTreeWidget</extends>
+			<header>tribler.gui.widgets.torrentfiletreewidget.h</header>
+		</customwidget>
+		<customwidget>
+			<class>PreformattedTorrentFileTreeWidget</class>
+			<extends>QTableWidget</extends>
+			<header>tribler.gui.widgets.torrentfiletreewidget.h</header>
+		</customwidget>
+		<customwidget>
+			<class>EllipseButton</class>
+			<extends>QToolButton</extends>
+			<header>tribler.gui.widgets.ellipsebutton.h</header>
+		</customwidget>
+		<customwidget>
+			<class>UnderlineTabButton</class>
+			<extends>QToolButton</extends>
+			<header>tribler.gui.widgets.underlinetabbutton.h</header>
+		</customwidget>
+		<customwidget>
+			<class>TabButtonPanel</class>
+			<extends>QWidget</extends>
+			<header>tribler.gui.widgets.tabbuttonpanel.h</header>
+			<container>1</container>
+		</customwidget>
+		<customwidget>
+			<class>SettingsPage</class>
+			<extends>QWidget</extends>
+			<header>tribler.gui.widgets.settingspage.h</header>
+			<container>1</container>
+		</customwidget>
+		<customwidget>
+			<class>DownloadsPage</class>
+			<extends>QWidget</extends>
+			<header>tribler.gui.widgets.downloadspage.h</header>
+			<container>1</container>
+		</customwidget>
+		<customwidget>
+			<class>DownloadsDetailsTabWidget</class>
+			<extends>QTabWidget</extends>
+			<header>tribler.gui.widgets.downloadsdetailstabwidget.h</header>
+			<container>1</container>
+		</customwidget>
+		<customwidget>
+			<class>LoadingPage</class>
+			<extends>QWidget</extends>
+			<header>tribler.gui.widgets.loadingpage.h</header>
+			<container>1</container>
+		</customwidget>
+		<customwidget>
+			<class>DiscoveringPage</class>
+			<extends>QWidget</extends>
+			<header>tribler.gui.widgets.discoveringpage.h</header>
+			<container>1</container>
+		</customwidget>
+		<customwidget>
+			<class>CircleButton</class>
+			<extends>QToolButton</extends>
+			<header>tribler.gui.widgets.circlebutton.h</header>
+		</customwidget>
+		<customwidget>
+			<class>DownloadProgressBar</class>
+			<extends>QWidget</extends>
+			<header>tribler.gui.widgets.downloadprogressbar.h</header>
+			<container>1</container>
+		</customwidget>
+		<customwidget>
+			<class>ChannelContentsWidget</class>
+			<extends>QWidget</extends>
+			<header>tribler.gui.widgets.channelcontentswidget.h</header>
+		</customwidget>
+		<customwidget>
+			<class>ClickableLineEdit</class>
+			<extends>QLineEdit</extends>
+			<header>tribler.gui.widgets.clickable_line_edit.h</header>
+		</customwidget>
+		<customwidget>
+			<class>SearchResultsWidget</class>
+			<extends>QWidget</extends>
+			<header>tribler.gui.widgets.searchresultswidget.h</header>
+		</customwidget>
+	</customwidgets>
+	<resources/>
+	<connections>
+		<connection>
+			<sender>top_search_bar</sender>
+			<signal>textChanged(QString)</signal>
+			<receiver>MainWindow</receiver>
+			<slot>on_search_text_change()</slot>
+			<hints>
+				<hint type="sourcelabel">
+					<x>308</x>
+					<y>24</y>
+				</hint>
+				<hint type="destinationlabel">
+					<x>427</x>
+					<y>317</y>
+				</hint>
+			</hints>
+		</connection>
+		<connection>
+			<sender>top_menu_button</sender>
+			<signal>clicked()</signal>
+			<receiver>MainWindow</receiver>
+			<slot>on_top_menu_button_click()</slot>
+			<hints>
+				<hint type="sourcelabel">
+					<x>17</x>
+					<y>24</y>
+				</hint>
+				<hint type="destinationlabel">
+					<x>427</x>
+					<y>317</y>
+				</hint>
+			</hints>
+		</connection>
+		<connection>
+			<sender>settings_button</sender>
+			<signal>clicked()</signal>
+			<receiver>MainWindow</receiver>
+			<slot>on_settings_button_click()</slot>
+			<hints>
+				<hint type="sourcelabel">
+					<x>1003</x>
+					<y>35</y>
+				</hint>
+				<hint type="destinationlabel">
+					<x>427</x>
+					<y>327</y>
+				</hint>
+			</hints>
+		</connection>
+		<connection>
+			<sender>force_shutdown_btn</sender>
+			<signal>clicked()</signal>
+			<receiver>MainWindow</receiver>
+			<slot>clicked_force_shutdown()</slot>
+			<hints>
+				<hint type="sourcelabel">
+					<x>221</x>
+					<y>101</y>
+				</hint>
+				<hint type="destinationlabel">
+					<x>20</x>
+					<y>20</y>
+				</hint>
+			</hints>
+		</connection>
+		<connection>
+			<sender>skip_conversion_btn</sender>
+			<signal>clicked()</signal>
+			<receiver>MainWindow</receiver>
+			<slot>clicked_skip_conversion()</slot>
+			<hints>
+				<hint type="sourcelabel">
+					<x>221</x>
+					<y>101</y>
+				</hint>
+				<hint type="destinationlabel">
+					<x>20</x>
+					<y>20</y>
+				</hint>
+			</hints>
+		</connection>
+		<connection>
+			<sender>left_menu_button_downloads</sender>
+			<signal>clicked()</signal>
+			<receiver>MainWindow</receiver>
+			<slot>clicked_menu_button_downloads()</slot>
+			<hints>
+				<hint type="sourcelabel">
+					<x>101</x>
+					<y>295</y>
+				</hint>
+				<hint type="destinationlabel">
+					<x>427</x>
+					<y>317</y>
+				</hint>
+			</hints>
+		</connection>
+		<connection>
+			<sender>left_menu_button_popular</sender>
+			<signal>clicked()</signal>
+			<receiver>MainWindow</receiver>
+			<slot>clicked_menu_button_popular()</slot>
+			<hints>
+				<hint type="sourcelabel">
+					<x>20</x>
+					<y>20</y>
+				</hint>
+				<hint type="destinationlabel">
+					<x>20</x>
+					<y>20</y>
+				</hint>
+			</hints>
+		</connection>
+	</connections>
+	<slots>
+		<slot>on_top_search_button_click()</slot>
+		<slot>on_add_torrent_button_click()</slot>
+		<slot>on_top_menu_button_click()</slot>
+		<slot>clicked_menu_button_downloads()</slot>
+		<slot>clicked_menu_button_subscriptions()</slot>
+		<slot>on_search_text_change()</slot>
+		<slot>clicked_menu_button_discovered()</slot>
+		<slot>on_settings_button_click()</slot>
+		<slot>clicked_menu_button_search()</slot>
+		<slot>clicked_force_shutdown()</slot>
+		<slot>clicked_skip_conversion()</slot>
+		<slot>clicked_menu_button_popular()</slot>
+	</slots>
 </ui>

--- a/src/tribler/gui/tribler_window.py
+++ b/src/tribler/gui/tribler_window.py
@@ -342,6 +342,9 @@ class TriblerWindow(QMainWindow):
 
         self.add_torrent_menu = self.create_add_torrent_menu()
         self.add_torrent_button.setMenu(self.add_torrent_menu)
+        # The line below adds a space between an icon and text.
+        # Unfortunately, I was unable to achieve this through CSS.
+        self.add_torrent_button.setText(" " + self.add_torrent_button.text())
 
         connect(self.debug_panel_button.clicked, self.clicked_debug_panel_button)
 


### PR DESCRIPTION
Fixes #7965

The bug is a combination of two facts:
1. QT dependencies upgrade made here: https://github.com/Tribler/tribler/pull/7944
2. Using the "trick" for hiding a menu arrow: https://github.com/Tribler/tribler/blob/03adf6a49744bad2a5e914324e713038d66bf10d/src/tribler/gui/qt_resources/mainwindow.ui#L340

The solution is to change `QPushButton` to `QToolButton` as it seems to work a bit more correctly in our specific case with hiding the menu indicator:

```css
QToolButton#add_torrent_button {
    border-style: outset;
    border-width: 1px;
    border-radius: 15px;
    border-color: grey;
    margin-left: 15px;
    padding-left: 10px;
    margin-right: 10px;
}
QToolButton::menu-indicator {
    image: none;
    width: 0px;
}
```

<img width="700" alt="image" src="https://github.com/Tribler/tribler/assets/13798583/26fa4fd2-cc43-4a52-a6cf-bae942d024c3">

Please note that the first commit is just a reformatting of the entire `mainwindow.ui` to maintain strict indentation.