### PR TITLE
Added workaround for deprecation of macos-12 runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [macos-12, ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest]  # macos-12 is no longer on GitHub Actions, we use the Mac mini for this
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -37,7 +37,7 @@ jobs:
           cd src
           python run_unit_tests.py -a
   macos:
-    runs-on: macos-12
+    runs-on: macos-14
     timeout-minutes: 2
     steps:
       - uses: actions/checkout@v4
@@ -47,9 +47,12 @@ jobs:
         with:
           python-version: '3.9'
           cache: 'pip'
+      - shell: bash
+        run: |
+          cp /opt/homebrew/opt/libsodium/lib/libsodium.dylib /Library/Frameworks/Python.framework/Versions/3.9/lib/libsodium.dylib
+          sed -i".backup" 's|libtorrent==1.2.19|https://tribler.org/libtorrent-2.0.11-cp39-cp39-macosx_14_0_arm64.whl|' requirements.txt
       - run: python -m pip install -r requirements.txt
       - name: Run unit tests
         run: |
           cd src
           python run_unit_tests.py -a
-

--- a/src/tribler/core/libtorrent/torrents.py
+++ b/src/tribler/core/libtorrent/torrents.py
@@ -149,7 +149,8 @@ def create_torrent_file(file_path_list: list[Path], params: InfoDict,  # noqa: C
         fs.add_file(str(relative), getsize(str(path)))
 
     piece_size = params[b"piece length"] if params.get(b"piece length") else 0
-    flags = lt.create_torrent_flags_t.optimize
+    flag_v1_only = 2**6  # Backward compatibility for libtorrent < 2.x
+    flags = lt.create_torrent_flags_t.optimize | flag_v1_only
     params = {k: (v.decode() if isinstance(v, bytes) else v) for k, v in params.items()}
 
     torrent = lt.create_torrent(fs, piece_size=piece_size, flags=flags)


### PR DESCRIPTION
Fixes #8200

This PR:

 - Updates the unit tests to use `macos-14` instead of `macos-12`.
 - Updates `create_torrent_file` to use the `v1_only` flag.
 - Removes `macos-12` from the build job.
