### PR TITLE
Update macOS version in GitHub workflows

### DIFF
--- a/.github/workflows/!PR.yml
+++ b/.github/workflows/!PR.yml
@@ -155,7 +155,7 @@ jobs:
     uses: ./.github/workflows/pytest.yml
     with:
       python-version: ${{needs.env.outputs.python-version}}
-      matrix: '{"os": ["windows-latest", "macos-latest"]}'
+      matrix: '{"os": ["windows-latest", "macos-13"]}'
       ref: ${{needs.env.outputs.source-ref}}
 
   guitest:
@@ -164,7 +164,7 @@ jobs:
     uses: ./.github/workflows/guitest.yml
     with:
       python-version: ${{needs.env.outputs.python-version}}
-      matrix: '{"os": ["ubuntu-latest", "macos-latest"]}'
+      matrix: '{"os": ["ubuntu-latest", "macos-13"]}'
       ref: ${{needs.env.outputs.source-ref}}
 
   application_tester:
@@ -173,7 +173,7 @@ jobs:
     uses: ./.github/workflows/application_tester.yml
     with:
       python-version: ${{needs.env.outputs.python-version}}
-      matrix: '{"os": ["windows-latest", "macos-latest"]}'
+      matrix: '{"os": ["windows-latest", "macos-13"]}'
       ref: ${{needs.env.outputs.source-ref}}
 
   # build binaries
@@ -193,7 +193,7 @@ jobs:
     uses: ./.github/workflows/build_mac.yml
     with:
       upload: ${{ needs.env.outputs.upload-binaries == 'true' }}
-      os: macos-latest
+      os: macos-12
       python-version: ${{needs.env.outputs.python-version}}
       ref: ${{needs.env.outputs.source-ref}}
 

--- a/.github/workflows/application_tester.yml
+++ b/.github/workflows/application_tester.yml
@@ -9,7 +9,7 @@ on:
         required: false
 
       matrix:
-        default: '{"os":["windows-latest", "macos-latest", "ubuntu-latest"]}'
+        default: '{"os":["windows-latest", "macos-13", "ubuntu-latest"]}'
         type: string
         required: false
 

--- a/.github/workflows/build_mac.yml
+++ b/.github/workflows/build_mac.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       os:
-        default: macos-latest
+        default: macos-12
         type: string
         required: false
 

--- a/.github/workflows/guitest.yml
+++ b/.github/workflows/guitest.yml
@@ -9,7 +9,7 @@ on:
         required: false
 
       matrix:
-        default: '{"os":["windows-latest", "macos-latest", "ubuntu-latest"]}'
+        default: '{"os":["windows-latest", "macos-13", "ubuntu-latest"]}'
         type: string
         required: false
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -9,7 +9,7 @@ on:
         required: false
 
       matrix:
-        default: '{"os":["windows-latest", "macos-latest", "ubuntu-latest"]}'
+        default: '{"os":["windows-latest", "macos-13", "ubuntu-latest"]}'
         type: string
         required: false
 


### PR DESCRIPTION
The macOS version used in the GitHub workflows has been updated. Previously, the latest version of macOS was being used for testing and building. Now, a specific version (macOS-13 for testing and macOS-12 for building) is set to ensure consistency across all tests and builds.

Fixes #8011