### PR TITLE
Refactor search functionality

### DIFF
--- a/src/tribler/core/components/content_discovery/restapi/tests/test_search_endpoint.py
+++ b/src/tribler/core/components/content_discovery/restapi/tests/test_search_endpoint.py
@@ -35,12 +35,17 @@ async def test_create_remote_search_request(rest_api, mock_content_discovery_com
     search_txt = "foo"
     await do_request(
         rest_api,
-        f'search/remote?txt_filter={search_txt}&max_rowid=1',
+        'search/remote',
+        params={
+            'fts_text': search_txt,
+            'filter': 'bar',
+            'max_rowid': 1
+        },
         request_type="PUT",
         expected_code=200,
         expected_json={"request_uuid": str(request_uuid), "peers": peers},
     )
-    assert sent['txt_filter'] == search_txt
+    assert sent['txt_filter'] == f'"{search_txt}" "bar"'
     sent.clear()
 
     # Test querying channel data by public key, e.g. for channel preview purposes

--- a/src/tribler/gui/widgets/search_results_model.py
+++ b/src/tribler/gui/widgets/search_results_model.py
@@ -6,10 +6,9 @@ from tribler.gui.widgets.tablecontentmodel import ChannelContentModel, get_item_
 
 
 class SearchResultsModel(ChannelContentModel):
-    def __init__(self, original_query, **kwargs):
-        self.original_query = original_query
+    def __init__(self, **kwargs):
         self.remote_results = {}
-        title = self.format_title()
+        title = self.format_title(**kwargs)
         super().__init__(channel_info={"name": title}, **kwargs)
         self.remote_results_received = False
         self.postponed_remote_results = []
@@ -17,8 +16,9 @@ class SearchResultsModel(ChannelContentModel):
         self.sort_by_rank = True
         self.original_search_results = []
 
-    def format_title(self):
-        q = self.original_query
+    def format_title(self,**kwargs):
+        original_query = kwargs.get('original_query', '')
+        q = original_query
         q = q if len(q) < 50 else q[:50] + '...'
         return f'Search results for {q}'
 

--- a/src/tribler/gui/widgets/tablecontentmodel.py
+++ b/src/tribler/gui/widgets/tablecontentmodel.py
@@ -336,16 +336,8 @@ class RemoteTableModel(QAbstractTableModel):
 
         if self.sort_by is not None:
             kwargs.update({"sort_by": self.sort_by, "sort_desc": self.sort_desc})
-
-        txt_filter = to_fts_query(self.text_filter)
-        if txt_filter:
-            kwargs.update({"txt_filter": txt_filter})
-            # Global full-text search queries should not request the total number of rows for several reasons:
-            # * The total number of rows is useful for paginated queries, and FTS queries in Tribler are not paginated.
-            # * Our goal is to display the most relevant results for the user at the top of the search result list.
-            #   The user doesn't need to see that the database has exactly 300001 results for the "MP3" search.
-            #   In other words, we should search like Google, not Altavista.
-            # * The result list also integrates the results from remote peers that are not from the local database.
+        if self.text_filter:
+            kwargs['filter'] = self.text_filter
             if 'origin_id' not in kwargs:
                 kwargs.pop("include_total", None)
 
@@ -410,8 +402,10 @@ class ChannelContentModel(RemoteTableModel):
             text_filter='',
             tags=None,
             type_filter=None,
+            original_query='',
+            fts_text='',
     ):
-        RemoteTableModel.__init__(self, parent=None)
+        super().__init__(None)
 
         self.column_position = {name: i for i, name in enumerate(self.columns_shown)}
         self.name_column_width = 0
@@ -432,7 +426,8 @@ class ChannelContentModel(RemoteTableModel):
         self.channel_info = channel_info
 
         self.endpoint_url = endpoint_url
-
+        self.original_query = original_query
+        self.fts_text = fts_text
         # Load the initial batch of entries
         self.perform_initial_query()
 
@@ -567,7 +562,8 @@ class ChannelContentModel(RemoteTableModel):
         """
         Fetch search results.
         """
-
+        kwargs['original_query'] = self.original_query
+        kwargs['fts_text'] = self.fts_text
         if self.type_filter is not None:
             kwargs.update({"metadata_type": self.type_filter})
         else:
@@ -624,9 +620,3 @@ class ChannelContentModel(RemoteTableModel):
 
     def on_new_entry_received(self, response):
         self.on_query_results(response, remote=True)
-
-
-class ChannelPreviewModel(ChannelContentModel):
-    def perform_query(self, **kwargs):
-        kwargs["remote"] = True
-        super().perform_query(**kwargs)


### PR DESCRIPTION
Improvements:
- all `to_fts_query` calls have been moved from GUI to Core

Fixes
- Remote search is fixed (it was broken in #7726)
- Content filter is fixed 


Closes #7075

![image](https://github.com/Tribler/tribler/assets/13798583/5a836fff-b28f-4d29-8380-249eb40bfab5)
