### PR TITLE
Fixed memory leak in the logging endpoint

### DIFF
--- a/src/tribler/core/restapi/logging_endpoint.py
+++ b/src/tribler/core/restapi/logging_endpoint.py
@@ -6,6 +6,24 @@ from aiohttp import web
 from tribler.core.restapi.rest_endpoint import RESTEndpoint, RESTResponse
 
 
+class RotatingMemoryHandler(MemoryHandler):
+    """
+    A custom MemoryHandler flusher. Instead of delegating to the ``target`` and flushing the ``buffer``, simply keep
+    the last ``capacity`` records in the buffer.
+    """
+
+    def flush(self) -> None:
+        """
+        This is called when our buffer is at capacity and needs to be flushed.
+        We get the handler lock and rotate the buffer.
+        """
+        self.acquire()
+        try:
+            self.buffer = self.buffer[-self.capacity:]
+        finally:
+            self.release()
+
+
 class LoggingEndpoint(RESTEndpoint):
     """
     This endpoint allows retrieval of the logs.
@@ -21,7 +39,7 @@ class LoggingEndpoint(RESTEndpoint):
 
         self.base_handler = logging.getLogger().handlers[0]
 
-        self.memory_logger = MemoryHandler(100000)
+        self.memory_logger = RotatingMemoryHandler(400)
         logging.getLogger().addHandler(self.memory_logger)
 
         self.app.add_routes([web.get("", self.get_logs)])


### PR DESCRIPTION
Fixes #8485 (once and for all, for the third time 🙂)

This PR:

 - Fixes a memory leak in the logging endpoint due to the `MemoryHandler` flushing mechanism.

I set the capacity to 400 records. This equates to roughly one minute of logging output before records start rotating out.