### PR TITLE
Updated libtorrent to 2.0.9

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -50,7 +50,7 @@ jobs:
       - shell: bash
         run: |
           cp /opt/homebrew/opt/libsodium/lib/libsodium.dylib /Library/Frameworks/Python.framework/Versions/3.9/lib/libsodium.dylib
-          sed -i".backup" 's|libtorrent==1.2.19|https://tribler.org/libtorrent-2.0.11-cp39-cp39-macosx_14_0_arm64.whl|' requirements.txt
+          sed -i".backup" 's|libtorrent==2.0.9|https://tribler.org/libtorrent-2.0.11-cp39-cp39-macosx_14_0_arm64.whl|' requirements.txt
       - run: python -m pip install -r requirements.txt
       - name: Run unit tests
         run: |

--- a/build/docker/build.Dockerfile
+++ b/build/docker/build.Dockerfile
@@ -1,4 +1,4 @@
-# libtorrent-1.2.19 does not support python 3.11 yet
+# libtorrent-2.0.9 does not support python 3.11 yet
 FROM python:3.10-slim
 
 RUN apt-get update \

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,9 @@
 bitarray
 configobj
 ipv8-rust-tunnels
-libtorrent==1.2.19
+libtorrent==2.0.9
 lz4
+marshmallow==3.23.3  # TODO: support 3.24.0 onward
 pillow
 pony
 pystray

--- a/src/tribler/core/libtorrent/restapi/torrentinfo_endpoint.py
+++ b/src/tribler/core/libtorrent/restapi/torrentinfo_endpoint.py
@@ -6,7 +6,7 @@ from asyncio.exceptions import TimeoutError as AsyncTimeoutError
 from binascii import hexlify, unhexlify
 from copy import deepcopy
 from ssl import SSLError
-from typing import TYPE_CHECKING, Iterable
+from typing import TYPE_CHECKING
 
 import libtorrent as lt
 from aiohttp import (
@@ -36,6 +36,8 @@ from tribler.core.restapi.rest_endpoint import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from aiohttp.abc import Request
     from aiohttp.typedefs import LooseHeaders
 
@@ -181,12 +183,7 @@ class TorrentInfoEndpoint(RESTEndpoint):
 
             if response.startswith(b'magnet'):
                 try:
-                    try:
-                        # libtorrent 1.2.19
-                        infohash = lt.parse_magnet_uri(uri)["info_hash"]  # type: ignore[index] # (checker uses 2.X)
-                    except TypeError:
-                        # libtorrent 2.0.9
-                        infohash = unhexlify(str(lt.parse_magnet_uri(uri).info_hash))
+                    infohash = unhexlify(str(lt.parse_magnet_uri(uri).info_hash))
                 except RuntimeError as e:
                     return RESTResponse(
                         {"error": {
@@ -203,12 +200,7 @@ class TorrentInfoEndpoint(RESTEndpoint):
             self._logger.info("magnet scheme detected")
 
             try:
-                try:
-                    # libtorrent 1.2.19
-                    infohash = lt.parse_magnet_uri(uri)["info_hash"]  # type: ignore[index] # (checker uses 2.X)
-                except TypeError:
-                    # libtorrent 2.0.9
-                    infohash = unhexlify(str(lt.parse_magnet_uri(uri).info_hash))
+                infohash = unhexlify(str(lt.parse_magnet_uri(uri).info_hash))
             except RuntimeError as e:
                 return RESTResponse(
                     {"error": {

--- a/src/tribler/test_unit/core/libtorrent/restapi/test_torrentinfo_endpoint.py
+++ b/src/tribler/test_unit/core/libtorrent/restapi/test_torrentinfo_endpoint.py
@@ -4,6 +4,7 @@ from binascii import unhexlify
 from ssl import SSLError
 from unittest.mock import AsyncMock, Mock, patch
 
+import libtorrent
 from aiohttp import ClientConnectorCertificateError, ClientConnectorError, ClientResponseError, ServerConnectionError
 from ipv8.test.base import TestBase
 from ipv8.test.REST.rest_base import MockRequest, response_to_json
@@ -167,9 +168,10 @@ class TestTorrentInfoEndpoint(TestBase):
         """
         self.download_manager.get_metainfo = AsyncMock(return_value=None)
         request = MockRequest("/api/torrentinfo", query={"hops": 0, "uri": "magnet://"})
+        alert = Mock(info_hash=libtorrent.sha1_hash(b"\x01" * 20))
 
         with patch.dict(tribler.core.libtorrent.restapi.torrentinfo_endpoint.__dict__,
-                        {"lt": Mock(parse_magnet_uri=Mock(return_value={"info_hash": b"\x01" * 20}))}):
+                        {"lt": Mock(parse_magnet_uri=Mock(return_value=alert))}):
             response = await self.endpoint.get_torrent_info(request)
         response_body_json = await response_to_json(response)
 
@@ -436,13 +438,14 @@ class TestTorrentInfoEndpoint(TestBase):
         """
         self.download_manager.get_metainfo = AsyncMock(return_value=None)
         request = MockRequest("/api/torrentinfo", query={"hops": 0, "uri": "https://127.0.0.1/file"})
+        alert = Mock(info_hash=libtorrent.sha1_hash(b"\x01" * 20))
 
         with patch.dict(tribler.core.libtorrent.restapi.torrentinfo_endpoint.__dict__,
                         {"unshorten": mock_unshorten}), \
                 patch("tribler.core.libtorrent.restapi.torrentinfo_endpoint.query_uri",
                       AsyncMock(return_value=b"magnet://")), \
                 patch.dict(tribler.core.libtorrent.restapi.torrentinfo_endpoint.__dict__,
-                           {"lt": Mock(parse_magnet_uri=Mock(return_value={"info_hash": b"\x01" * 20}))}):
+                           {"lt": Mock(parse_magnet_uri=Mock(return_value=alert))}):
             response = await self.endpoint.get_torrent_info(request)
         response_body_json = await response_to_json(response)
 
@@ -459,13 +462,14 @@ class TestTorrentInfoEndpoint(TestBase):
         """
         self.download_manager.get_metainfo = AsyncMock(return_value=None)
         request = MockRequest("/api/torrentinfo", query={"hops": 0, "uri": "https://127.0.0.1/file"})
+        alert = Mock(info_hash=libtorrent.sha1_hash(b"\x01" * 20))
 
         with patch.dict(tribler.core.libtorrent.restapi.torrentinfo_endpoint.__dict__,
                         {"unshorten": mock_unshorten}), \
                 patch("tribler.core.libtorrent.restapi.torrentinfo_endpoint.query_uri",
                       AsyncMock(return_value=b"magnet://")), \
                 patch.dict(tribler.core.libtorrent.restapi.torrentinfo_endpoint.__dict__,
-                           {"lt": Mock(parse_magnet_uri=Mock(return_value={"info_hash": b"\x01" * 20}))}):
+                           {"lt": Mock(parse_magnet_uri=Mock(return_value=alert))}):
             response = await self.endpoint.get_torrent_info(request)
         response_body_json = await response_to_json(response)
 


### PR DESCRIPTION
Fixes #5556
Fixes #6737
Fixes #6853

This PR:

 - Updates the `libtorrent` version to `2.0.9`.
 - Updates the `libtorrent` session to allow for I2P peers.
 - Updates the `marshmallow` version to `3.23.3`.
 
The newest marshmallow version(s >= 3.24.0) [requires updates in IPv8](https://github.com/Tribler/py-ipv8/issues/1333).