### PR TITLE
Add setting to remember download columns width

### DIFF
--- a/src/tribler/gui/qt_resources/mainwindow.ui
+++ b/src/tribler/gui/qt_resources/mainwindow.ui
@@ -1380,6 +1380,30 @@ color: white;margin-top:10px;</string>
 																				</property>
 																			</widget>
 																		</item>
+																		<item row="17" column="0">
+																			<widget class="QLabel" name="label_7">
+																				<property name="font">
+																					<font>
+																						<weight>75</weight>
+																						<bold>true</bold>
+																					</font>
+																				</property>
+																				<property name="styleSheet">
+																					<string notr="true">font-weight: bold;
+color: white;margin-top:10px;</string>
+																				</property>
+																				<property name="text">
+																					<string>Downloads table</string>
+																				</property>
+																			</widget>
+																		</item>
+																		<item row="18" column="0">
+																			<widget class="QCheckBox" name="downloads_header_state_checkbox">
+																				<property name="text">
+																					<string>Remember header state (keeps columns width and order)</string>
+																				</property>
+																			</widget>
+																		</item>
 																	</layout>
 																</widget>
 																<widget class="QWidget" name="settings_connection_tab">

--- a/src/tribler/gui/widgets/downloadspage.py
+++ b/src/tribler/gui/widgets/downloadspage.py
@@ -85,13 +85,12 @@ class DownloadsPage(AddBreadcrumbOnShowMixin, QWidget):
     def initialize_downloads_page(self):
         self.window().downloads_tab.initialize()
         connect(self.window().downloads_tab.clicked_tab_button, self.on_downloads_tab_button_clicked)
-
         connect(self.window().start_download_button.clicked, self.on_start_download_clicked)
         connect(self.window().stop_download_button.clicked, self.on_stop_download_clicked)
         connect(self.window().remove_download_button.clicked, self.on_remove_download_clicked)
-
+        connect(self.window().downloads_list.header().sectionResized, self.on_header_change)
+        connect(self.window().downloads_list.header().sortIndicatorChanged, self.on_header_change)
         connect(self.window().downloads_list.itemSelectionChanged, self.on_selection_change)
-
         connect(self.window().downloads_list.customContextMenuRequested, self.on_right_click_item)
 
         self.window().download_details_widget.initialize_details_widget()
@@ -99,11 +98,23 @@ class DownloadsPage(AddBreadcrumbOnShowMixin, QWidget):
 
         connect(self.window().downloads_filter_input.textChanged, self.on_filter_text_changed)
 
-        self.window().downloads_list.header().setSortIndicator(12, Qt.AscendingOrder)
-        self.window().downloads_list.header().resizeSection(12, 146)
+        state = self.window().gui_settings.value("downloads_header_state", None)
+        if state is None:
+            self.window().downloads_list.header().resizeSection(12, 146)
+            self.window().downloads_list.header().setSortIndicator(12, Qt.AscendingOrder)
+        else:
+            self.window().downloads_list.header().restoreState(state)
 
         self.background_refresh_downloads_timer.setSingleShot(True)
         connect(self.background_refresh_downloads_timer.timeout, self.on_background_refresh_downloads_timer)
+
+    def on_header_change(self, *args, **kwargs):
+        gui_settings = self.window().gui_settings
+        if gui_settings.value("downloads_header_state", None) is not None:
+            gui_settings.setValue(
+                "downloads_header_state",
+                self.window().downloads_list.header().saveState()
+            )
 
     def on_filter_text_changed(self, text):
         self.window().downloads_list.clearSelection()

--- a/src/tribler/gui/widgets/settingspage.py
+++ b/src/tribler/gui/widgets/settingspage.py
@@ -180,6 +180,10 @@ class SettingsPage(AddBreadcrumbOnShowMixin, QWidget):
             get_gui_setting(gui_settings, "disable_tags", True, is_bool=True)
         )
 
+        # The header state of the downloads table
+        if gui_settings.value("downloads_header_state", None) is not None:
+            self.window().downloads_header_state_checkbox.setChecked(True)
+
         # Log directory
         self.window().log_location_input.setText(settings['general']['log_dir'])
 
@@ -508,6 +512,10 @@ class SettingsPage(AddBreadcrumbOnShowMixin, QWidget):
         gui_settings.setValue("ask_download_settings", self.window().always_ask_location_checkbox.isChecked())
         gui_settings.setValue("use_monochrome_icon", self.window().use_monochrome_icon_checkbox.isChecked())
         gui_settings.setValue("minimize_to_tray", self.window().minimize_to_tray_checkbox.isChecked())
+        if self.window().downloads_header_state_checkbox.isChecked():
+            gui_settings.setValue("downloads_header_state", self.window().downloads_list.header().saveState())
+        else:
+            gui_settings.remove("downloads_header_state")
         self.save_language_selection()
         self.window().tray_show_message(tr("Tribler settings"), tr("Settings saved"))
 


### PR DESCRIPTION
Are you tired of having to resize the columns in the download page all the time? me too...

This PR adds a couple of setting to set column width, for now i prefer to just have it as a "hidden" config option and in future versions we can add it in the UI, and more fancy stuff

____

This is how it looks like with my favorite options, I like the name to be the widest and the progress a bit wider than the default

![Screenshot from 2024-05-06 13-17-44](https://github.com/Tribler/tribler/assets/545474/250a8a56-1e9c-418e-9a9c-4ababe362c6b)

____

Here is the new setting:
 
![Screenshot from 2024-05-07 19-55-30](https://github.com/Tribler/tribler/assets/545474/7cf4d1a4-ef42-43c6-a5ad-a87f30ed1498)


____

My goal is to make small changes as I get myself familiar with the code base, then I would be able to take on some more challenging issues 