### PR TITLE
Allow downloading of torrents with invalid SSL certs

### DIFF
--- a/src/tribler/core/libtorrent/download_manager/download_manager.py
+++ b/src/tribler/core/libtorrent/download_manager/download_manager.py
@@ -632,7 +632,7 @@ class DownloadManager(TaskManager):
         """
         logger.info("Start download from URI: %s", uri)
 
-        uri = await unshorten(uri)
+        uri, _ = await unshorten(uri)
         scheme = URL(uri).scheme
 
         if scheme in ("http", "https"):

--- a/src/tribler/core/libtorrent/restapi/torrentinfo_endpoint.py
+++ b/src/tribler/core/libtorrent/restapi/torrentinfo_endpoint.py
@@ -158,9 +158,8 @@ class TorrentInfoEndpoint(RESTEndpoint):
                                     "message": "uri parameter missing"
                                 }}, status=HTTP_BAD_REQUEST)
 
-        uri = await unshorten(p_uri)
+        uri, valid_cert = await unshorten(p_uri)
         scheme = URL(uri).scheme
-        valid_cert = True
 
         if scheme == "file":
             file_path = url_to_path(uri)

--- a/src/tribler/core/libtorrent/torrents.py
+++ b/src/tribler/core/libtorrent/torrents.py
@@ -5,12 +5,13 @@ from asyncio import CancelledError, Future
 from contextlib import suppress
 from hashlib import sha1
 from os.path import getsize
-from typing import TYPE_CHECKING, Callable, Iterable, TypedDict, TypeVar
+from typing import TYPE_CHECKING, Callable, TypedDict, TypeVar
 
 import libtorrent as lt
 from typing_extensions import ParamSpec
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
     from pathlib import Path
 
     from tribler.core.libtorrent.download_manager.download import Download
@@ -20,7 +21,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 WrappedParams = ParamSpec("WrappedParams")
 WrappedReturn = TypeVar("WrappedReturn")
-Wrapped = Callable[WrappedParams, WrappedReturn]
+Wrapped = Callable[WrappedParams, WrappedReturn]  # We are forced to type ignore in Python 3.9, revisit in 3.10!
 
 
 def check_handle(default: WrappedReturn) -> Wrapped:
@@ -31,7 +32,9 @@ def check_handle(default: WrappedReturn) -> Wrapped:
     """
 
     def wrap(f: Wrapped) -> Wrapped:
-        def invoke_func(self: Download, *args: WrappedParams.args, **kwargs: WrappedParams.kwargs) -> WrappedReturn:
+        def invoke_func(self: Download,
+                        *args: WrappedParams.args, **kwargs: WrappedParams.kwargs  # type: ignore[valid-type]
+                        ) -> WrappedReturn:
             if self.handle and self.handle.is_valid():
                 return f(self, *args, **kwargs)
             return default
@@ -48,8 +51,9 @@ def require_handle(func: Wrapped) -> Wrapped:
     Author(s): Egbert Bouman
     """
 
-    def invoke_func(self: Download, *args: WrappedParams.args,
-                    **kwargs: WrappedParams.kwargs) -> Future[WrappedReturn | None]:
+    def invoke_func(self: Download,
+                    *args: WrappedParams.args, **kwargs: WrappedParams.kwargs  # type: ignore[valid-type]
+                    ) -> Future[WrappedReturn | None]:
         result_future: Future[WrappedReturn | None] = Future()
 
         def done_cb(fut: Future[lt.torrent_handle]) -> None:
@@ -86,7 +90,9 @@ def check_vod(default: WrappedReturn) -> Wrapped:
     """
 
     def wrap(f: Wrapped) -> Wrapped:
-        def invoke_func(self: Stream, *args: WrappedParams.args, **kwargs: WrappedParams.kwargs) -> WrappedReturn:
+        def invoke_func(self: Stream,
+                        *args: WrappedParams.args, **kwargs: WrappedParams.kwargs  # type: ignore[valid-type]
+                        ) -> WrappedReturn:
             if self.enabled:
                 return f(self, *args, **kwargs)
             return default

--- a/src/tribler/core/rss/rss.py
+++ b/src/tribler/core/rss/rss.py
@@ -73,7 +73,7 @@ class RSSWatcher:
         """
         for url in urls:
             try:
-                uri = await unshorten(url)
+                uri, _ = await unshorten(url)
                 response = await query_uri(uri, valid_cert=False)
             except (ServerConnectionError, ClientResponseError, SSLError, ClientConnectorError,
                     AsyncTimeoutError, ValueError) as e:

--- a/src/tribler/test_unit/core/libtorrent/restapi/test_torrentinfo_endpoint.py
+++ b/src/tribler/test_unit/core/libtorrent/restapi/test_torrentinfo_endpoint.py
@@ -18,11 +18,11 @@ from tribler.core.restapi.rest_endpoint import HTTP_BAD_REQUEST, HTTP_INTERNAL_S
 from tribler.test_unit.core.libtorrent.mocks import TORRENT_WITH_DIRS_CONTENT
 
 
-async def mock_unshorten(uri: str) -> str:
+async def mock_unshorten(uri: str) -> tuple[str, bool]:
     """
     Don't following links.
     """
-    return uri
+    return uri, True
 
 
 class TestTorrentInfoEndpoint(TestBase):

--- a/src/tribler/test_unit/core/libtorrent/test_uris.py
+++ b/src/tribler/test_unit/core/libtorrent/test_uris.py
@@ -109,7 +109,7 @@ class TestURIs(TestBase):
         """
         url = "udp://tracker.example.com/"
 
-        unshortened = await unshorten(url)
+        unshortened, _ = await unshorten(url)
 
         self.assertEqual(url, unshortened)
 
@@ -126,7 +126,7 @@ class TestURIs(TestBase):
                     __aenter__=AsyncMock(return_value=Mock(status=200, headers={istr("Location"): "test"}))
                 ))))
         ))}):
-            unshortened = await unshorten(url)
+            unshortened, _ = await unshorten(url)
 
         self.assertEqual(url, unshortened)
 
@@ -143,7 +143,7 @@ class TestURIs(TestBase):
                     __aenter__=AsyncMock(return_value=Mock(status=301, headers={}))
                 ))))
         ))}):
-            unshortened = await unshorten(url)
+            unshortened, _ = await unshorten(url)
 
         self.assertEqual(url, unshortened)
 
@@ -160,6 +160,6 @@ class TestURIs(TestBase):
                     __aenter__=AsyncMock(return_value=Mock(status=301, headers={istr("Location"): "test"}))
                 ))))
         ))}):
-            unshortened = await unshorten(url)
+            unshortened, _ = await unshorten(url)
 
         self.assertEqual("test", unshortened)


### PR DESCRIPTION
Fixes #7785

This PR:

 - Updates the torrent addition logic to allow for invalid SSL certificates.
