### PR TITLE
Added one-time signing keys to windows build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,8 @@ jobs:
         run: |
           git fetch --tags
           git for-each-ref --count=1 --sort=-creatordate --format '%(refname)' refs/tags > raw_tag.txt
-          echo "GITHUB_TAG=$(git name-rev --tags --name-only $(cat raw_tag.txt))" >> $GITHUB_ENV
+          GITHUB_TAG=$(git name-rev --tags --name-only $(cat raw_tag.txt))
+          echo "GITHUB_TAG=${GITHUB_TAG#v}" >> $GITHUB_ENV
       - name: Build Executables (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
         run: |

--- a/build/win/keygen_config.txt
+++ b/build/win/keygen_config.txt
@@ -1,0 +1,23 @@
+[ req ]
+prompt              = no
+default_bits        = 4096
+distinguished_name  = req_distinguished_name
+
+string_mask         = utf8only
+default_md          = sha256
+x509_extensions     = v3_ca
+
+[ req_distinguished_name ]
+countryName                     = NL
+stateOrProvinceName             = ZH
+localityName                    = nl_NL
+organizationName                = Delft University of Technology
+organizationalUnitName          = Tribler
+commonName                      = Tribler
+emailAddress                    = info@tribler.org
+
+[ v3_ca ]
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid:always,issuer
+basicConstraints = critical, CA:true
+keyUsage = critical, digitalSignature


### PR DESCRIPTION
Related to #5648

This PR:

 - Fixes the Windows build not being signed at all*.
 - Updates the build action to strip the "v" out of the tag.

I'm not 100% sure if the paths are correct for GitHub Actions but there is only one way to find out 🙂 

*Ideally, we would have a beter solution (see #5648) but a cheap signature is still better than none at all.