### PR TITLE
Added gir1.2-ayatanaappindicator3-0.1 Debian fallback

### DIFF
--- a/build/debian/tribler/debian/control
+++ b/build/debian/tribler/debian/control
@@ -12,7 +12,7 @@ Package: tribler
 Architecture: all
 Depends: libsodium23,
          gir1.2-gtk-4.0 | gir1.2-gtk-3.0,
-         gir1.2-appindicator3-0.1
+         gir1.2-appindicator3-0.1 | gir1.2-ayatanaappindicator3-0.1
 Description: Python based Bittorrent/Internet TV application
  Through our own dedicated Tor-like network for torrent downloading you can
  search and download torrents with less worries or censorship. We are trying


### PR DESCRIPTION
Fixes #8277

This PR:

 - Adds a fallback to `gir1.2-ayatanaappindicator3-0.1` if `gir1.2-appindicator3-0.1` is not available.
