### PR TITLE
Hook in weekly mutation test

### DIFF
--- a/.github/workflows/weekly_mutation_tests.yml
+++ b/.github/workflows/weekly_mutation_tests.yml
@@ -1,0 +1,47 @@
+name: Weekly mutation tests (Friday 00:00)
+on:
+  schedule:
+    - cron: '0 0 * * 5'
+
+jobs:
+  mutationtests:
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'Tribler/tribler' }}
+    steps:
+      - name: Checkout Tribler/tribler
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: 'true'
+          path: 'tribler'
+      - name: Check for changes
+        run: |
+          cd tribler
+          echo "NUM_COMMITS=$(git log --oneline --since '7 days ago' | wc -l)" >> $GITHUB_ENV
+      - name: Setup Python 3.10
+        uses: actions/setup-python@v5
+        if: ${{ env.NUM_COMMITS > 0 }}
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+      - name: Install dependencies
+        if: ${{ env.NUM_COMMITS > 0 }}
+        run: |
+          cd tribler
+          python -m pip install -r requirements.txt
+      - name: Checkout Tribler/mutpy
+        if: ${{ env.NUM_COMMITS > 0 }}
+        uses: actions/checkout@v4
+        with:
+          repository: 'Tribler/mutpy'
+          path: 'mutpy'
+      - name: Run mutation tests
+        if: ${{ env.NUM_COMMITS > 0 }}
+        run: |
+          cd mutpy
+          python3 -m pip install .
+          cd bin
+          python3 github_report.py --codebase tribler
+      - name: Publish report
+        if: ${{ env.NUM_COMMITS > 0 }}
+        run: cat mutpy/bin/report.md >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Fixes #8078

This PR:

 - Adds a weekly mutation test workflow.
 
Successful run (with `workflow_dispatch`): https://github.com/qstokkink/tribler/actions/runs/11611966702 

