### PR TITLE
Don't allow tracker changes while loading

### DIFF
--- a/src/tribler/ui/src/pages/Downloads/Trackers.tsx
+++ b/src/tribler/ui/src/pages/Downloads/Trackers.tsx
@@ -76,6 +76,12 @@ export default function Trackers({ download }: { download: Download }) {
         }
     ]
 
+    if (download.trackers.length === 0)
+        return <svg className="animate-spin h-3 w-3 text-black dark:text-white ml-4 mt-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                   <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                   <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+               </svg>;
+
     return (
         <div>
             <div className="border-b-4 border-muted">


### PR DESCRIPTION
Fixes #8494

This PR:

 - Updates the GUI to show a loading spinner while the download's trackers are not available yet.

This avoids users adding a tracker while the trackers cannot be changed, leading to errors.