### PR TITLE
WIP: Fixed missing shell for rm command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,6 +80,7 @@ jobs:
       - name: Setup npm
         uses: actions/setup-node@v4
       - name: Build npm
+        shell: bash
         run: |
           cd src/tribler/ui/
           npm install


### PR DESCRIPTION
This PR:

 - Fixes the build action not using the right shell for the `rm` command.