### PR TITLE
Use Ubuntu 20.04 for building

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       matrix:
         include:  # macos-12 is no longer on GitHub Actions, we use the Mac mini for this
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             architecture: x64
           - os: ubuntu-latest
             architecture: aarch64
@@ -115,9 +115,10 @@ jobs:
       # Individual builds #
       #####################
       - name: Build Executables (Ubuntu x64)
-        if: matrix.os == 'ubuntu-latest' && matrix.architecture == 'x64'
+        if: matrix.os == 'ubuntu-20.04' && matrix.architecture == 'x64'
         run: |
-          sudo apt-get install -y --allow-downgrades alien cpio=2.13+dfsg-7 devscripts fakeroot gir1.2-gtk-4.0 libgirepository1.0-dev rpm
+          sudo apt-get update -q -y
+          sudo apt-get install -y --allow-downgrades alien devscripts fakeroot gir1.2-gtk-3.0 libgirepository1.0-dev rpm
           ./build/debian/makedist_debian.sh
           
           cd build/debian

--- a/doc/building/linux.rst
+++ b/doc/building/linux.rst
@@ -9,7 +9,7 @@ First, install additional requirements:
 
 .. code-block::
 
-    sudo apt-get -y install alien cpio=2.13+dfsg-7 devscripts fakeroot gir1.2-gtk-4.0 libgirepository1.0-dev rpm libcairo2-dev patchelf
+    sudo apt-get -y install alien devscripts fakeroot gir1.2-gtk-3.0 libgirepository1.0-dev rpm libcairo2-dev patchelf
     python -m pip install --upgrade -r build/requirements.txt
 
 Second, create the ``.deb`` file in the ``dist`` directory.


### PR DESCRIPTION
Fixes https://github.com/Tribler/tribler/issues/8242.

I removed `cpio=2.13+dfsg-7` since it isn't needed nor is version `2.13+dfsg-7` available on Ubuntu 20.04.