### PR TITLE
Cherry-pick important fixes to the release branch

### DIFF
--- a/src/run_tribler.py
+++ b/src/run_tribler.py
@@ -12,6 +12,7 @@ import encodings.idna  # pylint: disable=unused-import
 from tribler.core.sentry_reporter.sentry_reporter import SentryReporter, SentryStrategy
 from tribler.core.sentry_reporter.sentry_scrubber import SentryScrubber
 from tribler.core.utilities.asyncio_fixes.finish_accept_patch import apply_finish_accept_patch
+from tribler.core.utilities.asyncio_fixes.proactor_recvfrom_patch import apply_proactor_recvfrom_patch
 from tribler.core.utilities.slow_coro_detection.main_thread_stack_tracking import start_main_thread_stack_tracing
 from tribler.core.utilities.osutils import get_root_state_directory
 from tribler.core.utilities.utilities import is_frozen
@@ -95,6 +96,7 @@ def main():
     if parsed_args.core:
         if sys.platform == 'win32':
             apply_finish_accept_patch()
+            apply_proactor_recvfrom_patch()
 
         from tribler.core.utilities.pony_utils import track_slow_db_sessions
         track_slow_db_sessions()

--- a/src/tribler/core/sentry_reporter/sentry_reporter.py
+++ b/src/tribler/core/sentry_reporter/sentry_reporter.py
@@ -27,6 +27,7 @@ TYPE = 'type'
 LAST_CORE_OUTPUT = 'last_core_output'
 LAST_PROCESSES = 'last_processes'
 PLATFORM = 'platform'
+PROCESS_ARCHITECTURE = 'process_architecture'
 OS = 'os'
 MACHINE = 'machine'
 COMMENTS = 'comments'
@@ -213,6 +214,7 @@ class SentryReporter:
 
         # tags
         tags = event[TAGS]
+        tags[PROCESS_ARCHITECTURE] = get_value(post_data, PROCESS_ARCHITECTURE)
         tags[VERSION] = get_value(post_data, VERSION)
         tags[MACHINE] = get_value(post_data, MACHINE)
         tags[OS] = get_value(post_data, OS)

--- a/src/tribler/core/sentry_reporter/sentry_scrubber.py
+++ b/src/tribler/core/sentry_reporter/sentry_scrubber.py
@@ -172,17 +172,22 @@ class SentryScrubber:
         if isinstance(entity, dict):
             result = {}
             for key, value in entity.items():
-                if key in self.dict_keys_for_scrub:
+                if key in self.dict_keys_for_scrub and isinstance(value, str):
                     value = value.strip()
                     fake_value = obfuscate_string(value)
                     placeholder = self.create_placeholder(fake_value)
                     self.add_sensitive_pair(value, placeholder)
-                result[key] = self.scrub_entity_recursively(value, depth)
+                    result[key] = placeholder
+                else:
+                    result[key] = self.scrub_entity_recursively(value, depth)
             return result
 
         return entity
 
     def add_sensitive_pair(self, text, placeholder):
+        if not (text and text.strip()):  # We should not replace empty substrings in the middle of other strings
+            return
+
         if text in self.sensitive_occurrences:
             return
 

--- a/src/tribler/core/sentry_reporter/sentry_tools.py
+++ b/src/tribler/core/sentry_reporter/sentry_tools.py
@@ -200,9 +200,6 @@ def obfuscate_string(s: str, part_of_speech: str = 'noun') -> str:
 
     The same random words will be generated for the same given strings.
     """
-    if not s:
-        return s
-
     faker = Faker(locale='en_US')
     faker.seed_instance(s)
     return faker.word(part_of_speech=part_of_speech)

--- a/src/tribler/core/sentry_reporter/tests/test_sentry_reporter.py
+++ b/src/tribler/core/sentry_reporter/tests/test_sentry_reporter.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from copy import deepcopy
 from unittest.mock import MagicMock, Mock, patch
 
@@ -6,7 +7,7 @@ import pytest
 from tribler.core.sentry_reporter.sentry_reporter import (
     ADDITIONAL_INFORMATION, BROWSER, COMMENTS, CONTEXTS, LAST_CORE_OUTPUT, MACHINE, NAME, OS, OS_ENVIRON,
     PLATFORM, PLATFORM_DETAILS,
-    REPORTER, STACKTRACE, STACKTRACE_CONTEXT, STACKTRACE_EXTRA, SYSINFO, SentryReporter,
+    PROCESS_ARCHITECTURE, REPORTER, STACKTRACE, STACKTRACE_CONTEXT, STACKTRACE_EXTRA, SYSINFO, SentryReporter,
     SentryStrategy,
     TAGS, TRIBLER, TYPE, VALUE, VERSION, this_sentry_strategy,
 )
@@ -26,7 +27,7 @@ DEFAULT_EVENT = {
             ADDITIONAL_INFORMATION: {},
         },
     },
-    TAGS: {MACHINE: None, OS: None, PLATFORM: None, PLATFORM_DETAILS: None, VERSION: None},
+    TAGS: {MACHINE: None, OS: None, PLATFORM: None, PLATFORM_DETAILS: None, PROCESS_ARCHITECTURE: None, VERSION: None},
 }
 
 
@@ -242,8 +243,9 @@ def test_send_post_data(sentry_reporter):
     expected[CONTEXTS][REPORTER][STACKTRACE] = ['l1', 'l2']
     expected[CONTEXTS][REPORTER][STACKTRACE_EXTRA] = ['l3', 'l4']
     expected[CONTEXTS][REPORTER][COMMENTS] = 'comment'
+    expected[CONTEXTS][REPORTER][ADDITIONAL_INFORMATION] = defaultdict(dict)
     expected[TAGS] = {MACHINE: 'x86_64', OS: 'posix', PLATFORM: None, PLATFORM_DETAILS: None,
-                      VERSION: '0.0.0'}
+                      PROCESS_ARCHITECTURE: None, VERSION: '0.0.0'}
 
     assert actual == expected
 

--- a/src/tribler/core/sentry_reporter/tests/test_sentry_scrubber.py
+++ b/src/tribler/core/sentry_reporter/tests/test_sentry_scrubber.py
@@ -213,16 +213,16 @@ def test_scrub_event(scrubber):
     }
     assert scrubber.scrub_event(event) == {
         'the very first item': '<highlight>',
-        'server_name': '<protection>',
+        'server_name': '<kid>',
         CONTEXTS: {
             REPORTER: {
                 'any': {
-                    'USERNAME': '<father>',
+                    'USERNAME': '<conference>',
                     'USERDOMAIN_ROAMINGPROFILE': '<protection>',
                     'PATH': '/users/<highlight>/apps',
                     'TMP_WIN': 'C:\\Users\\<restaurant>\\AppData\\Local\\Temp',
-                    'USERDOMAIN': '<marriage>',
-                    'COMPUTERNAME': '<message>',
+                    'USERDOMAIN': '<tune>',
+                    'COMPUTERNAME': '<lady>',
                 },
                 STACKTRACE: [
                     'Traceback (most recent call last):',
@@ -301,15 +301,20 @@ def test_scrub_dict(scrubber):
     assert scrubber.scrub_entity_recursively(None) is None
     assert scrubber.scrub_entity_recursively({}) == {}
 
-    given = {'PATH': '/home/username/some/', 'USERDOMAIN': 'UD', 'USERNAME': 'U', 'REPEATED': 'user username UD U'}
+    assert scrubber.scrub_entity_recursively({'key': [1]}) == {'key': [1]}  # non-string values should not lead to error
+
+    given = {'PATH': '/home/username/some/', 'USERDOMAIN': 'UD', 'USERNAME': 'U', 'REPEATED': 'user username UD U',
+             'key': ''}
     assert scrubber.scrub_entity_recursively(given) == {'PATH': '/home/<highlight>/some/',
                                                         'REPEATED': 'user <highlight> <school> <night>',
                                                         'USERDOMAIN': '<school>',
-                                                        'USERNAME': '<night>'}
+                                                        'USERNAME': '<night>',
+                                                        'key': '<dress>'}
 
-    assert 'username' in scrubber.sensitive_occurrences.keys()
-    assert 'UD' in scrubber.sensitive_occurrences.keys()
-    assert 'U' in scrubber.sensitive_occurrences.keys()
+    assert 'username' in scrubber.sensitive_occurrences
+    assert 'UD' in scrubber.sensitive_occurrences
+    assert 'U' in scrubber.sensitive_occurrences
+    assert '' not in scrubber.sensitive_occurrences
 
 
 def test_scrub_list(scrubber):

--- a/src/tribler/core/sentry_reporter/tests/test_sentry_tools.py
+++ b/src/tribler/core/sentry_reporter/tests/test_sentry_tools.py
@@ -144,8 +144,7 @@ def test_extract_dict():
 
 
 OBFUSCATED_STRINGS = [
-    (None, None),
-    ('', ''),
+    ('', 'dress'),
     ('any', 'challenge'),
     ('string', 'quality'),
 ]

--- a/src/tribler/core/utilities/asyncio_fixes/proactor_recvfrom_patch.py
+++ b/src/tribler/core/utilities/asyncio_fixes/proactor_recvfrom_patch.py
@@ -1,0 +1,58 @@
+from asyncio.log import logger
+
+try:
+    import _overlapped
+except ImportError:
+    _overlapped = None
+
+
+NULL = 0
+
+ERROR_PORT_UNREACHABLE = 1234  # _overlapped.ERROR_PORT_UNREACHABLE, available in Python >= 3.11
+ERROR_NETNAME_DELETED = 64
+ERROR_OPERATION_ABORTED = 995
+
+patch_applied = False
+
+
+def apply_proactor_recvfrom_patch():  # pragma: no cover
+    global patch_applied  # pylint: disable=global-statement
+    if patch_applied:
+        return
+
+    from asyncio import IocpProactor  # pylint: disable=import-outside-toplevel
+
+    IocpProactor.recvfrom = patched_recvfrom
+
+    patch_applied = True
+    logger.info("Patched IocpProactor.recvfrom to handle ERROR_PORT_UNREACHABLE")
+
+
+# pylint: disable=protected-access
+
+
+def patched_recvfrom(self, conn, nbytes, flags=0):
+    self._register_with_iocp(conn)
+    ov = _overlapped.Overlapped(NULL)
+    try:
+        ov.WSARecvFrom(conn.fileno(), nbytes, flags)
+    except BrokenPipeError:
+        return self._result((b'', None))
+
+    def finish_recvfrom(trans, key, ov, error_class=OSError):  # pylint: disable=unused-argument
+        try:
+            return ov.getresult()
+        except error_class as exc:
+            if exc.winerror in (ERROR_NETNAME_DELETED, ERROR_OPERATION_ABORTED):
+                raise ConnectionResetError(*exc.args)  # pylint: disable=raise-missing-from
+
+            # ******************** START OF THE PATCH ********************
+            # WSARecvFrom will report ERROR_PORT_UNREACHABLE when the same
+            # socket was used to send to an address that is not listening.
+            if exc.winerror == ERROR_PORT_UNREACHABLE:
+                return b'', None  # ignore the error
+            # ******************** END OF THE PATCH **********************
+
+            raise
+
+    return self._register(ov, conn, finish_recvfrom)

--- a/src/tribler/core/utilities/asyncio_fixes/tests/test_proactor_recvfrom_patch.py
+++ b/src/tribler/core/utilities/asyncio_fixes/tests/test_proactor_recvfrom_patch.py
@@ -1,0 +1,82 @@
+from unittest.mock import Mock, patch
+
+import pytest
+
+from tribler.core.utilities.asyncio_fixes.proactor_recvfrom_patch import ERROR_NETNAME_DELETED, \
+    ERROR_OPERATION_ABORTED, ERROR_PORT_UNREACHABLE, patched_recvfrom
+
+
+# pylint: disable=protected-access
+
+
+@patch('tribler.core.utilities.asyncio_fixes.proactor_recvfrom_patch._overlapped')
+def test_patched_recvfrom_broken_pipe_error(overlapped):
+    proactor, conn, nbytes, flags, ov = (Mock() for _ in range(5))
+    overlapped.Overlapped.return_value = ov
+    conn.fileno.return_value = Mock()
+    ov.WSARecvFrom.side_effect = BrokenPipeError()
+    proactor._result.return_value = Mock()
+
+    result = patched_recvfrom(proactor, conn, nbytes, flags)
+
+    proactor._register_with_iocp.assert_called_with(conn)
+    overlapped.Overlapped.assert_called_with(0)
+    ov.WSARecvFrom.assert_called_with(conn.fileno.return_value, nbytes, flags)
+    proactor._result.assert_called_with((b'', None))
+    assert result is proactor._result.return_value
+
+
+@patch('tribler.core.utilities.asyncio_fixes.proactor_recvfrom_patch._overlapped')
+def test_patched_recvfrom(overlapped):
+    proactor, conn, nbytes, flags, ov, trans, key = (Mock() for _ in range(7))
+    overlapped.Overlapped.return_value = ov
+    conn.fileno.return_value = Mock()
+    proactor._register.return_value = Mock()
+
+    result = patched_recvfrom(proactor, conn, nbytes, flags)
+    proactor._register.assert_called_once()
+    assert result is proactor._register.return_value
+    args = proactor._register.call_args.args
+    assert args[:2] == (ov, conn) and len(args) == 3
+
+    finish_recvfrom = args[2]
+
+    class OSErrorMock(Exception):
+        def __init__(self, winerror):
+            self.winerror = winerror
+
+    with patch('tribler.core.utilities.asyncio_fixes.proactor_recvfrom_patch.OSError', 'OSErrorMock'):
+
+        # Should raise ConnectionResetError if ov.getresult() raises OSError with winerror=ERROR_NETNAME_DELETED
+
+        ov.getresult.assert_not_called()
+        ov.getresult.side_effect = OSErrorMock(ERROR_NETNAME_DELETED)
+        with pytest.raises(ConnectionResetError):
+            finish_recvfrom(trans, key, ov, error_class=OSErrorMock)
+
+        # Should raise ConnectionResetError if ov.getresult() raises OSError with winerror=ERROR_OPERATION_ABORTED
+
+        ov.getresult.side_effect = OSErrorMock(ERROR_OPERATION_ABORTED)
+        with pytest.raises(ConnectionResetError):
+            finish_recvfrom(trans, key, ov, error_class=OSErrorMock)
+
+        # Should return empty result if ov.getresult() raises OSError with winerror=ERROR_PORT_UNREACHABLE
+
+        ov.getresult.side_effect = OSErrorMock(ERROR_PORT_UNREACHABLE)
+        result = finish_recvfrom(trans, key, ov, error_class=OSErrorMock)
+        assert result == (b'', None)
+
+        # Should reraise any other OSError raised by ov.getresult()
+
+        ov.getresult.side_effect = OSErrorMock(-1)
+        with pytest.raises(OSErrorMock):
+            finish_recvfrom(trans, key, ov, error_class=OSErrorMock)
+
+        # Should return result of ov.getresult() if no exceptions arisen
+
+        ov.getresult.side_effect = None
+        ov.getresult.return_value = Mock()
+        result = finish_recvfrom(trans, key, ov)
+        assert result is ov.getresult.return_value
+
+        assert ov.getresult.call_count == 5

--- a/src/tribler/gui/dialogs/feedbackdialog.py
+++ b/src/tribler/gui/dialogs/feedbackdialog.py
@@ -11,7 +11,7 @@ from PyQt5 import uic
 from PyQt5.QtWidgets import QAction, QDialog, QMessageBox, QTreeWidgetItem
 
 from tribler.core.components.reporter.reported_error import ReportedError
-from tribler.core.sentry_reporter.sentry_reporter import SentryReporter
+from tribler.core.sentry_reporter.sentry_reporter import PROCESS_ARCHITECTURE, SentryReporter
 from tribler.core.sentry_reporter.sentry_scrubber import SentryScrubber
 from tribler.core.sentry_reporter.sentry_tools import CONTEXT_DELIMITER, LONG_TEXT_DELIMITER
 from tribler.gui.sentry_mixin import AddBreadcrumbOnShowMixin
@@ -142,6 +142,7 @@ class FeedbackDialog(AddBreadcrumbOnShowMixin, QDialog):
         stack = self.error_text_edit.toPlainText()
 
         post_data = {
+            PROCESS_ARCHITECTURE: platform.architecture()[0],
             "version": self.tribler_version,
             "machine": platform.machine(),
             "os": platform.platform(),


### PR DESCRIPTION
This PR cherry-picks important fixes from the main branch to the release branch.
* Adding Sentry tag that allows distinguishing errors of 32-bit and 64-bit Tribler versions on Windows;
* The fix for a problem when reports were undelivered to Sentry from some user machines (while declared as "reported");
* The fix for the UDP server hung.