### PR TITLE
Disable translation services

### DIFF
--- a/src/tribler/ui/index.html
+++ b/src/tribler/ui/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" translate="no">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/x-icon" href="/public/favicon.ico" />


### PR DESCRIPTION
Hopefully fixes https://github.com/Tribler/tribler/issues/8251.

I've disabled translation services for the entire page. To me, this seems reasonable, since we have our own localization stuff anyway. We can always revisit this later, but I think for now stability is more important.