### PR TITLE
WIP: Added Mac signing entitlements

### DIFF
--- a/build/mac/entitlements.plist
+++ b/build/mac/entitlements.plist
@@ -1,0 +1,12 @@
+<!-- This file was copied from https://github.com/pyinstaller/pyinstaller/issues/4629#issuecomment-574375331 -->
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- These are required for binaries built by PyInstaller -->
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
+</dict>
+</plist>

--- a/build/mac/sign_app.sh
+++ b/build/mac/sign_app.sh
@@ -23,4 +23,4 @@ fi
 
 echo "Signing $APP_FILE with Apple Dev ID: $APPLE_DEV_ID"
 SIGN_MSG="Developer ID Application: $APPLE_DEV_ID"
-codesign --deep --force --verbose --sign "$SIGN_MSG" --options runtime $APP_FILE
+codesign --deep --force --verbose --sign "$SIGN_MSG" --entitlements ./build/mac/entitlements.plist --options runtime $APP_FILE


### PR DESCRIPTION
This PR:

 - Fixes the Mac `.app` not running after the `codesign` step.

Notes: 

 - I may have to do the same thing for `sign_dmg.sh`, though I would prefer everything magically working after this.