### PR TITLE
Fixed PyInstaller copying file as folder

### DIFF
--- a/build/tribler.spec
+++ b/build/tribler.spec
@@ -49,7 +49,7 @@ data_to_copy = [
     (os.path.join(src_dir, "tribler", "core"), 'tribler_source/tribler/core'),
     (os.path.join(src_dir, "tribler", "ui"), 'tribler_source/tribler/ui'),
     (os.path.join(root_dir, "build", "win", "resources"), 'tribler_source/resources'),
-    (os.path.join(root_dir, "tribler.dist-info", "METADATA"), 'tribler.dist-info/METADATA'),
+    (os.path.join(root_dir, "tribler.dist-info", "METADATA"), 'tribler.dist-info'),
 
     (os.path.dirname(aiohttp_apispec.__file__), 'aiohttp_apispec')
 ]


### PR DESCRIPTION
Fixes the current build failure on Mac. According to [the docs](https://pyinstaller.org/en/stable/spec-files.html#adding-data-files):

```
        The first string specifies the file or files as they are in this system now.
        The second specifies the name of the folder to contain the files at run-time.
```


