### PR TITLE
Incremented run-on-arc-action version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,7 +129,7 @@ jobs:
 
       - name: Build Executables (Ubuntu aarch64)
         if: matrix.os == 'ubuntu-latest' && matrix.architecture == 'aarch64'
-        uses: uraimo/run-on-arch-action@v2
+        uses: uraimo/run-on-arch-action@v3
         id: run_ubuntu_aarch64
         with:
           arch: ${{ matrix.architecture }}


### PR DESCRIPTION
Fixes the v8.1.2 [build failure](https://github.com/Tribler/tribler/actions/runs/13852550070).

Confirmed fix on my fork: https://github.com/qstokkink/tribler/actions/runs/13853306201
