### PR TITLE
Fixed Debian/Windows builds not detecting their own version

### DIFF
--- a/build/win/build.py
+++ b/build/win/build.py
@@ -61,7 +61,7 @@ def get_freeze_build_options():
         ("src/tribler/ui/public", "tribler_source/tribler/ui/public"),
         ("src/tribler/ui/dist", "tribler_source/tribler/ui/dist"),
         ("build/win/resources", "tribler_source/resources"),
-        "tribler.dist-info/METADATA"
+        ("tribler.dist-info/METADATA", "lib/tribler.dist-info/METADATA")
     ]
 
     # These packages will be excluded from the build


### PR DESCRIPTION
Fixes #8198

This PR:

 - Fixes `build.py` for `cx_Freeze` not including tribler dist info.

This fix was locally confirmed for Ubuntu, I'll test Windows later.