### PR TITLE
Updated development docs for 8.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ Lost in development?
 License
 =======
 
-This file is part of Tribler, Copyright 2004-2023. Tribler is licensed under the GNU General Public License, version 3 (GPL-3.0), as published by the Free Software Foundation on 29 June 2007. Tribler is free software: you can redistribute it and/or modify it under the terms of this license. Tribler is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  For more details, see the full terms and conditions in the `LICENSE.txt <LICENSE.txt>`_ file at the root of this repository, or visit https://www.gnu.org/licenses/gpl-3.0.html.
+This file is part of Tribler, Copyright 2004-2024. Tribler is licensed under the GNU General Public License, version 3 (GPL-3.0), as published by the Free Software Foundation on 29 June 2007. Tribler is free software: you can redistribute it and/or modify it under the terms of this license. Tribler is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  For more details, see the full terms and conditions in the `LICENSE.txt <LICENSE.txt>`_ file at the root of this repository, or visit https://www.gnu.org/licenses/gpl-3.0.html.
 
 
 .. |pr_closed| image:: https://img.shields.io/github/issues-pr-closed/tribler/tribler.svg?style=flat

--- a/doc/basics/docker.rst
+++ b/doc/basics/docker.rst
@@ -1,3 +1,6 @@
+.. warning::
+ This document is out-of-date for the newest 8.0 source code.
+
 Running Tribler in Docker
 =========================
 

--- a/doc/basics/running.rst
+++ b/doc/basics/running.rst
@@ -3,6 +3,7 @@ Running Tribler from Source
 
 In order to run Tribler from its source you will need to perform some setup.
 We assume you have ``git`` and ``python`` installed.
+If you want to run a GUI for Tribler, you will need ``npm`` installed too.
 
 
 Steps
@@ -10,20 +11,34 @@ Steps
 
 1. Clone the Tribler repo:
 
-.. code-block:: bash
+.. code-block::
 
-    git clone https://github.com/tribler/tribler
-    
-    
-2. Install python packages:
+    git clone --recursive https://github.com/tribler/tribler
 
-.. code-block:: bash
+.. warning::
+ Tribler uses submodules.
+ If you (1) download the ZIP or (2) forget to recursively clone, your ``pyipv8`` folder will be empty.
+ Repair the former by `downloading the IPv8 zip <https://github.com/Tribler/py-ipv8>`_ and extracting it in the ``pyipv8`` folder and repair the latter by running ``git submodule update --init``.
+    
+2. Install the python dependencies:
+
+.. code-block::
 
     python -m pip install --upgrade -r tribler/requirements.txt
 
-3. Run Tribler:
+3. Build the GUI:
 
-.. code-block:: bash
+.. code-block::
+
+    cd src/tribler/ui/
+    npm install
+    npm run build
+
+4. Add the IPv8 submodule to your ``PYTHONPATH``. For example, (Windows) ``set PYTHONPATH=%PYTHONPATH%;pyipv8``, (Linux) ``export PYTHONPATH="${PYTHONPATH}:pyipv8"`` or (PyCharm) right click the ``pyipv8`` folder and ``Mark Directory as/Sources Root``.
+
+5. Run Tribler:
+
+.. code-block::
 
     cd src
     python run_tribler.py
@@ -35,25 +50,17 @@ If this is your case, continue reading for your appropriate platform.
 MacOS
 -----
 
-You may need to install QT5 and other packages separately:
+You may need to install  other packages separately:
 
-.. code-block:: bash
+.. code-block::
 
-    # QT5
-    brew install python3 qt5 sip pyqt5
-    brew cask install qt-creator  # if you want the visual designer
-    brew link qt5 --force  # to allow access qmake from the terminal
-    qmake --version  # test whether qt is installed correctly
-    export PATH="/usr/local/opt/qt@5/bin:$PATH"
-    
-    # Other packages
     brew install gmp mpfr libmpc libsodium
 
 The security system on MacOS can prevent ``libsodium.dylib`` from being dynamically linked into Tribler when running Python.
 If this library cannot be loaded, it gives an error that libsodium could not be found.
 You can link or copy ``libsodium.dylib`` into the Tribler root directory:
 
-.. code-block:: bash
+.. code-block::
 
     cd tribler  # Wherever you have Tribler installed
     cp /usr/local/lib/libsodium.dylib ./ || cp /opt/local/lib/libsodium.dylib ./

--- a/doc/building/linux.rst
+++ b/doc/building/linux.rst
@@ -2,29 +2,21 @@ Building on Linux
 =================
 
 We assume you've set up your environment to run Tribler.
+Don't forget to build the GUI using NPM!
 Run the following commands in your terminal (assuming you are in the Tribler's repository root folder).
-
-.. code-block:: none
-
-    git describe | python -c "import sys; print(next(sys.stdin).lstrip('v'))" > .TriblerVersion
-    git rev-parse HEAD > .TriblerCommit
 
 First, install additional requirements:
 
-.. code-block:: none
+.. code-block::
 
-    sudo apt-get -y install debhelper devscripts
-    sudo apt-get -y install libxcb-xinerama0-dev libqt5x11extras5 libgirepository1.0-dev
+    sudo apt-get -y install alien cpio=2.13+dfsg-7 devscripts fakeroot gir1.2-gtk-4.0 libgirepository1.0-dev rpm
     python -m pip install --upgrade -r requirements-build.txt
 
 Second, create the ``.deb`` file in the ``dist`` directory.
+You can set the ``GITHUB_TAG`` to whatever you want to have your version set as.
 
-.. code-block:: none
+.. code-block::
 
-    export QT_QPA_PLATFORM=offscreen
-    export QT_ACCESSIBILITY=1
-    export QT_IM_MODULE=ibus
-    export "TRIBLER_VERSION=$(head -n 1 .TriblerVersion)"
+    export GITHUB_TAG="1.2.3"
 
     ./build/debian/makedist_debian.sh
-

--- a/doc/building/mac.rst
+++ b/doc/building/mac.rst
@@ -2,30 +2,21 @@ Building on Mac
 ===============
 
 We assume you've set up your environment to run Tribler.
+Don't forget to build the GUI using NPM!
 Run the following commands in your terminal (assuming you are in the Tribler's repository root folder).
-
-.. code-block:: none
-
-    git describe | python -c "import sys; print(next(sys.stdin).lstrip('v'))" > .TriblerVersion
-    git rev-parse HEAD > .TriblerCommit
-
-    python ./build/update_version.py -r .
 
 First, install additional requirements:
 
-.. code-block:: none
+.. code-block::
 
     python -m pip install -r requirements-build.txt
 
 
 Second, create the ``.dmg`` file in the ``dist`` directory.
+You can set the ``GITHUB_TAG`` to whatever you want to have your version set as.
 
-.. code-block:: none
+.. code-block::
 
-    export QT_QPA_PLATFORM=offscreen
-    export QT_ACCESSIBILITY=1
-    export QT_IM_MODULE=ibus
-    export "TRIBLER_VERSION=$(head -n 1 .TriblerVersion)"
+    export GITHUB_TAG="1.2.3"
 
     ./build/mac/makedist_macos.sh
-

--- a/doc/building/windows.rst
+++ b/doc/building/windows.rst
@@ -1,64 +1,33 @@
 Building on Windows
 ===================
 
-This section contains information about building Tribler on Windows. In the end you should be left with a ``.exe`` file which, when opened, enables users to install Tribler on their system.
-This guide installs a 64-bit version of Tribler and has been tested on Windows 10 and Windows 2008 Server R2, 64-bit. It is recommended to create this builder on a system that is already able to run Tribler from a git checkout (it means that all the required packages required by Tribler are installed already). In case you want to build a 32 bit version, just install all the dependencies mentioned in 32 bit version.
-Information about setting up a developer environment on Windows can be found `here <../development/development_on_windows.rst>`__.
+We assume you've set up your environment to run Tribler.
+Don't forget to build the GUI using NPM!
+Additionally, you will need to install:
 
-**When you have installed zope, an empty** ``__init__.py`` **file must be present in the zope folder. If this file is missing, a** ``No module named zope`` **error will be thrown. Create this file in the** ``site-packages/zope`` **folder if it does not exist.**
+- ``NSIS``, the ``SimpleFC`` plugin, and the ``nsProcess`` plugin.
+- The latest ``libsodium.dll`` release.
+- ``Microsoft Visual Studio 2022 Enterprise``. ``2022 Community`` will also work, but you need to edit `tribler.nsi` in the appropriate place.
+- ``Windows Kits 10.0.19041.0``.
+- ``OpenSSL``.
 
-Required packages
------------------
+.. note::
+ If you install any of these applications to non-default folders, you will need to modify the build scripts.
 
-To build a Tribler installer, you'll need some additional scripts and packages. The versions used as of writing this guide are mentioned next to the package or script.
-* The git command tools (version 2.7.0) are required to fetch the latest release information. These can be downloaded from `here <https://git-scm.com/download/win>`__.
-* PyInstaller, a tool to create an executable from python files. Install the latest version from pip: ``pip install pyinstaller``.
-* The builder needs to find all packages that are required by Tribler so make sure you can run Tribler on your machine and that there are no missing dependencies.
-* Nullsoft Scriptable Install System (NSIS) (version 2.5.0) is a script-driven Installer authoring tool for Microsoft Windows with minimal overhead. It can be downloaded `here <http://nsis.sourceforge.net/Download>`__. We selected version 2.5 as the uninstall functions were not called properly in 3.03b.
-* Three plugins are required.The UAC plugin is the first. This can be downloaded from `here <http://nsis.sourceforge.net/UAC_plug-in>`__ (version 0.2.4c). How to install a plugin can be found `here <http://nsis.sourceforge.net/How_can_I_install_a_plugin>`__.
-* The second plugin that is needed is AccessControl plug-in (version 1.0.8.1). It can be downloaded `here <http://nsis.sourceforge.net/AccessControl_plug-in>`__.
-* The third plugin required is NSIS Simple Firewall Plugin (version 1.2.0). You can download it `here <http://nsis.sourceforge.net/NSIS_Simple_Firewall_Plugin>`__.
-* The fourth plugin needed is NSProcess (Version 1.6.7), which can be downloaded `here <http://nsis.sourceforge.net/NsProcess_plugin>`__.
-* A version of Microsoft Visual Studio should be installed (we use 2012), but make sure you do not have the build-tools only. The full (community) edition can be downloaded `here <https://www.visualstudio.com/en-us/downloads/download-visual-studio-vs.aspx>`__.
+Run the following commands in your command prompt (assuming you are in the Tribler's repository root folder).
 
-Other packages can be installed using ``pip``:
+First, install additional requirements:
 
-.. code-block:: bash
+.. code-block::
 
     python -m pip install -r requirements-build.txt
 
 
-Building & Packaging Tribler
-----------------------------
+Second, create the ``.exe`` file in the ``dist`` directory.
+You can set the ``GITHUB_TAG`` to whatever you want to have your version set as.
 
-Start by cloning Tribler if you haven't done already (using the ``git clone`` command).
-Next, create a ``build`` folder directly on your ``C:\`` drive.
-Inside the ``build`` folder, put the following items:
+.. code-block::
 
-1. A folder ``certs`` containing a ``.pfx`` key. In our case it's named ``swarmplayerprivatekey.pfx``. Make sure to rename paths in ``makedist_win.bat`` to match your file name.
-2. ``vc_redist_110.exe`` (Visual C++ Redistributable for Visual Studio 2012), which is available `here <https://www.microsoft.com/en-us/download/details.aspx?id=30679>`__. In case you build 32 bit, get the x86 version. Once more, don't forget to rename the file.
-3. ``libsodium.dll`` which can be downloaded from `libsodium.org <https://download.libsodium.org/libsodium/releases/>`_ (as of writing version 1.0.8).
-4. The openssl dll files ``libeay32.dll``, ``libssl32.dll`` and ``ssleay32.dll`` (place them in a directory named ``openssl``).
-
-Then:
-
-* Set a ``PASSWORD`` `environment variable <https://www.microsoft.com/resources/documentation/windows/xp/all/proddocs/en-us/sysdm_advancd_environmnt_addchange_variable.mspx?mfr=true>`__ with its value set to the password matching the one set in your ``.pfx`` file.
-* Create the ``.TriblerVersion`` file with the result of execution of the following command: ``git describe | python -c "import sys; print(next(sys.stdin).lstrip('v'))"``
-* Create the ``.TriblerCommit`` file with the result of execution of the following command: ``git rev-parse HEAD``
-* Set the ``TRIBLER_VERSION`` environment variable with the content of the ``.TriblerVersion`` file.
-* Set the ``QT_QPA_PLATFORM=offscreen`` environment variable
-* Set the ``QT_ACCESSIBILITY=1`` environment variable
-* Set the ``QT_IM_MODULE=ibus`` environment variable
-
-Finally, open a command prompt and enter the following commands (Change 11.0 depending on your version of Microsoft Visual Studio):
-Note that for building 32 bit you need to pass anything but 64, i.e. 32 or 86 to the ``update_version.py`` script.
-
-.. code-block:: bash
-
-    python build\update_version.py 64
-    python build\win\replace_nsi.py -r . --architecture x64
+    set GITHUB_TAG="1.2.3"
 
     build\win\makedist_win.bat
-
-This builds an ``.exe`` installer which installs Tribler.
-

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,22 +1,12 @@
-Welcome to Tribler's documentation!
-===================================
+.. note::
+ Looking for user documentation? Check out https://www.tribler.org/howto.html
+
+Welcome to Tribler's developer documentation!
+=============================================
 
 Tribler aims to give anonymous access to content. We are trying to make privacy, strong cryptography, and authentication the Internet norm.
 
-For the past 20 years we have been building a very robust Peer-to-Peer system.
-Today Tribler is robust: "the only way to take Tribler down is to take The Internet down" (but a single software bug could end everything).
-   
-
-Obtaining the latest release
-============================
-
-Just click `here <https://github.com/Tribler/tribler/releases/latest>`__ and download the latest package for your OS.
-
-Obtaining support
-=================
-
-If you found a bug or have a feature request, please make sure you read our contribution rules and then `open an issue <https://github.com/Tribler/tribler/issues/new>`_. We will have a look at it ASAP.
-
+These documents specify how to run Tribler from the latest source code and how to build Tribler distributions.
    
 Table of contents
 =================


### PR DESCRIPTION
Fixes #8096

This PR:

 - Updates the developer documentation for the 8.0 release.

The Docker docs still need to be properly looked at. I'll leave that for later: after the merge of #8108