### PR TITLE
Added more default DHT routers

### DIFF
--- a/src/tribler/core/libtorrent/download_manager/download_manager.py
+++ b/src/tribler/core/libtorrent/download_manager/download_manager.py
@@ -40,10 +40,13 @@ SOCKS5_PROXY_DEF = 2
 LTSTATE_FILENAME = "lt.state"
 METAINFO_CACHE_PERIOD = 5 * 60
 DEFAULT_DHT_ROUTERS = [
+    ("dht.aelitis.com", 6881),
+    ("dht.libtorrent.org", 6881),
     ("dht.libtorrent.org", 25401),
+    ("dht.transmissionbt.com", 6881),
+    ("router.bitcomet.com", 6881),
     ("router.bittorrent.com", 6881),
     ("router.utorrent.com", 6881),
-    ("dht.transmissionbt.com", 6881),
 ]
 DEFAULT_LT_EXTENSIONS = [
     lt.create_ut_metadata_plugin,


### PR DESCRIPTION
Fixes #5900

This PR:

 - Adds some additional DHT routers.

See the discussion in #5900: adding DHT routers probably won't increase download speed. However, this does build more resiliency - should any of the servers go offline.

