### PR TITLE
Fixes for the `Versions` UI tab

### DIFF
--- a/src/tribler/ui/public/locales/en_US.json
+++ b/src/tribler/ui/public/locales/en_US.json
@@ -16,6 +16,7 @@
     "Seeding": "Seeding",
     "Anonymity": "Anonymity",
     "Debug": "Debug",
+    "Versions": "Versions",
     "ImportTorrentFile": "Import torrent from file(s)",
     "ImportTorrentURL": "Import torrent from magnet/URL",
     "CreateTorrent": "Create torrent from file(s)",

--- a/src/tribler/ui/public/locales/es_ES.json
+++ b/src/tribler/ui/public/locales/es_ES.json
@@ -16,6 +16,7 @@
     "Seeding": "Sembrado",
     "Anonymity": "Anonimato",
     "Debug": "Depurar",
+    "Versions": "Versiones",
     "ImportTorrentFile": "Importar torrent desde archivo",
     "ImportTorrentURL": "Importar un torrent desde un magnet/URL",
     "CreateTorrent": "Crear torrent a partir de archivo(s)",

--- a/src/tribler/ui/public/locales/ko_KR.json
+++ b/src/tribler/ui/public/locales/ko_KR.json
@@ -16,6 +16,7 @@
     "Seeding": "시딩",
     "Anonymity": "익명성",
     "Debug": "디버그",
+    "Versions": "버전",
     "ImportTorrentFile": "파일에서 토런트 가져오기",
     "ImportTorrentURL": "마그넷/URL에서 토렌트 가져오기",
     "CreateTorrent": "파일에서 토렌트 만들기",

--- a/src/tribler/ui/public/locales/pt_BR.json
+++ b/src/tribler/ui/public/locales/pt_BR.json
@@ -16,6 +16,7 @@
     "Seeding": "Seeding",
     "Anonymity": "Anonimidade",
     "Debug": "Depurar",
+    "Versions": "Versões",
     "ImportTorrentFile": "Importar torrent do um arquivo",
     "ImportTorrentURL": "Importar torrent de magnet/URL",
     "CreateTorrent": "Criar torrent de um arquivo(s)",

--- a/src/tribler/ui/public/locales/ru_RU.json
+++ b/src/tribler/ui/public/locales/ru_RU.json
@@ -16,6 +16,7 @@
     "Seeding": "Раздача",
     "Anonymity": "Анонимность",
     "Debug": "Отладка",
+    "Versions": "Версии",
     "ImportTorrentFile": "Загрузить торрент из файла",
     "ImportTorrentURL": "Загрузить торрент по URL/magnet-ссылке",
     "CreateTorrent": "Создать торрент",

--- a/src/tribler/ui/public/locales/zh_CN.json
+++ b/src/tribler/ui/public/locales/zh_CN.json
@@ -16,6 +16,7 @@
     "Seeding": "做种",
     "Anonymity": "匿名",
     "Debug": "调试",
+    "Versions": "版本",
     "ImportTorrentFile": "从文件导入种子",
     "ImportTorrentURL": "从磁力/URL 导入种子",
     "CreateTorrent": "从文件创建种子",

--- a/src/tribler/ui/src/pages/Settings/Versions.tsx
+++ b/src/tribler/ui/src/pages/Settings/Versions.tsx
@@ -106,44 +106,44 @@ export default function Versions() {
     return (
         <div className="p-6">
             <div className="grid grid-cols-4 gap-2 items-center">
-                <Label className="whitespace-nowrap pr-5 font-bold">
+                <Label className="whitespace-nowrap pr-5 font-bold" key="current_version_header">
                     {t('VersionCurrent')}:
                 </Label>
-                <Suspense fallback={<Label>...</Label>}>
-                    <Label>
+                <Suspense fallback={<Label key="current_version_label">...</Label>}>
+                    <Label key="current_version_label">
                         {version ? version : "..."}
                     </Label>
                 </Suspense>
-                <Suspense fallback={<Label></Label>}>
-                    {newVersion ? <Label>{t('VersionAvailable')}: {newVersion}</Label> : <Label></Label>}
+                <Suspense fallback={<Label key="current_version_available"></Label>}>
+                    {newVersion ? <Label key="current_version_available">{t('VersionAvailable')}: {newVersion}</Label> : <Label key="current_version_available"></Label>}
                 </Suspense>
-                <Label></Label>
+                <Label key="spacer1"></Label>
 
-                <Label style={{marginBottom: "1cm"}}></Label>
-                <Label></Label><Label></Label><Label></Label>
+                <Label style={{marginBottom: "1cm"}} key="spacer2"></Label>
+                <Label key="spacer3"></Label><Label key="spacer4"></Label><Label key="spacer5"></Label>
 
-                <Label className="whitespace-nowrap pr-5 font-bold">{t('VersionOld')}</Label>
-                <Label></Label><Label></Label><Label></Label>
+                <Label className="whitespace-nowrap pr-5 font-bold" key="old_version_header">{t('VersionOld')}</Label>
+                <Label key="spacer6"></Label><Label key="spacer7"></Label><Label key="spacer8"></Label>
 
                 {
                     versions.reduce((r: string[], e: string) => {r.push(e, e, e, e); return r;}, new Array<string>()).map(function(old_version: string, i: number){
                         switch (i % 4){
                             case 0: {
-                                return (<Label>{old_version}</Label>)
+                                return (<Label key={`current_version_label_${i}`}>{old_version}</Label>)
                             }
                             case 1: {
-                                return (<Label></Label>)  // Blank column to outline with the data above
+                                return (<Label key={`spacer_${9+i}`}></Label>)  // Blank column to outline with the data above
                             }
                             case 2: {
                                 return (
                                            (typeof canUpgrade === "string") && (canUpgrade == old_version) ? (
-                                               isUpgrading ? <div className="flex justify-center p-5 gap-1"><RefreshCw opacity="0.5" className="animate-spin duration-500" /><Label className="content-center text-muted-foreground">{t('VersionUpgrading')}...</Label></div>
-                                               : <Button variant="default" type="submit" onClick={(e) => clickedImport(e, old_version)}>{t('VersionImport')}</Button>)
-                                           : <Label></Label>
+                                               isUpgrading ? <div className="flex justify-center p-5 gap-1"><RefreshCw opacity="0.5" className="animate-spin duration-500" key={`import_status_${i}`} /><Label className="content-center text-muted-foreground">{t('VersionUpgrading')}...</Label></div>
+                                               : <Button variant="default" type="submit" onClick={(e) => clickedImport(e, old_version)} key={`import_status_${i}`}>{t('VersionImport')}</Button>)
+                                           : <Label key={`import_status_${i}`}></Label>
                                        )
                             }
                             default: {
-                                return (<Button variant="destructive" type="submit" onClick={(e) => clickedRemove(e, old_version)}>{t('VersionRemove')}</Button>)
+                                return (<Button variant="destructive" type="submit" onClick={(e) => clickedRemove(e, old_version)} key={`remove_button_${i}`}>{t('VersionRemove')}</Button>)
                             }
                         }
                     })


### PR DESCRIPTION
This PR:

 - Fixes the `Settings` / `Versions` tab not being translated.
 - Fixes the warning that lists should have `key` attributes for the `Versions` page.
