### PR TITLE
Fixed setting values in missing config sections

### DIFF
--- a/src/tribler/test_unit/test_tribler_config.py
+++ b/src/tribler/test_unit/test_tribler_config.py
@@ -41,3 +41,14 @@ class TestTriblerConfigManager(TestBase):
         config.set("libtorrent/download_defaults/seeding_time", 42)
 
         self.assertEqual(42, config.get("libtorrent/download_defaults/seeding_time"))
+
+    def test_set_on_old(self) -> None:
+        """
+        Test if we can set a key on an old dict that is missing it.
+        """
+        config = TriblerConfigManager()
+        config.configuration = {k: v for k, v in config.configuration.items() if k != "rss"}
+
+        config.set("rss/enabled", True)
+
+        self.assertTrue(config.get("rss/enabled"))

--- a/src/tribler/tribler_config.py
+++ b/src/tribler/tribler_config.py
@@ -332,5 +332,15 @@ class TriblerConfigManager:
         """
         current = self.configuration
         for part in Path(option).parts[:-1]:
-            current = current[part]
+            if part in current:
+                current = current[part]
+            else:
+                # Fetch from defaults instead. Same as ``get()``, but now we inject defaults before overwriting.
+                out = DEFAULT_CONFIG
+                for df_part in Path(option).parts:
+                    out = out.get(df_part)
+                    if df_part == part:
+                        # We found the missing section, inject the defaults here and continue traversing the dict.
+                        current[part] = out
+                        break
         current[Path(option).parts[-1]] = value


### PR DESCRIPTION
Fixes #8466

This PR:

 - Fixes missing sections not regenerating from the default config when setting values.