### PR TITLE
Set UTF-8 for all ConfigObj instances

### DIFF
--- a/src/tribler/core/libtorrent/download_manager/download_config.py
+++ b/src/tribler/core/libtorrent/download_manager/download_config.py
@@ -125,12 +125,12 @@ class DownloadConfig:
         Create a new download config from the given Tribler configuration.
         """
         spec_file_name = DownloadConfig.get_spec_file_name(settings)
-        defaults = ConfigObj(StringIO(SPEC_CONTENT))
+        defaults = ConfigObj(StringIO(SPEC_CONTENT), encoding="utf-8")
         defaults["filename"] = spec_file_name
         Path(spec_file_name).parent.mkdir(parents=True, exist_ok=True)  # Required for the next write
         with open(spec_file_name, "wb") as spec_file:
             defaults.write(spec_file)
-        defaults = ConfigObj(StringIO(), configspec=spec_file_name)
+        defaults = ConfigObj(StringIO(), configspec=spec_file_name, encoding="utf-8")
         defaults.validate(Validator())
         config = DownloadConfig(defaults)
 
@@ -147,7 +147,7 @@ class DownloadConfig:
         """
         Create a copy of this config.
         """
-        return DownloadConfig(ConfigObj(self.config))
+        return DownloadConfig(ConfigObj(self.config, encoding="utf-8"))
 
     def write(self, filename: Path) -> None:
         """

--- a/src/tribler/core/libtorrent/download_manager/download_manager.py
+++ b/src/tribler/core/libtorrent/download_manager/download_manager.py
@@ -1004,7 +1004,8 @@ class DownloadManager(TaskManager):
         Load a checkpoint from a given file name.
         """
         try:
-            conf_obj = ConfigObj(str(filename), configspec=DownloadConfig.get_spec_file_name(self.config))
+            conf_obj = ConfigObj(str(filename), configspec=DownloadConfig.get_spec_file_name(self.config),
+                                 encoding="utf-8")
             conf_obj.validate(Validator())
             config = DownloadConfig(conf_obj)
         except Exception:

--- a/src/tribler/ui/src/dialogs/SaveAs.tsx
+++ b/src/tribler/ui/src/dialogs/SaveAs.tsx
@@ -155,8 +155,11 @@ export default function SaveAs(props: SaveAsProps & JSX.IntrinsicAttributes & Di
 
             if (response === undefined) {
                 setError(`${t("ToastErrorGetMetainfo")} ${t("ToastErrorGenNetworkErr")}`);
+            } else if ('error' in response && typeof response.error === 'object') {
+                let errorCode = response.error as {handled: boolean, code: string, message: string};
+                setError(`${t("ToastErrorGetMetainfo")} ${errorCode.code}`);
             } else if (isErrorDict(response)) {
-                setError(`t("ToastErrorGetMetainfo")} ${response.error}`);
+                setError(`${t("ToastErrorGetMetainfo")} ${response.error}`);
             } else if (response) {
                 const info = getFilesFromMetainfo(response.metainfo);
                 var files = info.files;

--- a/src/tribler/upgrade_script.py
+++ b/src/tribler/upgrade_script.py
@@ -53,7 +53,7 @@ def _import_7_14_settings(src: str, dst: TriblerConfigManager) -> None:
     """
     Read the file at the source path and import its settings.
     """
-    old = ConfigObj(src)
+    old = ConfigObj(src, encoding="utf-8")
     _copy_if_exists(old, "api/key", dst, "api/key")
     _copy_if_exists(old, "api/http_enabled", dst, "api/http_enabled")
     _copy_if_exists(old, "api/https_enabled", dst, "api/https_enabled")


### PR DESCRIPTION
Fixes #8239

This PR:

 - Fixes a syntax error in the string formatting in `SaveAs.tsx`.
 - Updates all `ConfigObj` instances to use `utf-8`, instead of the default `ascii`.

Notes:
- This is a confirmed fix for the setup described in https://github.com/Tribler/tribler/issues/8239#issuecomment-2451886971
- The compile step uncovered that we use the "error" key inconsistently. Sometimes it's a string and sometimes it's a mapping.