### PR TITLE
Small QOL fixes for Debian builds

### DIFF
--- a/build/debian/makedist_debian.sh
+++ b/build/debian/makedist_debian.sh
@@ -24,6 +24,6 @@ cd ./build/debian/tribler
 export DEBEMAIL="info@tribler.org"
 export DEBFULLNAME="Tribler"
 dch -v $GITHUB_TAG "New release"
-dch -v $GITHUB_TAG "See https://github.com/Tribler/tribler/releases/tag/$GITHUB_TAG for more info"
+dch -v $GITHUB_TAG "See https://github.com/Tribler/tribler/releases/tag/v$GITHUB_TAG for more info"
 
 dpkg-buildpackage -b -rfakeroot -us -uc

--- a/build/setup.py
+++ b/build/setup.py
@@ -46,7 +46,7 @@ version_numbers = [str(value) for value in map(int, re.findall(r"\d+", raw_versi
 version = Version(".".join(version_numbers))
 
 # cx_Freeze does not automatically make the package metadata
-os.mkdir("tribler.dist-info")
+os.makedirs("tribler.dist-info", exist_ok=True)
 with open("tribler.dist-info/METADATA", "w") as metadata_file:
     metadata_file.write(f"""Metadata-Version: 2.3
 Name: Tribler


### PR DESCRIPTION
This PR:

 - Fixes the GitHub tag url fed to `dch`.
 - Updates `setup.py` to allow `tribler.dist-info` to exist.
 