### PR TITLE
Various version related fixes

### DIFF
--- a/build/setup.py
+++ b/build/setup.py
@@ -45,6 +45,13 @@ raw_version = os.getenv("GITHUB_TAG")
 version_numbers = [str(value) for value in map(int, re.findall(r"\d+", raw_version))]
 version = Version(".".join(version_numbers))
 
+# cx_Freeze does not automatically make the package metadata
+os.mkdir("tribler.dist-info")
+with open("tribler.dist-info/METADATA", "w") as metadata_file:
+    metadata_file.write(f"""Metadata-Version: 2.3
+Name: Tribler
+Version: {str(version)}""")
+
 setup(
     name="tribler",
     version=str(version),

--- a/build/tribler.spec
+++ b/build/tribler.spec
@@ -27,6 +27,13 @@ raw_version = os.getenv("GITHUB_TAG")
 version_numbers = [str(value) for value in map(int, re.findall(r"\d+", raw_version))]
 version_str = str(Version(".".join(version_numbers)))
 
+# PyInstaller can automatically generate metadata but I don't trust it (Quinten)
+os.mkdir("tribler.dist-info")
+with open("tribler.dist-info/METADATA", "w") as metadata_file:
+    metadata_file.write(f"""Metadata-Version: 2.3
+Name: Tribler
+Version: {version_str}""")
+
 # On macOS, we always show the console to prevent the double-dock bug (although the OS does not actually show the console).
 # See https://github.com/Tribler/tribler/issues/3817
 show_console = os.environ.get('SHOW_CONSOLE', 'false') == 'true'
@@ -42,6 +49,7 @@ data_to_copy = [
     (os.path.join(src_dir, "tribler", "core"), 'tribler_source/tribler/core'),
     (os.path.join(src_dir, "tribler", "ui"), 'tribler_source/tribler/ui'),
     (os.path.join(root_dir, "build", "win", "resources"), 'tribler_source/resources'),
+    (os.path.join(root_dir, "tribler.dist-info", "METADATA"), 'tribler.dist-info/METADATA'),
 
     (os.path.dirname(aiohttp_apispec.__file__), 'aiohttp_apispec')
 ]

--- a/build/win/build.py
+++ b/build/win/build.py
@@ -61,6 +61,7 @@ def get_freeze_build_options():
         ("src/tribler/ui/public", "tribler_source/tribler/ui/public"),
         ("src/tribler/ui/dist", "tribler_source/tribler/ui/dist"),
         ("build/win/resources", "tribler_source/resources"),
+        "tribler.dist-info/METADATA"
     ]
 
     # These packages will be excluded from the build

--- a/src/tribler/core/libtorrent/download_manager/download_manager.py
+++ b/src/tribler/core/libtorrent/download_manager/download_manager.py
@@ -30,6 +30,7 @@ from tribler.core.libtorrent.download_manager.download_state import DownloadStat
 from tribler.core.libtorrent.torrentdef import MetainfoDict, TorrentDef, TorrentDefNoMetainfo
 from tribler.core.libtorrent.uris import unshorten, url_to_path
 from tribler.core.notifier import Notification, Notifier
+from tribler.tribler_config import VERSION_SUBDIR
 
 if TYPE_CHECKING:
     from tribler.core.libtorrent.download_manager.dht_health_manager import DHTHealthManager
@@ -299,13 +300,12 @@ class DownloadManager(TaskManager):
         libtorrent_port = self.config.get("libtorrent/port")
         logger.info("Libtorrent port: %d", libtorrent_port)
         if hops == 0:
-            settings["user_agent"] = "Tribler/Experimental"
+            settings["user_agent"] = 'Tribler/' + VERSION_SUBDIR
             enable_utp = self.config.get("libtorrent/utp")
             settings["enable_outgoing_utp"] = enable_utp
             settings["enable_incoming_utp"] = enable_utp
             settings["prefer_rc4"] = True
             settings["listen_interfaces"] = f"0.0.0.0:{libtorrent_port or 6881}"
-            settings["handshake_client_version"] = "Tribler/Experimental"
         else:
             settings["enable_outgoing_utp"] = True
             settings["enable_incoming_utp"] = True


### PR DESCRIPTION
Fixes #8134
Fixes #8133

This PR:

 - Fixes missing `METADATA` file generation.
 - Fixes the libtorrent user agent being set to `Tribler/Experimental`.
 - Removes sharing the IPv8 public key through libtorrent.

Note that PyInstaller does support metadata generation. However, I'd like the `tribler.spec` and `setup.py` to remain pretty close.