### PR TITLE
Fixed missing dependency in deb file

### DIFF
--- a/build/debian/tribler/debian/control
+++ b/build/debian/tribler/debian/control
@@ -12,6 +12,7 @@ Package: tribler
 Architecture: all
 Depends: libsodium23,
          gir1.2-gtk-4.0,
+         gir1.2-appindicator3-0.1,
          libgirepository1.0-dev
 Description: Python based Bittorrent/Internet TV application
  Through our own dedicated Tor-like network for torrent downloading you can


### PR DESCRIPTION
Fixes #8194

This PR:

 - Fixes the `.deb` build crashing early due to a missing dependency.
 
 Now `sudo apt install ./tribler_8.0.1_all.deb` correctly pulls in the correct dependencies.
