### PR TITLE
Fixed error reporter not checking for undefined handled key

### DIFF
--- a/src/tribler/ui/src/services/reporting.ts
+++ b/src/tribler/ui/src/services/reporting.ts
@@ -33,8 +33,7 @@ export function formatAxiosError(error: Error | AxiosError): ErrorDict | undefin
             // We don't need to do anything, but the GUI should not crash on this
             return undefined;
          }
-         var handled = error.response.data?.error?.handled
-         if (error.response.data.error.handled == false) {
+         if (error.response.data?.error?.handled == false) {
             // This is an error that conforms to the internal unhandled error format: ask the user what to do
             handleHTTPError(error);
          }


### PR DESCRIPTION
Fixes #8184

This PR:

 - Fixes the GUI error reporter not checking if `handled` is `undefined`.
