### PR TITLE
Added warning when adding torrent from invalid HTTPS

### DIFF
--- a/src/tribler/ui/public/locales/en_US.json
+++ b/src/tribler/ui/public/locales/en_US.json
@@ -101,6 +101,7 @@
     "Download": "Download",
     "Cancel": "Cancel",
     "LoadingTorrent": "Loading torrent files {{method, string}}...",
+    "HTTPSCertificateInvalid": "The server has an invalid HTTPS certificate!\nAn attacker could have given you the wrong torrent.",
     "anonymously": "anonymously",
     "directly": "directly",
     "MagnetDialogInputLabel": "Please enter the URL/magnet link in the field below:",

--- a/src/tribler/ui/public/locales/es_ES.json
+++ b/src/tribler/ui/public/locales/es_ES.json
@@ -101,6 +101,7 @@
     "Download": "Descarga",
     "Cancel": "Cancelar",
     "LoadingTorrent": "Cargando archivos torrent {{method, string}}...",
+    "HTTPSCertificateInvalid": "¡El servidor tiene un certificado HTTPS no válido!\nUn atacante podría haberte proporcionado el torrent equivocado.",
     "anonymously": "anónimamente",
     "directly": "directamente",
     "MagnetDialogInputLabel": "Introduzca el enlace URL/magnet en el siguiente recuadro:",

--- a/src/tribler/ui/public/locales/ko_KR.json
+++ b/src/tribler/ui/public/locales/ko_KR.json
@@ -98,6 +98,7 @@
     "Download": "내려받기",
     "Cancel": "취소",
     "LoadingTorrent": "토렌트 파일 {{method, string}}을(를) 불러오는 중...",
+    "HTTPSCertificateInvalid": "서버에 잘못된 HTTPS 인증서가 있습니다!\n공격자가 잘못된 토렌트를 제공했을 수도 있습니다.",
     "anonymously": "무기명",
     "directly": "직접",
     "MagnetDialogInputLabel": "아래에 URL/마그넷 링크를 입력 :",

--- a/src/tribler/ui/public/locales/pt_BR.json
+++ b/src/tribler/ui/public/locales/pt_BR.json
@@ -95,6 +95,8 @@
     "DownloadTorrent": "Baixar torrent",
     "Download": "Download",
     "Cancel": "Cancelar",
+    "LoadingTorrent": "Carregando arquivos torrent {{method, string}}...",
+    "HTTPSCertificateInvalid": "O servidor possui um certificado HTTPS inválido!\nUm invasor pode ter fornecido o torrent errado.",
     "MagnetDialogInputLabel": "Por favor adicione o link URL/magnet no campo abaixo:",
     "MagnetDialogHeader": "Adicionar torrent de um link URL/magnet",
     "MagnetDialogError": "Não foi possível processar URL/link magnético",

--- a/src/tribler/ui/public/locales/ru_RU.json
+++ b/src/tribler/ui/public/locales/ru_RU.json
@@ -101,6 +101,7 @@
     "Download": "Входящий",
     "Cancel": "Отмена",
     "LoadingTorrent": "Загружаем список файлов торрента {{method, string}}...",
+    "HTTPSCertificateInvalid": "Сервер имеет недействительный сертификат HTTPS!\nЗлоумышленник мог предоставить вам неправильный торрент.",
     "anonymously": "анонимно",
     "directly": "напрямую",
     "MagnetDialogInputLabel": "Пожалуйста, введите URL/magnet-ссылку в поле ниже:",

--- a/src/tribler/ui/public/locales/zh_CN.json
+++ b/src/tribler/ui/public/locales/zh_CN.json
@@ -100,6 +100,7 @@
     "Download": "下载",
     "Cancel": "取消",
     "LoadingTorrent": "正在载入种子文件 {{method, string}}……",
+    "HTTPSCertificateInvalid": "服务器的 HTTPS 证书无效！\n攻击者可能给您提供了错误的种子。",
     "anonymously": "匿名",
     "directly": "直接",
     "MagnetDialogInputLabel": "请在下面字段输入 URL/磁力链接：",

--- a/src/tribler/ui/src/dialogs/SaveAs.tsx
+++ b/src/tribler/ui/src/dialogs/SaveAs.tsx
@@ -16,7 +16,7 @@ import { Settings } from "@/models/settings.model";
 import { useTranslation } from "react-i18next";
 import { TFunction } from 'i18next';
 import { PathInput } from "@/components/path-input";
-import { ChevronDown, ChevronRight } from "lucide-react";
+import { ChevronDown, ChevronRight, AlertTriangle } from "lucide-react";
 import { FileTreeItem } from "@/models/file.model";
 
 
@@ -95,6 +95,7 @@ export default function SaveAs(props: SaveAsProps & JSX.IntrinsicAttributes & Di
 
     const [settings, setSettings] = useState<Settings | undefined>();
     const [error, setError] = useState<string | undefined>();
+    const [warning, setWarning] = useState<string | undefined>();
     const [exists, setExists] = useState<boolean>(false);
     const [files, setFiles] = useState<FileTreeItem[]>([]);
 
@@ -164,6 +165,7 @@ export default function SaveAs(props: SaveAsProps & JSX.IntrinsicAttributes & Di
                 setFiles(files);
                 setParams((prev) => ({ ...prev, selected_files: getSelectedFilesFromTree(files[0]) }));
                 setExists(!!response.download_exists);
+                setWarning((!('valid_certificate' in response) || (response.valid_certificate == true)) ? undefined : t("HTTPSCertificateInvalid"));
             }
         }
         reload();
@@ -268,6 +270,12 @@ export default function SaveAs(props: SaveAsProps & JSX.IntrinsicAttributes & Di
                     </label>
                 </div>
                 <DialogFooter>
+                    {warning && (
+                        <div className="flex flex-row text-muted-foreground space-x-2">
+                            <AlertTriangle className="self-center" />
+                            <label className="whitespace-pre-line text-xs self-center">{warning}</label>
+                        </div>
+                    )}
                     <Button
                         variant="outline"
                         type="submit"

--- a/src/tribler/ui/src/services/tribler.service.ts
+++ b/src/tribler/ui/src/services/tribler.service.ts
@@ -220,7 +220,7 @@ export class TriblerService {
 
     // Torrents / search
 
-    async getMetainfo(uri: string): Promise<undefined | ErrorDict | {metainfo: string, download_exists: boolean}> {
+    async getMetainfo(uri: string): Promise<undefined | ErrorDict | {metainfo: string, download_exists: boolean, valid_certificate: boolean}> {
         try {
             return (await this.http.get(`/torrentinfo?uri=${uri}`)).data;
         } catch (error) {


### PR DESCRIPTION
Fixes #1680

This PR:

 - Adds support (and a warning) for adding torrents from an HTTPS url with an invalid certificate.

[[screenshot available here]](https://github.com/Tribler/tribler/issues/1680#issuecomment-2422225207)