### PR TITLE
Performance improvements for getting/selecting files using the web API

### DIFF
--- a/src/tribler/core/components/libtorrent/download_manager/download.py
+++ b/src/tribler/core/components/libtorrent/download_manager/download.py
@@ -474,7 +474,7 @@ class Download(TaskManager):
                 self.stop()
 
     @check_handle()
-    def set_selected_files(self, selected_files=None, prio: int = 4, force: bool = False):
+    def set_selected_files(self, selected_files=None, prio: int = 4, force: bool = False, no_tree=False):
         if not force and self.stream is not None:
             return
         if not isinstance(self.tdef, TorrentDefNoMetainfo) and not self.get_share_mode():
@@ -483,8 +483,15 @@ class Download(TaskManager):
             else:
                 self.config.set_selected_files(selected_files)
 
-            tree = self.tdef.torrent_file_tree
             total_files = self.tdef.torrent_info.num_files()
+            if no_tree:
+                file_priorities = [0] * total_files if not selected_files else [1] * total_files
+                for index in selected_files:
+                    file_priorities[index] = prio
+                self.set_file_priorities(file_priorities)
+                return
+
+            tree = self.tdef.torrent_file_tree
 
             if not selected_files:
                 selected_files = range(total_files)

--- a/src/tribler/core/components/libtorrent/restapi/downloads_endpoint.py
+++ b/src/tribler/core/components/libtorrent/restapi/downloads_endpoint.py
@@ -107,7 +107,8 @@ class DownloadsEndpoint(RESTEndpoint):
         """
         files_json = []
         files_completion = {name: progress for name, progress in download.get_state().get_files_completion()}
-        selected_files = download.config.get_selected_files()
+        # We use a dict for performance reasons
+        selected_files = {fi: True for fi in (download.config.get_selected_files() or range(len(files_completion)))}
         file_index = 0
         for fn, size in download.get_def().get_files_with_length():
             files_json.append({
@@ -115,7 +116,7 @@ class DownloadsEndpoint(RESTEndpoint):
                 # We always return files in Posix format to make GUI independent of Core and simplify testing
                 "name": str(PurePosixPath(fn)),
                 "size": size,
-                "included": (file_index in selected_files or not selected_files),
+                "included": selected_files.get(file_index, False),
                 "progress": files_completion.get(fn, 0.0)
             })
             file_index += 1

--- a/src/tribler/core/components/libtorrent/restapi/downloads_endpoint.py
+++ b/src/tribler/core/components/libtorrent/restapi/downloads_endpoint.py
@@ -466,7 +466,7 @@ class DownloadsEndpoint(RESTEndpoint):
             num_files = len(download.tdef.get_files())
             if not all([0 <= index < num_files for index in selected_files_list]):
                 return RESTResponse({"error": "index out of range"}, status=HTTP_BAD_REQUEST)
-            download.set_selected_files(selected_files_list)
+            download.set_selected_files(selected_files_list, no_tree=True)
 
         if state := parameters.get('state'):
             if state == "resume":

--- a/src/tribler/core/components/libtorrent/restapi/downloads_endpoint.py
+++ b/src/tribler/core/components/libtorrent/restapi/downloads_endpoint.py
@@ -512,7 +512,7 @@ class DownloadsEndpoint(RESTEndpoint):
 
         return RESTResponse(lt.bencode(torrent), headers={'content-type': 'application/x-bittorrent',
                                                           'Content-Disposition': 'attachment; filename=%s.torrent'
-                                                                                 % hexlify(infohash).encode('utf-8')})
+                                                                                 % hexlify(infohash)})
 
     @docs(
         tags=["Libtorrent"],


### PR DESCRIPTION
While working on the webui (https://github.com/Tribler/tribler/issues/7736), I noticed that getting and selecting files was very slow, to the point that the core was locking up. This PR fixes this problem.

I tested this PR using a torrent with 28700 files in it, and got a 11x speedup for getting files and a 50x speedup for selecting files. (on my machine it now takes 0.4s to get 28.7K files and 0.13s to change the selected files).

With these speedups, I don't have to use to the tree logic when building the webui, and I can just use standard client-side pagination. This makes things much simpler.