### PR TITLE
Fixed api/https_certfile setting being ignored

### DIFF
--- a/src/tribler/core/restapi/rest_manager.py
+++ b/src/tribler/core/restapi/rest_manager.py
@@ -279,7 +279,7 @@ class RESTManager:
         Start serving HTTPS requests.
         """
         ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
-        ssl_context.load_cert_chain(Path(self.config.get("state_dir")) / "https_certfile")
+        ssl_context.load_cert_chain(Path(self.config.get("api/https_certfile")))
 
         port = self.config.get("api/https_port")
         self.site_https = web.TCPSite(runner, self.https_host, port, ssl_context=ssl_context)


### PR DESCRIPTION
Fixes #8293

This PR:

 - Fixes `api/https_certfile` not being used.

