### PR TITLE
Updated get_entries_query to ingore deprecated kwargs

### DIFF
--- a/src/tribler/core/database/store.py
+++ b/src/tribler/core/database/store.py
@@ -548,13 +548,17 @@ class MetadataStore:
             self_checked_torrent: bool | None = None,
             health_checked_after: int | None = None,
             popular: bool | None = None,
+            **kwargs
     ) -> Query:
         """
         This method implements REST-friendly way to get entries from the database.
 
+        Warning! For Pony magic to work, iteration variable name (e.g. 'g') should be the same everywhere!
+
         :return: PonyORM query object corresponding to the given params.
         """
-        # Warning! For Pony magic to work, iteration variable name (e.g. 'g') should be the same everywhere!
+        if kwargs:
+            self._logger.info("get_entries_query got ignored kwargs: %s", ", ".join(kwargs.keys()))
 
         if txt_filter:
             pony_query = self.search_keyword(txt_filter, origin_id=origin_id)

--- a/src/tribler/test_unit/core/database/test_store.py
+++ b/src/tribler/test_unit/core/database/test_store.py
@@ -210,3 +210,18 @@ class TestMetadataStore(TestBase[MockCommunity]):
         self.assertEqual(20, ordered1.size)
         self.assertEqual(10, ordered2.size)
         self.assertEqual(1, ordered3.size)
+
+    @db_session
+    def test_get_entries_query_deprecated(self) -> None:
+        """
+        Test if the get entries query ignores invalid arguments.
+        """
+        self.metadata_store.TorrentMetadata.add_ffa_from_dict({"infohash": b"\xab" * 20, "title": "abc", "size": 20})
+        self.metadata_store.TorrentMetadata.add_ffa_from_dict({"infohash": b"\xcd" * 20, "title": "def", "size": 1})
+        self.metadata_store.TorrentMetadata.add_ffa_from_dict({"infohash": b"\xef" * 20, "title": "ghi", "size": 10})
+
+        ordered1, ordered2, ordered3 = self.metadata_store.get_entries_query(sort_by="size", sort_desc=True,
+                                                                             exclude_deleted="1")[:]
+        self.assertEqual(20, ordered1.size)
+        self.assertEqual(10, ordered2.size)
+        self.assertEqual(1, ordered3.size)


### PR DESCRIPTION
Fixes #8201

This PR:

 - Updates `get_entries_query` to ignore invalid `kwargs`, allowing responses to peers using old protocol versions.
