### PR TITLE
Fix issue with opening magnet link from browser

### DIFF
--- a/src/run_tribler.py
+++ b/src/run_tribler.py
@@ -147,7 +147,7 @@ def init_config(parsed_args: Arguments) -> TriblerConfigManager:
         config.write()
 
     if "CORE_API_KEY" in os.environ:
-        config.set("api/key", os.environ.get("CORE_API_KEY"))
+        config.set("api/key", os.environ.get("CORE_API_KEY")))
         config.write()
 
     if config.get("api/key") is None:
@@ -247,6 +247,12 @@ async def main() -> None:
             return
 
         await session.start()
+
+        # Check for magnet link argument and start download if provided
+        if torrent_uri and torrent_uri.startswith("magnet:"):
+            logger.info("Starting download from magnet link argument")
+            await session.download_manager.start_download_from_uri(torrent_uri)
+
     except Exception as exc:
         show_error(exc, True)
 


### PR DESCRIPTION
Fixes #8460

Add support for opening magnet links from a browser when Tribler is not already running.

* Add a check for a magnet link argument in the `main` function of `src/run_tribler.py`.
* Start the download if a magnet link argument is provided in `src/run_tribler.py`.

