### PR TITLE
READY: Set active downloads/seeds to unlimited

### DIFF
--- a/src/tribler/core/libtorrent/download_manager/download_manager.py
+++ b/src/tribler/core/libtorrent/download_manager/download_manager.py
@@ -287,7 +287,10 @@ class DownloadManager(TaskManager):
                                             "enable_upnp": int(self.config.get("libtorrent/upnp")),
                                             "enable_dht": int(self.config.get("libtorrent/dht")),
                                             "enable_lsd": int(self.config.get("libtorrent/lsd")),
-                                            "enable_natpmp": int(self.config.get("libtorrent/natpmp"))}
+                                            "enable_natpmp": int(self.config.get("libtorrent/natpmp")),
+                                            "active_downloads": -1,
+                                            "active_seeds": -1
+                                            }
 
         # Copy construct so we don't modify the default list
         extensions = list(DEFAULT_LT_EXTENSIONS)


### PR DESCRIPTION
Related to #6801

This PR:

 - Updates `active_downloads` and `active_seeds` to be unlimited by default (capped to 500 in total by libtorrent internally).

This seems like a better default than a max of 3 downloads and 5 seeds.

![screenshot](https://github.com/user-attachments/assets/2f842fdc-d5f2-4d6f-86a2-e14be1501174)

A follow-up PR should make this configurable in the GUI.