### PR TITLE
WIP: Added a new version notification on startup

### DIFF
--- a/src/tribler/ui/src/components/layouts/Header.tsx
+++ b/src/tribler/ui/src/components/layouts/Header.tsx
@@ -10,14 +10,17 @@ import { triblerService } from "@/services/tribler.service";
 import { useInterval } from "@/hooks/useInterval";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "../ui/dialog";
 import { useEffect, useState } from "react";
+import toast, { Toaster } from 'react-hot-toast';
 import Cookies from "js-cookie";
 import { DialogDescription } from "@radix-ui/react-dialog";
 import { Ban } from "lucide-react";
+import { useTranslation } from "react-i18next";
 
 export function Header() {
     const [online, setOnline] = useState<boolean>(true);
     const [shutdownLogs, setShutdownLogs] = useState<string[]>([]);
     const [searchParams, setSearchParams] = useSearchParams();
+    const { t } = useTranslation();
 
     useEffect(() => {
         const key = searchParams.get("key");
@@ -43,7 +46,13 @@ export function Header() {
     }, 1000);
 
     useEffect(() => {
-        (async () => { triblerService.addEventListener("tribler_shutdown_state", OnShutdownEvent) })();
+        (async () => {
+            triblerService.addEventListener("tribler_shutdown_state", OnShutdownEvent) })();
+            triblerService.getNewVersion().then(
+                (result) => {
+                    if (result) toast(t("VersionAvailable") + ": " + result, {icon: "ℹ", });},
+                (error) => {}
+            );
         return () => {
             (async () => { triblerService.removeEventListener("tribler_shutdown_state", OnShutdownEvent) })();
         }
@@ -119,6 +128,13 @@ export function Header() {
                     </div>
                 </div>
             </header>
+
+            <Toaster
+                position="bottom-left"
+                toastOptions={{
+                    className: 'bg-accent text-foreground font-light',
+                }}
+            />
         </>
     )
 }

--- a/src/tribler/ui/src/pages/Settings/SaveButton.tsx
+++ b/src/tribler/ui/src/pages/Settings/SaveButton.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@/components/ui/button";
-import toast, { Toaster } from 'react-hot-toast';
+import toast from 'react-hot-toast';
 import { useTranslation } from "react-i18next";
 
 
@@ -26,12 +26,6 @@ export default function SaveButton(props: SaveButtonProps) {
     return (
         <>
             <Button type="submit" className="mt-2" onClick={save}>{t('Save')}</Button>
-            <Toaster
-                position="bottom-left"
-                toastOptions={{
-                    className: 'bg-accent text-foreground font-light',
-                }}
-            />
         </>
     )
 }


### PR DESCRIPTION
Fixes #8128

This PR:

 - Adds a version check call in the `Header.tsx`, displaying a toast when a new version is available.
 - Updates the `Toast` to be defined in the `Header.tsx` instead of `SaveButton.tsx`.
 
See #8128 for reasons why this does not use the new version event (this was my original intention).

