### PR TITLE
Allow magnet links to resolve later when adding URIs

### DIFF
--- a/src/tribler/ui/src/components/add-torrent.tsx
+++ b/src/tribler/ui/src/components/add-torrent.tsx
@@ -91,13 +91,15 @@ export function AddTorrent() {
                                     setTorrent(undefined);
                                     setUrlDialogOpen(false);
                                     (async () => {
-                                        const response = await triblerService.getMetainfo(uriInput);
-                                        if (response === undefined) {
-                                            toast.error(`${t("ToastErrorDownloadStart")} ${t("ToastErrorGenNetworkErr")}`);
-                                        } else if (isErrorDict(response)){
-                                            toast.error(`${t("ToastErrorDownloadStart")} ${response.error.message}`);
-                                        } else {
-                                            setSaveAsDialogOpen(true);
+                                        if (uriInputRef.current !== null) {
+                                            const response = await triblerService.getMetainfo(uriInputRef.current.value, true);
+                                            if (response === undefined) {
+                                                toast.error(`${t("ToastErrorDownloadStart")} ${t("ToastErrorGenNetworkErr")}`);
+                                            } else if (isErrorDict(response)){
+                                                toast.error(`${t("ToastErrorDownloadStart")} ${response.error.message}`);
+                                            } else {
+                                                setSaveAsDialogOpen(true);
+                                            }
                                         }
                                     })();
                                 }

--- a/src/tribler/ui/src/dialogs/SaveAs.tsx
+++ b/src/tribler/ui/src/dialogs/SaveAs.tsx
@@ -149,7 +149,7 @@ export default function SaveAs(props: SaveAsProps & JSX.IntrinsicAttributes & Di
                 response = await triblerService.getMetainfoFromFile(torrent);
             }
             else if (uri) {
-                response = await triblerService.getMetainfo(uri);
+                response = await triblerService.getMetainfo(uri, false);
             }
 
             if (response === undefined) {

--- a/src/tribler/ui/src/services/tribler.service.ts
+++ b/src/tribler/ui/src/services/tribler.service.ts
@@ -228,9 +228,9 @@ export class TriblerService {
 
     // Torrents / search
 
-    async getMetainfo(uri: string): Promise<undefined | ErrorDict | {metainfo: string, download_exists: boolean, valid_certificate: boolean}> {
+    async getMetainfo(uri: string, skipMagnet: boolean): Promise<undefined | ErrorDict | {metainfo: string, download_exists: boolean, valid_certificate: boolean}> {
         try {
-            return (await this.http.get(`/torrentinfo?uri=${uri}`)).data;
+            return (await this.http.get(`/torrentinfo?uri=${uri}&skipmagnet=${skipMagnet}`)).data;
         } catch (error) {
             return formatAxiosError(error as Error | AxiosError);
         }


### PR DESCRIPTION
Fixes #8416

This PR:

 - Adds a `skipmagnet` parameter to the `torrentinfo` endpoint, allowing magnet links to resolve later in the `SaveAs` dialog (or not at all).

This should both do all the fancy HTTP forwarding and forward magnet links quickly to the SaveAs dialog. However, the price is another parameter for `getMetainfo()`.

