### PR TITLE
Added missing Ubuntu package

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Build Executables (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
         run: |
-          sudo apt-get install -y --allow-downgrades alien cpio=2.13+dfsg-7 devscripts fakeroot gir1.2-gtk-4.0 rpm
+          sudo apt-get install -y --allow-downgrades alien cpio=2.13+dfsg-7 devscripts fakeroot gir1.2-gtk-4.0 libgirepository1.0-dev rpm
           ./build/debian/makedist_debian.sh
       - name: Build Executables (MacOS-12)
         if: matrix.os == 'macos-12'


### PR DESCRIPTION
This should fix the failing build of https://github.com/Tribler/tribler/actions/runs/10350852789

(I don't know how this passed on the TriblerExperimental repository, perhaps some cached dependencies?)
