### PR TITLE
Various `8.1.0` fixes

### DIFF
--- a/src/tribler/core/libtorrent/download_manager/download_manager.py
+++ b/src/tribler/core/libtorrent/download_manager/download_manager.py
@@ -294,7 +294,8 @@ class DownloadManager(TaskManager):
             "allow_i2p_mixed": 1,
             "announce_to_all_tiers": int(self.config.get("libtorrent/announce_to_all_tiers")),
             "announce_to_all_trackers": int(self.config.get("libtorrent/announce_to_all_trackers")),
-            "max_concurrent_http_announces": int(self.config.get("libtorrent/max_concurrent_http_announces"))
+            "max_concurrent_http_announces": int(self.config.get("libtorrent/max_concurrent_http_announces")),
+            "disk_write_mode": 0  # always_pwrite
         }
 
         # Copy construct so we don't modify the default list

--- a/src/tribler/core/libtorrent/download_manager/download_manager.py
+++ b/src/tribler/core/libtorrent/download_manager/download_manager.py
@@ -1089,8 +1089,7 @@ class DownloadManager(TaskManager):
                 basename = hexlify(infohash).decode() + ".conf"
                 filename = self.get_checkpoint_dir() / basename
                 self._logger.debug("Removing download checkpoint %s", filename)
-                if os.access(filename, os.F_OK):
-                    os.remove(filename)
+                filename.unlink(missing_ok=True)
             except:
                 # Show must go on
                 self._logger.exception("Could not remove state")


### PR DESCRIPTION
Fixes #8489 (experimental fix)
Fixes #8485

This PR:

 - Updates `DownloadManager.remove_config()` to use `Path.unlink()` instead of `os.access()` + `os.remove()`. At best, this fixes #8489, and in the worst case this only modernizes the code.
 - Updates `DownloadManager.create_session()` to use the `always_pwrite` flag.
