### PR TITLE
Fixed anon download test not waiting for port

### DIFF
--- a/src/tribler/test_integration/test_anon_download.py
+++ b/src/tribler/test_integration/test_anon_download.py
@@ -194,6 +194,10 @@ class TestAnonymousDownload(TestBase[TriblerTunnelCommunity]):
 
         download = await self.download_manager_downloader.start_download(tdef=TorrentDefNoMetainfo(infohash, b"test"),
                                                                          config=config)
+
+        while not self.download_manager_seeder.listen_ports[0]:
+            await sleep(0.1)
+
         self.overlay(DOWNLOADER).bittorrent_peers[download] = {
             ("127.0.0.1", self.download_manager_seeder.listen_ports[0]["127.0.0.1"])
         }


### PR DESCRIPTION
Fixes #8143

This PR:

 - Fixes `start_anon_download` not waiting for `listen_ports` to be created.

Validated fix with:

```patch
diff --git a/src/tribler/core/libtorrent/download_manager/download_manager.py b/src/tribler/core/libtorrent/download_manager/download_manager.py
index 6346306eb..4d71bc241 100644
--- a/src/tribler/core/libtorrent/download_manager/download_manager.py
+++ b/src/tribler/core/libtorrent/download_manager/download_manager.py
@@ -475,7 +475,10 @@ class DownloadManager(TaskManager):
 
         if alert_type == "listen_succeeded_alert":
             ls_alert = cast(lt.listen_succeeded_alert, alert)
-            self.listen_ports[hops][ls_alert.address] = ls_alert.port
+            def do_later(address, port):
+                self.listen_ports[hops][address] = port
+            self.register_anonymous_task("later", do_later, ls_alert.address, ls_alert.port, delay=3)
+            #self.listen_ports[hops][ls_alert.address] = ls_alert.port
 
         elif alert_type == "peer_disconnected_alert":
             self.notifier.notify(Notification.peer_disconnected,
```