### PR TITLE
Remove the torrent grouping feature based on names

### DIFF
--- a/src/tribler/gui/widgets/search_results_model.py
+++ b/src/tribler/gui/widgets/search_results_model.py
@@ -14,7 +14,6 @@ class SearchResultsModel(ChannelContentModel):
         self.remote_results_received = False
         self.postponed_remote_results = []
         self.highlight_remote_results = True
-        self.group_by_name = True
         self.sort_by_rank = True
         self.original_search_results = []
 

--- a/src/tribler/gui/widgets/tablecontentdelegate.py
+++ b/src/tribler/gui/widgets/tablecontentdelegate.py
@@ -379,11 +379,6 @@ class TagsMixin:
         debug = False  # change to True to see the search rank of items and to highlight remote items
         item_name = data_item["name"]
 
-        group = data_item.get("group")
-        if group:
-            has_remote_items = any(group_item.get('remote') for group_item in group.values())
-            item_name += f"    (+ {len(group)} similar{' *' if debug and has_remote_items else ''})"
-
         if debug:
             rank = data_item.get("rank")
             if rank is not None:

--- a/src/tribler/gui/widgets/tablecontentmodel.py
+++ b/src/tribler/gui/widgets/tablecontentmodel.py
@@ -116,7 +116,6 @@ class RemoteTableModel(QAbstractTableModel):
         self.saved_scroll_state = None
         self.qt_object_destroyed = False
 
-        self.group_by_name = False
         self.sort_by_rank = False
         self.text_filter = ''
 
@@ -204,7 +203,6 @@ class RemoteTableModel(QAbstractTableModel):
         # Only add unique items to the table model and reverse mapping from unique ids to rows is built.
         insert_index = 0 if on_top else len(self.data_items)
         unique_new_items = []
-        name_mapping = {item['name']: item for item in self.data_items} if self.group_by_name else {}
         now = time.time()
         for item in items:
             if remote:
@@ -218,21 +216,12 @@ class RemoteTableModel(QAbstractTableModel):
             item_uid = get_item_uid(item)
             if item_uid not in self.item_uid_map:
 
-                prev_item = name_mapping.get(item['name'])
-                if self.group_by_name and prev_item is not None and not on_top and prev_item['type'] == REGULAR_TORRENT:
-                    group = prev_item.setdefault('group', {})
-                    if item_uid not in group:
-                        group[item_uid] = item
-                else:
-                    self.item_uid_map[item_uid] = insert_index
-                    if 'infohash' in item:
-                        self.item_uid_map[item['infohash']] = insert_index
-                    unique_new_items.append(item)
+                self.item_uid_map[item_uid] = insert_index
+                if 'infohash' in item:
+                    self.item_uid_map[item['infohash']] = insert_index
+                unique_new_items.append(item)
 
-                    if self.group_by_name and item['type'] == REGULAR_TORRENT and prev_item is None:
-                        name_mapping[item['name']] = item
-
-                    insert_index += 1
+                insert_index += 1
         return unique_new_items, insert_index
 
     def add_items(self, new_items, on_top=False, remote=False):


### PR DESCRIPTION
This PR disables the torrent grouping feature based on torrent names as was requested by @synctext.
The feature has been introduced in 
 - #7025
 
![image](https://github.com/Tribler/tribler/assets/13798583/ccac0173-b4ab-41c3-bd01-f509509ce7ce)
