### PR TITLE
Fetch availability for download details

### DIFF
--- a/src/tribler/ui/src/pages/Downloads/index.tsx
+++ b/src/tribler/ui/src/pages/Downloads/index.tsx
@@ -158,7 +158,7 @@ export default function Downloads({ statusFilter }: { statusFilter: number[] }) 
             infohash = infohashes[0] ?? "";
 
         // Don't bother the user on error, just try again later.
-        const response = await triblerService.getDownloads(infohash, !!infohash, !!infohash);
+        const response = await triblerService.getDownloads(infohash, !!infohash, !!infohash, !!infohash);
         if (response !== undefined && !isErrorDict(response)) {
             setDownloads(response.filter((download: Download) => {
                 return statusFilter.includes(download.status_code);

--- a/src/tribler/ui/src/services/tribler.service.ts
+++ b/src/tribler/ui/src/services/tribler.service.ts
@@ -48,9 +48,9 @@ export class TriblerService {
 
     // Downloads
 
-    async getDownloads(infohash: string = '', getPeers: boolean = false, getPieces: boolean = false): Promise<undefined | ErrorDict | Download[]> {
+    async getDownloads(infohash: string = '', getPeers: boolean = false, getPieces: boolean = false, getAvailability: boolean = false): Promise<undefined | ErrorDict | Download[]> {
         try {
-            return (await this.http.get(`/downloads?infohash=${infohash}&get_peers=${+getPeers}&get_pieces=${+getPieces}`)).data.downloads;
+            return (await this.http.get(`/downloads?infohash=${infohash}&get_peers=${+getPeers}&get_pieces=${+getPieces}&get_availability=${+getAvailability}`)).data.downloads;
         } catch (error) {
             return formatAxiosError(error as Error | AxiosError);
         }


### PR DESCRIPTION
Fixes #8216

This PR:

 - Updates `getDownloads` to pass `get_availability` to the core and uses it in the download details.
