### PR TITLE
Fixed wrong YAML syntax in Docker build file

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -4,6 +4,7 @@ on: workflow_dispatch
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  REF_NAME: ${{ github.ref_name }}
 
 jobs:
   build-and-push-image:
@@ -41,10 +42,6 @@ jobs:
           echo "TAG1=${TAG,,}" >> $GITHUB_ENV
           echo "TAG2=${COMMIT,,}" >> $GITHUB_ENV
           echo "TAG3=${VERSION,,}" >> $GITHUB_ENV
-        env:
-          REGISTRY=${{ env.REGISTRY }}
-          IMAGE_NAME=${{ env.IMAGE_NAME }}
-          REF_NAME=${{ github.ref_name }}
 
       - name: Build and push Docker image
         id: push


### PR DESCRIPTION
Fixes #8125 (again, oops)

This PR:

 - Fixes env vars in `build_docker.yml` being specified with `=` instead of `:`.

