### PR TITLE
Added internal BitTorrent v2 support

### DIFF
--- a/src/tribler/core/libtorrent/download_manager/download_manager.py
+++ b/src/tribler/core/libtorrent/download_manager/download_manager.py
@@ -1024,7 +1024,7 @@ class DownloadManager(TaskManager):
         Load the checkpoint files in the checkpoint directory.
         """
         self._logger.info("Load checkpoints...")
-        checkpoint_filenames = list(self.get_checkpoint_dir().glob("*.conf"))
+        checkpoint_filenames = sorted(self.get_checkpoint_dir().glob("*.conf"), key=lambda p: len(p.parts[-1]))
         self.checkpoints_count = len(checkpoint_filenames)
         for i, filename in enumerate(checkpoint_filenames, start=1):
             await self.load_checkpoint(filename)

--- a/src/tribler/core/libtorrent/download_manager/download_state.py
+++ b/src/tribler/core/libtorrent/download_manager/download_state.py
@@ -287,6 +287,12 @@ class DownloadState:
                 for index, (path, size) in enumerate(files):
                     completion_frac = (float(progress[index]) / size) if size > 0 else 1
                     completion.append((path, completion_frac))
+            elif progress and len(progress) > len(files) and self.download.tdef.torrent_info_loaded():
+                # We need to remap
+                remapping = self.download.tdef.get_file_indices()
+                for index, (path, size) in enumerate(files):
+                    completion_frac = (float(progress[remapping[index]]) / size) if size > 0 else 1
+                    completion.append((path, completion_frac))
 
         return completion
 

--- a/src/tribler/test_unit/core/libtorrent/mocks.py
+++ b/src/tribler/test_unit/core/libtorrent/mocks.py
@@ -63,7 +63,7 @@ TORRENT_WITH_VIDEO = (
             b'6:lengthi10e'
             b'4:name13:somevideo.mp4'
             b'12:piece lengthi524288e'
-            b'6:pieces10:\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01'
+            b'6:pieces20:\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01'
         b'e'
     b'e'
 )

--- a/src/tribler/test_unit/core/libtorrent/restapi/test_downloads_endpoint.py
+++ b/src/tribler/test_unit/core/libtorrent/restapi/test_downloads_endpoint.py
@@ -490,6 +490,7 @@ class TestDownloadsEndpoint(TestBase):
         """
         download = self.create_mock_download()
         download.tdef.metainfo = {b"info": {b"files": [{b"path": {b"hi.txt"}, b"length": 0}]}}
+        download.tdef.get_file_indices = Mock(return_value=[0])
         self.download_manager.get_download = Mock(return_value=download)
         request = MockRequest("/api/downloads/" + "01" * 20, "PATCH", {"selected_files": [99999999999]},
                               {"infohash": "01" * 20})
@@ -506,6 +507,7 @@ class TestDownloadsEndpoint(TestBase):
         """
         download = self.create_mock_download()
         download.tdef.metainfo = {b"info": {b"files": [{b"path": {b"hi.txt"}, b"length": 0}]}}
+        download.tdef.get_file_indices = Mock(return_value=[0])
         self.download_manager.get_download = Mock(return_value=download)
         request = MockRequest("/api/downloads/" + "01" * 20, "PATCH", {"selected_files": [0]}, {"infohash": "01" * 20})
 

--- a/src/tribler/ui/src/dialogs/SaveAs.tsx
+++ b/src/tribler/ui/src/dialogs/SaveAs.tsx
@@ -3,7 +3,7 @@ import { useEffect, useMemo, useState } from "react";
 import toast from 'react-hot-toast';
 import { triblerService } from "@/services/tribler.service";
 import { isErrorDict } from "@/services/reporting";
-import { filesToTree, fixTreeProps, formatBytes, getFilesFromMetainfo, getRowSelection, getSelectedFilesFromTree, unwrapMagnetSO } from "@/lib/utils";
+import { filesToTree, fixTreeProps, formatBytes, getRowSelection, getSelectedFilesFromTree, unwrapMagnetSO } from "@/lib/utils";
 import { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { DialogProps } from "@radix-ui/react-dialog";
@@ -159,10 +159,9 @@ export default function SaveAs(props: SaveAsProps & JSX.IntrinsicAttributes & Di
             } else if (isErrorDict(response)) {
                 setError(`${t("ToastErrorGetMetainfo")} ${response.error.message}`);
             } else if (response) {
-                const info = getFilesFromMetainfo(response.metainfo);
-                var files = info.files;
+                var files = response.files;
                 files.sort((f1: any, f2: any) => f1.name > f2.name ? 1 : -1);
-                files = filesToTree(files, info.name, (magnet_selected_files === null) ? new Set() : unwrapMagnetSO(magnet_selected_files));
+                files = filesToTree(files, response.name, (magnet_selected_files === null) ? new Set() : unwrapMagnetSO(magnet_selected_files));
                 setFiles(files);
                 setParams((prev) => ({ ...prev, selected_files: getSelectedFilesFromTree(files[0]) }));
                 setExists(!!response.download_exists);

--- a/src/tribler/ui/src/lib/utils.ts
+++ b/src/tribler/ui/src/lib/utils.ts
@@ -19,20 +19,6 @@ export function unhexlify(input: string) {
     return new TextDecoder().decode(new Uint8Array([...input.matchAll(/[0-9a-f]{2}/g)].map(a => parseInt(a[0], 16))));
 };
 
-export function getFilesFromMetainfo(metainfo: string) {
-    const info = JSON.parse(unhexlify(metainfo))?.info || {};
-    if (!info?.files) {
-        return {
-            files: [{ size: info.length, name: info.name, index: 0 }],
-            name: info.name
-        };
-    }
-    return {
-        files: info.files.map((file: any, i: number) => ({ size: file.length, name: file.path.join('\\'), index: i })),
-        name: info.name
-    };
-}
-
 export function getMagnetLink(infohash: string, name: string): string {
     return `magnet:?xt=urn:btih:${infohash}&dn=${encodeURIComponent(name)}`;
 }
@@ -168,7 +154,7 @@ export const filesToTree = (files: FileTreeItem[], defaultName = "root", preSele
         file.name.split(separator).reduce((r: any, name, i, a) => {
             if (!r[name]) {
                 r[name] = { result: [] };
-                r.result.push({ included: preSelected.has(result.length), ...file, name, subRows: r[name].result })
+                r.result.push({ included: (preSelected.size == 0) || preSelected.has(file.index), ...file, name, subRows: r[name].result })
             }
             return r[name];
         }, level)
@@ -213,7 +199,7 @@ export const getSelectedFilesFromTree = (tree: FileTreeItem, included: boolean =
     if (tree.subRows && tree.subRows.length) {
         for (const item of tree.subRows) {
             for (const i of getSelectedFilesFromTree(item, included))
-                selectedFiles.push(i);
+                selectedFiles.push(item.index);
         }
     }
     else if (tree.included === included)

--- a/src/tribler/ui/src/pages/Downloads/Files.tsx
+++ b/src/tribler/ui/src/pages/Downloads/Files.tsx
@@ -77,11 +77,11 @@ export default function Files({ download }: { download: Download }) {
         const shouldInclude = row.original.included == false;
         // Get all indices that need toggling
         const toggleIndices = getSelectedFilesFromTree(row.original, !shouldInclude);
-        const currentIndcices = getSelectedFilesFromTree(files[0]);
+        const currentIndices = getSelectedFilesFromTree(files[0]);
         if (shouldInclude)
-            var selectedIndices = [...new Set(currentIndcices).union(new Set(toggleIndices))];
+            var selectedIndices = [...new Set(currentIndices).union(new Set(toggleIndices))];
         else
-            var selectedIndices = [...new Set(currentIndcices).difference(new Set(toggleIndices))];
+            var selectedIndices = [...new Set(currentIndices).difference(new Set(toggleIndices))];
 
         triblerService.setDownloadFiles(download.infohash, selectedIndices).then((response) => {
             if (response === undefined) {

--- a/src/tribler/ui/src/services/tribler.service.ts
+++ b/src/tribler/ui/src/services/tribler.service.ts
@@ -228,7 +228,7 @@ export class TriblerService {
 
     // Torrents / search
 
-    async getMetainfo(uri: string, skipMagnet: boolean): Promise<undefined | ErrorDict | {metainfo: string, download_exists: boolean, valid_certificate: boolean}> {
+    async getMetainfo(uri: string, skipMagnet: boolean): Promise<undefined | ErrorDict | {files: {index: number, name: string, size: number}[], name: string, download_exists: boolean, valid_certificate: boolean}> {
         try {
             return (await this.http.get(`/torrentinfo?uri=${uri}&skipmagnet=${skipMagnet}`)).data;
         } catch (error) {
@@ -236,7 +236,7 @@ export class TriblerService {
         }
     }
 
-    async getMetainfoFromFile(torrent: File): Promise<undefined | ErrorDict | {infohash: string, metainfo: string, download_exists: boolean}> {
+    async getMetainfoFromFile(torrent: File): Promise<undefined | ErrorDict | {infohash: string, files: {index: number, name: string, size: number}[], name: string, download_exists: boolean}> {
         try {
             return (await this.http.put('/torrentinfo', torrent, {
                 headers: {


### PR DESCRIPTION
Fixes #8457

Note: this is not the big refactor into `libtorrent`, just the bare minimum not to crash on v2 info dicts.

This PR:

 - Adds v2 info dict support into the `TorrentDef`.
 - Adds `TorrentDef.get_file_indices()` to fetch the file indices of the file list[^1].
 - Updates `Files.tsx` to use `currentIndices` instead of `currentIndcices`.
 - Updates various GUI files to not depend on the file list length for indices[^1].
 - Updates the `TorrentInfoEndpoint` to no longer return the raw metainfo, but instead give the files and names directly (this was previously derived inside the GUI).
 
[^1]: The list of files is not (or, no longer) equal to the list of indices (these include padding files now).
