### PR TITLE
Fix empty download list when ratio is infinity

### DIFF
--- a/src/tribler/core/libtorrent/download_manager/download_state.py
+++ b/src/tribler/core/libtorrent/download_manager/download_state.py
@@ -6,7 +6,6 @@ Author(s): Arno Bakker
 from __future__ import annotations
 
 import logging
-import math
 from enum import Enum
 from typing import TYPE_CHECKING
 
@@ -214,7 +213,8 @@ class DownloadState:
             return 0
 
         if not self.all_time_download:
-            return 0 if not self.all_time_upload else math.inf
+            # We're returning -1 instead of infinity, as it avoids issues when JSON encoding.
+            return 0 if not self.all_time_upload else -1
 
         return self.all_time_upload / self.all_time_download
 

--- a/src/tribler/test_unit/core/libtorrent/download_manager/test_download_state.py
+++ b/src/tribler/test_unit/core/libtorrent/download_manager/test_download_state.py
@@ -1,4 +1,3 @@
-import math
 from io import StringIO
 from pathlib import Path
 from unittest.mock import Mock
@@ -116,7 +115,7 @@ class TestDownloadState(TestBase):
         """
         state = DownloadState(Mock(), Mock(all_time_upload=200, all_time_download=0), None)
 
-        self.assertEqual(math.inf, state.get_all_time_ratio())
+        self.assertEqual(-1, state.get_all_time_ratio())
 
     def test_get_files_completion(self) -> None:
         """

--- a/src/tribler/ui/src/pages/Downloads/Details.tsx
+++ b/src/tribler/ui/src/pages/Downloads/Details.tsx
@@ -68,7 +68,12 @@ export default function DownloadDetails({ selectedDownloads }: { selectedDownloa
                         </div>
                         <div className="flex flex-row">
                             <div className="basis-1/4">{t('Ratio')}</div>
-                            <div className="basis-3/4">{download?.all_time_ratio.toFixed(2)} ({formatBytes(download?.all_time_upload)} upload; {formatBytes(download?.all_time_download)} dowload)</div>
+                            <div className="basis-3/4">{
+                                download.all_time_ratio < 0 ?
+                                    String(`∞`) :
+                                    download?.all_time_ratio.toFixed(2)}
+                                &nbsp;({formatBytes(download?.all_time_upload)} upload; {formatBytes(download?.all_time_download)} dowload)
+                            </div>
                         </div>
                         <div className="flex flex-row">
                             <div className="basis-1/4">{t('Availability')}</div>

--- a/src/tribler/ui/src/pages/Settings/Seeding.tsx
+++ b/src/tribler/ui/src/pages/Settings/Seeding.tsx
@@ -31,7 +31,7 @@ export default function Seeding() {
     return (
         <div className="p-6 w-full">
             <RadioGroup
-                defaultValue="forever"
+                defaultValue={settings?.libtorrent?.download_defaults?.seeding_mode || "forever"}
                 onValueChange={(value) => {
                     if (settings) {
                         setSettings({


### PR DESCRIPTION
Fixes https://github.com/Tribler/tribler/issues/8209.

Also fixes:
* An issue with erroneously not seeding at all when `seeding_mode = 'ratio'`.
When upload was 0 and download > 0, the ratio became ∞, and the seeding ratio was immediately reached. This stopped the download before seeding could even begin.
* Seeding settings in the web UI.