### PR TITLE
Fixed exotic mktemp failure

### DIFF
--- a/build/debian/tribler/usr/bin/tribler
+++ b/build/debian/tribler/usr/bin/tribler
@@ -4,5 +4,5 @@
 echo "Starting Tribler..."
 
 pushd "/usr/share/tribler"
-exec /usr/share/tribler/tribler "$@" > `mktemp /tmp/$USER-tribler-XXXXXXXX.log` 2>&1
+exec /usr/share/tribler/tribler "$@" > `mktemp "/tmp/$USER-tribler-XXXXXX.log"` 2>&1
 popd


### PR DESCRIPTION
Fixes #8388 (assuming the Internet is correct)

This PR:

 - Updates the Debian run script to allow for spaces in the filename and adhere to 6-X `mktemp` format.

Locally built to validate that it works.