### PR TITLE
Add sorting to all tables

### DIFF
--- a/src/tribler/ui/src/components/ui/simple-table.tsx
+++ b/src/tribler/ui/src/components/ui/simple-table.tsx
@@ -1,16 +1,45 @@
 import { SetStateAction, useEffect, useRef, useState } from 'react';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { getCoreRowModel, useReactTable, flexRender, getFilteredRowModel, getPaginationRowModel, getExpandedRowModel, getSortedRowModel } from '@tanstack/react-table';
-import type { ColumnDef, Row, PaginationState, RowSelectionState, ColumnFiltersState, ExpandedState } from '@tanstack/react-table';
+import type { ColumnDef, Row, PaginationState, RowSelectionState, ColumnFiltersState, ExpandedState, ColumnDefTemplate, HeaderContext } from '@tanstack/react-table';
 import { cn } from '@/lib/utils';
 import { Select, SelectContent, SelectGroup, SelectItem, SelectLabel } from './select';
 import { Button } from './button';
-import { ChevronLeftIcon, ChevronRightIcon, DoubleArrowLeftIcon, DoubleArrowRightIcon } from '@radix-ui/react-icons';
+import { ArrowDownIcon, ArrowUpIcon, ChevronLeftIcon, ChevronRightIcon, DoubleArrowLeftIcon, DoubleArrowRightIcon } from '@radix-ui/react-icons';
 import * as SelectPrimitive from "@radix-ui/react-select"
 import type { Table as ReactTable } from '@tanstack/react-table';
 import { useTranslation } from 'react-i18next';
 import { useResizeObserver } from '@/hooks/useResizeObserver';
 
+
+export function getHeader<T>(name: string, translate: boolean = true, addSorting: boolean = true): ColumnDefTemplate<HeaderContext<T, unknown>> | undefined {
+    if (!addSorting) {
+        return () => {
+            const { t } = useTranslation();
+            return <span className='select-none'>{translate ? t(name) : name}</span>;
+        }
+    }
+
+    return ({ column }) => {
+        const { t } = useTranslation();
+        return (
+            <div className='select-none flex'>
+                <span
+                    className="cursor-pointer hover:text-black dark:hover:text-white flex flex-row items-center"
+                    onClick={() => column.toggleSorting()}>
+                    {translate ? t(name) : name}
+                    {column.getIsSorted() === "desc" ? (
+                        <ArrowDownIcon className="ml-2" />
+                    ) : column.getIsSorted() === "asc" ? (
+                        <ArrowUpIcon className="ml-2" />
+                    ) : (
+                        <></>
+                    )}
+                </span>
+            </div>
+        )
+    }
+}
 
 interface ReactTableProps<T extends object> {
     data: T[];

--- a/src/tribler/ui/src/dialogs/SaveAs.tsx
+++ b/src/tribler/ui/src/dialogs/SaveAs.tsx
@@ -1,9 +1,9 @@
-import SimpleTable from "@/components/ui/simple-table";
+import SimpleTable, { getHeader } from "@/components/ui/simple-table";
 import { useEffect, useMemo, useState } from "react";
 import toast from 'react-hot-toast';
 import { triblerService } from "@/services/tribler.service";
 import { isErrorDict } from "@/services/reporting";
-import { filesToTree, fixTreeProps, formatBytes, getFilesFromMetainfo, getRowSelection, getSelectedFilesFromTree, translateHeader } from "@/lib/utils";
+import { filesToTree, fixTreeProps, formatBytes, getFilesFromMetainfo, getRowSelection, getSelectedFilesFromTree } from "@/lib/utils";
 import { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { DialogProps } from "@radix-ui/react-dialog";
@@ -32,7 +32,7 @@ function startDownloadCallback(response: any, t: TFunction) {
 const getFileColumns = ({ onSelectedFiles }: { onSelectedFiles: (row: Row<FileTreeItem>) => void }): ColumnDef<FileTreeItem>[] => [
     {
         accessorKey: "name",
-        header: translateHeader('Name'),
+        header: getHeader('Name'),
         cell: ({ row }) => {
             return (
                 <div
@@ -55,7 +55,7 @@ const getFileColumns = ({ onSelectedFiles }: { onSelectedFiles: (row: Row<FileTr
     },
     {
         accessorKey: "size",
-        header: translateHeader('Size'),
+        header: getHeader('Size'),
         cell: ({ row }) => {
             return (
                 <div className='flex items-center'>

--- a/src/tribler/ui/src/lib/utils.ts
+++ b/src/tribler/ui/src/lib/utils.ts
@@ -7,7 +7,6 @@ import es from 'javascript-time-ago/locale/es'
 import pt from 'javascript-time-ago/locale/pt'
 import ru from 'javascript-time-ago/locale/ru'
 import zh from 'javascript-time-ago/locale/zh'
-import Cookies from "js-cookie";
 import { useTranslation } from "react-i18next";
 import { triblerService } from "@/services/tribler.service";
 import { FileLink, FileTreeItem } from "@/models/file.model";
@@ -139,13 +138,6 @@ export function getRowSelection(input: any[], selected_func: (item: any) => bool
         selection[index.toString()] = selected_func(item);
     }
     return selection;
-}
-
-export function translateHeader(name: string) {
-    return () => {
-        const { t } = useTranslation();
-        return t(name);
-    }
 }
 
 export function filterDuplicates(data: any[], key: string) {

--- a/src/tribler/ui/src/pages/Debug/Asyncio/Tasks.tsx
+++ b/src/tribler/ui/src/pages/Debug/Asyncio/Tasks.tsx
@@ -1,4 +1,4 @@
-import SimpleTable from "@/components/ui/simple-table";
+import SimpleTable, { getHeader } from "@/components/ui/simple-table";
 import { ColumnDef } from "@tanstack/react-table";
 import { useState } from "react";
 import { ipv8Service } from "@/services/ipv8.service";
@@ -11,26 +11,26 @@ import { formatTimeDiff } from "@/lib/utils";
 const taskColumns: ColumnDef<Task>[] = [
     {
         accessorKey: "taskmanager",
-        header: "Taskmanager",
+        header: getHeader("Taskmanager", false),
     },
     {
         accessorKey: "name",
-        header: "Name",
+        header: getHeader("Name", false),
         cell: ({ row }) => {
             return <span className="line-clamp-1">{row.original.name}</span>
         },
     },
     {
         accessorKey: "running",
-        header: "Running?",
+        header: getHeader("Running?", false),
     },
     {
         accessorKey: "interval",
-        header: "Interval",
+        header: getHeader("Interval", false),
     },
     {
         accessorKey: "start_time",
-        header: "Started",
+        header: getHeader("Started", false),
         cell: ({ row }) => {
             return row.original.start_time && <span>{formatTimeDiff(row.original.start_time)}</span>
         },

--- a/src/tribler/ui/src/pages/Debug/DHT/Buckets.tsx
+++ b/src/tribler/ui/src/pages/Debug/DHT/Buckets.tsx
@@ -1,4 +1,4 @@
-import SimpleTable from "@/components/ui/simple-table";
+import SimpleTable, { getHeader } from "@/components/ui/simple-table";
 import { useState } from "react";
 import { ipv8Service } from "@/services/ipv8.service";
 import { isErrorDict } from "@/services/reporting";
@@ -11,18 +11,18 @@ import { useInterval } from '@/hooks/useInterval';
 const bucketColumns: ColumnDef<Bucket>[] = [
     {
         accessorKey: "prefix",
-        header: "Prefix",
+        header: getHeader("Prefix", false),
     },
     {
         accessorKey: "last_changed",
-        header: "Last changed",
+        header: getHeader("Last changed", false),
         cell: ({ row }) => {
             return <span>{formatTimeDiff(row.original.last_changed)}</span>
         },
     },
     {
         accessorKey: "peer",
-        header: "# Peers",
+        header: getHeader("# Peers", false),
         cell: ({ row }) => {
             return <span>{row.original.peers.length}</span>
         },

--- a/src/tribler/ui/src/pages/Debug/DHT/Statistics.tsx
+++ b/src/tribler/ui/src/pages/Debug/DHT/Statistics.tsx
@@ -1,4 +1,4 @@
-import SimpleTable from "@/components/ui/simple-table";
+import SimpleTable, { getHeader } from "@/components/ui/simple-table";
 import { useState } from "react";
 import { ipv8Service } from "@/services/ipv8.service";
 import { isErrorDict } from "@/services/reporting";
@@ -10,11 +10,11 @@ import { useInterval } from '@/hooks/useInterval';
 const statisticColumns: ColumnDef<KeyValue>[] = [
     {
         accessorKey: "key",
-        header: "Key",
+        header: getHeader("Key", false),
     },
     {
         accessorKey: "value",
-        header: "Value",
+        header: getHeader("Value", false),
         cell: ({ row }) => {
             return <span className="whitespace-pre">{row.original.value}</span>
         },

--- a/src/tribler/ui/src/pages/Debug/General/index.tsx
+++ b/src/tribler/ui/src/pages/Debug/General/index.tsx
@@ -1,4 +1,4 @@
-import SimpleTable from "@/components/ui/simple-table";
+import SimpleTable, { getHeader } from "@/components/ui/simple-table";
 import { formatBytes } from "@/lib/utils";
 import { KeyValue } from "@/models/keyvalue.model";
 import { triblerService } from "@/services/tribler.service";
@@ -11,11 +11,11 @@ import { useInterval } from '@/hooks/useInterval';
 const generalColumns: ColumnDef<KeyValue>[] = [
     {
         accessorKey: "key",
-        header: "Key",
+        header: getHeader("Key", false),
     },
     {
         accessorKey: "value",
-        header: "Value",
+        header: getHeader("Value", false),
     },
 ]
 

--- a/src/tribler/ui/src/pages/Debug/IPv8/Details.tsx
+++ b/src/tribler/ui/src/pages/Debug/IPv8/Details.tsx
@@ -1,4 +1,4 @@
-import SimpleTable from "@/components/ui/simple-table";
+import SimpleTable, { getHeader } from "@/components/ui/simple-table";
 import { useState } from "react";
 import { ipv8Service } from "@/services/ipv8.service";
 import { isErrorDict } from "@/services/reporting";
@@ -10,11 +10,11 @@ import { useInterval } from '@/hooks/useInterval';
 const statisticColumns: ColumnDef<OverlayMsgStats>[] = [
     {
         accessorKey: "name",
-        header: "Name",
+        header: getHeader("Name", false),
     },
     {
         accessorKey: "bytes_up",
-        header: "Upload (MB)",
+        header: getHeader("Upload (MB)", false),
         cell: ({ row }) => {
             if (row.original.identifier < 0) { return }
             return <span>{(row.original.bytes_up / 1024 ** 2).toFixed(3)}</span>
@@ -22,7 +22,7 @@ const statisticColumns: ColumnDef<OverlayMsgStats>[] = [
     },
     {
         accessorKey: "bytes_down",
-        header: "Download (MB)",
+        header: getHeader("Download (MB)", false),
         cell: ({ row }) => {
             if (row.original.identifier < 0) { return }
             return <span>{(row.original.bytes_down / 1024 ** 2).toFixed(3)}</span>
@@ -30,7 +30,7 @@ const statisticColumns: ColumnDef<OverlayMsgStats>[] = [
     },
     {
         accessorKey: "num_up",
-        header: "# Msgs sent",
+        header: getHeader("# Msgs sent", false),
         cell: ({ row }) => {
             if (row.original.identifier < 0) { return }
             return <span>{row.original.num_up}</span>
@@ -38,7 +38,7 @@ const statisticColumns: ColumnDef<OverlayMsgStats>[] = [
     },
     {
         accessorKey: "num_down",
-        header: "# Msgs received",
+        header: getHeader("# Msgs received", false),
         cell: ({ row }) => {
             if (row.original.identifier < 0) { return }
             return <span>{row.original.num_down}</span>

--- a/src/tribler/ui/src/pages/Debug/IPv8/Overlays.tsx
+++ b/src/tribler/ui/src/pages/Debug/IPv8/Overlays.tsx
@@ -1,4 +1,4 @@
-import SimpleTable from "@/components/ui/simple-table";
+import SimpleTable, { getHeader } from "@/components/ui/simple-table";
 import { ColumnDef } from "@tanstack/react-table";
 import { useState } from "react";
 import { ipv8Service } from "@/services/ipv8.service";
@@ -12,25 +12,25 @@ import { useResizeObserver } from "@/hooks/useResizeObserver";
 const overlayColumns: ColumnDef<Overlay>[] = [
     {
         accessorKey: "overlay_name",
-        header: "Name",
+        header: getHeader("Name", false),
     },
     {
         accessorKey: "id",
-        header: "Community ID",
+        header: getHeader("Community ID", false),
         cell: ({ row }) => {
             return <span>{row.original.id.slice(0, 10)}</span>
         },
     },
     {
         accessorKey: "my_peer",
-        header: "My peer",
+        header: getHeader("My peer", false),
         cell: ({ row }) => {
             return <span>{row.original.my_peer.slice(0, 10)}</span>
         },
     },
     {
         accessorKey: "peers",
-        header: "Peers",
+        header: getHeader("Peers", false),
         cell: ({ row }) => {
             return (
                 <span className={`font-medium ${(row.original.peers.length < 20) ? `text-green-400` :
@@ -42,7 +42,7 @@ const overlayColumns: ColumnDef<Overlay>[] = [
     },
     {
         accessorKey: "statistics.bytes_up",
-        header: "Upload (MB)",
+        header: getHeader("Upload (MB)", false),
         cell: ({ row }) => {
             if (Object.keys(row.original.statistics).length === 0) { return 'N/A' }
             return <span>{(row.original.statistics.bytes_up / 1024 ** 2).toFixed(3)}</span>
@@ -50,7 +50,7 @@ const overlayColumns: ColumnDef<Overlay>[] = [
     },
     {
         accessorKey: "statistics.bytes_down",
-        header: "Download (MB)",
+        header: getHeader("Download (MB)", false),
         cell: ({ row }) => {
             if (Object.keys(row.original.statistics).length === 0) { return 'N/A' }
             return <span>{(row.original.statistics.bytes_down / 1024 ** 2).toFixed(3)}</span>
@@ -58,7 +58,7 @@ const overlayColumns: ColumnDef<Overlay>[] = [
     },
     {
         accessorKey: "statistics.num_up",
-        header: "# Msg sent",
+        header: getHeader("# Msg sent", false),
         cell: ({ row }) => {
             if (Object.keys(row.original.statistics).length === 0) { return 'N/A' }
             return <span>{row.original.statistics.num_up}</span>
@@ -66,7 +66,7 @@ const overlayColumns: ColumnDef<Overlay>[] = [
     },
     {
         accessorKey: "statistics.num_down",
-        header: "# Msg received",
+        header: getHeader("# Msg received", false),
         cell: ({ row }) => {
             if (Object.keys(row.original.statistics).length === 0) { return 'N/A' }
             return <span>{row.original.statistics.num_down}</span>
@@ -74,7 +74,7 @@ const overlayColumns: ColumnDef<Overlay>[] = [
     },
     {
         accessorKey: "statistics.diff_time",
-        header: "Diff (sec)",
+        header: getHeader("Diff (sec)", false),
         cell: ({ row }) => {
             if (Object.keys(row.original.statistics).length === 0) { return 'N/A' }
             return <span>{row.original.statistics.diff_time.toFixed(3)}</span>
@@ -85,15 +85,15 @@ const overlayColumns: ColumnDef<Overlay>[] = [
 const peerColumns: ColumnDef<Peer>[] = [
     {
         accessorKey: "ip",
-        header: "IP",
+        header: getHeader("IP", false),
     },
     {
         accessorKey: "port",
-        header: "Port",
+        header: getHeader("Port", false),
     },
     {
         accessorKey: "public_key",
-        header: "Public key",
+        header: getHeader("Public key", false),
         cell: ({ row }) => {
             return <p className="max-w-[700px] text-ellipsis overflow-hidden">{row.original.public_key}</p>
         },

--- a/src/tribler/ui/src/pages/Debug/Libtorrent/index.tsx
+++ b/src/tribler/ui/src/pages/Debug/Libtorrent/index.tsx
@@ -1,4 +1,4 @@
-import SimpleTable from "@/components/ui/simple-table";
+import SimpleTable, { getHeader } from "@/components/ui/simple-table";
 import { Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { KeyValue } from "@/models/keyvalue.model";
@@ -12,11 +12,11 @@ import { useInterval } from '@/hooks/useInterval';
 export const libtorrentColumns: ColumnDef<KeyValue>[] = [
     {
         accessorKey: "key",
-        header: "Key",
+        header: getHeader("Key", false),
     },
     {
         accessorKey: "value",
-        header: "Value",
+        header: getHeader("Value", false),
     },
 ]
 

--- a/src/tribler/ui/src/pages/Debug/Tunnels/Circuits.tsx
+++ b/src/tribler/ui/src/pages/Debug/Tunnels/Circuits.tsx
@@ -1,4 +1,4 @@
-import SimpleTable from "@/components/ui/simple-table";
+import SimpleTable, { getHeader } from "@/components/ui/simple-table";
 import { useState } from "react";
 import { ipv8Service } from "@/services/ipv8.service";
 import { isErrorDict } from "@/services/reporting";
@@ -11,47 +11,47 @@ import { useInterval } from '@/hooks/useInterval';
 const circuitColumns: ColumnDef<Circuit>[] = [
     {
         accessorKey: "circuit_id",
-        header: "Circuit ID",
+        header: getHeader("Circuit ID", false),
     },
     {
         accessorKey: "actual_hops",
-        header: "Hops",
+        header: getHeader("Hops", false),
         cell: ({ row }) => {
             return <span>{row.original.actual_hops} / {row.original.goal_hops}</span>
         },
     },
     {
         accessorKey: "type",
-        header: "Type",
+        header: getHeader("Type", false),
     },
     {
         accessorKey: "state",
-        header: "State",
+        header: getHeader("State", false),
     },
     {
         accessorKey: "bytes_up",
-        header: "Up",
+        header: getHeader("Up", false),
         cell: ({ row }) => {
             return <span>{formatBytes(row.original.bytes_up)}</span>
         },
     },
     {
         accessorKey: "bytes_down",
-        header: "Down",
+        header: getHeader("Down", false),
         cell: ({ row }) => {
             return <span>{formatBytes(row.original.bytes_down)}</span>
         },
     },
     {
         accessorKey: "uptime",
-        header: "Uptime",
+        header: getHeader("Uptime", false),
         cell: ({ row }) => {
             return <span>{formatTimeDiff(row.original.creation_time)}</span>
         },
     },
     {
         accessorKey: "exit_flags",
-        header: "Exit flags",
+        header: getHeader("Exit flags", false),
         cell: ({ row }) => {
             return <span>{formatFlags(row.original.exit_flags)}</span>
         },

--- a/src/tribler/ui/src/pages/Debug/Tunnels/Exits.tsx
+++ b/src/tribler/ui/src/pages/Debug/Tunnels/Exits.tsx
@@ -1,4 +1,4 @@
-import SimpleTable from "@/components/ui/simple-table";
+import SimpleTable, { getHeader } from "@/components/ui/simple-table";
 import { useState } from "react";
 import { ipv8Service } from "@/services/ipv8.service";
 import { isErrorDict } from "@/services/reporting";
@@ -11,29 +11,29 @@ import { useInterval } from '@/hooks/useInterval';
 const exitColumns: ColumnDef<Exit>[] = [
     {
         accessorKey: "circuit_from",
-        header: "From circuit",
+        header: getHeader("From circuit", false),
     },
     {
         accessorKey: "enabled",
-        header: "Enabled?",
+        header: getHeader("Enabled?", false),
     },
     {
         accessorKey: "bytes_up",
-        header: "Up",
+        header: getHeader("Up", false),
         cell: ({ row }) => {
             return <span>{formatBytes(row.original.bytes_up)}</span>
         },
     },
     {
         accessorKey: "bytes_down",
-        header: "Down",
+        header: getHeader("Down", false),
         cell: ({ row }) => {
             return <span>{formatBytes(row.original.bytes_down)}</span>
         },
     },
     {
         accessorKey: "uptime",
-        header: "Uptime",
+        header: getHeader("Uptime", false),
         cell: ({ row }) => {
             return <span>{formatTimeDiff(row.original.creation_time)}</span>
         },

--- a/src/tribler/ui/src/pages/Debug/Tunnels/Peers.tsx
+++ b/src/tribler/ui/src/pages/Debug/Tunnels/Peers.tsx
@@ -1,4 +1,4 @@
-import SimpleTable from "@/components/ui/simple-table";
+import SimpleTable, { getHeader } from "@/components/ui/simple-table";
 import { useState } from "react";
 import { ipv8Service } from "@/services/ipv8.service";
 import { isErrorDict } from "@/services/reporting";
@@ -11,23 +11,23 @@ import { useInterval } from '@/hooks/useInterval';
 const peerColumns: ColumnDef<Peer>[] = [
     {
         accessorKey: "ip",
-        header: "IP",
+        header: getHeader("IP", false),
     },
     {
         accessorKey: "port",
-        header: "Port",
+        header: getHeader("Port", false),
     },
     {
         accessorKey: "mid",
-        header: "Mid",
+        header: getHeader("Mid", false),
     },
     {
         accessorKey: "is_key_compatible",
-        header: "Key compatible?",
+        header: getHeader("Key compatible?", false),
     },
     {
         accessorKey: "flags",
-        header: "Flags",
+        header: getHeader("Flags", false),
         cell: ({ row }) => {
             return <span>{formatFlags(row.original.flags)}</span>
         },

--- a/src/tribler/ui/src/pages/Debug/Tunnels/Relays.tsx
+++ b/src/tribler/ui/src/pages/Debug/Tunnels/Relays.tsx
@@ -1,4 +1,4 @@
-import SimpleTable from "@/components/ui/simple-table";
+import SimpleTable, { getHeader } from "@/components/ui/simple-table";
 import { ColumnDef } from "@tanstack/react-table";
 import { useState } from "react";
 import { ipv8Service } from "@/services/ipv8.service";
@@ -11,33 +11,33 @@ import { useInterval } from '@/hooks/useInterval';
 const relayColumns: ColumnDef<Relay>[] = [
     {
         accessorKey: "circuit_from",
-        header: "From circuit",
+        header: getHeader("From circuit", false),
     },
     {
         accessorKey: "circuit_to",
-        header: "To circuit",
+        header: getHeader("To circuit", false),
     },
     {
         accessorKey: "is_rendezvous",
-        header: "Rendezvous?",
+        header: getHeader("Rendezvous?", false),
     },
     {
         accessorKey: "bytes_up",
-        header: "Up",
+        header: getHeader("Up", false),
         cell: ({ row }) => {
             return <span>{formatBytes(row.original.bytes_up)}</span>
         },
     },
     {
         accessorKey: "bytes_down",
-        header: "Down",
+        header: getHeader("Down", false),
         cell: ({ row }) => {
             return <span>{formatBytes(row.original.bytes_down)}</span>
         },
     },
     {
         accessorKey: "uptime",
-        header: "Uptime",
+        header: getHeader("Uptime", false),
         cell: ({ row }) => {
             return <span>{formatTimeDiff(row.original.creation_time)}</span>
         },

--- a/src/tribler/ui/src/pages/Debug/Tunnels/Swarms.tsx
+++ b/src/tribler/ui/src/pages/Debug/Tunnels/Swarms.tsx
@@ -1,4 +1,4 @@
-import SimpleTable from "@/components/ui/simple-table";
+import SimpleTable, { getHeader } from "@/components/ui/simple-table";
 import { useState } from "react";
 import { ipv8Service } from "@/services/ipv8.service";
 import { isErrorDict } from "@/services/reporting";
@@ -11,41 +11,41 @@ import { useInterval } from '@/hooks/useInterval';
 const swarmColumns: ColumnDef<Swarm>[] = [
     {
         accessorKey: "info_hash",
-        header: "Infohash",
+        header: getHeader("Infohash", false),
     },
     {
         accessorKey: "num_seeders",
-        header: "# Seeders",
+        header: getHeader("# Seeders", false),
     },
     {
         accessorKey: "num_connections",
-        header: "# Connections",
+        header: getHeader("# Connections", false),
     },
     {
         accessorKey: "num_connections_incomplete",
-        header: "# Pending",
+        header: getHeader("# Pending", false),
     },
     {
         accessorKey: "seeding",
-        header: "Seeding?",
+        header: getHeader("Seeding?", false),
     },
     {
         accessorKey: "last_lookup",
-        header: "Last lookup",
+        header: getHeader("Last lookup", false),
         cell: ({ row }) => {
             return <span>{formatTimeDiff(row.original.last_lookup)}</span>
         },
     },
     {
         accessorKey: "bytes_up",
-        header: "Up",
+        header: getHeader("Up", false),
         cell: ({ row }) => {
             return <span>{formatBytes(row.original.bytes_down)}</span>
         },
     },
     {
         accessorKey: "bytes_down",
-        header: "Down",
+        header: getHeader("Down", false),
         cell: ({ row }) => {
             return <span>{formatBytes(row.original.bytes_down)}</span>
         },

--- a/src/tribler/ui/src/pages/Downloads/Files.tsx
+++ b/src/tribler/ui/src/pages/Downloads/Files.tsx
@@ -5,7 +5,7 @@ import { Download } from "@/models/download.model";
 import { Dispatch, MutableRefObject, SetStateAction, useEffect, useMemo, useRef, useState } from "react";
 import { isErrorDict } from "@/services/reporting";
 import { triblerService } from "@/services/tribler.service";
-import SimpleTable from "@/components/ui/simple-table";
+import SimpleTable, { getHeader } from "@/components/ui/simple-table";
 import { ChevronDown, ChevronRight } from "lucide-react";
 import { Checkbox } from "@/components/ui/checkbox";
 import { filesToTree, formatBytes, getSelectedFilesFromTree } from "@/lib/utils";
@@ -13,7 +13,7 @@ import { useTranslation } from "react-i18next";
 
 const getFileColumns = ({ onSelectedFiles }: { onSelectedFiles: (row: Row<FileTreeItem>) => void }): ColumnDef<FileTreeItem>[] => [
     {
-        header: "Path",
+        header: getHeader("Path"),
         accessorKey: "path",
         cell: ({ row }) => {
             return (
@@ -36,7 +36,7 @@ const getFileColumns = ({ onSelectedFiles }: { onSelectedFiles: (row: Row<FileTr
         }
     },
     {
-        header: "Size",
+        header: getHeader("Size"),
         accessorKey: "size",
         cell: ({ row }) => {
             return (
@@ -48,7 +48,7 @@ const getFileColumns = ({ onSelectedFiles }: { onSelectedFiles: (row: Row<FileTr
         },
     },
     {
-        header: "Progress",
+        header: getHeader("Progress"),
         accessorKey: "progress",
         cell: ({ row }) => {
             return <span>{((row.original.progress || 0) * 100).toFixed(1)}%</span>

--- a/src/tribler/ui/src/pages/Downloads/Peers.tsx
+++ b/src/tribler/ui/src/pages/Downloads/Peers.tsx
@@ -1,8 +1,8 @@
 import { ColumnDef } from "@tanstack/react-table";
-import { formatBytes, translateHeader } from "@/lib/utils";
+import { formatBytes } from "@/lib/utils";
 import { Download } from "@/models/download.model";
 import { Peer } from "@/models/bittorrentpeer.model";
-import SimpleTable from "@/components/ui/simple-table";
+import SimpleTable, { getHeader } from "@/components/ui/simple-table";
 
 
 const peerFlags = (peer: Peer) => {
@@ -37,42 +37,42 @@ const peerFlags = (peer: Peer) => {
 const peerColumns: ColumnDef<Peer>[] = [
     {
         accessorKey: "ip",
-        header: translateHeader('PeerIpPort'),
+        header: getHeader('PeerIpPort'),
         cell: ({ row }) => {
             return <span>{row.original.ip} ({row.original.port})</span>
         },
     },
     {
         accessorKey: "completed",
-        header: translateHeader('Completed'),
+        header: getHeader('Completed'),
         cell: ({ row }) => {
             return <span>{(row.original.completed * 100).toFixed(0)}%</span>
         },
     },
     {
         accessorKey: "downrate",
-        header: translateHeader('SpeedDown'),
+        header: getHeader('SpeedDown'),
         cell: ({ row }) => {
             return <span>{formatBytes(row.original.downrate)}/s</span>
         },
     },
     {
         accessorKey: "uprate",
-        header: translateHeader('SpeedUp'),
+        header: getHeader('SpeedUp'),
         cell: ({ row }) => {
             return <span>{formatBytes(row.original.uprate)}/s</span>
         },
     },
     {
         accessorKey: "flags",
-        header: translateHeader('Flags'),
+        header: getHeader('Flags'),
         cell: ({ row }) => {
             return <span>{peerFlags(row.original)}</span>
         },
     },
     {
         accessorKey: "extended_version",
-        header: translateHeader('Client'),
+        header: getHeader('Client'),
     },
 ]
 

--- a/src/tribler/ui/src/pages/Downloads/Trackers.tsx
+++ b/src/tribler/ui/src/pages/Downloads/Trackers.tsx
@@ -1,8 +1,7 @@
 import { useState } from "react";
 import toast from 'react-hot-toast';
-import SimpleTable from "@/components/ui/simple-table";
+import SimpleTable, { getHeader } from "@/components/ui/simple-table";
 import { Dialog, DialogClose, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
-import { translateHeader } from "@/lib/utils";
 import { Download } from "@/models/download.model";
 import { Tracker } from "@/models/tracker.model ";
 import { ColumnDef } from "@tanstack/react-table";
@@ -27,15 +26,15 @@ export default function Trackers({ download }: { download: Download }) {
     const trackerColumns: ColumnDef<TrackerRow>[] = [
         {
             accessorKey: "url",
-            header: translateHeader('Name'),
+            header: getHeader('Name'),
         },
         {
             accessorKey: "status",
-            header: translateHeader('Status'),
+            header: getHeader('Status'),
         },
         {
             accessorKey: "peers",
-            header: translateHeader('Peers'),
+            header: getHeader('Peers'),
         },
         {
             header: "",

--- a/src/tribler/ui/src/pages/Downloads/index.tsx
+++ b/src/tribler/ui/src/pages/Downloads/index.tsx
@@ -1,15 +1,12 @@
 import Actions from "./Actions";
 import DownloadDetails from "./Details";
-import SimpleTable from "@/components/ui/simple-table"
+import SimpleTable, { getHeader } from "@/components/ui/simple-table"
 import { Download } from "@/models/download.model";
-import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress"
-import { capitalize, formatBytes, translateHeader } from "@/lib/utils";
+import { capitalize, formatBytes } from "@/lib/utils";
 import { isErrorDict } from "@/services/reporting";
 import { triblerService } from "@/services/tribler.service";
-import { CaretSortIcon } from "@radix-ui/react-icons";
 import { ColumnDef } from "@tanstack/react-table"
-import { ArrowDownIcon, ArrowUpIcon } from "lucide-react";
 import { Card, CardHeader } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import {
@@ -35,39 +32,21 @@ const downloadColumns: ColumnDef<Download>[] = [
     {
         accessorKey: "name",
         minSize: 0,
-        header: ({ column }) => {
-            const { t } = useTranslation();
-            return (
-                <Button
-                    className="pl-0"
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}>
-                    {t('Name')}
-                    {column.getIsSorted() === "desc" ? (
-                        <ArrowDownIcon className="ml-2 h-4 w-4" />
-                    ) : column.getIsSorted() === "asc" ? (
-                        <ArrowUpIcon className="ml-2 h-4 w-4" />
-                    ) : (
-                        <CaretSortIcon className="ml-2 h-4 w-4" />
-                    )}
-                </Button>
-            )
-        },
+        header: getHeader('Name'),
         cell: ({ row }) => {
             return <span className="break-all line-clamp-1">{row.original.name}</span>
         },
     },
     {
         accessorKey: "size",
-        header: translateHeader('Size'),
+        header: getHeader('Size'),
         cell: ({ row }) => {
             return <span>{formatBytes(row.original.size)}</span>
         },
     },
     {
         accessorKey: "status",
-        header: translateHeader('Status'),
+        header: getHeader('Status'),
         cell: ({ row }) => {
             return (
                 <div className="grid">
@@ -83,35 +62,35 @@ const downloadColumns: ColumnDef<Download>[] = [
     },
     {
         accessorKey: "num_seeds",
-        header: translateHeader('Seeds'),
+        header: getHeader('Seeds'),
         cell: ({ row }) => {
             return <span>{row.original.num_connected_seeds} ({row.original.num_seeds})</span>
         },
     },
     {
         accessorKey: "num_peers",
-        header: translateHeader('Peers'),
+        header: getHeader('Peers'),
         cell: ({ row }) => {
             return <span>{row.original.num_connected_peers} ({row.original.num_peers})</span>
         },
     },
     {
         accessorKey: "speed_down",
-        header: translateHeader('SpeedDown'),
+        header: getHeader('SpeedDown'),
         cell: ({ row }) => {
             return <span>{formatBytes(row.original.speed_down)}/s</span>
         },
     },
     {
         accessorKey: "speed_up",
-        header: translateHeader('SpeedUp'),
+        header: getHeader('SpeedUp'),
         cell: ({ row }) => {
             return <span>{formatBytes(row.original.speed_up)}/s</span>
         },
     },
     {
         accessorKey: "hops",
-        header: translateHeader('Hops'),
+        header: getHeader('Hops'),
     },
 ]
 

--- a/src/tribler/ui/src/pages/Downloads/index.tsx
+++ b/src/tribler/ui/src/pages/Downloads/index.tsx
@@ -194,6 +194,7 @@ export default function Downloads({ statusFilter }: { statusFilter: number[] }) 
                             allowMultiSelect={true}
                             onSelectedRowsChange={setSelectedDownloads}
                             maxHeight={Math.max((parentRect?.height ?? 50)-50, 50)}
+                            storeSortingState="download-sorting"
                         />
                     </Card>
                 </div>

--- a/src/tribler/ui/src/pages/Popular/index.tsx
+++ b/src/tribler/ui/src/pages/Popular/index.tsx
@@ -1,11 +1,11 @@
-import SimpleTable from "@/components/ui/simple-table";
+import SimpleTable, { getHeader } from "@/components/ui/simple-table";
 import SaveAs from "@/dialogs/SaveAs";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { triblerService } from "@/services/tribler.service";
 import { isErrorDict } from "@/services/reporting";
 import { Torrent } from "@/models/torrent.model";
 import { ColumnDef } from "@tanstack/react-table";
-import { categoryIcon, filterDuplicates, formatBytes, formatTimeAgo, getMagnetLink, translateHeader } from "@/lib/utils";
+import { categoryIcon, filterDuplicates, formatBytes, formatTimeAgo, getMagnetLink } from "@/lib/utils";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useInterval } from '@/hooks/useInterval';
 
@@ -29,7 +29,7 @@ const getColumns = ({ onDownload }: { onDownload: (torrent: Torrent) => void }):
     },
     {
         accessorKey: "name",
-        header: translateHeader('Name'),
+        header: getHeader('Name'),
         cell: ({ row }) => {
             return <span
                 className="cursor-pointer hover:underline break-all line-clamp-1"
@@ -40,14 +40,14 @@ const getColumns = ({ onDownload }: { onDownload: (torrent: Torrent) => void }):
     },
     {
         accessorKey: "size",
-        header: translateHeader('Size'),
+        header: getHeader('Size'),
         cell: ({ row }) => {
             return <span className="whitespace-nowrap">{formatBytes(row.original.size)}</span>
         },
     },
     {
         accessorKey: "created",
-        header: translateHeader('Created'),
+        header: getHeader('Created'),
         cell: ({ row }) => {
             return <span className="whitespace-nowrap">{formatTimeAgo(row.original.created)}</span>
         },

--- a/src/tribler/ui/src/pages/Popular/index.tsx
+++ b/src/tribler/ui/src/pages/Popular/index.tsx
@@ -111,6 +111,7 @@ export default function Popular() {
             <SimpleTable
                 data={torrents}
                 columns={torrentColumns}
+                storeSortingState="popular-sorting"
             />
         </>
     )

--- a/src/tribler/ui/src/pages/Search/index.tsx
+++ b/src/tribler/ui/src/pages/Search/index.tsx
@@ -150,6 +150,7 @@ export default function Search() {
             <SimpleTable
                 data={torrents}
                 columns={torrentColumns}
+                storeSortingState="search-sorting"
             />
         </>
     )

--- a/src/tribler/ui/src/pages/Search/index.tsx
+++ b/src/tribler/ui/src/pages/Search/index.tsx
@@ -1,4 +1,4 @@
-import SimpleTable from "@/components/ui/simple-table";
+import SimpleTable, { getHeader } from "@/components/ui/simple-table";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { triblerService } from "@/services/tribler.service";
 import { isErrorDict } from "@/services/reporting";
@@ -30,7 +30,7 @@ const getColumns = ({ onDownload }: { onDownload: (torrent: Torrent) => void }):
     },
     {
         accessorKey: "name",
-        header: "Name",
+        header: getHeader("Name"),
         cell: ({ row }) => {
             return <span
                 className="cursor-pointer hover:underline break-all line-clamp-1"
@@ -41,21 +41,21 @@ const getColumns = ({ onDownload }: { onDownload: (torrent: Torrent) => void }):
     },
     {
         accessorKey: "size",
-        header: "Size",
+        header: getHeader("Size"),
         cell: ({ row }) => {
             return <span className="whitespace-nowrap">{formatBytes(row.original.size)}</span>
         },
     },
     {
         accessorKey: "num_seeders",
-        header: "Health",
+        header: getHeader("Health"),
         cell: ({ row }) => {
             return <SwarmHealth torrent={row.original} />
         },
     },
     {
         accessorKey: "created",
-        header: "Created",
+        header: getHeader("Created"),
         cell: ({ row }) => {
             return <span className="whitespace-nowrap">{formatTimeAgo(row.original.created)}</span>
         },


### PR DESCRIPTION
This PR adds sorting to all tables in the UI. I've included the tables in the debug panel, but disabled translating the header name.

Also fixes https://github.com/Tribler/tribler/issues/1261. Note that I'm only storing the sorting state for `Download` / `Popular` / `Search` tables. The sorting state is stored in local storage.