### PR TITLE
Fixed ReadTheDocs image generation

### DIFF
--- a/doc/.readthedocs.yaml
+++ b/doc/.readthedocs.yaml
@@ -14,6 +14,9 @@ build:
     python: "3.10"
   apt_packages:
     - graphviz
+  jobs:
+    pre_build:
+      - dot -Tsvg "doc/reference/software_architecture.dot" -o "doc/reference/software_architecture.svg";
 
 python:
   install:


### PR DESCRIPTION
Fixes https://tribler.readthedocs.io/en/latest/reference/software_architecture.html showing the string `reference/software_architecture.svg` instead of the image.

This PR:

 - Adds the `svg` generation step into `.readthedocs.yaml` (next to the Makefile).
 
I'm roughly 51% positive that this will fix the issue. However, I don't know for sure.

