### PR TITLE
Updated docker build script to get the latest stable release

### DIFF
--- a/build/docker/compose.yml
+++ b/build/docker/compose.yml
@@ -2,10 +2,27 @@
 services:
   tribler:
     image: ghcr.io/tribler/tribler:latest
-    network_mode: host
+    security_opt:
+      - apparmor:unconfined  # Not ideal, but allows DBUS communication TO host from the container (see "dirty hack")
     environment:
-      CORE_API_PORT: 8085
-      CORE_API_KEY: "changeme"
+      # DBUS/Xorg stuff
+      - DISPLAY=$DISPLAY
+      - DBUS_SESSION_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS
+      - XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR
+      - XAUTHORITY=$XAUTHORITY
+      - XDG_CACHE_HOME=$XDG_CACHE_HOME
+      # Dirty hack to forward org.freedesktop.portal.Desktop DBUS to host
+      - BROWSER=x-www-browser
+      # Tribler settings
+      - CORE_API_PORT=8085
+      - CORE_API_KEY=changeme
+    network_mode: host
     volumes:
-      - ~/.Tribler/git:/home/user/.Tribler
-      - ~/Downloads/TriblerDownloads:/home/user/Downloads/TriblerDownloads
+      # Tray icons
+      - $XDG_CACHE_HOME/tmp/:$XDG_CACHE_HOME/tmp/
+      # Xorg stuff
+      - /run:/run
+      # Tribler directories
+      - ~/.Tribler:/state
+      - ~/downloads/TriblerDownloads:/downloads
+    user: $(id -u):$(id -g)


### PR DESCRIPTION
Related to #6591

This PR:

 - Updates `build.Dockerfile` to provide the **latest-stable full-GUI Tribler** (instead of headless) experience for X.Org-supporting platforms, including the tray icon and webbrowser opening.
 
Docker containers aren't really supposed to be able to manipulate the host and Python `webbrowser` doesn't normally forward to external services. So, some funky stuff is happening:
1. We fool Python into thinking the `x-www-browser` is installed. This is actually bash script that sends a `org.freedesktop.portal.OpenURI.OpenURI` event to the D-Bus with the URL it was called with.
2. We inherit the X.Org files from disk (volume), X.Org environment variables, and the user id from the host. This allows the host to interpret D-Bus events as its own.
3. _(Side note)_ We also need `network_mode: host` to forward events, but we were already using this for networking anyway.
4. We circumvent AppArmor to not block any D-Bus event (I would have appreciated a less priviledged approach - but I guess this will do for now).

I'll have to test if GitHub Packages correctly bundles this when it is built "for real" instead of locally on my machine. But, assuming there are no issues, this will be all I do for #6591 until the Tribler 8.2.0. milestone rolls around.