### PR TITLE
Rein in KnowledgeCommunity peer count

### DIFF
--- a/src/tribler/core/components.py
+++ b/src/tribler/core/components.py
@@ -183,7 +183,7 @@ class DatabaseComponent(ComponentLauncher):
 @precondition('session.config.get("knowledge_community/enabled")')
 @overlay("tribler.core.knowledge.community", "KnowledgeCommunity")
 @kwargs(db="session.db", key='session.ipv8.keys["secondary"].key')
-class KnowledgeComponent(CommunityLauncherWEndpoints):
+class KnowledgeComponent(BaseLauncher):
     """
     Launch instructions for the knowledge community.
     """


### PR DESCRIPTION
Fixes #8292

This PR:

 - Updates the `KnowledgeCommunity` to more aggressively ward off superfluous peers.
 
 From my local tests, this is enough to keep the peer count under control. In the worst case, we can also blacklist/ban peers: but this does not seem necessary (yet).