### PR TITLE
Improved error handling in torrent info endpoint

### DIFF
--- a/src/tribler/core/components/libtorrent/restapi/torrentinfo_endpoint.py
+++ b/src/tribler/core/components/libtorrent/restapi/torrentinfo_endpoint.py
@@ -82,12 +82,12 @@ class TorrentInfoEndpoint(RESTEndpoint):
         scheme = scheme_from_url(uri)
 
         if scheme == FILE_SCHEME:
-            file = url_to_path(uri)
+            file_path = url_to_path(uri)
             try:
-                tdef = await TorrentDef.load(file)
+                tdef = await TorrentDef.load(file_path)
                 metainfo = tdef.metainfo
-            except (FileNotFoundError, TypeError, ValueError, RuntimeError):
-                return RESTResponse({"error": f"error while decoding torrent file: {file}"},
+            except (OSError, TypeError, ValueError, RuntimeError):
+                return RESTResponse({"error": f"error while decoding torrent file: {file_path}"},
                                     status=HTTP_INTERNAL_SERVER_ERROR)
         elif scheme in (HTTP_SCHEME, HTTPS_SCHEME):
             try:


### PR DESCRIPTION
Updated the TorrentInfoEndpoint class to catch OSError, which includes FileNotFoundError and PermissionError, while decoding a torrent file. This ensures that the server responds with an appropriate 500 error message when such issues occur.

Fixes #7974