### PR TITLE
Add codesign for macos build

### DIFF
--- a/build/mac/makedist_macos.sh
+++ b/build/mac/makedist_macos.sh
@@ -7,6 +7,7 @@ set -e # exit when any command fails
 
 APPNAME=Tribler
 LOG_LEVEL=${LOG_LEVEL:-"DEBUG"}
+SIGN_MSG=${SIGN_MSG:-"Developer ID Application: Your Name (Team ID)"}
 
 if [ -e .TriblerVersion ]; then
     DMGNAME="Tribler-$(cat .TriblerVersion)"
@@ -46,6 +47,9 @@ ln -s /Applications dist/installdir/Applications
 touch dist/installdir
 
 mkdir -p dist/temp
+
+# sign app
+codesign --deep --force --verbose --sign "$SIGN_MSG" dist/installdir/$APPNAME.app
 
 # create image
 hdiutil create -fs HFS+ -srcfolder dist/installdir -format UDRW -scrub -volname ${APPNAME} dist/$APPNAME.dmg
@@ -109,3 +113,8 @@ python3 ./build/mac/licenseDMG.py dist/$APPNAME.dmg LICENSE
 if [ ! -z "$DMGNAME" ]; then
     mv dist/$APPNAME.dmg dist/$DMGNAME.dmg
 fi
+
+# sign the dmg and verify
+codesign --force --verify --verbose --sign "$SIGN_MSG" dist/$DMGNAME.dmg
+codesign --verify --verbose=4 dist/$DMGNAME.dmg
+spctl --assess --type open --context context:primary-signature -v dist/$DMGNAME.dmg

--- a/build/mac/makedist_macos.sh
+++ b/build/mac/makedist_macos.sh
@@ -49,7 +49,7 @@ touch dist/installdir
 mkdir -p dist/temp
 
 # sign app
-codesign --deep --force --verbose --sign "$SIGN_MSG" dist/installdir/$APPNAME.app
+codesign --deep --force --verbose --sign "$SIGN_MSG" --options runtime dist/installdir/$APPNAME.app
 
 # create image
 hdiutil create -fs HFS+ -srcfolder dist/installdir -format UDRW -scrub -volname ${APPNAME} dist/$APPNAME.dmg

--- a/build/mac/makedist_macos.sh
+++ b/build/mac/makedist_macos.sh
@@ -47,6 +47,7 @@ touch dist/installdir
 
 mkdir -p dist/temp
 
+# Sign the app if environment variables are set
 if [ -n "$CODE_SIGN_ENABLED" ] && [ -n "$APPLE_DEV_ID" ]; then
     echo "Signing $APPNAME.app with ID: $APPLE_DEV_ID"
     SIGN_MSG="Developer ID Application: $APPLE_DEV_ID"
@@ -116,7 +117,7 @@ if [ ! -z "$DMGNAME" ]; then
     mv dist/$APPNAME.dmg dist/$DMGNAME.dmg
 fi
 
-# sign the dmg and verify
+# Sign the dmg package and verify it
 if [ -n "$CODE_SIGN_ENABLED" ] && [ -n "$APPLE_DEV_ID" ]; then
     codesign --force --verify --verbose --sign "$SIGN_MSG" dist/$DMGNAME.dmg
     codesign --verify --verbose=4 dist/$DMGNAME.dmg


### PR DESCRIPTION
This PR adds code signing for MacOS build.

The sign message which includes the Signer's Identity is to be passed via environment variable during the build process.

The final dmg created after code signing works well on earlier version of MacOS without issues. However, for the newer version of the macos, to pass through the gatekeeper, the DMG and included executables needs to be notarized using notary tool. At the moment, the notarization is not passing yet.

The fix for notarization is outside the scope of this PR. That will be addressed as part of the build script pipeline in Jenkins as notarization can take up to 30 mins to complete and requires setting up key profiles.