### PR TITLE
Load additional magnet URI fields

### DIFF
--- a/src/tribler/core/libtorrent/download_manager/download.py
+++ b/src/tribler/core/libtorrent/download_manager/download.py
@@ -878,9 +878,9 @@ class Download(TaskManager):
         Add the given trackers to the handle.
         """
         self.handle = cast(lt.torrent_handle, self.handle)
-        if hasattr(self.handle, "add_tracker"):
-            for tracker in trackers:
-                self.handle.add_tracker({"url": tracker, "verified": False})
+        for tracker in trackers:
+            self.handle.add_tracker({"url": tracker, "verified": False})
+        self.handle.force_reannounce()
 
     @check_handle(None)
     def get_magnet_link(self) -> str:
@@ -898,6 +898,16 @@ class Download(TaskManager):
         """
         self.handle = cast(lt.torrent_handle, self.handle)
         self.handle.connect_peer(addr, 0)
+
+    @require_handle
+    def add_url_seed(self, addr: str) -> None:
+        """
+        Add a URL seed to this download.
+
+        :param addr: The URL address to connect to
+        """
+        self.handle = cast(lt.torrent_handle, self.handle)
+        self.handle.add_url_seed(addr)
 
     @require_handle
     def set_priority(self, priority: int) -> None:


### PR DESCRIPTION
Fixes #8363

This PR:

 - Adds support for parsing selected files, trackers, peers, and url seeds from magnet links.
 - Adds support for adding URL seeds to a `Download`.
 - Updates `Download.add_trackers()` to reannounce for immediate effect, instead of waiting for the next resume data alert ([see libtorrent docs](https://libtorrent.org/reference-Torrent_Handle.html#trackers-replace-trackers-add-tracker-post-trackers)).
