### PR TITLE
Various 8.1.1 fixes

### DIFF
--- a/src/tribler/core/libtorrent/download_manager/download.py
+++ b/src/tribler/core/libtorrent/download_manager/download.py
@@ -185,7 +185,12 @@ class Download(TaskManager):
 
         Note: a finished recheck causes a ``torrent_finished_alert``: hooking into that causes an infinite loop!
         """
+        await self.future_added
+        if self.get_state().get_progress() == 1.0:
+            self._logger.info("Skipping recheck of %s, already finished when added!", str(self))
+            return
         await self.future_finished
+        self._logger.info("Force rechecking %s after completion!", str(self))
         self.force_recheck()
 
     @task

--- a/src/tribler/core/libtorrent/download_manager/download_manager.py
+++ b/src/tribler/core/libtorrent/download_manager/download_manager.py
@@ -295,7 +295,8 @@ class DownloadManager(TaskManager):
             "announce_to_all_tiers": int(self.config.get("libtorrent/announce_to_all_tiers")),
             "announce_to_all_trackers": int(self.config.get("libtorrent/announce_to_all_trackers")),
             "max_concurrent_http_announces": int(self.config.get("libtorrent/max_concurrent_http_announces")),
-            "disk_write_mode": 0  # always_pwrite
+            "disk_write_mode": 0,  # always_pwrite
+            "mmap_file_size_cutoff": 2147483647  # use pwrite for files up to maxint * 16kB ("always")
         }
 
         # Copy construct so we don't modify the default list


### PR DESCRIPTION
Fixes #8485
Fixes #8503

This PR:

 - Fixes Tribler considering initial loading as new completion of a torrent, forcing rechecks when using `check_after_complete`.
 - Updates `mmap_file_size_cutoff` to the maximum value.

Hopefully, this is the last magic value we need to get the libtorrent 2 memory usage under control 🙏 