### PR TITLE
Add multiple session detection, avoid multiple tabs

### DIFF
--- a/src/tribler/test_unit/core/restapi/test_events_endpoint.py
+++ b/src/tribler/test_unit/core/restapi/test_events_endpoint.py
@@ -115,7 +115,7 @@ class TestEventsEndpoint(TestBase):
 
         self.assertEqual(200, response.status)
         self.assertEqual((b'event: events_start\n'
-                          b'data: {"public_key": "", "version": "git"}'
+                          b'data: {"public_key": "", "version": "git", "sessions": "0"}'
                           b'\n\n'), request.payload_writer.captured[0])
 
     async def test_establish_connection_with_error(self) -> None:


### PR DESCRIPTION
Fixes #8379

This PR:

 - Adds an `/info` route to the `EventsEndpoint`.
 - Fixes multiple tabs getting opened when double-clicking torrents, when an existing session is present. When not adding a torrent, a tab is still opened (otherwise, a remote session could lock you out from connecting to the core).
 - Updates `find_api_server` to query the events endpoint and return basic session/events info.

