### PR TITLE
READY: Consolidate error responses

### DIFF
--- a/src/tribler/core/content_discovery/restapi/search_endpoint.py
+++ b/src/tribler/core/content_discovery/restapi/search_endpoint.py
@@ -75,10 +75,16 @@ class SearchEndpoint(RESTEndpoint):
         try:
             sanitized = DatabaseEndpoint.sanitize_parameters(request.query)
         except (ValueError, KeyError) as e:
-            return RESTResponse({"error": f"Error processing request parameters: {e}"}, status=HTTP_BAD_REQUEST)
+            return RESTResponse({"error": {
+                "handled": True,
+                "message": f"Error processing request parameters: {e}"
+            }}, status=HTTP_BAD_REQUEST)
         query = request.query.get("fts_text")
         if query is None:
-            return RESTResponse({"error": f"Got search with no fts_text: {dict(request.query)}"},
+            return RESTResponse({"error": {
+                                    "handled": True,
+                                    "message": f"Got search with no fts_text: {dict(request.query)}"
+                                }},
                                 status=HTTP_BAD_REQUEST)
         if t_filter := request.query.get("filter"):
             query += f" {t_filter}"

--- a/src/tribler/core/database/restapi/database_endpoint.py
+++ b/src/tribler/core/database/restapi/database_endpoint.py
@@ -184,7 +184,10 @@ class DatabaseEndpoint(RESTEndpoint):
         try:
             timeout = int(request.query.get("timeout", TORRENT_CHECK_TIMEOUT))
         except ValueError as e:
-            return RESTResponse({"error": f"Error processing timeout parameter: {e}"}, status=HTTP_BAD_REQUEST)
+            return RESTResponse({"error": {
+                                    "handled": True,
+                                    "message": f"Error processing timeout parameter: {e}"
+                                }}, status=HTTP_BAD_REQUEST)
 
         if self.torrent_checker is None:
             return RESTResponse({"checking": False})
@@ -270,16 +273,24 @@ class DatabaseEndpoint(RESTEndpoint):
             sanitized = self.sanitize_parameters(request.query)
             tags = sanitized.pop("tags", None)
         except (ValueError, KeyError):
-            return RESTResponse({"error": "Error processing request parameters"}, status=HTTP_BAD_REQUEST)
+            return RESTResponse({"error": {
+                                    "handled": True,
+                                    "message": "Error processing request parameters"
+                                }}, status=HTTP_BAD_REQUEST)
 
         if self.tribler_db is None:
-            return RESTResponse({"error": "Tribler DB not initialized"}, status=HTTP_NOT_FOUND)
+            return RESTResponse({"error": {
+                                    "handled": True,
+                                    "message": "Tribler DB not initialized"
+                                }}, status=HTTP_NOT_FOUND)
 
         include_total = request.query.get("include_total", "")
         query = request.query.get("fts_text")
         if query is None:
-            return RESTResponse({"error": f"Got search with no fts_text: {dict(request.query)}"},
-                                status=HTTP_BAD_REQUEST)
+            return RESTResponse({"error": {
+                                    "handled": True,
+                                    "message": f"Got search with no fts_text: {dict(request.query)}"
+                                }}, status=HTTP_BAD_REQUEST)
         if t_filter := request.query.get("filter"):
             query += f" {t_filter}"
         fts = to_fts_query(query)
@@ -354,7 +365,10 @@ class DatabaseEndpoint(RESTEndpoint):
         """
         args = request.query
         if "q" not in args:
-            return RESTResponse({"error": "query parameter missing"}, status=HTTP_BAD_REQUEST)
+            return RESTResponse({"error": {
+                                    "handled": True,
+                                    "message": "query parameter missing"
+                                }}, status=HTTP_BAD_REQUEST)
 
         keywords = args["q"].strip().lower()
         results = request.context[0].get_auto_complete_terms(keywords, max_terms=5)

--- a/src/tribler/core/knowledge/restapi/knowledge_endpoint.py
+++ b/src/tribler/core/knowledge/restapi/knowledge_endpoint.py
@@ -63,9 +63,15 @@ class KnowledgeEndpoint(RESTEndpoint):
         """
         try:
             if len(infohash) != 40:
-                return False, RESTResponse({"error": "Invalid infohash"}, status=HTTP_BAD_REQUEST)
+                return False, RESTResponse({"error": {
+                                                "handled": True,
+                                                "message": "Invalid infohash"
+                                            }}, status=HTTP_BAD_REQUEST)
         except binascii.Error:
-            return False, RESTResponse({"error": "Invalid infohash"}, status=HTTP_BAD_REQUEST)
+            return False, RESTResponse({"error": {
+                                            "handled": True,
+                                            "message": "Invalid infohash"
+                                        }}, status=HTTP_BAD_REQUEST)
 
         return True, None
 
@@ -77,7 +83,8 @@ class KnowledgeEndpoint(RESTEndpoint):
                 "schema": schema(UpdateTagsResponse={"success": Boolean()})
             },
             HTTP_BAD_REQUEST: {
-                "schema": HandledErrorSchema, "example": {"error": "Invalid tag length"}},
+                "schema": HandledErrorSchema, "example": {"error": {"handled": True, "message": "Invalid tag length"}}
+            }
         },
         description="This endpoint updates a particular torrent with the provided metadata."
     )
@@ -97,7 +104,10 @@ class KnowledgeEndpoint(RESTEndpoint):
         for statement in params["statements"]:
             obj = statement["object"]
             if not is_valid_resource(obj):
-                return RESTResponse({"error": "Invalid tag length"}, status=HTTP_BAD_REQUEST)
+                return RESTResponse({"error": {
+                                        "handled": True,
+                                        "message": "Invalid tag length"
+                                    }}, status=HTTP_BAD_REQUEST)
 
             statements.append(statement)
 
@@ -146,7 +156,8 @@ class KnowledgeEndpoint(RESTEndpoint):
                 "schema": schema(SuggestedTagsResponse={"suggestions": List(String)})
             },
             HTTP_BAD_REQUEST: {
-                "schema": HandledErrorSchema, "example": {"error": "Invalid infohash"}},
+                "schema": HandledErrorSchema, "example": {"error": {"handled": True, "message": "Invalid infohash"}}
+            }
         },
         description="This endpoint updates a particular torrent with the provided tags."
     )

--- a/src/tribler/core/libtorrent/restapi/create_torrent_endpoint.py
+++ b/src/tribler/core/libtorrent/restapi/create_torrent_endpoint.py
@@ -75,7 +75,7 @@ class CreateTorrentEndpoint(RESTEndpoint):
             },
             HTTP_BAD_REQUEST: {
                 "schema": HandledErrorSchema,
-                "examples": {"Error": {"error": "files parameter missing"}}
+                "examples": {"Error": {"error": {"handled": True, "message": "files parameter missing"}}}
             }
         }
     )
@@ -96,7 +96,10 @@ class CreateTorrentEndpoint(RESTEndpoint):
         if parameters.get("files"):
             file_path_list = [Path(p) for p in parameters["files"]]
         else:
-            return RESTResponse({"error": "files parameter missing"}, status=HTTP_BAD_REQUEST)
+            return RESTResponse({"error": {
+                                    "handled": True,
+                                    "message": "files parameter missing"
+                                }}, status=HTTP_BAD_REQUEST)
 
         if parameters.get("description"):
             params["comment"] = parameters["description"]

--- a/src/tribler/core/restapi/file_endpoint.py
+++ b/src/tribler/core/restapi/file_endpoint.py
@@ -83,7 +83,10 @@ class FileEndpoint(RESTEndpoint):
         recursively = request.query.get('recursively') != "0"
 
         if not path.exists():
-            return RESTResponse({"error": f"Directory {path} does not exist"}, status=HTTP_NOT_FOUND)
+            return RESTResponse({"error": {
+                                    "handled": True,
+                                    "message": f"Directory {path} does not exist"
+                                }}, status=HTTP_NOT_FOUND)
 
         results = [{"name": file.name,
                     "path": str(file.resolve())}

--- a/src/tribler/core/restapi/rest_endpoint.py
+++ b/src/tribler/core/restapi/rest_endpoint.py
@@ -87,7 +87,6 @@ def return_handled_exception(exception: Exception) -> RESTResponse:
     return RESTResponse({
         "error": {
             "handled": True,
-            "code": exception.__class__.__name__,
-            "message": str(exception)
+            "message": f"{exception.__class__.__name__}: {exception!s}"
         }
     }, status=HTTP_INTERNAL_SERVER_ERROR)

--- a/src/tribler/core/restapi/rest_manager.py
+++ b/src/tribler/core/restapi/rest_manager.py
@@ -84,7 +84,10 @@ class ApiKeyMiddleware:
         """
         if self.authenticate(request):
             return await handler(request)
-        return RESTResponse({"error": "Unauthorized access"}, status=HTTP_UNAUTHORIZED)
+        return RESTResponse({"error": {
+            "handled": True,
+            "message": "Unauthorized access"
+        }}, status=HTTP_UNAUTHORIZED)
 
     def authenticate(self, request: Request) -> bool:
         """
@@ -120,12 +123,11 @@ async def error_middleware(request: Request, handler: Callable[[Request], Awaita
             "handled": True,
             "message": http_error.text,
         }}, status=HTTP_REQUEST_ENTITY_TOO_LARGE)
-    except Exception as e:
+    except Exception:
         full_exception = traceback.format_exc()
 
         return RESTResponse({"error": {
             "handled": False,
-            "code": e.__class__.__name__,
             "message": str(full_exception)
         }}, status=HTTP_INTERNAL_SERVER_ERROR)
     return response

--- a/src/tribler/core/versioning/restapi/versioning_endpoint.py
+++ b/src/tribler/core/versioning/restapi/versioning_endpoint.py
@@ -151,7 +151,8 @@ class VersioningEndpoint(RESTEndpoint):
                 "schema": schema(RemoveVersionResponse={"success": Bool})
             },
             HTTP_BAD_REQUEST: {
-                "schema": schema(RemoveVersionNotFoundResponse={"error": String})
+                "schema": schema(RemoveVersionNotFoundResponse={"error": schema(ErrorResponse={"handled": Bool,
+                                                                                               "message": String})})
             }
         }
     )
@@ -161,6 +162,9 @@ class VersioningEndpoint(RESTEndpoint):
         """
         version = request.match_info["version"]
         if not version:
-            return RESTResponse({"error": "No version given"}, status=HTTP_BAD_REQUEST)
+            return RESTResponse({"error": {
+                                    "handled": True,
+                                    "message": "No version given"
+                                }}, status=HTTP_BAD_REQUEST)
         request.context[0].remove_version(version)
         return RESTResponse({"success": True})

--- a/src/tribler/test_unit/core/knowledge/restapi/test_knowledge_endpoint.py
+++ b/src/tribler/test_unit/core/knowledge/restapi/test_knowledge_endpoint.py
@@ -123,7 +123,7 @@ class TestKnowledgeEndpoint(TestBase):
         response_body_json = await response_to_json(response)
 
         self.assertEqual(400, response.status)
-        self.assertEqual("Invalid infohash", response_body_json["error"])
+        self.assertEqual("Invalid infohash", response_body_json["error"]["message"])
 
     async def test_add_invalid_tag_too_short(self) -> None:
         """
@@ -136,7 +136,7 @@ class TestKnowledgeEndpoint(TestBase):
         response_body_json = await response_to_json(response)
 
         self.assertEqual(400, response.status)
-        self.assertEqual("Invalid tag length", response_body_json["error"])
+        self.assertEqual("Invalid tag length", response_body_json["error"]["message"])
 
     async def test_add_invalid_tag_too_long(self) -> None:
         """
@@ -149,7 +149,7 @@ class TestKnowledgeEndpoint(TestBase):
         response_body_json = await response_to_json(response)
 
         self.assertEqual(400, response.status)
-        self.assertEqual("Invalid tag length", response_body_json["error"])
+        self.assertEqual("Invalid tag length", response_body_json["error"]["message"])
 
     async def test_modify_tags(self) -> None:
         """
@@ -190,7 +190,7 @@ class TestKnowledgeEndpoint(TestBase):
         response_body_json = await response_to_json(response)
 
         self.assertEqual(400, response.status)
-        self.assertEqual("Invalid infohash", response_body_json["error"])
+        self.assertEqual("Invalid infohash", response_body_json["error"]["message"])
 
     async def test_get_suggestions(self) -> None:
         """

--- a/src/tribler/test_unit/core/libtorrent/restapi/test_create_torrent_endpoint.py
+++ b/src/tribler/test_unit/core/libtorrent/restapi/test_create_torrent_endpoint.py
@@ -66,7 +66,7 @@ class TestCreateTorrentEndpoint(TestBase):
         response_body_json = await response_to_json(response)
 
         self.assertEqual(HTTP_BAD_REQUEST, response.status)
-        self.assertEqual("files parameter missing", response_body_json["error"])
+        self.assertEqual("files parameter missing", response_body_json["error"]["message"])
 
     async def test_failure_oserror(self) -> None:
         """
@@ -78,8 +78,7 @@ class TestCreateTorrentEndpoint(TestBase):
 
         self.assertEqual(HTTP_INTERNAL_SERVER_ERROR, response.status)
         self.assertTrue(response_body_json["error"]["handled"])
-        self.assertEqual("OSError", response_body_json["error"]["code"])
-        self.assertEqual("test", response_body_json["error"]["message"])
+        self.assertEqual("OSError: test", response_body_json["error"]["message"])
 
     async def test_failure_unicodedecodeerror(self) -> None:
         """
@@ -92,7 +91,8 @@ class TestCreateTorrentEndpoint(TestBase):
 
         self.assertEqual(HTTP_INTERNAL_SERVER_ERROR, response.status)
         self.assertTrue(response_body_json["error"]["handled"])
-        self.assertEqual("UnicodeDecodeError", response_body_json["error"]["code"])
+        self.assertEqual("UnicodeDecodeError: 'utf-8' codec can't decode bytes in position 0-0: 𓀬",
+                         response_body_json["error"]["message"])
 
     async def test_failure_runtimeerror(self) -> None:
         """
@@ -104,8 +104,7 @@ class TestCreateTorrentEndpoint(TestBase):
 
         self.assertEqual(HTTP_INTERNAL_SERVER_ERROR, response.status)
         self.assertTrue(response_body_json["error"]["handled"])
-        self.assertEqual("RuntimeError", response_body_json["error"]["code"])
-        self.assertEqual("test", response_body_json["error"]["message"])
+        self.assertEqual("RuntimeError: test", response_body_json["error"]["message"])
 
     async def test_create_default(self) -> None:
         """

--- a/src/tribler/test_unit/core/libtorrent/restapi/test_downloads_endpoint.py
+++ b/src/tribler/test_unit/core/libtorrent/restapi/test_downloads_endpoint.py
@@ -483,7 +483,7 @@ class TestDownloadsEndpoint(TestBase):
         response_body_json = await response_to_json(response)
 
         self.assertEqual(HTTP_BAD_REQUEST, response.status)
-        self.assertEqual("uri parameter missing", response_body_json["error"])
+        self.assertEqual("uri parameter missing", response_body_json["error"]["message"])
 
     async def test_add_download_unsafe_anon_error(self) -> None:
         """
@@ -497,7 +497,8 @@ class TestDownloadsEndpoint(TestBase):
         response_body_json = await response_to_json(response)
 
         self.assertEqual(HTTP_BAD_REQUEST, response.status)
-        self.assertEqual("Cannot set anonymous download without safe seeding enabled", response_body_json["error"])
+        self.assertEqual("Cannot set anonymous download without safe seeding enabled",
+                         response_body_json["error"]["message"])
 
     async def test_add_download_default_parameters(self) -> None:
         """
@@ -551,7 +552,7 @@ class TestDownloadsEndpoint(TestBase):
         response_body_json = await response_to_json(response)
 
         self.assertEqual(HTTP_INTERNAL_SERVER_ERROR, response.status)
-        self.assertEqual("invalid uri", response_body_json["error"])
+        self.assertEqual("invalid uri", response_body_json["error"]["message"])
 
     async def test_delete_download_no_remove_data(self) -> None:
         """
@@ -561,7 +562,7 @@ class TestDownloadsEndpoint(TestBase):
         response_body_json = await response_to_json(response)
 
         self.assertEqual(HTTP_BAD_REQUEST, response.status)
-        self.assertEqual("remove_data parameter missing", response_body_json["error"])
+        self.assertEqual("remove_data parameter missing", response_body_json["error"]["message"])
 
     async def test_delete_download_no_download(self) -> None:
         """
@@ -573,7 +574,7 @@ class TestDownloadsEndpoint(TestBase):
         response_body_json = await response_to_json(response)
 
         self.assertEqual(HTTP_NOT_FOUND, response.status)
-        self.assertEqual("this download does not exist", response_body_json["error"])
+        self.assertEqual("this download does not exist", response_body_json["error"]["message"])
 
     async def test_delete_download_no_data(self) -> None:
         """
@@ -619,9 +620,8 @@ class TestDownloadsEndpoint(TestBase):
         response_body_json = await response_to_json(response)
 
         self.assertEqual(HTTP_INTERNAL_SERVER_ERROR, response.status)
-        self.assertEqual("OSError", response_body_json["error"]["code"])
         self.assertTrue(response_body_json["error"]["handled"])
-        self.assertEqual("", response_body_json["error"]["message"])
+        self.assertEqual("OSError: ", response_body_json["error"]["message"])
 
     async def test_update_download_no_download(self) -> None:
         """
@@ -633,7 +633,7 @@ class TestDownloadsEndpoint(TestBase):
         response_body_json = await response_to_json(response)
 
         self.assertEqual(HTTP_NOT_FOUND, response.status)
-        self.assertEqual("this download does not exist", response_body_json["error"])
+        self.assertEqual("this download does not exist", response_body_json["error"]["message"])
 
     async def test_update_download_anon_hops_garbage(self) -> None:
         """
@@ -644,7 +644,7 @@ class TestDownloadsEndpoint(TestBase):
         response_body_json = await response_to_json(response)
 
         self.assertEqual(HTTP_BAD_REQUEST, response.status)
-        self.assertEqual("anon_hops must be the only parameter in this request", response_body_json["error"])
+        self.assertEqual("anon_hops must be the only parameter in this request", response_body_json["error"]["message"])
 
     async def test_update_download_anon_hops_update(self) -> None:
         """
@@ -673,9 +673,8 @@ class TestDownloadsEndpoint(TestBase):
         response_body_json = await response_to_json(response)
 
         self.assertEqual(HTTP_INTERNAL_SERVER_ERROR, response.status)
-        self.assertEqual("OSError", response_body_json["error"]["code"])
         self.assertTrue(response_body_json["error"]["handled"])
-        self.assertEqual("", response_body_json["error"]["message"])
+        self.assertEqual("OSError: ", response_body_json["error"]["message"])
 
     async def test_update_download_selected_files_out_of_range(self) -> None:
         """
@@ -690,7 +689,7 @@ class TestDownloadsEndpoint(TestBase):
         response_body_json = await response_to_json(response)
 
         self.assertEqual(HTTP_BAD_REQUEST, response.status)
-        self.assertEqual("index out of range", response_body_json["error"])
+        self.assertEqual("index out of range", response_body_json["error"]["message"])
 
     async def test_update_download_selected_files(self) -> None:
         """
@@ -719,7 +718,7 @@ class TestDownloadsEndpoint(TestBase):
         response_body_json = await response_to_json(response)
 
         self.assertEqual(HTTP_BAD_REQUEST, response.status)
-        self.assertEqual("unknown state parameter", response_body_json["error"])
+        self.assertEqual("unknown state parameter", response_body_json["error"]["message"])
 
     async def test_update_download_state_resume(self) -> None:
         """
@@ -783,7 +782,7 @@ class TestDownloadsEndpoint(TestBase):
         response_body_json = await response_to_json(response)
 
         self.assertEqual(HTTP_BAD_REQUEST, response.status)
-        self.assertEqual("Target directory (I don't exist) does not exist", response_body_json["error"])
+        self.assertEqual("Target directory (I don't exist) does not exist", response_body_json["error"]["message"])
 
     async def test_update_download_state_move_storage(self) -> None:
         """
@@ -828,7 +827,7 @@ class TestDownloadsEndpoint(TestBase):
         response_body_json = await response_to_json(response)
 
         self.assertEqual(HTTP_NOT_FOUND, response.status)
-        self.assertEqual("this download does not exist", response_body_json["error"])
+        self.assertEqual("this download does not exist", response_body_json["error"]["message"])
 
     async def test_get_torrent_no_torrent_data(self) -> None:
         """
@@ -840,7 +839,7 @@ class TestDownloadsEndpoint(TestBase):
         response_body_json = await response_to_json(response)
 
         self.assertEqual(HTTP_NOT_FOUND, response.status)
-        self.assertEqual("this download does not exist", response_body_json["error"])
+        self.assertEqual("this download does not exist", response_body_json["error"]["message"])
 
     async def test_get_torrent(self) -> None:
         """
@@ -866,7 +865,7 @@ class TestDownloadsEndpoint(TestBase):
         response_body_json = await response_to_json(response)
 
         self.assertEqual(HTTP_NOT_FOUND, response.status)
-        self.assertEqual("this download does not exist", response_body_json["error"])
+        self.assertEqual("this download does not exist", response_body_json["error"]["message"])
 
     async def test_get_files_without_path(self) -> None:
         """
@@ -942,7 +941,7 @@ class TestDownloadsEndpoint(TestBase):
         response_body_json = await response_to_json(response)
 
         self.assertEqual(HTTP_NOT_FOUND, response.status)
-        self.assertEqual("this download does not exist", response_body_json["error"])
+        self.assertEqual("this download does not exist", response_body_json["error"]["message"])
 
     async def test_collapse_tree_directory(self) -> None:
         """
@@ -973,7 +972,7 @@ class TestDownloadsEndpoint(TestBase):
         response_body_json = await response_to_json(response)
 
         self.assertEqual(HTTP_NOT_FOUND, response.status)
-        self.assertEqual("this download does not exist", response_body_json["error"])
+        self.assertEqual("this download does not exist", response_body_json["error"]["message"])
 
     async def test_expand_tree_directory(self) -> None:
         """
@@ -1003,7 +1002,7 @@ class TestDownloadsEndpoint(TestBase):
         response_body_json = await response_to_json(response)
 
         self.assertEqual(HTTP_NOT_FOUND, response.status)
-        self.assertEqual("this download does not exist", response_body_json["error"])
+        self.assertEqual("this download does not exist", response_body_json["error"]["message"])
 
     async def test_select_tree_path(self) -> None:
         """
@@ -1032,7 +1031,7 @@ class TestDownloadsEndpoint(TestBase):
         response_body_json = await response_to_json(response)
 
         self.assertEqual(HTTP_NOT_FOUND, response.status)
-        self.assertEqual("this download does not exist", response_body_json["error"])
+        self.assertEqual("this download does not exist", response_body_json["error"]["message"])
 
     async def test_deselect_tree_path(self) -> None:
         """
@@ -1061,7 +1060,7 @@ class TestDownloadsEndpoint(TestBase):
         response_body_json = await response_to_json(response)
 
         self.assertEqual(HTTP_NOT_FOUND, response.status)
-        self.assertEqual("this download does not exist", response_body_json["error"])
+        self.assertEqual("this download does not exist", response_body_json["error"]["message"])
 
     async def test_stream_unsatisfiable(self) -> None:
         """
@@ -1176,7 +1175,7 @@ class TestDownloadsEndpoint(TestBase):
         response_body_json = await response_to_json(response)
 
         self.assertEqual(500, response.status)
-        self.assertEqual("invalid torrent handle used", response_body_json["error"])
+        self.assertEqual("invalid torrent handle used", response_body_json["error"]["message"])
 
     async def test_remove_tracker(self) -> None:
         """
@@ -1241,7 +1240,7 @@ class TestDownloadsEndpoint(TestBase):
         response_body_json = await response_to_json(response)
 
         self.assertEqual(500, response.status)
-        self.assertEqual("invalid torrent handle used", response_body_json["error"])
+        self.assertEqual("invalid torrent handle used", response_body_json["error"]["message"])
 
     async def test_tracker_force_announce(self) -> None:
         """
@@ -1306,4 +1305,4 @@ class TestDownloadsEndpoint(TestBase):
         response_body_json = await response_to_json(response)
 
         self.assertEqual(500, response.status)
-        self.assertEqual("invalid torrent handle used", response_body_json["error"])
+        self.assertEqual("invalid torrent handle used", response_body_json["error"]["message"])

--- a/src/tribler/test_unit/core/libtorrent/restapi/test_torrentinfo_endpoint.py
+++ b/src/tribler/test_unit/core/libtorrent/restapi/test_torrentinfo_endpoint.py
@@ -58,7 +58,7 @@ class TestTorrentInfoEndpoint(TestBase):
         response_body_json = await response_to_json(response)
 
         self.assertEqual(HTTP_BAD_REQUEST, response.status)
-        self.assertEqual("wrong value of 'hops' parameter: foo", response_body_json["error"])
+        self.assertEqual("wrong value of 'hops' parameter: foo", response_body_json["error"]["message"])
 
     async def test_get_torrent_info_bad_scheme(self) -> None:
         """
@@ -68,7 +68,7 @@ class TestTorrentInfoEndpoint(TestBase):
         response_body_json = await response_to_json(response)
 
         self.assertEqual(HTTP_BAD_REQUEST, response.status)
-        self.assertEqual("invalid uri", response_body_json["error"])
+        self.assertEqual("invalid uri", response_body_json["error"]["message"])
 
     async def test_get_torrent_info_no_metainfo(self) -> None:
         """
@@ -80,7 +80,7 @@ class TestTorrentInfoEndpoint(TestBase):
         response_body_json = await response_to_json(response)
 
         self.assertEqual(HTTP_INTERNAL_SERVER_ERROR, response.status)
-        self.assertEqual("metainfo error", response_body_json["error"])
+        self.assertEqual("metainfo error", response_body_json["error"]["message"])
 
     async def test_get_torrent_info_file_filenotfounderror(self) -> None:
         """
@@ -91,7 +91,7 @@ class TestTorrentInfoEndpoint(TestBase):
         response_body_json = await response_to_json(response)
 
         self.assertEqual(HTTP_INTERNAL_SERVER_ERROR, response.status)
-        self.assertEqual("error while decoding torrent file: .", response_body_json["error"])
+        self.assertEqual("error while decoding torrent file: .", response_body_json["error"]["message"])
 
     async def test_get_torrent_info_file_typeerror(self) -> None:
         """
@@ -102,7 +102,7 @@ class TestTorrentInfoEndpoint(TestBase):
         response_body_json = await response_to_json(response)
 
         self.assertEqual(HTTP_INTERNAL_SERVER_ERROR, response.status)
-        self.assertEqual("error while decoding torrent file: .", response_body_json["error"])
+        self.assertEqual("error while decoding torrent file: .", response_body_json["error"]["message"])
 
     async def test_get_torrent_info_file_valueerror(self) -> None:
         """
@@ -113,7 +113,7 @@ class TestTorrentInfoEndpoint(TestBase):
         response_body_json = await response_to_json(response)
 
         self.assertEqual(HTTP_INTERNAL_SERVER_ERROR, response.status)
-        self.assertEqual("error while decoding torrent file: .", response_body_json["error"])
+        self.assertEqual("error while decoding torrent file: .", response_body_json["error"]["message"])
 
     async def test_get_torrent_info_file_runtimeerror(self) -> None:
         """
@@ -124,7 +124,7 @@ class TestTorrentInfoEndpoint(TestBase):
         response_body_json = await response_to_json(response)
 
         self.assertEqual(HTTP_INTERNAL_SERVER_ERROR, response.status)
-        self.assertEqual("error while decoding torrent file: .", response_body_json["error"])
+        self.assertEqual("error while decoding torrent file: .", response_body_json["error"]["message"])
 
     async def test_get_torrent_info_magnet_runtimeerror_compat(self) -> None:
         """
@@ -136,7 +136,8 @@ class TestTorrentInfoEndpoint(TestBase):
         response_body_json = await response_to_json(response)
 
         self.assertEqual(HTTP_BAD_REQUEST, response.status)
-        self.assertEqual("Error while getting an infohash from magnet: RuntimeError: ", response_body_json["error"])
+        self.assertEqual("Error while getting an infohash from magnet: RuntimeError: ",
+                         response_body_json["error"]["message"])
 
     async def test_get_torrent_info_magnet_runtimeerror_modern(self) -> None:
         """
@@ -151,7 +152,8 @@ class TestTorrentInfoEndpoint(TestBase):
         response_body_json = await response_to_json(response)
 
         self.assertEqual(HTTP_BAD_REQUEST, response.status)
-        self.assertEqual("Error while getting an infohash from magnet: RuntimeError: ", response_body_json["error"])
+        self.assertEqual("Error while getting an infohash from magnet: RuntimeError: ",
+                         response_body_json["error"]["message"])
 
     async def test_get_torrent_info_magnet_no_metainfo(self) -> None:
         """
@@ -165,7 +167,7 @@ class TestTorrentInfoEndpoint(TestBase):
         response_body_json = await response_to_json(response)
 
         self.assertEqual(HTTP_INTERNAL_SERVER_ERROR, response.status)
-        self.assertEqual("metainfo error", response_body_json["error"])
+        self.assertEqual("metainfo error", response_body_json["error"]["message"])
         self.assertEqual(b"\x01" * 20, self.download_manager.get_metainfo.call_args.args[0])
         self.assertEqual(60, self.download_manager.get_metainfo.call_args.kwargs["timeout"])
         self.assertEqual(0, self.download_manager.get_metainfo.call_args.kwargs["hops"])
@@ -184,7 +186,7 @@ class TestTorrentInfoEndpoint(TestBase):
         response_body_json = await response_to_json(response)
 
         self.assertEqual(HTTP_INTERNAL_SERVER_ERROR, response.status)
-        self.assertEqual("test", response_body_json["error"])
+        self.assertEqual("test", response_body_json["error"]["message"])
 
     async def test_get_torrent_info_http_clientresponseerror(self) -> None:
         """
@@ -199,7 +201,7 @@ class TestTorrentInfoEndpoint(TestBase):
         response_body_json = await response_to_json(response)
 
         self.assertEqual(HTTP_INTERNAL_SERVER_ERROR, response.status)
-        self.assertEqual("0, message='', url='test'", response_body_json["error"])
+        self.assertEqual("0, message='', url='test'", response_body_json["error"]["message"])
 
     async def test_get_torrent_info_http_sslerror(self) -> None:
         """
@@ -214,7 +216,7 @@ class TestTorrentInfoEndpoint(TestBase):
         response_body_json = await response_to_json(response)
 
         self.assertEqual(HTTP_INTERNAL_SERVER_ERROR, response.status)
-        self.assertEqual("('test',)", response_body_json["error"])
+        self.assertEqual("('test',)", response_body_json["error"]["message"])
 
     async def test_get_torrent_info_http_clientconnectorerror(self) -> None:
         """
@@ -230,7 +232,7 @@ class TestTorrentInfoEndpoint(TestBase):
         response_body_json = await response_to_json(response)
 
         self.assertEqual(HTTP_INTERNAL_SERVER_ERROR, response.status)
-        self.assertEqual("Cannot connect to host test:42 ssl:default [None]", response_body_json["error"])
+        self.assertEqual("Cannot connect to host test:42 ssl:default [None]", response_body_json["error"]["message"])
 
     async def test_get_torrent_info_http_timeouterror(self) -> None:
         """
@@ -245,7 +247,7 @@ class TestTorrentInfoEndpoint(TestBase):
         response_body_json = await response_to_json(response)
 
         self.assertEqual(HTTP_INTERNAL_SERVER_ERROR, response.status)
-        self.assertEqual("test", response_body_json["error"])
+        self.assertEqual("test", response_body_json["error"]["message"])
 
     async def test_get_torrent_info_http_valueerror(self) -> None:
         """
@@ -260,7 +262,7 @@ class TestTorrentInfoEndpoint(TestBase):
         response_body_json = await response_to_json(response)
 
         self.assertEqual(HTTP_INTERNAL_SERVER_ERROR, response.status)
-        self.assertEqual("test", response_body_json["error"])
+        self.assertEqual("test", response_body_json["error"]["message"])
 
     async def test_get_torrent_info_https_serverconnectionerror(self) -> None:
         """
@@ -275,7 +277,7 @@ class TestTorrentInfoEndpoint(TestBase):
         response_body_json = await response_to_json(response)
 
         self.assertEqual(HTTP_INTERNAL_SERVER_ERROR, response.status)
-        self.assertEqual("test", response_body_json["error"])
+        self.assertEqual("test", response_body_json["error"]["message"])
 
     async def test_get_torrent_info_https_clientresponseerror(self) -> None:
         """
@@ -290,7 +292,7 @@ class TestTorrentInfoEndpoint(TestBase):
         response_body_json = await response_to_json(response)
 
         self.assertEqual(HTTP_INTERNAL_SERVER_ERROR, response.status)
-        self.assertEqual("0, message='', url='test'", response_body_json["error"])
+        self.assertEqual("0, message='', url='test'", response_body_json["error"]["message"])
 
     async def test_get_torrent_info_https_sslerror(self) -> None:
         """
@@ -305,7 +307,7 @@ class TestTorrentInfoEndpoint(TestBase):
         response_body_json = await response_to_json(response)
 
         self.assertEqual(HTTP_INTERNAL_SERVER_ERROR, response.status)
-        self.assertEqual("('test',)", response_body_json["error"])
+        self.assertEqual("('test',)", response_body_json["error"]["message"])
 
     async def test_get_torrent_info_https_clientconnectorerror(self) -> None:
         """
@@ -321,7 +323,7 @@ class TestTorrentInfoEndpoint(TestBase):
         response_body_json = await response_to_json(response)
 
         self.assertEqual(HTTP_INTERNAL_SERVER_ERROR, response.status)
-        self.assertEqual("Cannot connect to host test:42 ssl:default [None]", response_body_json["error"])
+        self.assertEqual("Cannot connect to host test:42 ssl:default [None]", response_body_json["error"]["message"])
 
     async def test_get_torrent_info_https_timeouterror(self) -> None:
         """
@@ -336,7 +338,7 @@ class TestTorrentInfoEndpoint(TestBase):
         response_body_json = await response_to_json(response)
 
         self.assertEqual(HTTP_INTERNAL_SERVER_ERROR, response.status)
-        self.assertEqual("test", response_body_json["error"])
+        self.assertEqual("test", response_body_json["error"]["message"])
 
     async def test_get_torrent_info_https_valueerror(self) -> None:
         """
@@ -351,7 +353,7 @@ class TestTorrentInfoEndpoint(TestBase):
         response_body_json = await response_to_json(response)
 
         self.assertEqual(HTTP_INTERNAL_SERVER_ERROR, response.status)
-        self.assertEqual("test", response_body_json["error"])
+        self.assertEqual("test", response_body_json["error"]["message"])
 
     async def test_get_torrent_info_https_certificate_error(self) -> None:
         """
@@ -389,7 +391,7 @@ class TestTorrentInfoEndpoint(TestBase):
         response_body_json = await response_to_json(response)
 
         self.assertEqual(HTTP_INTERNAL_SERVER_ERROR, response.status)
-        self.assertEqual("metainfo error", response_body_json["error"])
+        self.assertEqual("metainfo error", response_body_json["error"]["message"])
 
     async def test_get_torrent_info_https_no_metainfo(self) -> None:
         """
@@ -405,7 +407,7 @@ class TestTorrentInfoEndpoint(TestBase):
         response_body_json = await response_to_json(response)
 
         self.assertEqual(HTTP_INTERNAL_SERVER_ERROR, response.status)
-        self.assertEqual("metainfo error", response_body_json["error"])
+        self.assertEqual("metainfo error", response_body_json["error"]["message"])
 
     async def test_get_torrent_info_http_redirect_magnet_no_metainfo(self) -> None:
         """
@@ -424,7 +426,7 @@ class TestTorrentInfoEndpoint(TestBase):
         response_body_json = await response_to_json(response)
 
         self.assertEqual(HTTP_INTERNAL_SERVER_ERROR, response.status)
-        self.assertEqual("metainfo error", response_body_json["error"])
+        self.assertEqual("metainfo error", response_body_json["error"]["message"])
         self.assertEqual(b"\x01" * 20, self.download_manager.get_metainfo.call_args.args[0])
         self.assertEqual(60.0, self.download_manager.get_metainfo.call_args.kwargs["timeout"])
         self.assertEqual(0, self.download_manager.get_metainfo.call_args.kwargs["hops"])
@@ -447,7 +449,7 @@ class TestTorrentInfoEndpoint(TestBase):
         response_body_json = await response_to_json(response)
 
         self.assertEqual(HTTP_INTERNAL_SERVER_ERROR, response.status)
-        self.assertEqual("metainfo error", response_body_json["error"])
+        self.assertEqual("metainfo error", response_body_json["error"]["message"])
         self.assertEqual(b"\x01" * 20, self.download_manager.get_metainfo.call_args.args[0])
         self.assertEqual(60.0, self.download_manager.get_metainfo.call_args.kwargs["timeout"])
         self.assertEqual(0, self.download_manager.get_metainfo.call_args.kwargs["hops"])
@@ -464,7 +466,7 @@ class TestTorrentInfoEndpoint(TestBase):
         response_body_json = await response_to_json(response)
 
         self.assertEqual(HTTP_INTERNAL_SERVER_ERROR, response.status)
-        self.assertEqual("invalid response", response_body_json["error"])
+        self.assertEqual("invalid response", response_body_json["error"]["message"])
 
     async def test_get_torrent_info_invalid_response_empty_info(self) -> None:
         """
@@ -477,7 +479,7 @@ class TestTorrentInfoEndpoint(TestBase):
         response_body_json = await response_to_json(response)
 
         self.assertEqual(HTTP_INTERNAL_SERVER_ERROR, response.status)
-        self.assertEqual("invalid response", response_body_json["error"])
+        self.assertEqual("invalid response", response_body_json["error"]["message"])
 
     async def test_get_torrent_info_valid_download(self) -> None:
         """

--- a/src/tribler/test_unit/core/restapi/test_rest_endpoint.py
+++ b/src/tribler/test_unit/core/restapi/test_rest_endpoint.py
@@ -85,5 +85,4 @@ class TestRESTEndpoint(TestBase):
 
         self.assertEqual(HTTP_INTERNAL_SERVER_ERROR, response.status)
         self.assertTrue(response_body_json["error"]["handled"])
-        self.assertEqual("ValueError", response_body_json["error"]["code"])
-        self.assertEqual("test message", response_body_json["error"]["message"])
+        self.assertEqual("ValueError: test message", response_body_json["error"]["message"])

--- a/src/tribler/test_unit/core/restapi/test_rest_manager.py
+++ b/src/tribler/test_unit/core/restapi/test_rest_manager.py
@@ -72,7 +72,7 @@ class TestRESTManager(TestBase):
         response_body_json = await response_to_json(response)
 
         self.assertEqual(HTTP_UNAUTHORIZED, response.status)
-        self.assertEqual("Unauthorized access", response_body_json["error"])
+        self.assertEqual("Unauthorized access", response_body_json["error"]["message"])
 
     async def test_key_middleware_valid_unprotected(self) -> None:
         """
@@ -172,7 +172,6 @@ class TestRESTManager(TestBase):
 
         self.assertEqual(HTTP_INTERNAL_SERVER_ERROR, response.status)
         self.assertFalse(response_body_json["error"]["handled"])
-        self.assertEqual("ValueError", response_body_json["error"]["code"])
         self.assertTrue(response_body_json["error"]["message"].startswith("Traceback (most recent call last):"))
 
     def test_add_endpoint(self) -> None:

--- a/src/tribler/ui/src/components/add-torrent.tsx
+++ b/src/tribler/ui/src/components/add-torrent.tsx
@@ -138,7 +138,7 @@ export function AddTorrent() {
                                 if (response === undefined) {
                                     toast.error(`${t("ToastErrorStartDownload")} ${t("ToastErrorGenNetworkErr")}`);
                                 } else if (isErrorDict(response)){
-                                    toast.error(`${t("ToastErrorStartDownload")} ${response.error}`);
+                                    toast.error(`${t("ToastErrorStartDownload")} ${response.error.message}`);
                                 }
                              })();
                         }

--- a/src/tribler/ui/src/components/language-select.tsx
+++ b/src/tribler/ui/src/components/language-select.tsx
@@ -25,7 +25,7 @@ const LanguageSelect = () => {
         if (response === undefined) {
             toast.error(`${t("ToastErrorSetLanguage")} ${t("ToastErrorGenNetworkErr")}`);
         } else if (isErrorDict(response)){
-            toast.error(`${t("ToastErrorSetLanguage")} ${response.error}`);
+            toast.error(`${t("ToastErrorSetLanguage")} ${response.error.message}`);
         }
     };
 

--- a/src/tribler/ui/src/components/layouts/Header.tsx
+++ b/src/tribler/ui/src/components/layouts/Header.tsx
@@ -139,7 +139,7 @@ export function Header() {
                                         if (response === undefined) {
                                             toast.error(`${"ToastErrorShutdown"} ${"ToastErrorGenNetworkErr"}`);
                                         } else if (isErrorDict(response)){
-                                            toast.error(`${"ToastErrorShutdown"} ${response.error}`);
+                                            toast.error(`${"ToastErrorShutdown"} ${response.error.message}`);
                                         }
                                     })
                                 }}

--- a/src/tribler/ui/src/components/swarm-health.tsx
+++ b/src/tribler/ui/src/components/swarm-health.tsx
@@ -37,7 +37,7 @@ export function SwarmHealth({ torrent }: { torrent: Torrent }) {
                                     toast.error(`${t("ToastErrorDownloadCheck")} ${t("ToastErrorGenNetworkErr")}`);
                                 } else if (isErrorDict(response)) {
                                     setChecking(false);
-                                    toast.error(`${t("ToastErrorDownloadCheck")} ${response.error}`);
+                                    toast.error(`${t("ToastErrorDownloadCheck")} ${response.error.message}`);
                                 }
                             });
                         }}

--- a/src/tribler/ui/src/dialogs/CreateTorrent.tsx
+++ b/src/tribler/ui/src/dialogs/CreateTorrent.tsx
@@ -57,7 +57,7 @@ export default function CreateTorrent(props: JSX.IntrinsicAttributes & DialogPro
         if (settings === undefined){
             toast.error(`${t("ToastErrorDefaultDLDir")} ${t("ToastErrorGenNetworkErr")}`);
         } else if (isErrorDict(settings)) {
-            toast.error(`${t("ToastErrorDefaultDLDir")} ${settings.error}`);
+            toast.error(`${t("ToastErrorDefaultDLDir")} ${settings.error.message}`);
         } else {
             setDestination(settings.libtorrent.download_defaults.saveas);
         }
@@ -68,7 +68,7 @@ export default function CreateTorrent(props: JSX.IntrinsicAttributes & DialogPro
         if (response === undefined){
             toast.error(`${t("ToastErrorDirectoryAdd")} ${t("ToastErrorGenNetworkErr")}`);
         } else if (isErrorDict(response)) {
-            toast.error(`${t("ToastErrorDirectoryAdd")} ${response.error}`);
+            toast.error(`${t("ToastErrorDirectoryAdd")} ${response.error.message}`);
         } else {
             setFiles([
                 ...files,
@@ -180,7 +180,7 @@ export default function CreateTorrent(props: JSX.IntrinsicAttributes & DialogPro
                                         toast.error(`${t("ToastErrorCreateTorrent", {name: name})} ${t("ToastErrorGenNetworkErr")}`);
                                     } else if (isErrorDict(response)) {
                                         // Quinten: according to the typing, response could not be a ErrorDict here?!
-                                        toast.error(`${t("ToastErrorCreateTorrent", {name: name})} ${(response as ErrorDict).error}`);
+                                        toast.error(`${t("ToastErrorCreateTorrent", {name: name})} ${(response as ErrorDict).error.message}`);
                                     }
                                 }
                             );

--- a/src/tribler/ui/src/dialogs/SaveAs.tsx
+++ b/src/tribler/ui/src/dialogs/SaveAs.tsx
@@ -25,7 +25,7 @@ function startDownloadCallback(response: any, t: TFunction) {
     if (response === undefined) {
         toast.error(`${t("ToastErrorDownloadStart")} ${t("ToastErrorGenNetworkErr")}`);
     } else if (isErrorDict(response)) {
-        toast.error(`${t("ToastErrorDownloadStart")} ${response.error}`);
+        toast.error(`${t("ToastErrorDownloadStart")} ${response.error.message}`);
     }
 }
 
@@ -131,7 +131,7 @@ export default function SaveAs(props: SaveAsProps & JSX.IntrinsicAttributes & Di
                 setError(`${t("ToastErrorGetSettings")} ${t("ToastErrorGenNetworkErr")}`);
                 return;
             } else if (isErrorDict(newSettings)) {
-                setError(`${t("ToastErrorGetSettings")} ${newSettings.error}`);
+                setError(`${t("ToastErrorGetSettings")} ${newSettings.error.message}`);
                 return;
             }
             const safeSeeding = !!newSettings?.libtorrent?.download_defaults?.safeseeding_enabled;
@@ -155,11 +155,8 @@ export default function SaveAs(props: SaveAsProps & JSX.IntrinsicAttributes & Di
 
             if (response === undefined) {
                 setError(`${t("ToastErrorGetMetainfo")} ${t("ToastErrorGenNetworkErr")}`);
-            } else if ('error' in response && typeof response.error === 'object') {
-                let errorCode = response.error as {handled: boolean, code: string, message: string};
-                setError(`${t("ToastErrorGetMetainfo")} ${errorCode.code}`);
             } else if (isErrorDict(response)) {
-                setError(`${t("ToastErrorGetMetainfo")} ${response.error}`);
+                setError(`${t("ToastErrorGetMetainfo")} ${response.error.message}`);
             } else if (response) {
                 const info = getFilesFromMetainfo(response.metainfo);
                 var files = info.files;

--- a/src/tribler/ui/src/dialogs/SelectRemotePath.tsx
+++ b/src/tribler/ui/src/dialogs/SelectRemotePath.tsx
@@ -42,7 +42,7 @@ export default function SelectRemotePath(props: SelectRemotePathProps & JSX.Intr
         if (response === undefined) {
             toast.error(`${t("ToastErrorBrowseFiles")} ${t("ToastErrorGenNetworkErr")}`);
         } else if (isErrorDict(response)){
-            toast.error(`${t("ToastErrorBrowseFiles")} ${response.error}`);
+            toast.error(`${t("ToastErrorBrowseFiles")} ${response.error.message}`);
         } else {
             setPaths(response.paths);
             setCurrentPath(response.current);

--- a/src/tribler/ui/src/pages/Debug/Asyncio/Health.tsx
+++ b/src/tribler/ui/src/pages/Debug/Asyncio/Health.tsx
@@ -31,7 +31,7 @@ export default function Health() {
             if (response === undefined) {
                 toast.error(`${t("ToastErrorEnableHealth")} ${t("ToastErrorGenNetworkErr")}`);
             } else if (isErrorDict(response)){
-                toast.error(`${t("ToastErrorEnableHealth")} ${response.error}`);
+                toast.error(`${t("ToastErrorEnableHealth")} ${response.error.message}`);
             }
         })();
         return () => {
@@ -40,7 +40,7 @@ export default function Health() {
                 if (response === undefined) {
                     toast.error(`${t("ToastErrorDisableHealth")} ${t("ToastErrorGenNetworkErr")}`);
                 } else if (isErrorDict(response)){
-                    toast.error(`${t("ToastErrorDisableHealth")} ${response.error}`);
+                    toast.error(`${t("ToastErrorDisableHealth")} ${response.error.message}`);
                 }
             })();
         }

--- a/src/tribler/ui/src/pages/Debug/Asyncio/SlowTasks.tsx
+++ b/src/tribler/ui/src/pages/Debug/Asyncio/SlowTasks.tsx
@@ -30,7 +30,7 @@ export default function SlowTasks() {
             if (response === undefined) {
                 toast.error(`${t("ToastErrorEnableAsyncio")} ${t("ToastErrorGenNetworkErr")}`);
             } else if (isErrorDict(response)){
-                toast.error(`${t("ToastErrorEnableAsyncio")} ${response.error}`);
+                toast.error(`${t("ToastErrorEnableAsyncio")} ${response.error.message}`);
             }
         })();
         return () => {
@@ -39,7 +39,7 @@ export default function SlowTasks() {
                 if (response === undefined) {
                     toast.error(`${t("ToastErrorDisableAsyncio")} ${t("ToastErrorGenNetworkErr")}`);
                 } else if (isErrorDict(response)){
-                    toast.error(`${t("ToastErrorDisableAsyncio")} ${response.error}`);
+                    toast.error(`${t("ToastErrorDisableAsyncio")} ${response.error.message}`);
                 }
             })();
         }
@@ -67,7 +67,7 @@ export default function SlowTasks() {
                                 if (response === undefined) {
                                     toast.error(`${t("ToastErrorSlowness")} ${t("ToastErrorGenNetworkErr")}`);
                                 } else if (isErrorDict(response)){
-                                    toast.error(`${t("ToastErrorSlowness")} ${response.error}`);
+                                    toast.error(`${t("ToastErrorSlowness")} ${response.error.message}`);
                                 }
                             });
                         }}

--- a/src/tribler/ui/src/pages/Downloads/Actions.tsx
+++ b/src/tribler/ui/src/pages/Downloads/Actions.tsx
@@ -38,7 +38,7 @@ export default function Actions({ selectedDownloads }: { selectedDownloads: Down
                 if (response === undefined) {
                     toast.error(`${t("ToastErrorDownloadPlay")} ${t("ToastErrorGenNetworkErr")}`);
                 } else if (isErrorDict(response)) {
-                    toast.error(`${t("ToastErrorDownloadPlay")} ${response.error}`);
+                    toast.error(`${t("ToastErrorDownloadPlay")} ${response.error.message}`);
                 }
             })();
         });
@@ -50,7 +50,7 @@ export default function Actions({ selectedDownloads }: { selectedDownloads: Down
                 if (response === undefined) {
                     toast.error(`${t("ToastErrorDownloadStop")} ${t("ToastErrorGenNetworkErr")}`);
                 } else if (isErrorDict(response)) {
-                    toast.error(`${t("ToastErrorDownloadStop")} ${response.error}`);
+                    toast.error(`${t("ToastErrorDownloadStop")} ${response.error.message}`);
                 }
             })();
         });
@@ -62,7 +62,7 @@ export default function Actions({ selectedDownloads }: { selectedDownloads: Down
                 if (response === undefined) {
                     toast.error(`${t("ToastErrorDownloadRemove")} ${t("ToastErrorGenNetworkErr")}`);
                 } else if (isErrorDict(response)) {
-                    toast.error(`${t("ToastErrorDownloadRemove")} ${response.error}`);
+                    toast.error(`${t("ToastErrorDownloadRemove")} ${response.error.message}`);
                 }
             })();
         });
@@ -75,7 +75,7 @@ export default function Actions({ selectedDownloads }: { selectedDownloads: Down
                 if (response === undefined) {
                     toast.error(`${t("ToastErrorDownloadCheck")} ${t("ToastErrorGenNetworkErr")}`);
                 } else if (isErrorDict(response)) {
-                    toast.error(`${t("ToastErrorDownloadCheck")} ${response.error}`);
+                    toast.error(`${t("ToastErrorDownloadCheck")} ${response.error.message}`);
                 }
             })();
         });
@@ -100,7 +100,7 @@ export default function Actions({ selectedDownloads }: { selectedDownloads: Down
             if (response === undefined) {
                 toast.error(`${t("ToastErrorDownloadMove")} ${t("ToastErrorGenNetworkErr")}`);
             } else if (isErrorDict(response)) {
-                toast.error(`${t("ToastErrorDownloadMove")} ${response.error}`);
+                toast.error(`${t("ToastErrorDownloadMove")} ${response.error.message}`);
             }
         });
         setStorageDialogOpen(false);
@@ -112,7 +112,7 @@ export default function Actions({ selectedDownloads }: { selectedDownloads: Down
                 if (response === undefined) {
                     toast.error(`${t("ToastErrorDownloadSetHops")} ${t("ToastErrorGenNetworkErr")}`);
                 } else if (isErrorDict(response)) {
-                    toast.error(`${t("ToastErrorDownloadSetHops")} ${response.error}`);
+                    toast.error(`${t("ToastErrorDownloadSetHops")} ${response.error.message}`);
                 }
             })();
         });

--- a/src/tribler/ui/src/pages/Downloads/Files.tsx
+++ b/src/tribler/ui/src/pages/Downloads/Files.tsx
@@ -87,7 +87,7 @@ export default function Files({ download }: { download: Download }) {
             if (response === undefined) {
                 toast.error(`${t("ToastErrorDownloadSetFiles")} ${t("ToastErrorGenNetworkErr")}`);
             } else if (isErrorDict(response)) {
-                toast.error(`${t("ToastErrorDownloadSetFiles")} ${response.error}`);
+                toast.error(`${t("ToastErrorDownloadSetFiles")} ${response.error.message}`);
             }
         });
         updateFiles(setFiles, download, initialized);

--- a/src/tribler/ui/src/pages/Downloads/Trackers.tsx
+++ b/src/tribler/ui/src/pages/Downloads/Trackers.tsx
@@ -47,7 +47,7 @@ export default function Trackers({ download }: { download: Download }) {
                                 if (response === undefined) {
                                     toast.error(`${"ToastErrorTrackerCheck"} ${"ToastErrorGenNetworkErr"}`);
                                 } else if (isErrorDict(response)){
-                                    toast.error(`${"ToastErrorTrackerCheck"} ${response.error}`);
+                                    toast.error(`${"ToastErrorTrackerCheck"} ${response.error.message}`);
                                 }
                             });
                         }}>{t("ForceRecheck")}</Button>)
@@ -63,7 +63,7 @@ export default function Trackers({ download }: { download: Download }) {
                                 if (response === undefined) {
                                     toast.error(`${"ToastErrorTrackerRemove"} ${"ToastErrorGenNetworkErr"}`);
                                 } else if (isErrorDict(response)){
-                                    toast.error(`${"ToastErrorTrackerRemove"} ${response.error}`);
+                                    toast.error(`${"ToastErrorTrackerRemove"} ${response.error.message}`);
                                 } else {
                                     download.trackers = download.trackers.filter(tracker => {return tracker.url != props.row.original.url});
                                     var button = event.target as HTMLButtonElement;
@@ -110,7 +110,7 @@ export default function Trackers({ download }: { download: Download }) {
                                         if (response === undefined) {
                                             toast.error(`${"ToastErrorTrackerAdd"} ${"ToastErrorGenNetworkErr"}`);
                                         } else if (isErrorDict(response)) {
-                                            toast.error(`${"ToastErrorTrackerAdd"} ${response.error}`);
+                                            toast.error(`${"ToastErrorTrackerAdd"} ${response.error.message}`);
                                         }
                                     });
                                     setTrackerDialogOpen(false);

--- a/src/tribler/ui/src/pages/Settings/Anonymity.tsx
+++ b/src/tribler/ui/src/pages/Settings/Anonymity.tsx
@@ -18,7 +18,7 @@ export default function Anonimity() {
             if (response === undefined) {
                 toast.error(`${t("ToastErrorGetSettings")} ${t("ToastErrorGenNetworkErr")}`);
             } else if (isErrorDict(response)){
-                toast.error(`${t("ToastErrorGetSettings")} ${response.error}`);
+                toast.error(`${t("ToastErrorGetSettings")} ${response.error.message}`);
             } else {
                 setSettings(response);
             }
@@ -64,7 +64,7 @@ export default function Anonimity() {
                         if (response === undefined) {
                             toast.error(`${t("ToastErrorSetSettings")} ${t("ToastErrorGenNetworkErr")}`);
                         } else if (isErrorDict(response)){
-                            toast.error(`${t("ToastErrorSetSettings")} ${response.error}`);
+                            toast.error(`${t("ToastErrorSetSettings")} ${response.error.message}`);
                         }
                     }
                 }}

--- a/src/tribler/ui/src/pages/Settings/Bandwidth.tsx
+++ b/src/tribler/ui/src/pages/Settings/Bandwidth.tsx
@@ -19,7 +19,7 @@ export default function Bandwith() {
             if (response === undefined) {
                 toast.error(`${t("ToastErrorGetSettings")} ${t("ToastErrorGenNetworkErr")}`);
             } else if (isErrorDict(response)){
-                toast.error(`${t("ToastErrorGetSettings")} ${response.error}`);
+                toast.error(`${t("ToastErrorGetSettings")} ${response.error.message}`);
             } else {
                 setSettings(response);
             }
@@ -85,7 +85,7 @@ export default function Bandwith() {
                         if (response === undefined) {
                             toast.error(`${t("ToastErrorSetSettings")} ${t("ToastErrorGenNetworkErr")}`);
                         } else if (isErrorDict(response)){
-                            toast.error(`${t("ToastErrorSetSettings")} ${response.error}`);
+                            toast.error(`${t("ToastErrorSetSettings")} ${response.error.message}`);
                         }
                     }
                 }}

--- a/src/tribler/ui/src/pages/Settings/Connection.tsx
+++ b/src/tribler/ui/src/pages/Settings/Connection.tsx
@@ -21,7 +21,7 @@ export default function Connection() {
             if (response === undefined) {
                 toast.error(`${t("ToastErrorGetSettings")} ${t("ToastErrorGenNetworkErr")}`);
             } else if (isErrorDict(response)){
-                toast.error(`${t("ToastErrorGetSettings")} ${response.error}`);
+                toast.error(`${t("ToastErrorGetSettings")} ${response.error.message}`);
             } else {
                 setSettings(response);
             }
@@ -195,7 +195,7 @@ export default function Connection() {
                         if (response === undefined) {
                             toast.error(`${t("ToastErrorSetSettings")} ${t("ToastErrorGenNetworkErr")}`);
                         } else if (isErrorDict(response)){
-                            toast.error(`${t("ToastErrorSetSettings")} ${response.error}`);
+                            toast.error(`${t("ToastErrorSetSettings")} ${response.error.message}`);
                         }
                     }
                 }}

--- a/src/tribler/ui/src/pages/Settings/Debugging.tsx
+++ b/src/tribler/ui/src/pages/Settings/Debugging.tsx
@@ -18,7 +18,7 @@ export default function Debugging() {
             if (response === undefined) {
                 toast.error(`${t("ToastErrorGetSettings")} ${t("ToastErrorGenNetworkErr")}`);
             } else if (isErrorDict(response)){
-                toast.error(`${t("ToastErrorGetSettings")} ${response.error}`);
+                toast.error(`${t("ToastErrorGetSettings")} ${response.error.message}`);
             } else {
                 setSettings(response);
             }
@@ -78,7 +78,7 @@ export default function Debugging() {
                         if (response === undefined) {
                             toast.error(`${t("ToastErrorSetSettings")} ${t("ToastErrorGenNetworkErr")}`);
                         } else if (isErrorDict(response)){
-                            toast.error(`${t("ToastErrorSetSettings")} ${response.error}`);
+                            toast.error(`${t("ToastErrorSetSettings")} ${response.error.message}`);
                         } else {
                             window.location.reload();
                         }

--- a/src/tribler/ui/src/pages/Settings/General.tsx
+++ b/src/tribler/ui/src/pages/Settings/General.tsx
@@ -21,7 +21,7 @@ export default function General() {
             if (response === undefined) {
                 toast.error(`${t("ToastErrorGetSettings")} ${t("ToastErrorGenNetworkErr")}`);
             } else if (isErrorDict(response)){
-                toast.error(`${t("ToastErrorGetSettings")} ${response.error}`);
+                toast.error(`${t("ToastErrorGetSettings")} ${response.error.message}`);
             } else {
                 setSettings(response);
             }
@@ -209,7 +209,7 @@ export default function General() {
                         if (response === undefined) {
                             toast.error(`${t("ToastErrorSetSettings")} ${t("ToastErrorGenNetworkErr")}`);
                         } else if (isErrorDict(response)){
-                            toast.error(`${t("ToastErrorSetSettings")} ${response.error}`);
+                            toast.error(`${t("ToastErrorSetSettings")} ${response.error.message}`);
                         }
                     }
                 }}

--- a/src/tribler/ui/src/pages/Settings/Seeding.tsx
+++ b/src/tribler/ui/src/pages/Settings/Seeding.tsx
@@ -20,7 +20,7 @@ export default function Seeding() {
             if (response === undefined) {
                 toast.error(`${t("ToastErrorGetSettings")} ${t("ToastErrorGenNetworkErr")}`);
             } else if (isErrorDict(response)){
-                toast.error(`${t("ToastErrorGetSettings")} ${response.error}`);
+                toast.error(`${t("ToastErrorGetSettings")} ${response.error.message}`);
             } else {
                 setSettings(response);
             }
@@ -114,7 +114,7 @@ export default function Seeding() {
                         if (response === undefined) {
                             toast.error(`${t("ToastErrorSetSettings")} ${t("ToastErrorGenNetworkErr")}`);
                         } else if (isErrorDict(response)){
-                            toast.error(`${t("ToastErrorSetSettings")} ${response.error}`);
+                            toast.error(`${t("ToastErrorSetSettings")} ${response.error.message}`);
                         }
                     }
                 }}

--- a/src/tribler/ui/src/pages/Settings/Versions.tsx
+++ b/src/tribler/ui/src/pages/Settings/Versions.tsx
@@ -25,7 +25,7 @@ export default function Versions() {
                 toast.error(`${t("ToastErrorUpgradeFailed")} ${t("ToastErrorGenNetworkErr")}`);
                 setIsUpgrading(false);
             } else if (isErrorDict(response)){
-                toast.error(`${t("ToastErrorUpgradeFailed")} ${response.error}`);
+                toast.error(`${t("ToastErrorUpgradeFailed")} ${response.error.message}`);
                 setIsUpgrading(false);
             }
         });
@@ -36,7 +36,7 @@ export default function Versions() {
             if (response === undefined) {
                 toast.error(`${t("ToastErrorRemoveVersion", {version: old_version})} ${t("ToastErrorGenNetworkErr")}`);
             } else if (isErrorDict(response)){
-                toast.error(`${t("ToastErrorRemoveVersion", {version: old_version})}  ${response.error}`);
+                toast.error(`${t("ToastErrorRemoveVersion", {version: old_version})}  ${response.error.message}`);
             } else {
                 setVersions(versions.filter((v) => v != old_version));
             }

--- a/src/tribler/ui/src/services/reporting.ts
+++ b/src/tribler/ui/src/services/reporting.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosError } from "axios";
 
-export interface ErrorDict { [error: string]: string; };
+export interface ErrorDict { [error: string]: {handled: boolean, message: string}; };
 
 export function isErrorDict(object: any): object is ErrorDict {
     return (typeof object === 'object') && ('error' in object);


### PR DESCRIPTION
Fixes #8263

This PR:

 - Updates all instances of error RESTResponses to conform to `{error: {handled: bool, message: string}}`.
 
 Notes:
 - In `rest_endpoint.py` I do prefix the exception class because it is lost after the `str()` conversion. In `rest_manager.py` I don't prefix the exception class because it is already part of the traceback.
