### PR TITLE
Fixed inconsistent inclusion of padding files in tdef

### DIFF
--- a/src/tribler/core/libtorrent/torrentdef.py
+++ b/src/tribler/core/libtorrent/torrentdef.py
@@ -638,8 +638,12 @@ class TorrentDef:
             metainfo_v1 = cast(InfoDict, self.metainfo[b"info"])
             # Multi-file v1 torrent
             files = cast(FileDict, metainfo_v1[b"files"])
+            storage = cast(lt.torrent_info, self.torrent_info).files()  # If we have metainfo, we have torrent_info
 
-            for file_dict in files:
+            for index, file_dict in enumerate(files):
+                # Ignore padding files, to align with v2 metainfo
+                if storage.file_flags(index) != 0:
+                    continue
                 if b"path.utf-8" in file_dict:
                     # This file has an utf-8 encoded list of elements.
                     # We assume that it is correctly encoded and use it normally.

--- a/src/tribler/test_unit/core/libtorrent/download_manager/test_download_state.py
+++ b/src/tribler/test_unit/core/libtorrent/download_manager/test_download_state.py
@@ -155,11 +155,11 @@ class TestDownloadState(TestBase):
         """
         download = Download(TorrentDef.load_from_memory(TORRENT_WITH_DIRS_CONTENT), self.dlmngr,
                             checkpoint_disabled=True, config=DownloadConfig(ConfigObj(StringIO(SPEC_CONTENT))))
-        for file_spec in download.tdef.metainfo[b"info"][b"files"]:
-            file_spec[b"length"] = 0
-        download.handle = Mock(is_valid=Mock(return_value=True), file_progress=Mock(return_value=[]))
+        download.tdef.metainfo[b"info"][b"files"][0][b"length"] = 0  # Other five files have length of 6
+        download.handle = Mock(is_valid=Mock(return_value=True), file_progress=Mock(return_value=[0, 6, 6, 6, 6, 6]))
         download_state = DownloadState(download, Mock(), None)
 
+        self.assertEqual(6, len(download_state.get_files_completion()))
         for _, progress in download_state.get_files_completion():
             self.assertEqual(1.0, progress)
 


### PR DESCRIPTION
Fixes #8366
Fixes #8468

This PR:

 - Fixes `_get_all_files_as_unicode_with_length` including padding files for v1 metainfo.
 
 
This is a tiny step toward leaning more on the `torrent_info` in the `TorrentDef`. Looking at it, we can probably replace `_get_all_files_as_unicode_with_length` with about three lines of code, if we lean on `torrent_def` fully. That's for a future PR though.