### PR TITLE
Updated anon download test to have a unique file

### DIFF
--- a/src/tribler/test_integration/test_anon_download.py
+++ b/src/tribler/test_integration/test_anon_download.py
@@ -175,8 +175,8 @@ class TestAnonymousDownload(TestBase[TriblerTunnelCommunity]):
         config = await self.add_mock_download_config(self.download_manager_seeder, 0)
         config.set_safe_seeding(False)
 
-        with open(config.get_dest_dir() / "ubuntu-15.04-desktop-amd64.iso", "wb") as f:  # noqa: ASYNC101
-            f.write(bytes([0] * 524288))
+        with open(config.get_dest_dir() / "ubuntu-15.04-desktop-amd64.iso", "wb") as f:  # noqa: ASYNC230
+            f.write(bytes([1] * 524288))
 
         metainfo = create_torrent_file([config.get_dest_dir() / "ubuntu-15.04-desktop-amd64.iso"], {})["metainfo"]
         tdef = TorrentDef(metainfo=libtorrent.bdecode(metainfo))


### PR DESCRIPTION
Fixes #8109

This PR:

 - Updates the file contents used in `test_anon_download` to be unique, w.r.t. `test_hidden_services`.