### PR TITLE
Fixed startup version check not checking for error

### DIFF
--- a/src/tribler/ui/src/components/layouts/Header.tsx
+++ b/src/tribler/ui/src/components/layouts/Header.tsx
@@ -61,7 +61,7 @@ export function Header() {
             triblerService.addEventListener("tribler_shutdown_state", OnShutdownEvent) })();
             triblerService.getNewVersion().then(
                 (result) => {
-                    if (result) toast(t("VersionAvailable") + ": " + result, {icon: "ℹ", });},
+                    if (result && !isErrorDict(result)) toast(t("VersionAvailable") + ": " + result, {icon: "ℹ", });},
                 (error) => {}
             );
         return () => {


### PR DESCRIPTION
This PR:

 - Fixes the startup version check not checking for error responses.

When browsing to the Tribler URL with an invalid key, you would see this (doubled because I run `npm run dev`):

![screenshot](https://github.com/user-attachments/assets/5f2cb92f-2f29-4b96-b8dd-d90636c2b8b4)


