### PR TITLE
Removed pinned marshmallow version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ configobj
 ipv8-rust-tunnels
 libtorrent==2.0.9
 lz4
-marshmallow==3.23.3  # TODO: support 3.24.0 onward
 pillow
 pony
 pystray


### PR DESCRIPTION
This PR:

 - Removes the `marshmallow` version pinning. This is no longer necessary, since `3.25.0`.

