### PR TITLE
Fixed magnet parsing overwriting user file selection

### DIFF
--- a/src/tribler/core/libtorrent/download_manager/download_manager.py
+++ b/src/tribler/core/libtorrent/download_manager/download_manager.py
@@ -644,7 +644,7 @@ class DownloadManager(TaskManager):
             params = lt.parse_magnet_uri(uri)
             name = params.name.encode()
             infohash = unhexlify(str(params.info_hash))
-            if config:
+            if config and not config.get_selected_files():
                 config.set_selected_files([i for i in range(len(params.file_priorities))
                                            if params.file_priorities[i] > 0])
             logger.info("Name: %s. Infohash: %s", name, infohash)

--- a/src/tribler/ui/src/lib/utils.ts
+++ b/src/tribler/ui/src/lib/utils.ts
@@ -37,6 +37,16 @@ export function getMagnetLink(infohash: string, name: string): string {
     return `magnet:?xt=urn:btih:${infohash}&dn=${encodeURIComponent(name)}`;
 }
 
+export function unwrapMagnetSO(selectedFiles: string): Set<number> {
+    const out = new Set<number>();
+    for (var indices of selectedFiles.split(',')){
+        for (var index of indices.split('-')) {
+            out.add(+index);
+        }
+    }
+    return out;
+}
+
 export function categoryIcon(name: category): string {
     const categoryEmojis: Record<string, string> = {
         Video: '🎦',
@@ -144,7 +154,7 @@ export function filterDuplicates(data: any[], key: string) {
     });
 }
 
-export const filesToTree = (files: FileTreeItem[], defaultName = "root", separator: string = '\\') => {
+export const filesToTree = (files: FileTreeItem[], defaultName = "root", preSelected: Set<number> = new Set(), separator: string = '\\') => {
     if (files.length <= 1) {
         if (files.length == 1 && files[0].included == undefined)
             files[0].included = true;
@@ -158,7 +168,7 @@ export const filesToTree = (files: FileTreeItem[], defaultName = "root", separat
         file.name.split(separator).reduce((r: any, name, i, a) => {
             if (!r[name]) {
                 r[name] = { result: [] };
-                r.result.push({ included: true, ...file, name, subRows: r[name].result })
+                r.result.push({ included: preSelected.has(result.length), ...file, name, subRows: r[name].result })
             }
             return r[name];
         }, level)

--- a/src/tribler/ui/src/pages/Downloads/Files.tsx
+++ b/src/tribler/ui/src/pages/Downloads/Files.tsx
@@ -59,7 +59,7 @@ const getFileColumns = ({ onSelectedFiles }: { onSelectedFiles: (row: Row<FileTr
 async function updateFiles(setFiles: Dispatch<SetStateAction<FileTreeItem[]>>, download: Download, initialized: MutableRefObject<boolean>) {
     const response = await triblerService.getDownloadFiles(download.infohash);
     if (response !== undefined && !isErrorDict(response)) {
-        const files = filesToTree(response, download.name, '/');
+        const files = filesToTree(response, download.name, undefined, '/');
         setFiles(files);
     } else {
         // Don't bother the user on error, just try again later.


### PR DESCRIPTION
Fixes #8455

This PR:

 - Adds preselection from magnet links to the `SaveAs` dialog.
 - Fixes the preselected files of a magnet link overwriting the (later) user configuration.

Note that I'm parsing the magnet link in the GUI. This avoids editing the existing REST endpoint and/or calling another REST route to fetch the preselected files as a result of the magnet link.