### PR TITLE
Do not void valid metadata mixed with deprecated metadata

### DIFF
--- a/src/tribler/core/database/store.py
+++ b/src/tribler/core/database/store.py
@@ -388,7 +388,8 @@ class MetadataStore:
         payload_list = []
         while offset < len(chunk_data):
             payload, offset = read_payload_with_offset(chunk_data, offset)
-            if payload:
+            if payload and isinstance(payload, TorrentMetadataPayload):
+                # Silently ignore deprecated payloads
                 payload_list.append(payload)
 
         if health_info and len(health_info) == len(payload_list):


### PR DESCRIPTION
Fixes #8160

This PR:

 - Updates squashed blob unpacking behavior to first unpack deprecated payloads and then filter them out (instead of throwing away the whole list).

