### PR TITLE
Reduce torrent checking intensity

### DIFF
--- a/src/tribler/core/components.py
+++ b/src/tribler/core/components.py
@@ -339,6 +339,7 @@ class UserActivityComponent(BaseLauncher):
         out["manager"] = UserActivityManager(TaskManager(), session, max_query_history)
         return out
 
+
 @precondition('session.config.get("versioning/enabled")')
 class VersioningComponent(ComponentLauncher):
     """

--- a/src/tribler/core/session.py
+++ b/src/tribler/core/session.py
@@ -38,6 +38,9 @@ from tribler.core.restapi.webui_endpoint import WebUIEndpoint
 from tribler.core.socks5.server import Socks5Server
 
 if TYPE_CHECKING:
+    from tribler.core.database.store import MetadataStore
+    from tribler.core.database.tribler_database import TriblerDatabase
+    from tribler.core.torrent_checker.torrent_checker import TorrentChecker
     from tribler.tribler_config import TriblerConfigManager
 
 logger = logging.getLogger(__name__)
@@ -113,9 +116,9 @@ class Session:
         self.rest_manager = RESTManager(self.config)
 
         # Optional globals, set by components:
-        self.db = None
-        self.mds = None
-        self.torrent_checker = None
+        self.db: TriblerDatabase | None = None
+        self.mds: MetadataStore | None = None
+        self.torrent_checker: TorrentChecker | None = None
 
     def register_launchers(self) -> None:
         """

--- a/src/tribler/core/torrent_checker/torrent_checker.py
+++ b/src/tribler/core/torrent_checker/torrent_checker.py
@@ -33,7 +33,7 @@ TRACKER_SELECTION_INTERVAL = 1  # The interval for querying a random tracker
 TORRENT_SELECTION_INTERVAL = 10  # The interval for checking the health of a random torrent
 MIN_TORRENT_CHECK_INTERVAL = 900  # How much time we should wait before checking a torrent again
 TORRENT_CHECK_RETRY_INTERVAL = 30  # Interval when the torrent was successfully checked for the last time
-MAX_TORRENTS_CHECKED_PER_SESSION = 50
+MAX_TORRENTS_CHECKED_PER_SESSION = 5  # (5 random + 5 per tracker = 10 torrents) per 10 seconds
 
 TORRENT_SELECTION_POOL_SIZE = 2  # How many torrents to check (popular or random) during periodic check
 USER_CHANNEL_TORRENT_SELECTION_POOL_SIZE = 5  # How many torrents to check from user's channel during periodic check
@@ -57,7 +57,7 @@ class TorrentChecker(TaskManager):
     A class to check the health of torrents.
     """
 
-    def __init__(self,  # noqa: PLR0913
+    def __init__(self,
                  config: TriblerConfigManager,
                  download_manager: DownloadManager,
                  notifier: Notifier,

--- a/src/tribler/core/user_activity/manager.py
+++ b/src/tribler/core/user_activity/manager.py
@@ -31,7 +31,7 @@ class UserActivityManager:
         self.queries: OrderedDict[str, typing.Set[InfoHash]] = OrderedDict()
         self.max_query_history = max_query_history
         self.database_manager: UserActivityLayer = session.db.user_activity
-        self.torrent_checker: TorrentChecker = session.torrent_checker
+        self.torrent_checker: TorrentChecker | None = session.torrent_checker
         self.task_manager = task_manager
 
         # Hook events
@@ -84,5 +84,6 @@ class UserActivityManager:
         """
         Check the health of a given infohash.
         """
-        self.task_manager.register_anonymous_task("Check preferable torrent",
-                                                  self.torrent_checker.check_torrent_health, infohash)
+        if self.torrent_checker:
+            self.task_manager.register_anonymous_task("Check preferable torrent",
+                                                      self.torrent_checker.check_torrent_health, infohash)


### PR DESCRIPTION
Fixes #8081

This PR:

 - Updates the torrent checker to only go up to ~1 metadata request per second.
 - Updates the Session's types.

