### PR TITLE
Fixes #8040: improved error handling in set_proxy_settings

### DIFF
--- a/src/tribler/core/components/libtorrent/download_manager/download_manager.py
+++ b/src/tribler/core/components/libtorrent/download_manager/download_manager.py
@@ -369,26 +369,28 @@ class DownloadManager(TaskManager):
         """
         settings = {"proxy_type": ptype, "proxy_hostnames": True, "proxy_peer_connections": True}
 
-        try:
-            if not all(v is not None for v in server):
-                raise ValueError('Host and port should not be None')
+        if server:
+            try:
+                if not all(v is not None for v in server):
+                    raise ValueError('Host and port should not be None')
 
-            host, port = server
-            port = int(port)
-            settings["proxy_hostname"] = host
-            settings["proxy_port"] = port
-        except (ValueError, TypeError) as e:
-            self._logger.exception(e)
+                host, port = server
+                port = int(port)
+                settings["proxy_hostname"] = host
+                settings["proxy_port"] = port
+            except (ValueError, TypeError) as e:
+                self._logger.exception(e)
 
-        try:
-            if not all(v is not None for v in auth):
-                raise ValueError('Username and password should not be None')
+        if auth:
+            try:
+                if not all(v is not None for v in auth):
+                    raise ValueError('Username and password should not be None')
 
-            username, proxy_password = auth
-            settings["proxy_username"] = username
-            settings["proxy_password"] = proxy_password
-        except (ValueError, TypeError) as e:
-            self._logger.exception(e)
+                username, proxy_password = auth
+                settings["proxy_username"] = username
+                settings["proxy_password"] = proxy_password
+            except (ValueError, TypeError) as e:
+                self._logger.exception(e)
 
         self.set_session_settings(session, settings)
 

--- a/src/tribler/core/components/libtorrent/tests/test_download_manager.py
+++ b/src/tribler/core/components/libtorrent/tests/test_download_manager.py
@@ -591,22 +591,40 @@ def test_set_proxy_corner_case(fake_dlmgr):
     # Test setting the proxy settings with None values
     session = Mock()
 
+    fake_dlmgr._logger = Mock()
+    fake_dlmgr.set_proxy_settings(session, 2)
+    fake_dlmgr._logger.exception.assert_not_called()
+    settings, = session.method_calls[-1].args
+    assert settings['proxy_type'] == 2
+    assert 'proxy_hostname' not in settings
+    assert 'proxy_port' not in settings
+    assert 'proxy_username' not in settings
+    assert 'proxy_password' not in settings
+
+    fake_dlmgr._logger.exception.reset_mock()
     fake_dlmgr.set_proxy_settings(session, 2, (None, None))
+    fake_dlmgr._logger.exception.assert_called()
     settings, = session.method_calls[-1].args
     assert settings['proxy_type'] == 2
     assert 'proxy_port' not in settings
 
+    fake_dlmgr._logger.exception.reset_mock()
     fake_dlmgr.set_proxy_settings(session, 3, (None,))
+    fake_dlmgr._logger.exception.assert_called()
     settings, = session.method_calls[-1].args
     assert settings['proxy_type'] == 3
     assert 'proxy_port' not in settings
 
+    fake_dlmgr._logger.exception.reset_mock()
     fake_dlmgr.set_proxy_settings(session, 3, (None, 123))
+    fake_dlmgr._logger.exception.assert_called()
     settings, = session.method_calls[-1].args
     assert settings['proxy_type'] == 3
     assert 'proxy_port' not in settings
 
+    fake_dlmgr._logger.exception.reset_mock()
     fake_dlmgr.set_proxy_settings(session, 3, (None, 123), ('name', None))
+    fake_dlmgr._logger.exception.assert_called()
     settings, = session.method_calls[-1].args
     assert settings['proxy_type'] == 3
     assert 'proxy_port' not in settings


### PR DESCRIPTION
This PR fixes #8040 by checking first whether do server/auth present or not