### PR TITLE
Added logging output to the General Debug tab

### DIFF
--- a/src/tribler/core/restapi/logging_endpoint.py
+++ b/src/tribler/core/restapi/logging_endpoint.py
@@ -1,0 +1,33 @@
+import logging
+from logging.handlers import MemoryHandler
+
+from aiohttp import web
+
+from tribler.core.restapi.rest_endpoint import RESTEndpoint, RESTResponse
+
+
+class LoggingEndpoint(RESTEndpoint):
+    """
+    This endpoint allows retrieval of the logs.
+    """
+
+    path = '/api/logging'
+
+    def __init__(self) -> None:
+        """
+        Create a new logging endpoint.
+        """
+        super().__init__()
+
+        self.base_handler = logging.getLogger().handlers[0]
+
+        self.memory_logger = MemoryHandler(100000)
+        logging.getLogger().addHandler(self.memory_logger)
+
+        self.app.add_routes([web.get("", self.get_logs)])
+
+    def get_logs(self, request: web.Request) -> RESTResponse:
+        """
+        Return the most recent logs.
+        """
+        return RESTResponse("\n".join(self.base_handler.format(r) for r in self.memory_logger.buffer))

--- a/src/tribler/core/session.py
+++ b/src/tribler/core/session.py
@@ -35,6 +35,7 @@ from tribler.core.notifier import Notification, Notifier
 from tribler.core.restapi.events_endpoint import EventsEndpoint
 from tribler.core.restapi.file_endpoint import FileEndpoint
 from tribler.core.restapi.ipv8_endpoint import IPv8RootEndpoint
+from tribler.core.restapi.logging_endpoint import LoggingEndpoint
 from tribler.core.restapi.rest_manager import RESTManager
 from tribler.core.restapi.settings_endpoint import SettingsEndpoint
 from tribler.core.restapi.shutdown_endpoint import ShutdownEndpoint
@@ -166,6 +167,7 @@ class Session:
         """
         Register all core REST endpoints without initializing them.
         """
+        self.rest_manager.add_endpoint(LoggingEndpoint())  # Do this first to register logging for the other endpoints.
         self.rest_manager.add_endpoint(WebUIEndpoint())
         self.rest_manager.add_endpoint(FileEndpoint())
         self.rest_manager.add_endpoint(CreateTorrentEndpoint(self.download_manager))

--- a/src/tribler/ui/src/services/tribler.service.ts
+++ b/src/tribler/ui/src/services/tribler.service.ts
@@ -218,6 +218,14 @@ export class TriblerService {
         }
     }
 
+    async getLogs(): Promise<undefined | ErrorDict | string> {
+        try {
+            return (await this.http.get('/logging')).data;
+        } catch (error) {
+            return formatAxiosError(error as Error | AxiosError);
+        }
+    }
+
     // Torrents / search
 
     async getMetainfo(uri: string): Promise<undefined | ErrorDict | {metainfo: string, download_exists: boolean, valid_certificate: boolean}> {


### PR DESCRIPTION
Fixes #8398

This PR:

 - Adds a new REST endpoint to retrieve logs.
 - Updates the `General` Debug tab to also show the logs.
