### PR TITLE
WIP: Removed libgirepository1.0-dev from deb Depends

### DIFF
--- a/build/debian/tribler/debian/control
+++ b/build/debian/tribler/debian/control
@@ -12,8 +12,7 @@ Package: tribler
 Architecture: all
 Depends: libsodium23,
          gir1.2-gtk-4.0,
-         gir1.2-appindicator3-0.1,
-         libgirepository1.0-dev
+         gir1.2-appindicator3-0.1
 Description: Python based Bittorrent/Internet TV application
  Through our own dedicated Tor-like network for torrent downloading you can
  search and download torrents with less worries or censorship. We are trying


### PR DESCRIPTION
Fixes #8217

This PR:

 - Removes `libgirepository1.0-dev` from the Debian `control` file.

