### PR TITLE
Added option to add trackers to a download

### DIFF
--- a/src/tribler/core/libtorrent/download_manager/download.py
+++ b/src/tribler/core/libtorrent/download_manager/download.py
@@ -749,10 +749,12 @@ class Download(TaskManager):
         self.handle = cast(lt.torrent_handle, self.handle)
         # Make sure all trackers are in the tracker_status dict
         try:
-            for announce_entry in self.handle.trackers():
-                url = announce_entry["url"]
-                if url not in self.tracker_status:
-                    self.tracker_status[url] = (0, "Not contacted yet")
+            tracker_urls = {tracker["url"] for tracker in self.handle.trackers()}
+            for removed in (set(self.tracker_status.keys()) - tracker_urls):
+                self.tracker_status.pop(removed)
+            for tracker_url in tracker_urls:
+                if tracker_url not in self.tracker_status:
+                    self.tracker_status[tracker_url] = (0, "Not contacted yet")
         except UnicodeDecodeError:
             self._logger.warning("UnicodeDecodeError in get_tracker_status")
 

--- a/src/tribler/ui/public/locales/en_US.json
+++ b/src/tribler/ui/public/locales/en_US.json
@@ -106,6 +106,8 @@
     "MagnetDialogInputLabel": "Please enter the URL/magnet link in the field below:",
     "MagnetDialogHeader": "Add torrent from URL/magnet link",
 	"MagnetDialogError": "Could not process URL/magnet link",
+    "TrackerDialogInputLabel": "Please enter the tracker URL in the field below:",
+    "TrackerDialogHeader": "Add torrent from tracker URL",
     "Add": "Add",
     "FilterByName": "Filter by name",
     "WithSelected": "With selected:",
@@ -159,5 +161,8 @@
     "ToastErrorDownloadSetHops": "Failed change the anonymity of download!",
     "ToastErrorDownloadSetFiles": "Failed to set files for download!",
     "ToastErrorUpgradeFailed": "Upgrade failed!",
-    "ToastErrorRemoveVersion": "Failed to remove version {{version}}!"
+    "ToastErrorRemoveVersion": "Failed to remove version {{version}}!",
+    "ToastErrorTrackerAdd": "Failed to add tracker!",
+    "ToastErrorTrackerRemove": "Failed to remove tracker!",
+    "ToastErrorTrackerCheck": "Failed to check tracker!"
 }

--- a/src/tribler/ui/public/locales/es_ES.json
+++ b/src/tribler/ui/public/locales/es_ES.json
@@ -106,6 +106,8 @@
     "MagnetDialogInputLabel": "Introduzca el enlace URL/magnet en el siguiente recuadro:",
     "MagnetDialogHeader": "Añadir torrent desde URL/enlace magnet",
     "MagnetDialogError": "No se pudo procesar la URL/enlace magnético",
+    "TrackerDialogInputLabel": "Introduzca la URL del rastreador en el campo siguiente:",
+    "TrackerDialogHeader": "Agregar torrent desde la URL del rastreador",
     "Add": "AÑADIR",
     "FilterByName": "Filtrar por nombre",
     "WithSelected": "Con seleccionado:",
@@ -159,5 +161,8 @@
     "ToastErrorDownloadSetHops": "¡Error al cambiar el anonimato de la descarga!",
     "ToastErrorDownloadSetFiles": "¡No se pudieron configurar los archivos para descargar!",
     "ToastErrorUpgradeFailed": "¡La actualización falló!",
-    "ToastErrorRemoveVersion": "No se pudo eliminar la versión {{version}}!"
+    "ToastErrorRemoveVersion": "No se pudo eliminar la versión {{version}}!",
+    "ToastErrorTrackerAdd": "¡No se pudo agregar el rastreador!",
+    "ToastErrorTrackerRemove": "¡No se pudo eliminar el rastreador!",
+    "ToastErrorTrackerCheck": "¡No se pudo verificar el rastreador!"
 }

--- a/src/tribler/ui/public/locales/pt_BR.json
+++ b/src/tribler/ui/public/locales/pt_BR.json
@@ -98,6 +98,8 @@
     "MagnetDialogInputLabel": "Por favor adicione o link URL/magnet no campo abaixo:",
     "MagnetDialogHeader": "Adicionar torrent de um link URL/magnet",
     "MagnetDialogError": "Não foi possível processar URL/link magnético",
+    "TrackerDialogInputLabel": "Insira o URL do rastreador no campo abaixo:",
+    "TrackerDialogHeader": "Adicionar torrent do URL do rastreador",
     "Add": "ADICIONAR",
     "FilterByName": "Filtrar por nome",
     "WithSelected": "Com selecionado:",
@@ -151,5 +153,8 @@
     "ToastErrorDownloadSetHops": "Falha ao alterar o anonimato do download!",
     "ToastErrorDownloadSetFiles": "Falha ao definir arquivos para download!",
     "ToastErrorUpgradeFailed": "Falha na atualização!",
-    "ToastErrorRemoveVersion": "Falha ao remover a versão {{version}}!"
+    "ToastErrorRemoveVersion": "Falha ao remover a versão {{version}}!",
+    "ToastErrorTrackerAdd": "Falha ao adicionar rastreador!",
+    "ToastErrorTrackerRemove": "Falha ao remover o rastreador!",
+    "ToastErrorTrackerCheck": "Falha ao verificar o rastreador!"
 }

--- a/src/tribler/ui/public/locales/ru_RU.json
+++ b/src/tribler/ui/public/locales/ru_RU.json
@@ -106,6 +106,8 @@
     "MagnetDialogInputLabel": "Пожалуйста, введите URL/magnet-ссылку в поле ниже:",
     "MagnetDialogHeader": "Добавить торренты по URL/magnet-ссылке",
     "MagnetDialogError": "Не удалось обработать URL/магнитную ссылку",
+    "TrackerDialogInputLabel": "Введите URL-адрес трекера в поле ниже:",
+    "TrackerDialogHeader": "Добавить торрент с URL-адреса трекера",
     "Add": "ДОБАВИТЬ",
     "FilterByName": "Фильтровать по имени",
     "WithSelected": "С выбранным:",
@@ -159,5 +161,8 @@
     "ToastErrorDownloadSetHops": "Не удалось изменить анонимность загрузки!",
     "ToastErrorDownloadSetFiles": "Не удалось установить файлы для скачивания!",
     "ToastErrorUpgradeFailed": "Обновление не удалось!",
-    "ToastErrorRemoveVersion": "Не удалось удалить версию {{version}}!"
+    "ToastErrorRemoveVersion": "Не удалось удалить версию {{version}}!",
+    "ToastErrorTrackerAdd": "Не удалось добавить трекер!",
+    "ToastErrorTrackerRemove": "Не удалось удалить трекер!",
+    "ToastErrorTrackerCheck": "Не удалось проверить трекер!"
 }

--- a/src/tribler/ui/public/locales/zh_CN.json
+++ b/src/tribler/ui/public/locales/zh_CN.json
@@ -105,6 +105,8 @@
     "MagnetDialogInputLabel": "请在下面字段输入 URL/磁力链接：",
     "MagnetDialogHeader": "从 URL/磁力链接添加种子文件",
     "MagnetDialogError": "无法处理 URL/磁力链接",
+    "TrackerDialogInputLabel": "请在下面的字段中输入跟踪器 URL：",
+    "TrackerDialogHeader": "从跟踪器 URL 添加 torrent",
     "Add": "添加",
     "FilterByName": "按名称过滤",
     "WithSelected": "已选择：",
@@ -158,5 +160,8 @@
     "ToastErrorDownloadSetHops": "更改下载匿名失败！",
     "ToastErrorDownloadSetFiles": "设置文件下载失败！",
     "ToastErrorUpgradeFailed": "升级失败！",
-    "ToastErrorRemoveVersion": "删除版本失败 {{version}}！"
+    "ToastErrorRemoveVersion": "删除版本失败 {{version}}！",
+    "ToastErrorTrackerAdd": "添加追踪器失败！",
+    "ToastErrorTrackerRemove": "删除跟踪器失败！",
+    "ToastErrorTrackerCheck": "检查追踪器失败！"
 }

--- a/src/tribler/ui/src/pages/Downloads/Trackers.tsx
+++ b/src/tribler/ui/src/pages/Downloads/Trackers.tsx
@@ -1,25 +1,131 @@
+import { useState } from "react";
+import toast from 'react-hot-toast';
 import SimpleTable from "@/components/ui/simple-table";
+import { Dialog, DialogClose, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { translateHeader } from "@/lib/utils";
 import { Download } from "@/models/download.model";
 import { Tracker } from "@/models/tracker.model ";
 import { ColumnDef } from "@tanstack/react-table";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { triblerService } from "@/services/tribler.service";
+import { isErrorDict } from "@/services/reporting";
+import { useTranslation } from "react-i18next";
 
 
-const trackerColumns: ColumnDef<Tracker>[] = [
-    {
-        accessorKey: "url",
-        header: translateHeader('Name'),
-    },
-    {
-        accessorKey: "status",
-        header: translateHeader('Status'),
-    },
-    {
-        accessorKey: "peers",
-        header: translateHeader('Peers'),
-    },
-]
+interface TrackerRow extends Tracker {
+    recheckButton: typeof Button;
+    removeButton: typeof Button;
+}
 
 export default function Trackers({ download }: { download: Download }) {
-    return <SimpleTable data={download.trackers} columns={trackerColumns} />
+    const { t } = useTranslation();
+
+    const [trackerDialogOpen, setTrackerDialogOpen] = useState<boolean>(false);
+    const [trackerInput, setTrackerInput] = useState('');
+
+    const trackerColumns: ColumnDef<TrackerRow>[] = [
+        {
+            accessorKey: "url",
+            header: translateHeader('Name'),
+        },
+        {
+            accessorKey: "status",
+            header: translateHeader('Status'),
+        },
+        {
+            accessorKey: "peers",
+            header: translateHeader('Peers'),
+        },
+        {
+            header: "",
+            accessorKey: "recheckButton",
+            cell: (props) => {
+                    return (["[DHT]", "[PeX]"].includes(props.row.original.url) ? <></> :
+                        <Button variant="secondary" className="max-h-6" onClick={(event) => {
+                            triblerService.forceCheckDownloadTracker(download.infohash, props.row.original.url).then((response) => {
+                                if (response === undefined) {
+                                    toast.error(`${"ToastErrorTrackerCheck"} ${"ToastErrorGenNetworkErr"}`);
+                                } else if (isErrorDict(response)){
+                                    toast.error(`${"ToastErrorTrackerCheck"} ${response.error}`);
+                                }
+                            });
+                        }}>{t("ForceRecheck")}</Button>)
+            }
+        },
+        {
+            header: "",
+            accessorKey: "removeButton",
+            cell: (props) => {
+                    return (["[DHT]", "[PeX]"].includes(props.row.original.url) ? <></> :
+                        <Button variant="secondary" className="max-h-6" onClick={(event) => {
+                            triblerService.removeDownloadTracker(download.infohash, props.row.original.url).then((response) => {
+                                if (response === undefined) {
+                                    toast.error(`${"ToastErrorTrackerRemove"} ${"ToastErrorGenNetworkErr"}`);
+                                } else if (isErrorDict(response)){
+                                    toast.error(`${"ToastErrorTrackerRemove"} ${response.error}`);
+                                } else {
+                                    download.trackers = download.trackers.filter(tracker => {return tracker.url != props.row.original.url});
+                                    var button = event.target as HTMLButtonElement;
+                                    button.disabled = true;
+                                    button.classList.add("cursor-not-allowed");
+                                    button.classList.add("opacity-50");
+                                }
+                            });
+                        }}>❌</Button>)
+            }
+        }
+    ]
+
+    return (
+        <div>
+            <div className="flex-col items-center grid-cols-1">
+                <SimpleTable data={download.trackers as TrackerRow[]} columns={trackerColumns} />
+                <div className="flex-none h-1 min-h-1 max-h-1 bg-secondary"></div>
+                <Button className="flex-none mx-4 my-2 min-w-24 max-h-8" variant="secondary" onClick={() => {setTrackerDialogOpen(true)}}>{t('Add')}</Button>
+            </div>
+            <Dialog open={trackerDialogOpen} onOpenChange={setTrackerDialogOpen}>
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>{t('TrackerDialogHeader')}</DialogTitle>
+                    </DialogHeader>
+                    <div className="grid gap-1 py-4 text-sm">
+                        {t('TrackerDialogInputLabel')}
+                        <div className="grid grid-cols-6 items-center gap-4">
+                            <Input
+                                id="uri"
+                                className="col-span-5 pt-0"
+                                value={trackerInput}
+                                onChange={(event) => setTrackerInput(event.target.value)}
+                            />
+                        </div>
+                    </div>
+                    <DialogFooter>
+                        <Button
+                            variant="outline"
+                            type="submit"
+                            onClick={() => {
+                                if (trackerInput) {
+                                    triblerService.addDownloadTracker(download.infohash, trackerInput).then((response) => {
+                                        if (response === undefined) {
+                                            toast.error(`${"ToastErrorTrackerAdd"} ${"ToastErrorGenNetworkErr"}`);
+                                        } else if (isErrorDict(response)){
+                                            toast.error(`${"ToastErrorTrackerAdd"} ${response.error}`);
+                                        }
+                                    });
+                                    setTrackerDialogOpen(false);
+                                }
+                            }}>
+                            {t('Add')}
+                        </Button>
+                        <DialogClose asChild>
+                            <Button variant="outline" type="button">
+                                {t('Cancel')}
+                            </Button>
+                        </DialogClose>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+        </div>
+    )
 }

--- a/src/tribler/ui/src/services/tribler.service.ts
+++ b/src/tribler/ui/src/services/tribler.service.ts
@@ -141,6 +141,31 @@ export class TriblerService {
         }
     }
 
+    async addDownloadTracker(infohash: string, trackerUrl: string): Promise<undefined | ErrorDict | boolean> {
+        try {
+            return (await this.http.put(`/downloads/${infohash}/trackers`, { url: trackerUrl })).data.added;
+        } catch (error) {
+            return formatAxiosError(error as Error | AxiosError);
+        }
+    }
+
+    async removeDownloadTracker(infohash: string, trackerUrl: string): Promise<undefined | ErrorDict | boolean> {
+        try {
+            return (await this.http.delete(`/downloads/${infohash}/trackers`, { data: { url: trackerUrl } })).data.removed;
+        } catch (error) {
+            return formatAxiosError(error as Error | AxiosError);
+        }
+    }
+
+    async forceCheckDownloadTracker(infohash: string, trackerUrl: string): Promise<undefined | ErrorDict | boolean> {
+        try {
+            return (await this.http.put(`/downloads/${infohash}/tracker_force_announce`, { url: trackerUrl })).data.forced;
+        } catch (error) {
+            return formatAxiosError(error as Error | AxiosError);
+        }
+
+    }
+
     // Statistics
 
     async getIPv8Statistics(): Promise<undefined | ErrorDict | {total_up: number, total_down: number}> {


### PR DESCRIPTION
Fixes #2529
Fixes #1797 (implements only force-rechecking, as priorities [don't fit that well](https://github.com/Tribler/tribler/issues/2529#issuecomment-2361103711) with `libtorrent`'s tiers)

This PR:

 - Adds GUI elements and REST API calls to add, remove, and force-check trackers.

![output](https://github.com/user-attachments/assets/7012cec0-8107-48c5-afdc-6158d7837c48)

