### PR TITLE
Fixed various upgrade issues

### DIFF
--- a/src/tribler/core/knowledge/community.py
+++ b/src/tribler/core/knowledge/community.py
@@ -85,7 +85,7 @@ class KnowledgeCommunity(Community):
                                   operation=operation)
             self.validate_operation(operation)
 
-            with db_session():
+            with db_session(serializable=True):
                 is_added = self.db.knowledge.add_operation(operation, signature.signature)
                 if is_added:
                     s = f"+ operation added ({operation.object!r} \"{operation.predicate}\" {operation.subject!r})"

--- a/src/tribler/core/versioning/manager.py
+++ b/src/tribler/core/versioning/manager.py
@@ -47,7 +47,7 @@ class VersioningManager:
         Get all versions in our state directory.
         """
         return [p for p in os.listdir(self.config.get("state_dir"))
-                if os.path.isdir(os.path.join(self.config.get("state_dir"), p))]
+                if os.path.isdir(os.path.join(self.config.get("state_dir"), p)) and p != "dlcheckpoints"]
 
     async def check_version(self) -> str | None:
         """
@@ -103,6 +103,9 @@ class VersioningManager:
         """
         Upgrade old database/download files to our current version.
         """
+        if self.task_manager.get_task("Upgrade") is not None:
+            logger.warning("Ignoring upgrade request: already upgrading.")
+            return
         src_dir = Path(self.config.get("state_dir")) / FROM
         dst_dir = Path(self.config.get_version_state_dir())
         self.task_manager.register_executor_task("Upgrade", upgrade, self.config,

--- a/src/tribler/ui/src/pages/Settings/Versions.tsx
+++ b/src/tribler/ui/src/pages/Settings/Versions.tsx
@@ -66,6 +66,12 @@ export default function Versions() {
                 }
             }
             case 2: {
+                const isUpgrading = await triblerService.isUpgrading();
+                if (!(isUpgrading === undefined) && !isErrorDict(isUpgrading)) {
+                    setIsUpgrading(isUpgrading);
+                } else {
+                    break;  // Don't bother the user on error, just initialize later.
+                }
                 const canUpgrade = await triblerService.canUpgrade();
                 if (!(canUpgrade === undefined) && !isErrorDict(canUpgrade)) {
                     setCanUpgrade(canUpgrade);


### PR DESCRIPTION
Fixes #8283
Fixes #8289

This PR:

 - Fixes `KnowledgeCommunity.on_message` not using `serializable=True`, causing `Database is locked` errors.
 - Fixes `upgrade_script` not being guarded by `db_session` because the `Database` is outside of Pony's control, causing `Database is locked` errors.
 - Fixes `dlcheckpoints` appearing as a Tribler version.
 - Fixes calling `perform_upgrade()` twice causing an unhandled exception.
 - Updates the versioning page to not wait several seconds before showing an update is in progress.
 - Updates the version upgrade to operate in batches, not all database content at once.


