### PR TITLE
Reset the torrent prop when adding URLs/magnet links

### DIFF
--- a/src/tribler/ui/src/components/add-torrent.tsx
+++ b/src/tribler/ui/src/components/add-torrent.tsx
@@ -87,6 +87,7 @@ export function AddTorrent() {
                             type="submit"
                             onClick={() => {
                                 if (uriInput) {
+                                    setTorrent(undefined);
                                     setUrlDialogOpen(false);
                                     setSaveAsDialogOpen(true);
                                 }


### PR DESCRIPTION
This PR fixes an issue where the `SaveAs` dialog shows the wrong torrent.