### PR TITLE
Upgrade stale action to v9

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,7 +7,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v8
+      - uses: actions/stale@v9
         with:
           stale-issue-message: 'This issue has not seen activity for 60 days. It is now marked as stale. Please provide additional information or this issue may be closed in the future. We value your contribution and would love to hear more!'
           stale-issue-label: 'status: stale'


### PR DESCRIPTION
The stale action used in the workflow has been upgraded from version 8 to version 9. 

Fixes #7994

Ref:
- https://github.com/actions/stale/releases/tag/v9.0.0

>Version 9 of this action updated the runtime to Node.js 20. All scripts are now run with Node.js 20 instead of Node.js 16 and are affected by any breaking changes between Node.js 16 and 20.

