### PR TITLE
Fixed unhexlify with variable length UTF-8 decoding

### DIFF
--- a/src/tribler/ui/src/lib/utils.ts
+++ b/src/tribler/ui/src/lib/utils.ts
@@ -31,11 +31,8 @@ export function capitalize(name: string) {
 }
 
 export function unhexlify(input: string) {
-    var result = '';
-    for (var i = 0, l = input.length; i < l; i += 2) {
-        result += String.fromCharCode(parseInt(input.slice(i, i + 2), 16));
-    }
-    return result;
+    // Solution by SuperStormer @ https://stackoverflow.com/a/76241398
+    return new TextDecoder().decode(new Uint8Array([...input.matchAll(/[0-9a-f]{2}/g)].map(a => parseInt(a[0], 16))));
 };
 
 export function getFilesFromMetainfo(metainfo: string) {


### PR DESCRIPTION
Fixes #8249

This PR:

 - Fixes `unhexlify()` not performing variable-length decoding for UTF-8.
 
 After fix (see #8249 for before):
![screenshot](https://github.com/user-attachments/assets/aabbd4f0-aec3-4008-a53a-786707ea0b10)

