### PR TITLE
Added announce to all trackers functionality

### DIFF
--- a/src/tribler/core/libtorrent/download_manager/download_manager.py
+++ b/src/tribler/core/libtorrent/download_manager/download_manager.py
@@ -283,14 +283,19 @@ class DownloadManager(TaskManager):
         # Due to a bug in Libtorrent 0.16.18, the outgoing_port and num_outgoing_ports value should be set in
         # the settings dictionary
         logger.info("Creating a session")
-        settings: dict[str, str | float] = {"outgoing_port": 0,
-                                            "num_outgoing_ports": 1,
-                                            "allow_multiple_connections_per_ip": 0,
-                                            "enable_upnp": int(self.config.get("libtorrent/upnp")),
-                                            "enable_dht": int(self.config.get("libtorrent/dht")),
-                                            "enable_lsd": int(self.config.get("libtorrent/lsd")),
-                                            "enable_natpmp": int(self.config.get("libtorrent/natpmp")),
-                                            "allow_i2p_mixed": 1}
+        settings: dict[str, str | float] = {
+            "outgoing_port": 0,
+            "num_outgoing_ports": 1,
+            "allow_multiple_connections_per_ip": 0,
+            "enable_upnp": int(self.config.get("libtorrent/upnp")),
+            "enable_dht": int(self.config.get("libtorrent/dht")),
+            "enable_lsd": int(self.config.get("libtorrent/lsd")),
+            "enable_natpmp": int(self.config.get("libtorrent/natpmp")),
+            "allow_i2p_mixed": 1,
+            "announce_to_all_tiers": int(self.config.get("libtorrent/announce_to_all_tiers")),
+            "announce_to_all_trackers": int(self.config.get("libtorrent/announce_to_all_trackers")),
+            "max_concurrent_http_announces": int(self.config.get("libtorrent/max_concurrent_http_announces"))
+        }
 
         # Copy construct so we don't modify the default list
         extensions = list(DEFAULT_LT_EXTENSIONS)
@@ -800,10 +805,7 @@ class DownloadManager(TaskManager):
         self.ltsettings[lt_session].update(new_settings)
 
         try:
-            if hasattr(lt_session, "apply_settings"):
-                lt_session.apply_settings(new_settings)
-            else:
-                lt_session.set_settings(new_settings)  # type: ignore[attr-defined] # (checker uses 2.X)
+            lt_session.apply_settings(new_settings)
         except OverflowError as e:
             msg = f"Overflow error when setting libtorrent sessions with settings: {new_settings}"
             raise OverflowError(msg) from e

--- a/src/tribler/tribler_config.py
+++ b/src/tribler/tribler_config.py
@@ -106,6 +106,9 @@ class LibtorrentConfig(TypedDict):
     upnp: bool
     natpmp: bool
     lsd: bool
+    announce_to_all_tiers: bool
+    announce_to_all_trackers: bool
+    max_concurrent_http_announces: int
 
     download_defaults: DownloadDefaultsConfig
 
@@ -214,6 +217,9 @@ DEFAULT_CONFIG = {
         upnp=True,
         natpmp=True,
         lsd=True,
+        announce_to_all_tiers=False,
+        announce_to_all_trackers=False,
+        max_concurrent_http_announces=50,
         download_defaults=DownloadDefaultsConfig(
             anonymity_enabled=True,
             number_hops=1,

--- a/src/tribler/ui/public/locales/en_US.json
+++ b/src/tribler/ui/public/locales/en_US.json
@@ -40,6 +40,8 @@
     "MaxConnections": "Max connections per download",
     "ZeroIsUnlimited": "0 = unlimited",
     "MinusOneIsUnlimited": "-1 = unlimited",
+    "EnableAnnounceAll": "Announce to all torrent trackers",
+    "MaxTrackerConnections": "Max concurrent tracker connections",
     "Password": "Password",
     "UploadRate": "Upload rate limit",
     "DownloadRate": "Download rate limit",

--- a/src/tribler/ui/public/locales/es_ES.json
+++ b/src/tribler/ui/public/locales/es_ES.json
@@ -40,6 +40,8 @@
     "MaxConnections": "Conexiones máximas por descarga",
     "ZeroIsUnlimited": "0 = ilimitadas",
     "MinusOneIsUnlimited": "-1 = ilimitadas",
+    "EnableAnnounceAll": "Anunciar a todos los rastreadores de torrents",
+    "MaxTrackerConnections": "Conexiones de seguimiento simultáneas máximas",
     "Password": "Contraseña",
     "UploadRate": "Límite de velocidad de subida",
     "DownloadRate": "Límite de velocidad de descarga",

--- a/src/tribler/ui/public/locales/ko_KR.json
+++ b/src/tribler/ui/public/locales/ko_KR.json
@@ -40,6 +40,8 @@
     "MaxConnections": "내려받기당 최대 연결 수",
     "ZeroIsUnlimited": "0 = 무제한",
     "MinusOneIsUnlimited": "-1 = 무제한",
+    "EnableAnnounceAll": "모든 토렌트 추적자에게 공지",
+    "MaxTrackerConnections": "최대 동시 추적기 연결",
     "Password": "비밀번호",
     "UploadRate": "올리기 속도 제한",
     "DownloadRate": "내려받기 속도 제한",

--- a/src/tribler/ui/public/locales/pt_BR.json
+++ b/src/tribler/ui/public/locales/pt_BR.json
@@ -38,6 +38,8 @@
     "MaxConnections": "Máximo de conexões por download",
     "ZeroIsUnlimited": "0 = sem limites",
     "MinusOneIsUnlimited": "-1 = sem limites",
+    "EnableAnnounceAll": "Anuncie a todos os rastreadores de torrent",
+    "MaxTrackerConnections": "Máximo de conexões simultâneas do rastreador",
     "Password": "Senha",
     "UploadRate": "Limite de upload",
     "DownloadRate": "Limite de upload",

--- a/src/tribler/ui/public/locales/ru_RU.json
+++ b/src/tribler/ui/public/locales/ru_RU.json
@@ -41,6 +41,8 @@
     "MaxConnections": "Макс. число соединений",
     "ZeroIsUnlimited": "0 = без ограничения",
     "MinusOneIsUnlimited": "-1 = без ограничения",
+    "EnableAnnounceAll": "Анонсируйте на всех торрент-трекерах",
+    "MaxTrackerConnections": "Максимальное количество одновременных подключений к трекеру",
     "Password": "Пароль",
     "UploadRate": "Исходящий трафик",
     "DownloadRate": "Входящий трафик",

--- a/src/tribler/ui/public/locales/zh_CN.json
+++ b/src/tribler/ui/public/locales/zh_CN.json
@@ -39,6 +39,8 @@
     "MaxConnections": "每个下载任务的最大连接数",
     "ZeroIsUnlimited": "0 = 无限制",
     "MinusOneIsUnlimited": "-1 = 无限制",
+    "EnableAnnounceAll": "向所有种子追踪者宣布",
+    "MaxTrackerConnections": "最大并发跟踪器连接数",
     "Password": "密码",
     "UploadRate": "上传速率限制",
     "DownloadRate": "下载速率限制",

--- a/src/tribler/ui/src/models/settings.model.tsx
+++ b/src/tribler/ui/src/models/settings.model.tsx
@@ -66,6 +66,9 @@ export interface Settings {
         upnp: boolean;
         natpmp: boolean;
         lsd: boolean;
+        announce_to_all_tiers: boolean;
+        announce_to_all_trackers: boolean;
+        max_concurrent_http_announces: number;
         download_defaults: {
             anonymity_enabled: boolean;
             number_hops: number;

--- a/src/tribler/ui/src/pages/Settings/Connection.tsx
+++ b/src/tribler/ui/src/pages/Settings/Connection.tsx
@@ -178,7 +178,7 @@ export default function Connection() {
                                 ...settings,
                                 libtorrent: {
                                     ...settings.libtorrent,
-                                    max_connections_download: Math.max(0, +event.target.value)
+                                    max_connections_download: Math.max(-1, +event.target.value)
                                 }
                             });
                         }
@@ -186,6 +186,47 @@ export default function Connection() {
                 />
                 <div></div>
                 <p className="text-xs p-0 pb-4 text-muted-foreground">{t('MinusOneIsUnlimited')}</p>
+
+                <Label htmlFor="announce_to_all" className="whitespace-nowrap pr-5">
+                    {t('EnableAnnounceAll')}
+                </Label>
+                <Checkbox
+                    id="announce_to_all"
+                    className="my-2"
+                    checked={(settings?.libtorrent.announce_to_all_tiers !== settings?.libtorrent.announce_to_all_trackers) ? "indeterminate" : settings?.libtorrent.announce_to_all_tiers}
+                    onCheckedChange={(value) => {
+                        if (settings) {
+                            setSettings({
+                                ...settings,
+                                libtorrent: {
+                                    ...settings.libtorrent,
+                                    announce_to_all_tiers: !!value,
+                                    announce_to_all_trackers: !!value
+                                }
+                            });
+                        }
+                    }}
+                />
+
+                <Label htmlFor="max_concurrent_http_announces" className="whitespace-nowrap pr-5">
+                    {t('MaxTrackerConnections')}
+                </Label>
+                <Input
+                    id="max_concurrent_http_announces"
+                    type="number"
+                    value={settings?.libtorrent?.max_concurrent_http_announces === undefined ? 50 : settings?.libtorrent?.max_concurrent_http_announces}
+                    onChange={(event) => {
+                        if (settings) {
+                            setSettings({
+                                ...settings,
+                                libtorrent: {
+                                    ...settings.libtorrent,
+                                    max_concurrent_http_announces: Math.max(1, +event.target.value)
+                                }
+                            });
+                        }
+                    }}
+                />
             </div>
 
             <SaveButton


### PR DESCRIPTION
Fixes #8287

This PR:

 - Updates libtorrent session creation to inherit the config values of `announce_to_all_tiers`, `announce_to_all_trackers`, and `max_concurrent_http_announces`. The former two are lumped together in the GUI as the `announce_to_all` setting.
 - Removes `set_settings` workaround for old libtorrent versions.
