### PR TITLE
WIP: Fixed `seeding_time` upgrade using wrong datatype

### DIFF
--- a/src/tribler/tribler_config.py
+++ b/src/tribler/tribler_config.py
@@ -211,7 +211,7 @@ DEFAULT_CONFIG = {
             saveas=str(Path("~/Downloads").expanduser()),
             seeding_mode="forever",
             seeding_ratio=2.0,
-            seeding_time=60,
+            seeding_time=60.0,
             channel_download=False,
             add_download_to_channel=False)
         ),

--- a/src/tribler/upgrade_script.py
+++ b/src/tribler/upgrade_script.py
@@ -90,7 +90,7 @@ def _import_7_14_settings(src: str, dst: TriblerConfigManager) -> None:
     _copy_if_exists(old, "download_defaults/saveas", dst, "libtorrent/download_defaults/saveas", str)
     _copy_if_exists(old, "download_defaults/seeding_mode", dst, "libtorrent/download_defaults/seeding_mode", str)
     _copy_if_exists(old, "download_defaults/seeding_ratio", dst, "libtorrent/download_defaults/seeding_ratio", float)
-    _copy_if_exists(old, "download_defaults/seeding_time", dst, "libtorrent/download_defaults/seeding_time", int)
+    _copy_if_exists(old, "download_defaults/seeding_time", dst, "libtorrent/download_defaults/seeding_time", float)
     _copy_if_exists(old, "download_defaults/channel_download",
                     dst, "libtorrent/download_defaults/channel_download", bool)
     _copy_if_exists(old, "download_defaults/add_download_to_channel",


### PR DESCRIPTION
Fixes #8308

This PR:

 - Fixes the `upgrade_script` attempting to convert a `float` string to an `int`.

