### PR TITLE
Recursively clone submodules for ReadTheDocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -2,6 +2,10 @@ version: 2
 
 formats: all
 
+submodules:
+  include: all
+  recursive: true
+
 build:
   # Check https://docs.readthedocs.io/en/stable/config-file/v2.html#build-os
   os: ubuntu-22.04


### PR DESCRIPTION
Fixes #7827 (again)

This PR:

 - Updates `.readthedocs.yaml` to fetch submodules.

I also added `recursive: true`, though this is (currently) not necessary for IPv8.

