### PR TITLE
Fixed mac build

### DIFF
--- a/build/tribler.spec
+++ b/build/tribler.spec
@@ -34,9 +34,13 @@ if sys.platform == 'darwin':
     show_console = True
 
 data_to_copy = [
+    # UI related files
+    (os.path.join(src_dir, "tribler", "ui", "dist"), 'ui/dist'),
+    (os.path.join(src_dir, "tribler", "ui", "public"), 'ui/public'),
+
+    # Tribler source files and resources
     (os.path.join(src_dir, "tribler", "core"), 'tribler_source/tribler/core'),
-    (os.path.join(src_dir, "tribler", "ui", "public"), 'tribler_source/tribler/ui/public'),
-    (os.path.join(src_dir, "tribler", "ui", "dist"), 'tribler_source/tribler/ui/dist'),
+    (os.path.join(src_dir, "tribler", "ui"), 'tribler_source/tribler/ui'),
     (os.path.join(root_dir, "build", "win", "resources"), 'tribler_source/resources'),
 
     (os.path.dirname(aiohttp_apispec.__file__), 'aiohttp_apispec')

--- a/src/run_tribler.py
+++ b/src/run_tribler.py
@@ -117,7 +117,7 @@ async def main() -> None:
     if server_url and torrent_uri:
         await start_download(config, server_url, torrent_uri)
 
-    image_path = Path(tribler.__file__).parent / "ui/public/tribler.png"
+    image_path = tribler.get_webui_root() / "public" / "tribler.png"
     image = Image.open(image_path.resolve())
     api_port = session.rest_manager.get_api_port()
     url = f"http://{config.get('api/http_host')}:{api_port}/ui/#/downloads/all?key={config.get('api/key')}"

--- a/src/tribler/__init__.py
+++ b/src/tribler/__init__.py
@@ -1,0 +1,14 @@
+import pathlib
+import sys
+
+
+def get_webui_root() -> pathlib.Path:
+    """
+    Get the location of the "ui" directory.
+
+    When compiled through PyInstaller, the ui directory changes.
+    When running from source or when using cx_Freeze, we can use the ``__file__``.
+    """
+    if hasattr(sys, '_MEIPASS'):
+        return pathlib.Path(sys._MEIPASS) / 'ui'  # noqa: SLF001
+    return pathlib.Path(__file__).parent.absolute() / "ui"

--- a/src/tribler/core/restapi/webui_endpoint.py
+++ b/src/tribler/core/restapi/webui_endpoint.py
@@ -1,9 +1,9 @@
 import logging
 import mimetypes
-import pathlib
 
 from aiohttp import ClientSession, web
 
+import tribler
 from tribler.core.restapi.rest_endpoint import RESTEndpoint, RESTResponse
 
 
@@ -22,7 +22,7 @@ class WebUIEndpoint(RESTEndpoint):
         self._logger = logging.getLogger(self.__class__.__name__)
         self.app.add_routes([web.get('/{path:.*}', self.return_files)])
 
-        self.webui_root = (pathlib.Path(__file__).absolute() / "../../../ui/").resolve()
+        self.webui_root = tribler.get_webui_root()
         self.has_dist = (self.webui_root / 'dist').exists()
         self.session = ClientSession() if not self.has_dist else None
 


### PR DESCRIPTION
Fixes #8121

This PR:

 - Defines an utility function to get the webui path
 - Updates pyinstaller tribler.spec to include ui files.
 
 The pyinstaller build created with the changes is verified to work on the Mac mini (Intel) build machine.

