### PR TITLE
Un-version dlcheckpoints

### DIFF
--- a/src/tribler/core/libtorrent/download_manager/download_manager.py
+++ b/src/tribler/core/libtorrent/download_manager/download_manager.py
@@ -93,7 +93,7 @@ class DownloadManager(TaskManager):
         super().__init__()
         self.config = config
 
-        self.state_dir = Path(config.get_version_state_dir())
+        self.state_dir = Path(config.get("state_dir"))
         self.ltsettings: dict[lt.session, dict] = {}  # Stores a copy of the settings dict for each libtorrent session
         self.ltsessions: dict[int, Future[lt.session]] = {}
         self.dht_health_manager: DHTHealthManager | None = None

--- a/src/tribler/upgrade_script.py
+++ b/src/tribler/upgrade_script.py
@@ -352,10 +352,11 @@ def upgrade(config: TriblerConfigManager, source: str, destination: str) -> None
     config.write()
 
     # Step 2: copy downloads
-    os.makedirs(os.path.join(destination, "dlcheckpoints"), exist_ok=True)
+    parent_directory = os.path.dirname(destination)  # Starting from 8.0.4 this is no longer versioned information
+    os.makedirs(os.path.join(parent_directory, "dlcheckpoints"), exist_ok=True)
     for checkpoint in os.listdir(os.path.join(source, "dlcheckpoints")):
         _copy_if_not_exist(os.path.join(source, "dlcheckpoints", checkpoint),
-                           os.path.join(destination, "dlcheckpoints", checkpoint))
+                           os.path.join(parent_directory, "dlcheckpoints", checkpoint))
 
     # Step 3: Copy tribler db.
     os.makedirs(os.path.join(destination, "sqlite"), exist_ok=True)


### PR DESCRIPTION
Fixes #8265

This PR:

 - Updates `dlcheckpoints` to no longer be stored in a versioned directory.

Notes:

 - The next pre-release will require a large banner that tells users to copy over their `dlcheckpoints` from a previous pre-release folder. Importing from the 7.14 release automatically creates the directory though.
