### PR TITLE
WIP: Catch ClientResponseError when checking running API

### DIFF
--- a/src/tribler/core/session.py
+++ b/src/tribler/core/session.py
@@ -94,7 +94,8 @@ async def _is_url_available(url: str, timeout: int=1) -> bool:
         try:
             async with session.get(url, timeout=timeout):
                 return True
-        except (asyncio.TimeoutError, aiohttp.client_exceptions.ClientConnectorError):
+        except (asyncio.TimeoutError, aiohttp.client_exceptions.ClientConnectorError,
+                aiohttp.client_exceptions.ClientResponseError):
             return False
 
 


### PR DESCRIPTION
Fixes #8415

This PR:

 - Fixes `ClientResponseError` not being caught in `_is_url_available`.