### PR TITLE
Change the WAL journal mode back to the default DELETE mode

### DIFF
--- a/src/tribler/core/components/database/db/store.py
+++ b/src/tribler/core/components/database/db/store.py
@@ -136,7 +136,7 @@ class MetadataStore:
         @self.db.on_connect
         def on_connect(_, connection):
             cursor = connection.cursor()
-            cursor.execute("PRAGMA journal_mode = WAL")
+            cursor.execute("PRAGMA journal_mode = DELETE")
             cursor.execute("PRAGMA synchronous = NORMAL")
             cursor.execute("PRAGMA temp_store = MEMORY")
             cursor.execute("PRAGMA foreign_keys = ON")


### PR DESCRIPTION
This PR fixes #8035.

The WAL mode is persistent, so it is necessary to switch it to DELETE mode at least once (see https://www.sqlite.org/wal.html).

After that, it is not strictly necessary to execute `PRAGMA journal_mode = DELETE` again, but executing it is cheap and fast, and consistently executing it every time the connection is open avoids some potential future errors.