### PR TITLE
Query peers for popular torrents

### DIFF
--- a/src/tribler/core/database/restapi/database_endpoint.py
+++ b/src/tribler/core/database/restapi/database_endpoint.py
@@ -122,6 +122,8 @@ class DatabaseEndpoint(RESTEndpoint):
             sanitized["channel_pk"] = unhexlify(parameters["channel_pk"])
         if "origin_id" in parameters:
             sanitized["origin_id"] = int(parameters["origin_id"])
+        if "popular" in parameters and parse_bool(parameters.get("popular", "false")):
+            sanitized["sort_by"] = "HEALTH"
         return sanitized
 
     @db_session

--- a/src/tribler/ui/src/pages/Popular/index.tsx
+++ b/src/tribler/ui/src/pages/Popular/index.tsx
@@ -1,6 +1,6 @@
 import SimpleTable from "@/components/ui/simple-table";
 import SaveAs from "@/dialogs/SaveAs";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { triblerService } from "@/services/tribler.service";
 import { Torrent } from "@/models/torrent.model";
 import { ColumnDef } from "@tanstack/react-table";
@@ -57,11 +57,31 @@ export default function Popular() {
     const [open, setOpen] = useState<boolean>(false)
     const [torrents, setTorrents] = useState<Torrent[]>([])
     const [torrentDoubleClicked, setTorrentDoubleClicked] = useState<Torrent | undefined>();
+    const [request, setRequest] = useState<string>("");
 
     useInterval(async () => {
         const popular = await triblerService.getPopularTorrents(true);
         setTorrents(filterDuplicates(popular, 'infohash'));
+        const remoteQuery = await triblerService.searchTorrentsRemote('', true);
+        setRequest(remoteQuery.request_uuid);
     }, 5000, true);
+
+    useEffect(() => {
+        (async () => { triblerService.addEventListener("remote_query_results", OnSearchEvent) })();
+        return () => {
+            (async () => { triblerService.removeEventListener("remote_query_results", OnSearchEvent) })();
+        }
+    }, [request]);
+
+    const OnSearchEvent = (event: MessageEvent) => {
+        const data = JSON.parse(event.data);
+        if (data.uuid !== request)
+            return;
+
+        for (const result of data.results) {
+            setTorrents((prevTorrents) => [...prevTorrents, result]);
+        }
+    }
 
     const handleDownload = useCallback((torrent: Torrent) => {
         setTorrentDoubleClicked(torrent);

--- a/src/tribler/ui/src/pages/Search/index.tsx
+++ b/src/tribler/ui/src/pages/Search/index.tsx
@@ -73,9 +73,9 @@ export default function Search() {
     useEffect(() => {
         const searchTorrents = async () => {
             if (!query) return;
-            const localResults = await triblerService.searchTorrentsLocal(query, true);
+            const localResults = await triblerService.searchTorrentsLocal(query);
             setTorrents(filterDuplicates(localResults, 'infohash'));
-            const remoteQuery = await triblerService.searchTorrentsRemote(query, true);
+            const remoteQuery = await triblerService.searchTorrentsRemote(query, false);
             setRequest(remoteQuery.request_uuid);
         }
         searchTorrents();

--- a/src/tribler/ui/src/services/tribler.service.ts
+++ b/src/tribler/ui/src/services/tribler.service.ts
@@ -147,12 +147,12 @@ export class TriblerService {
         return (await this.http.get(`/metadata/search/completions?q=${txt_filter}`)).data.completions;
     }
 
-    async searchTorrentsLocal(txt_filter: string, hide_xxx: boolean): Promise<Torrent[]> {
-        return (await this.http.get(`/metadata/search/local?first=1&last=200&metadata_type=300&exclude_deleted=1&fts_text=${txt_filter}&hide_xxx=${+hide_xxx}`)).data.results;
+    async searchTorrentsLocal(txt_filter: string): Promise<Torrent[]> {
+        return (await this.http.get(`/metadata/search/local?first=1&last=200&metadata_type=300&exclude_deleted=1&fts_text=${txt_filter}`)).data.results;
     }
 
-    async searchTorrentsRemote(txt_filter: string, hide_xxx: boolean): Promise<{ request_uuid: string, peers: string[] }> {
-        return (await this.http.put(`/search/remote?fts_text=${txt_filter}&hide_xxx=${+hide_xxx}&metadata_type=300&exclude_deleted=1`)).data;
+    async searchTorrentsRemote(txt_filter: string, popular: boolean): Promise<{ request_uuid: string, peers: string[] }> {
+        return (await this.http.put(`/search/remote?fts_text=${txt_filter}&popular=${+popular}&metadata_type=300&exclude_deleted=1`)).data;
     }
 
     // Settings


### PR DESCRIPTION
Fixes #8083

This PR:

 - Adds querying of peers for popular torrents.
 - Removes xxx filtering from endpoints (this no longer does anything).
