### PR TITLE
Remove duplicates in breadcrumbs

### DIFF
--- a/src/tribler/core/sentry_reporter/sentry_tools.py
+++ b/src/tribler/core/sentry_reporter/sentry_tools.py
@@ -3,8 +3,7 @@ simplify work with several data structures.
 """
 import re
 from dataclasses import dataclass
-from datetime import datetime
-from typing import Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, TypeVar
 
 from faker import Faker
 
@@ -57,39 +56,32 @@ def modify_value(d, key, function):
     return d
 
 
-def distinct_by(list_of_dict, key):
+T = TypeVar('T')
+
+
+def distinct_by(items: Optional[List[T]], getter: Callable[[T], Any]) -> Optional[List[T]]:
     """This function removes all duplicates from a list of dictionaries. A duplicate
     here is a dictionary that have the same value of the given key.
 
-    If no key field is presented in the item, then the item will not be considered
-    as a duplicate.
+    If no key field is presented in the dictionary, then the exception will be raised.
 
     Args:
-        list_of_dict: list of dictionaries
-        key: a field key that will be used for items comparison
+        items: list of dictionaries
+        getter: function that returns a key for the comparison
 
     Returns:
         Array of distinct items
     """
 
-    if not list_of_dict or not key:
-        return list_of_dict
+    if not items:
+        return items
 
-    values_viewed = set()
-    result = []
-
-    for item in list_of_dict:
-        value = get_value(item, key, None)
-        if value is None:
-            result.append(item)
-            continue
-
-        if value not in values_viewed:
-            result.append(item)
-
-        values_viewed.add(value)
-
-    return result
+    distinct = {}
+    for item in items:
+        key = getter(item)
+        if key not in distinct:
+            distinct[key] = item
+    return list(distinct.values())
 
 
 def format_version(version: Optional[str]) -> Optional[str]:
@@ -124,11 +116,12 @@ def obfuscate_string(s: str, part_of_speech: str = 'noun') -> str:
     return faker.word(part_of_speech=part_of_speech)
 
 
-def order_by_utc_time(breadcrumbs: Optional[List[Dict]]):
+def order_by_utc_time(breadcrumbs: Optional[List[Dict]], key: str = 'timestamp'):
     """ Order breadcrumbs by timestamp in ascending order.
 
     Args:
         breadcrumbs: List of breadcrumbs
+        key: Field name that will be used for sorting
 
     Returns:
         Ordered list of breadcrumbs
@@ -136,4 +129,4 @@ def order_by_utc_time(breadcrumbs: Optional[List[Dict]]):
     if not breadcrumbs:
         return breadcrumbs
 
-    return list(sorted(breadcrumbs, key=lambda breadcrumb: breadcrumb["timestamp"]))
+    return list(sorted(breadcrumbs, key=lambda breadcrumb: breadcrumb[key]))

--- a/src/tribler/core/sentry_reporter/tests/test_sentry_tools.py
+++ b/src/tribler/core/sentry_reporter/tests/test_sentry_tools.py
@@ -64,17 +64,41 @@ def test_safe_get():
     assert get_value({'key': 'value'}, 'key1', {}) == {}
 
 
+def test_distinct_none():
+    # Test distinct_by with None
+    assert distinct_by(None, lambda b: (b["timestamp"], b["message"])) is None
+
+
 def test_distinct():
-    assert distinct_by(None, None) is None
-    assert distinct_by([], None) == []
-    assert distinct_by([{'key': 'b'}, {'key': 'b'}, {'key': 'c'}, {'': ''}], 'key') == [
-        {'key': 'b'},
-        {'key': 'c'},
-        {'': ''},
+    # Test distinct_by with default getter
+    values = [
+        {'message': 'message 1', 'timestamp': 'timestamp 1', 'id': '1'},
+        {'message': 'message 1', 'timestamp': 'timestamp 1', 'id': '2'},
+        {'message': 'message 2', 'timestamp': 'timestamp 2', 'id': '3'}
     ]
 
-    # test nested
-    assert distinct_by([{'a': {}}], 'b') == [{'a': {}}]
+    expected = [
+        {'message': 'message 1', 'timestamp': 'timestamp 1', 'id': '1'},
+        {'message': 'message 2', 'timestamp': 'timestamp 2', 'id': '3'}
+    ]
+    assert distinct_by(values, lambda b: (b["timestamp"], b["message"])) == expected
+
+
+def test_distinct_key_error():
+    # Test distinct_by with missing key in getter
+    values = [
+        {'message': 'message 1', },
+    ]
+    with pytest.raises(KeyError):
+        distinct_by(values, lambda b: (b["timestamp"], b["message"]))
+
+
+
+def test_distinct_none_in_list():
+    # Test distinct_by with None in list
+    values = [None]
+    with pytest.raises(TypeError):
+        distinct_by(values, lambda b: (b["timestamp"], b["message"]))
 
 
 FORMATTED_VERSIONS = [


### PR DESCRIPTION
Introduced a new method `_format_breadcrumbs` to handle the formatting of breadcrumbs in `SentryReporter`. This includes removing duplicates and ordering by timestamp. The logic for this has been extracted from the `_before_send` method.

An event example: https://sentry.tribler.org/organizations/tribler/issues/2658/events/b42dc2acdc184c709ab8f9a60367c23e/

This is a post-work of 
- #8034