### PR TITLE
Show file trees in SaveAs / DownloadDetails components

### DIFF
--- a/src/tribler/ui/package.json
+++ b/src/tribler/ui/package.json
@@ -57,7 +57,7 @@
     "postcss": "^8.4.31",
     "react-hot-toast": "^2.4.1",
     "tailwindcss": "^3.3.3",
-    "typescript": "^4.6.4",
+    "typescript": "^5.5.0",
     "vite": "^3.1.0"
   }
 }

--- a/src/tribler/ui/src/models/file.model.tsx
+++ b/src/tribler/ui/src/models/file.model.tsx
@@ -1,9 +1,21 @@
 // For compile-time type checking and code completion
 
+import { CheckedState } from "@radix-ui/react-checkbox";
+
 export interface File {
     index: number;
     name: string;
     size: number;
     included: boolean;
     progress: number;
+}
+
+export interface FileTreeItem {
+    index: number;
+    name: string;
+    size: number;
+    downloaded?: number;
+    progress?: number;
+    included?: CheckedState;
+    subRows?: FileTreeItem[];
 }


### PR DESCRIPTION
This PR brings back file trees, similar to the way file selection worked before introducing the web UI.