### PR TITLE
Compile aarch64 deb

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,8 @@ jobs:
         include:  # macos-12 is no longer on GitHub Actions, we use the Mac mini for this
           - os: ubuntu-latest
             architecture: x64
+          - os: ubuntu-latest
+            architecture: aarch64
           - os: windows-latest
             architecture: x86
           - os: windows-latest
@@ -80,6 +82,7 @@ jobs:
           rm -rf pyipv8/systemd
           rm -rf pyipv8/ipv8/test
       - name: Setup Python ${{ matrix.architecture }}
+        if: matrix.architecture != 'aarch64'
         uses: actions/setup-python@v5
         with:
           python-version: '3.10'
@@ -88,6 +91,7 @@ jobs:
           cache-dependency-path: |
             **/build/requirements.txt
       - name: Install Dependencies
+        if: matrix.architecture != 'aarch64'
         run: |
           pip install --upgrade -r build/requirements.txt
       - name: Setup npm
@@ -110,12 +114,46 @@ jobs:
       #####################
       # Individual builds #
       #####################
-      - name: Build Executables (Ubuntu)
-        if: matrix.os == 'ubuntu-latest'
+      - name: Build Executables (Ubuntu x64)
+        if: matrix.os == 'ubuntu-latest' && matrix.architecture == 'x64'
         run: |
           sudo apt-get install -y --allow-downgrades alien cpio=2.13+dfsg-7 devscripts fakeroot gir1.2-gtk-4.0 libgirepository1.0-dev rpm
           ./build/debian/makedist_debian.sh
           mv build/debian/tribler_${GITHUB_TAG}_all.deb build/debian/tribler_${GITHUB_TAG}_${{ matrix.architecture }}.deb
+
+      - name: Build Executables (Ubuntu aarch64)
+        if: matrix.os == 'ubuntu-latest' && matrix.architecture == 'aarch64'
+        uses: uraimo/run-on-arch-action@v2
+        id: run_ubuntu_aarch64
+        with:
+          arch: ${{ matrix.architecture }}
+          distro: ubuntu22.04
+          githubToken: ${{ github.token }}
+          dockerRunArgs: |
+            --volume "${PWD}:/tribler"
+          env: |
+            GITHUB_TAG: ${{ env.GITHUB_TAG }}
+          shell: /bin/sh
+          install: |
+            apt-get update -q -y
+            apt-get install -q -y --allow-downgrades alien cpio=2.13+dfsg-7 devscripts fakeroot gir1.2-gtk-4.0 libgirepository1.0-dev rpm python3-pip libcairo2-dev
+          run: |
+            python3 -m pip install --upgrade pip
+            python3 -m pip install --upgrade -r /tribler/build/requirements.txt
+            python3 -m pip install meson ninja
+
+            cd /tribler
+            python3 -m pip install --upgrade cx_Freeze==7.2.3  # cx_Freeze workaround
+            cp /lib/${{ matrix.architecture }}-linux-gnu/libcrypt.so.1 libcrypt-06cd74a6.so.2  # cx_Freeze workaround
+            export PATH="/usr/local/bin:$PATH"
+            ./build/debian/makedist_debian.sh
+
+            cd build/debian
+            apt-get install -y --fix-broken ./tribler_${GITHUB_TAG}_all.deb
+            timeout 10s tribler -s || true
+            cat /tmp/*tribler*.log
+            
+            mv tribler_${GITHUB_TAG}_all.deb tribler_${GITHUB_TAG}_${{ matrix.architecture }}.deb
 
       - name: Build Executables (MacOS-12)
         if: matrix.os == 'macos-12'

--- a/build/win/build.py
+++ b/build/win/build.py
@@ -61,8 +61,11 @@ def get_freeze_build_options():
         ("src/tribler/ui/public", "tribler_source/tribler/ui/public"),
         ("src/tribler/ui/dist", "tribler_source/tribler/ui/dist"),
         ("build/win/resources", "tribler_source/resources"),
-        ("tribler.dist-info/METADATA", "lib/tribler.dist-info/METADATA")
+        ("tribler.dist-info/METADATA", "lib/tribler.dist-info/METADATA"),
     ]
+
+    if platform.system() == "Linux" and platform.machine() == "aarch64":
+        included_files.append(("libcrypt-06cd74a6.so.2", "lib/libcrypt-06cd74a6.so.2"))
 
     # These packages will be excluded from the build
     excluded_packages = [


### PR DESCRIPTION
Related to #5327, #5345

This PR:

 - Adds a `deb` build for `aarch64`.

Notes:
 - This builder locally tests in its own virtual environment. I'm still waiting for a phyiscal `aarch64` testing machine to arrive in the mail.
 - One workaround and a version pin is needed for `cx_Freeze` (in contact with repo author to get the issue fixed).
 - An Action run is available here: https://github.com/qstokkink/tribler/actions/runs/11590809339/job/32269182843