### PR TITLE
Updated libtorrent session creation to be async

### DIFF
--- a/src/tribler/core/libtorrent/download_manager/download.py
+++ b/src/tribler/core/libtorrent/download_manager/download.py
@@ -517,20 +517,20 @@ class Download(TaskManager):
 
         # When the send buffer watermark is too low, double the buffer size to a
         # maximum of 50MiB. This is the same mechanism as Deluge uses.
-        lt_session = self.download_manager.get_session(self.config.get_hops())
+        lt_session = self.download_manager.get_session(self.config.get_hops()).result()
         settings = self.download_manager.get_session_settings(lt_session)
         if alert.message().endswith("send buffer watermark too low (upload rate will suffer)"):
             if settings["send_buffer_watermark"] <= 26214400:
                 self._logger.info("Setting send_buffer_watermark to %s", 2 * settings["send_buffer_watermark"])
                 settings["send_buffer_watermark"] *= 2
-                self.download_manager.set_session_settings(self.download_manager.get_session(), settings)
+                self.download_manager.set_session_settings(self.download_manager.get_session().result(), settings)
         # When the write cache is too small, double the buffer size to a maximum
         # of 64MiB. Again, this is the same mechanism as Deluge uses.
         elif (alert.message().endswith("max outstanding disk writes reached")
               and settings["max_queued_disk_bytes"] <= 33554432):
             self._logger.info("Setting max_queued_disk_bytes to %s", 2 * settings["max_queued_disk_bytes"])
             settings["max_queued_disk_bytes"] *= 2
-            self.download_manager.set_session_settings(self.download_manager.get_session(), settings)
+            self.download_manager.set_session_settings(self.download_manager.get_session().result(), settings)
 
     def on_torrent_removed_alert(self, alert: lt.torrent_removed_alert) -> None:
         """
@@ -771,7 +771,7 @@ class Download(TaskManager):
             if info.source & info.pex:
                 pex_peers += 1
 
-        ltsession = self.download_manager.get_session(self.config.get_hops())
+        ltsession = self.download_manager.get_session(self.config.get_hops()).result()
         public = self.tdef and not self.tdef.is_private()
 
         result = self.tracker_status.copy()
@@ -864,7 +864,7 @@ class Download(TaskManager):
         self.tdef = tdef
 
     @check_handle(None)
-    def add_trackers(self, trackers: list[str]) -> None:
+    def add_trackers(self, trackers: list[bytes]) -> None:
         """
         Add the given trackers to the handle.
         """

--- a/src/tribler/core/libtorrent/restapi/libtorrent_endpoint.py
+++ b/src/tribler/core/libtorrent/restapi/libtorrent_endpoint.py
@@ -64,7 +64,7 @@ class LibTorrentEndpoint(RESTEndpoint):
         if hop not in self.download_manager.ltsessions:
             return RESTResponse({"hop": hop, "settings": {}})
 
-        lt_session = self.download_manager.ltsessions[hop]
+        lt_session = await self.download_manager.ltsessions[hop]
         if hop == 0:
             lt_settings = self.download_manager.get_session_settings(lt_session)
             lt_settings["peer_fingerprint"] = hexlify(lt_settings["peer_fingerprint"].encode()).decode()
@@ -107,10 +107,10 @@ class LibTorrentEndpoint(RESTEndpoint):
             hop = int(args["hop"])
 
         if hop not in self.download_manager.ltsessions or \
-                not hasattr(self.download_manager.ltsessions[hop], "post_session_stats"):
+                not hasattr(self.download_manager.ltsessions[hop].result(), "post_session_stats"):
             return RESTResponse({"hop": hop, "session": {}})
 
         self.download_manager.session_stats_callback = on_session_stats_alert_received
-        self.download_manager.ltsessions[hop].post_session_stats()
+        (await self.download_manager.ltsessions[hop]).post_session_stats()
         stats = await session_stats
         return RESTResponse({"hop": hop, "session": stats})

--- a/src/tribler/core/session.py
+++ b/src/tribler/core/session.py
@@ -162,7 +162,7 @@ class Session:
         for server in self.socks_servers:
             await server.start()
         self.download_manager.socks_listen_ports = [s.port for s in self.socks_servers]
-        self.download_manager.initialize()
+        await self.download_manager.initialize()
         self.download_manager.start()
 
         # IPv8

--- a/src/tribler/test_integration/test_anon_download.py
+++ b/src/tribler/test_integration/test_anon_download.py
@@ -162,7 +162,7 @@ class TestAnonymousDownload(TestBase[TriblerTunnelCommunity]):
         manager.metadata_tmpdir = Mock(name=config.get_dest_dir())
         manager.checkpoint_directory = config.get_dest_dir()
         manager.peer_mid = b"0000"
-        manager.initialize()
+        await manager.initialize()
         manager.start()
         await sleep(0)
 

--- a/src/tribler/test_integration/test_hidden_services.py
+++ b/src/tribler/test_integration/test_hidden_services.py
@@ -194,7 +194,7 @@ class TestHiddenServicesDownload(TestBase[TriblerTunnelCommunity]):
         manager.metadata_tmpdir = Mock(name=config.get_dest_dir())
         manager.checkpoint_directory = config.get_dest_dir()
         manager.peer_mid = b"0000"
-        manager.initialize()
+        await manager.initialize()
         manager.start()
         await sleep(0)
 
@@ -206,7 +206,7 @@ class TestHiddenServicesDownload(TestBase[TriblerTunnelCommunity]):
         """
         config = await self.add_mock_download_config(self.download_manager_seeder, 1)
 
-        with open(config.get_dest_dir() / "ubuntu-15.04-desktop-amd64.iso", "wb") as f:  # noqa: ASYNC101
+        with open(config.get_dest_dir() / "ubuntu-15.04-desktop-amd64.iso", "wb") as f:  # noqa: ASYNC230
             f.write(bytes([0] * 524288))
 
         metainfo = create_torrent_file([config.get_dest_dir() / "ubuntu-15.04-desktop-amd64.iso"], {})["metainfo"]

--- a/src/tribler/test_unit/core/libtorrent/download_manager/test_download.py
+++ b/src/tribler/test_unit/core/libtorrent/download_manager/test_download.py
@@ -669,7 +669,7 @@ class TestDownload(TestBase):
         self.assertTrue(download.config.config["TEST_CRASH"])
         self.assertEqual("name", download.config.config["download_defaults"]["name"])
 
-    def test_get_tracker_status_unicode_decode_error(self) -> None:
+    async def test_get_tracker_status_unicode_decode_error(self) -> None:
         """
         Test if a tracker status is returned when getting trackers leads to a UnicodeDecodeError.
 
@@ -677,7 +677,9 @@ class TestDownload(TestBase):
         """
         download = Download(TorrentDefNoMetainfo(b"\x01" * 20, b"name"), None, checkpoint_disabled=True,
                             config=self.create_mock_download_config())
-        download.download_manager = Mock(get_session=Mock(return_value=Mock(is_dht_running=Mock(return_value=False))))
+        fut = Future()
+        fut.set_result(Mock(is_dht_running=Mock(return_value=False)))
+        download.download_manager = Mock(get_session=Mock(return_value=fut))
         download.handle = Mock(is_valid=Mock(return_value=True),
                                get_peer_info=Mock(
                                    return_value=[Mock(source=1, dht=1, pex=0)] * 42 + [Mock(source=1, pex=1, dht=0)] * 7

--- a/src/tribler/test_unit/core/libtorrent/restapi/test_libtorrent_endpoint.py
+++ b/src/tribler/test_unit/core/libtorrent/restapi/test_libtorrent_endpoint.py
@@ -1,4 +1,4 @@
-from asyncio import ensure_future, sleep
+from asyncio import Future, ensure_future, sleep
 from binascii import hexlify
 from unittest.mock import Mock
 
@@ -76,7 +76,9 @@ class TestLibTorrentEndpoint(TestBase):
         """
         Test if getting settings for zero hops gives extended info.
         """
-        self.download_manager.ltsessions = {0: Mock()}
+        fut = Future()
+        fut.set_result(Mock())
+        self.download_manager.ltsessions = {0: fut}
         self.download_manager.get_session_settings = Mock(return_value={"peer_fingerprint": "test", "test": "test"})
 
         response = await self.endpoint.get_libtorrent_settings(GetLibtorrentSettingsRequest({}))
@@ -91,9 +93,9 @@ class TestLibTorrentEndpoint(TestBase):
         """
         Test if getting settings for more hops leaves out extended info.
         """
-        self.download_manager.ltsessions = {2: Mock(
-            get_settings=Mock(return_value={"test": "test"})
-        )}
+        fut = Future()
+        fut.set_result(Mock(get_settings=Mock(return_value={"test": "test"})))
+        self.download_manager.ltsessions = {2: fut}
 
         response = await self.endpoint.get_libtorrent_settings(GetLibtorrentSettingsRequest({"hop": 2}))
         response_body_json = await response_to_json(response)
@@ -132,7 +134,9 @@ class TestLibTorrentEndpoint(TestBase):
         """
         Test if getting session info for a known number of hops forwards the known settings.
         """
-        self.download_manager.ltsessions = {0: Mock()}
+        fut = Future()
+        fut.set_result(Mock())
+        self.download_manager.ltsessions = {0: fut}
 
         response_future = ensure_future(self.endpoint.get_libtorrent_session_info(GetLibtorrentSettingsRequest({})))
         await sleep(0)


### PR DESCRIPTION
Fixes #8060

This PR:

 - Updates `DownloadManager.ltsessions` to store futures instead of completed sessions.