### PR TITLE
Various UI enhancements/fixes

### DIFF
--- a/src/tribler/ui/package-lock.json
+++ b/src/tribler/ui/package-lock.json
@@ -41,6 +41,7 @@
         "react-router-dom": "^6.16.0",
         "tailwind-merge": "^1.14.0",
         "tailwindcss-animate": "^1.0.7",
+        "use-keyboard-shortcut": "^1.1.6",
         "zod": "^3.22.4"
       },
       "devDependencies": {
@@ -4083,6 +4084,15 @@
         }
       }
     },
+    "node_modules/use-keyboard-shortcut": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/use-keyboard-shortcut/-/use-keyboard-shortcut-1.1.6.tgz",
+      "integrity": "sha512-tOKjR7eKXQIfAgFMwhelpWSRTrwE1GaB8CE/47ohtcVCKxUdn7UbfNNhiigTkATpUVoPu+5tRPbHrwjIBgTYoQ==",
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
     "node_modules/use-sidecar": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.2.tgz",
@@ -6719,6 +6729,12 @@
       "requires": {
         "tslib": "^2.0.0"
       }
+    },
+    "use-keyboard-shortcut": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/use-keyboard-shortcut/-/use-keyboard-shortcut-1.1.6.tgz",
+      "integrity": "sha512-tOKjR7eKXQIfAgFMwhelpWSRTrwE1GaB8CE/47ohtcVCKxUdn7UbfNNhiigTkATpUVoPu+5tRPbHrwjIBgTYoQ==",
+      "requires": {}
     },
     "use-sidecar": {
       "version": "1.1.2",

--- a/src/tribler/ui/package.json
+++ b/src/tribler/ui/package.json
@@ -42,6 +42,7 @@
     "react-router-dom": "^6.16.0",
     "tailwind-merge": "^1.14.0",
     "tailwindcss-animate": "^1.0.7",
+    "use-keyboard-shortcut": "^1.1.6",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/src/tribler/ui/src/components/layouts/Header.tsx
+++ b/src/tribler/ui/src/components/layouts/Header.tsx
@@ -14,7 +14,7 @@ import { useEffect, useRef, useState } from "react";
 import toast, { Toaster } from 'react-hot-toast';
 import Cookies from "js-cookie";
 import { DialogDescription } from "@radix-ui/react-dialog";
-import { Ban } from "lucide-react";
+import { Ban, Loader } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { ScrollArea } from "../ui/scroll-area";
 
@@ -84,7 +84,8 @@ export function Header() {
                     }}
                 >
                     <DialogHeader>
-                        <DialogTitle className="flex items-center justify-center mb-3"><Ban className="inline mr-3" />
+                        <DialogTitle className="flex items-center justify-center mb-3">
+                            {online ? <Loader className="inline mr-3 animate-[spin_3s_linear_infinite]" /> : <Ban className="inline mr-3" />}
                             {online
                                 ? "Tribler is shutting down"
                                 : (shutdownLogs.length > 0

--- a/src/tribler/ui/src/components/ui/autocomplete.tsx
+++ b/src/tribler/ui/src/components/ui/autocomplete.tsx
@@ -78,8 +78,8 @@ export function Autocomplete({ placeholder, completions, onChange }: { placehold
                         </Button>
                     </div>
                 </div>
-                <div className="relative mt-2">
-                    {focus && (
+                {focus && suggestions.length > 0 &&(
+                    <div className="relative mt-2">
                         <div className="max-h-[300px] overflow-y-auto overflow-x-hidden absolute top-0 z-10 w-full rounded-md border bg-popover text-popover-foreground shadow-md outline-none animate-in">
                             {suggestions.length > 0 && (suggestions.map((suggestion, index) => (
                                 <div className={`p-1 text-foreground h-full overflow-auto  ${(selectedSuggestion === index + 1) ? 'bg-accent' : ''}`} key={index + 'a'}>
@@ -92,10 +92,9 @@ export function Autocomplete({ placeholder, completions, onChange }: { placehold
                                 </div>
                             )))}
                         </div>
-                    )}
-                </div>
+                    </div>
+                )}
             </div>
         </div>
-
     );
 }

--- a/src/tribler/ui/src/components/ui/autocomplete.tsx
+++ b/src/tribler/ui/src/components/ui/autocomplete.tsx
@@ -1,4 +1,6 @@
 import { useRef, useState } from "react";
+import { Button } from "./button";
+import { SearchIcon } from "lucide-react";
 
 
 export function Autocomplete({ placeholder, completions, onChange }: { placeholder: string, completions: (filter: string) => Promise<string[]>, onChange: (query: string) => void }) {
@@ -61,6 +63,19 @@ export function Autocomplete({ placeholder, completions, onChange }: { placehold
                             value={inputValue}
                             ref={inputRef}
                         />
+                        <Button
+                            variant="ghost"
+                            className="h-6 py-0 px-0
+                                       hover:outline hover:outline-neutral-500 outline-1 outline-offset-1
+                                       active:outline active:outline-neutral-900 dark:active:outline-neutral-200"
+                            onClick={() => {
+                                const query = (selectedSuggestion > 0) ? suggestions[selectedSuggestion - 1] : inputValue;
+                                handleSuggestionClick(query);
+                                inputRef.current?.blur();
+                            }}
+                        >
+                            <SearchIcon className="h-5" />
+                        </Button>
                     </div>
                 </div>
                 <div className="relative mt-2">

--- a/src/tribler/ui/src/components/ui/simple-table.tsx
+++ b/src/tribler/ui/src/components/ui/simple-table.tsx
@@ -10,6 +10,7 @@ import * as SelectPrimitive from "@radix-ui/react-select"
 import type { Table as ReactTable } from '@tanstack/react-table';
 import { useTranslation } from 'react-i18next';
 import { useResizeObserver } from '@/hooks/useResizeObserver';
+import useKeyboardShortcut from 'use-keyboard-shortcut';
 
 
 export function getHeader<T>(name: string, translate: boolean = true, addSorting: boolean = true): ColumnDefTemplate<HeaderContext<T, unknown>> | undefined {
@@ -96,6 +97,20 @@ function SimpleTable<T extends object>({
     const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>(filters || [])
     const [expanded, setExpanded] = useState<ExpandedState>({});
     const [sorting, setSorting] = useState<SortingState>(getStoredSortingState(storeSortingState) || []);
+
+    useKeyboardShortcut(
+        ["Control", "A"],
+        keys => {
+            if (allowMultiSelect) {
+                table.toggleAllRowsSelected(true);
+            }
+        },
+        {
+            overrideSystem: true,
+            ignoreInputFields: true,
+            repeatOnHold: false
+        }
+    );
 
     const table = useReactTable({
         data,

--- a/src/tribler/ui/src/components/ui/simple-table.tsx
+++ b/src/tribler/ui/src/components/ui/simple-table.tsx
@@ -69,6 +69,7 @@ interface ReactTableProps<T extends object> {
     maxHeight?: string | number;
     expandable?: boolean;
     storeSortingState?: string;
+    rowId?: (originalRow: T, index: number, parent?: Row<T>) => string,
 }
 
 function SimpleTable<T extends object>({
@@ -87,7 +88,8 @@ function SimpleTable<T extends object>({
     filters,
     maxHeight,
     expandable,
-    storeSortingState
+    storeSortingState,
+    rowId
 }: ReactTableProps<T>) {
     const [pagination, setPagination] = useState<PaginationState>({
         pageIndex: pageIndex ?? 0,
@@ -137,6 +139,7 @@ function SimpleTable<T extends object>({
         onExpandedChange: setExpanded,
         onSortingChange: setSorting,
         getSubRows: (row: any) => row?.subRows,
+        getRowId: rowId,
     });
 
     const { t } = useTranslation();

--- a/src/tribler/ui/src/config/menu.ts
+++ b/src/tribler/ui/src/config/menu.ts
@@ -16,7 +16,7 @@ interface NavItem {
 }
 
 interface NavItemWithChildren extends NavItem {
-    items?: NavItemWithChildren[]
+    items?: NavItem[]
 }
 
 export const sideMenu: NavItemWithChildren[] = [

--- a/src/tribler/ui/src/pages/Downloads/index.tsx
+++ b/src/tribler/ui/src/pages/Downloads/index.tsx
@@ -195,6 +195,7 @@ export default function Downloads({ statusFilter }: { statusFilter: number[] }) 
                             onSelectedRowsChange={setSelectedDownloads}
                             maxHeight={Math.max((parentRect?.height ?? 50) - 50, 50)}
                             storeSortingState="download-sorting"
+                            rowId={(row) => row.infohash}
                         />
                     </Card>
                 </div>

--- a/src/tribler/ui/src/pages/Popular/index.tsx
+++ b/src/tribler/ui/src/pages/Popular/index.tsx
@@ -112,6 +112,7 @@ export default function Popular() {
                 data={torrents}
                 columns={torrentColumns}
                 storeSortingState="popular-sorting"
+                rowId={(row) => row.infohash}
             />
         </>
     )

--- a/src/tribler/ui/src/pages/Search/index.tsx
+++ b/src/tribler/ui/src/pages/Search/index.tsx
@@ -151,6 +151,7 @@ export default function Search() {
                 data={torrents}
                 columns={torrentColumns}
                 storeSortingState="search-sorting"
+                rowId={(row) => row.infohash}
             />
         </>
     )


### PR DESCRIPTION
This PR contains the following enhancements/fixes to the web UI:
* Add a search button to the header.
* When clicking a menu, navigate directly to the last visited submenu. If no such submenu exists, use the first submenu.
* Hide search suggestions when the list is empty. This fixes a 1px line appearing when clicking on the search input.
* Show a spinner during shutdown making it easier to see when shutdown has completed.
* Allow selecting all downloads using ctrl+a (fixes https://github.com/Tribler/tribler/issues/8302).
* Use infohash as `RowId` in the downloads table. Since table selection is keyed by `RowId`, this fixes an issue with the selected download(s) magically changing after changing the hop count.
