### PR TITLE
Add fallback to GTK-3.0 in Debian Depends

### DIFF
--- a/build/debian/tribler/debian/control
+++ b/build/debian/tribler/debian/control
@@ -11,7 +11,7 @@ Vcs-Git: https://github.com/trible/tribler.git
 Package: tribler
 Architecture: all
 Depends: libsodium23,
-         gir1.2-gtk-4.0,
+         gir1.2-gtk-4.0 | gir1.2-gtk-3.0,
          gir1.2-appindicator3-0.1
 Description: Python based Bittorrent/Internet TV application
  Through our own dedicated Tor-like network for torrent downloading you can


### PR DESCRIPTION
Fixes #8242

This PR:

 - Adds a fallback to `gir1.2-gtk-3.0` if `gir1.2-gtk-4.0` is missing.

Using `gir1.2-gtk-3.0` has been confirmed to work in #8242.
