### PR TITLE
Add health column to popular torrents display

### DIFF
--- a/src/tribler/gui/widgets/popular/popular_torrents_model.py
+++ b/src/tribler/gui/widgets/popular/popular_torrents_model.py
@@ -2,7 +2,7 @@ from tribler.gui.widgets.tablecontentmodel import ChannelContentModel, Column
 
 
 class PopularTorrentsModel(ChannelContentModel):
-    columns_shown = (Column.CATEGORY, Column.NAME, Column.SIZE, Column.CREATED)
+    columns_shown = (Column.CATEGORY, Column.NAME, Column.SIZE, Column.HEALTH, Column.CREATED)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, endpoint_url='metadata/torrents/popular', **kwargs)


### PR DESCRIPTION
The popular torrents model now includes a 'health' column. This change enhances the information provided about each torrent, allowing users to make more informed decisions when selecting torrents.

Closes #6444