### PR TITLE
Use ENTRYPOINT instead of CMD for Docker

### DIFF
--- a/build/docker/build.Dockerfile
+++ b/build/docker/build.Dockerfile
@@ -1,6 +1,7 @@
 # Build & run instructions:
 # 1. docker build -f build/docker/build.Dockerfile .
-# 2. docker run --security-opt "apparmor:unconfined" -e XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR -e DISPLAY=$DISPLAY -e XAUTHORITY=$XAUTHORITY -e CORE_API_PORT=8085 -e CORE_API_KEY="changeme" --net="host" -v ~/.Tribler:/state -v ~/downloads/TriblerDownloads:/downloads --env DBUS_SESSION_BUS_ADDRESS="$DBUS_SESSION_BUS_ADDRESS" -e XDG_CACHE_HOME=$XDG_CACHE_HOME -v $XDG_CACHE_HOME/tmp/:$XDG_CACHE_HOME/tmp/ -v /run:/run --user $(id -u):$(id -g) -e BROWSER="x-www-browser" -it <<HASH>>
+# 2.a. docker run -e CORE_API_PORT=8085 -e CORE_API_KEY="changeme" -v ~/.Tribler:/state -v ~/downloads/TriblerDownloads:/downloads -v $XDG_CACHE_HOME/tmp:/hosttmp -v /run:/run --security-opt "apparmor:unconfined" --net="host" -e XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR -e DISPLAY=$DISPLAY -e XDG_CACHE_HOME=$XDG_CACHE_HOME -e XAUTHORITY=$XAUTHORITY -e DBUS_SESSION_BUS_ADDRESS="$DBUS_SESSION_BUS_ADDRESS" --user $(id -u):$(id -g) -it <<HASH>>
+# 2.b. docker run -e CORE_API_PORT=8085 -e CORE_API_KEY="changeme" -v ~/.Tribler:/state -v ~/downloads/TriblerDownloads:/downloads --net="host" -it <<HASH>> -s
 #
 # Common issue: "permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock"
 #          fix: "sudo chmod 666 /var/run/docker.sock"
@@ -19,9 +20,15 @@ RUN tag=`basename $(curl -Ls -o /dev/null -w %{url_effective} https://github.com
   && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 SHELL ["/bin/bash", "-c"]
-CMD export TMPDIR="${XDG_CACHE_HOME}"/tmp/ \
-  && mkdir -p ~/custombin \
-  && echo '#!/bin/bash' > ~/custombin/x-www-browser \
-  && echo 'gdbus call --session --dest=org.freedesktop.portal.Desktop --object-path=/org/freedesktop/portal/desktop --method=org.freedesktop.portal.OpenURI.OpenURI "" "$1" "{}"' >> ~/custombin/x-www-browser \
-  && chmod u+x ~/custombin/x-www-browser \
-  && PATH=~/custombin:$PATH /usr/share/tribler/tribler
+RUN mkdir -p /home/ubuntu/custombin \
+  && echo '#!/bin/bash' > /home/ubuntu/custombin/x-www-browser \
+  && echo 'gdbus call --session --dest=org.freedesktop.portal.Desktop --object-path=/org/freedesktop/portal/desktop --method=org.freedesktop.portal.OpenURI.OpenURI "" "$1" "{}"' >> /home/ubuntu/custombin/x-www-browser \
+  && chmod 777 /home/ubuntu/custombin/x-www-browser
+
+# This is supposed to give icons on Xorg systems, but it doesn't seem to always work.
+ENV TMPDIR="/hosttmp/"
+
+ENV PATH="/home/ubuntu/custombin:$PATH"
+ENV BROWSER="x-www-browser"
+
+ENTRYPOINT ["/usr/share/tribler/tribler"]

--- a/build/docker/compose.yml
+++ b/build/docker/compose.yml
@@ -19,7 +19,7 @@ services:
     network_mode: host
     volumes:
       # Tray icons
-      - $XDG_CACHE_HOME/tmp/:$XDG_CACHE_HOME/tmp/
+      - $XDG_CACHE_HOME/tmp/:/tmp
       # Xorg stuff
       - /run:/run
       # Tribler directories

--- a/doc/basics/docker.rst
+++ b/doc/basics/docker.rst
@@ -36,6 +36,14 @@ To run the docker image:
                --user $(id -u):$(id -g) -e BROWSER="x-www-browser" \
                -it ghcr.io/tribler/tribler:latest
 
+*Alternatively*, if you want to run *without opening the web GUI* and *without a tray icon*:
+
+.. code-block::
+
+    docker run -e CORE_API_PORT=8085 -e CORE_API_KEY="changeme" \
+               -v ~/.Tribler:/state -v ~/downloads/TriblerDownloads:/downloads \
+               --net="host" -it ghcr.io/tribler/tribler:latest -s
+
 You can then open Tribler in your web browser at the URL:
 
 .. code-block::


### PR DESCRIPTION
Fixes #8458

This PR:

 - Adds documentation on how to run Docker in headless mode.
 - Fixes `-s` not being passed into the Docker container, effectively disabling the ability to run in headless mode.
 
 For some reason, my tray icon is not working on the machine I tested this with. I've left that unfixed for now.
