### PR TITLE
Fixed the select event loop not being set on Windows

### DIFF
--- a/src/run_tribler.py
+++ b/src/run_tribler.py
@@ -134,5 +134,6 @@ async def main() -> None:
 
 
 if __name__ == "__main__":
-    asyncio.set_event_loop(asyncio.SelectorEventLoop())
+    if sys.platform == "win32":
+        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
     asyncio.run(main())

--- a/src/tribler/core/components.py
+++ b/src/tribler/core/components.py
@@ -284,6 +284,7 @@ class DHTDiscoveryComponent(BaseLauncher):
 
 
 @set_in_session("tunnel_community")
+@precondition('session.config.get("tunnel_community/enabled")')
 @after("DHTDiscoveryComponent")
 @walk_strategy("tribler.core.tunnel.discovery", "GoldenRatioStrategy", -1)
 @overlay("tribler.core.tunnel.community", "TriblerTunnelCommunity")


### PR DESCRIPTION
Fixes #8146

This PR:

 - Fixes the select event loop not being set on Windows.
 - Fixes the tunnel component not respecting its "enable" config value.

