### PR TITLE
Fixed mimetype being wrong in winreg

### DIFF
--- a/src/tribler/core/restapi/webui_endpoint.py
+++ b/src/tribler/core/restapi/webui_endpoint.py
@@ -42,6 +42,11 @@ class WebUIEndpoint(RESTEndpoint):
             response = web.FileResponse(resource)
             if path.endswith(".tsx"):
                 response.content_type = "application/javascript"
+            elif path.endswith(".js"):
+                # https://github.com/Tribler/tribler/issues/8279
+                response.content_type = "application/javascript"
+            elif path.endswith(".html"):
+                response.content_type = "text/html"
             elif (guessed_type := mimetypes.guess_type(path)[0]) is not None:
                 response.content_type = guessed_type
             else:


### PR DESCRIPTION
Fixes #8279

This PR:

 - Fixes a blank screen appearing if the Windows registry entry for `.js`, `Content Type` is set to something other than `application/javascript`.
 
 Notes:
 - For good measure, I also added `html` explicitly to avoid similar problems
 - I locally reproduced the error and confirmed this fix.
