### PR TITLE
Added Mac entitlement to disable lib validation

### DIFF
--- a/build/mac/entitlements.plist
+++ b/build/mac/entitlements.plist
@@ -8,5 +8,7 @@
 	<true/>
 	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
 	<true/>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
Fixes #8175

This PR:

 - Adds the unsigned library entitlement to the Mac build.

This build is tested to work on our Mac infrastructure.
