### PR TITLE
Add virtual scrolling

### DIFF
--- a/src/tribler/ui/package-lock.json
+++ b/src/tribler/ui/package-lock.json
@@ -27,6 +27,7 @@
         "@radix-ui/react-tabs": "^1.0.4",
         "@radix-ui/react-tooltip": "^1.0.7",
         "@tanstack/react-table": "^8.10.7",
+        "@tanstack/react-virtual": "^3.13.5",
         "@types/video.js": "^7.3.58",
         "axios": "^1.6.8",
         "class-variance-authority": "^0.7.0",
@@ -2641,6 +2642,22 @@
         "react-dom": ">=16"
       }
     },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.5.tgz",
+      "integrity": "sha512-MzSSMGkFWCDSb2xXqmdbfQqBG4wcRI3JKVjpYGZG0CccnViLpfRW4tGU97ImfBbSYzvEWJ/2SK/OiIoSmcUBAA==",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.13.5"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/@tanstack/table-core": {
       "version": "8.10.7",
       "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.10.7.tgz",
@@ -2648,6 +2665,15 @@
       "engines": {
         "node": ">=12"
       },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.13.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.5.tgz",
+      "integrity": "sha512-gMLNylxhJdUlfRR1G3U9rtuwUh2IjdrrniJIDcekVJN3/3i+bluvdMi3+eodnxzJq5nKnxnigo9h0lIpaqV6HQ==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
@@ -7660,10 +7686,23 @@
         "@tanstack/table-core": "8.10.7"
       }
     },
+    "@tanstack/react-virtual": {
+      "version": "3.13.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.5.tgz",
+      "integrity": "sha512-MzSSMGkFWCDSb2xXqmdbfQqBG4wcRI3JKVjpYGZG0CccnViLpfRW4tGU97ImfBbSYzvEWJ/2SK/OiIoSmcUBAA==",
+      "requires": {
+        "@tanstack/virtual-core": "3.13.5"
+      }
+    },
     "@tanstack/table-core": {
       "version": "8.10.7",
       "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.10.7.tgz",
       "integrity": "sha512-KQk5OMg5OH6rmbHZxuNROvdI+hKDIUxANaHlV+dPlNN7ED3qYQ/WkpY2qlXww1SIdeMlkIhpN/2L00rof0fXFw=="
+    },
+    "@tanstack/virtual-core": {
+      "version": "3.13.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.5.tgz",
+      "integrity": "sha512-gMLNylxhJdUlfRR1G3U9rtuwUh2IjdrrniJIDcekVJN3/3i+bluvdMi3+eodnxzJq5nKnxnigo9h0lIpaqV6HQ=="
     },
     "@types/d3-array": {
       "version": "3.2.1",

--- a/src/tribler/ui/package.json
+++ b/src/tribler/ui/package.json
@@ -28,6 +28,7 @@
     "@radix-ui/react-tabs": "^1.0.4",
     "@radix-ui/react-tooltip": "^1.0.7",
     "@tanstack/react-table": "^8.10.7",
+    "@tanstack/react-virtual": "^3.13.5",
     "@types/video.js": "^7.3.58",
     "axios": "^1.6.8",
     "class-variance-authority": "^0.7.0",

--- a/src/tribler/ui/src/components/ui/scroll-area.tsx
+++ b/src/tribler/ui/src/components/ui/scroll-area.tsx
@@ -8,11 +8,10 @@ const ScrollArea = React.forwardRef<
     React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root>
 >(({ className, children, ...props }, ref) => (
     <ScrollAreaPrimitive.Root
-        ref={ref}
         className={cn("relative overflow-hidden", className)}
         {...props}
     >
-        <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
+        <ScrollAreaPrimitive.Viewport ref={ref} className="h-full w-full rounded-[inherit]">
             {children}
         </ScrollAreaPrimitive.Viewport>
         <ScrollBar />

--- a/src/tribler/ui/src/components/ui/table.tsx
+++ b/src/tribler/ui/src/components/ui/table.tsx
@@ -1,24 +1,16 @@
 import * as React from "react"
 
 import { cn } from "@/lib/utils"
-import { ScrollArea } from "./scroll-area"
-
-interface ExtendedTableProps extends React.HTMLAttributes<HTMLTableElement> {
-    maxHeight?: string | number;
-    scrollClassName?: string;
-}
 
 const Table = React.forwardRef<
     HTMLTableElement,
-    ExtendedTableProps
->(({ className, scrollClassName, maxHeight, ...props }, ref) => (
-    <ScrollArea className={cn("relative w-full overflow-auto", scrollClassName)} style={{ maxHeight: maxHeight }}>
-        <table
-            ref={ref}
-            className={cn("w-full caption-bottom text-sm", className)}
-            {...props}
-        />
-    </ScrollArea>
+    React.HTMLAttributes<HTMLTableElement>
+>(({ className, ...props }, ref) => (
+    <table
+        ref={ref}
+        className={cn("w-full caption-bottom text-sm", className)}
+        {...props}
+    />
 ))
 Table.displayName = "Table"
 

--- a/src/tribler/ui/src/dialogs/CreateTorrent.tsx
+++ b/src/tribler/ui/src/dialogs/CreateTorrent.tsx
@@ -120,7 +120,7 @@ export default function CreateTorrent(props: JSX.IntrinsicAttributes & DialogPro
                         data={files}
                         columns={filenameColumns}
                         allowSelect={false}
-                        maxHeight={200} />
+                        style={{maxHeight: 200}} />
 
                     <div>
                         <SelectRemotePath

--- a/src/tribler/ui/src/dialogs/SaveAs.tsx
+++ b/src/tribler/ui/src/dialogs/SaveAs.tsx
@@ -243,7 +243,7 @@ export default function SaveAs(props: SaveAsProps & JSX.IntrinsicAttributes & Di
                             allowSelectCheckbox={true}
                             initialRowSelection={getRowSelection(files, () => true)}
                             expandable={true}
-                            maxHeight={200} />
+                            style={{maxHeight: 200}} />
                         {exists && <span className="text-center text-tribler text-sm">{t('DownloadExists')}</span>}
                     </>
                 }

--- a/src/tribler/ui/src/pages/Debug/Asyncio/SlowTasks.tsx
+++ b/src/tribler/ui/src/pages/Debug/Asyncio/SlowTasks.tsx
@@ -76,7 +76,7 @@ export default function SlowTasks() {
                     </Button>
                 </div>
                 {debug.messages && debug.messages.map((msg, index) => (
-                    <Card className="m-4">
+                    <Card key={index} className="m-4">
                         <CardContent className="p-4">
                             <span key={index} className="line-clamp-2 text-xs font-mono">{msg.message}</span>
                         </CardContent>

--- a/src/tribler/ui/src/pages/Debug/Asyncio/Tasks.tsx
+++ b/src/tribler/ui/src/pages/Debug/Asyncio/Tasks.tsx
@@ -50,6 +50,7 @@ export default function Tasks() {
 
     return (
         <SimpleTable
+            className="[&>[data-radix-scroll-area-viewport]]:max-h-[calc(100vh-97px)]"
             data={tasks}
             columns={taskColumns}
         />

--- a/src/tribler/ui/src/pages/Debug/DHT/Buckets.tsx
+++ b/src/tribler/ui/src/pages/Debug/DHT/Buckets.tsx
@@ -40,5 +40,8 @@ export default function Buckets() {
         }
     }, 5000, true);
 
-    return <SimpleTable data={buckets} columns={bucketColumns} />
+    return <SimpleTable
+        className="[&>[data-radix-scroll-area-viewport]]:max-h-[calc(100vh-97px)]"
+        data={buckets}
+        columns={bucketColumns} />
 }

--- a/src/tribler/ui/src/pages/Debug/DHT/Statistics.tsx
+++ b/src/tribler/ui/src/pages/Debug/DHT/Statistics.tsx
@@ -36,5 +36,8 @@ export default function Statistics() {
         }
     }, 5000, true);
 
-    return <SimpleTable data={statistics} columns={statisticColumns} />
+    return <SimpleTable
+        className="[&>[data-radix-scroll-area-viewport]]:max-h-[calc(100vh-97px)]"
+        data={statistics}
+        columns={statisticColumns} />
 }

--- a/src/tribler/ui/src/pages/Debug/IPv8/Details.tsx
+++ b/src/tribler/ui/src/pages/Debug/IPv8/Details.tsx
@@ -112,5 +112,10 @@ export default function Details() {
         }
     }, 5000, true);
 
-    return <SimpleTable data={statistics} columns={statisticColumns} expandable={true} initialState={{expanded: true}} />
+    return <SimpleTable
+        className="[&>[data-radix-scroll-area-viewport]]:max-h-[calc(100vh-97px)]"
+        data={statistics}
+        columns={statisticColumns}
+        expandable={true}
+        initialState={{ expanded: true }} />
 }

--- a/src/tribler/ui/src/pages/Debug/IPv8/Overlays.tsx
+++ b/src/tribler/ui/src/pages/Debug/IPv8/Overlays.tsx
@@ -34,7 +34,7 @@ const overlayColumns: ColumnDef<Overlay>[] = [
         cell: ({ row }) => {
             return (
                 <span className={`font-medium ${(row.original.peers.length < 20) ? `text-green-400` :
-                        ((row.original.peers.length < row.original.max_peers) ? 'text-yellow-400' : 'text-red-400')}`}>
+                    ((row.original.peers.length < row.original.max_peers) ? 'text-yellow-400' : 'text-red-400')}`}>
                     {row.original.peers.length}
                 </span>
             )
@@ -83,7 +83,10 @@ export default function Overlays() {
                     columns={overlayColumns}
                     allowSelect={true}
                     onSelectedRowsChange={(rows) => setSelectedOverlay(rows[0])}
-                    maxHeight={Math.max((parentRect?.height ?? 50) - 0, 50)}
+                    style={{
+                        height: parentRect?.height ?? 50,
+                        maxHeight: parentRect?.height ?? 50
+                    }}
                 />
             </ResizablePanel>
             <ResizableHandle className={`border-2 border-gray-300 dark:border-gray-600 ${selectedOverlay ? "flex" : "hidden"}`} />

--- a/src/tribler/ui/src/pages/Debug/Libtorrent/index.tsx
+++ b/src/tribler/ui/src/pages/Debug/Libtorrent/index.tsx
@@ -73,12 +73,14 @@ export default function Libtorrent() {
             </TabsList>
             <TabsContent value="settings" className="contents">
                 <SimpleTable
+                    className="[&>[data-radix-scroll-area-viewport]]:max-h-[calc(100vh-97px)]"
                     data={settings}
                     columns={libtorrentColumns}
                 />
             </TabsContent>
             <TabsContent value="session" className="contents">
                 <SimpleTable
+                    className="[&>[data-radix-scroll-area-viewport]]:max-h-[calc(100vh-97px)]"
                     data={session}
                     columns={libtorrentColumns}
                 />

--- a/src/tribler/ui/src/pages/Debug/Tunnels/Circuits.tsx
+++ b/src/tribler/ui/src/pages/Debug/Tunnels/Circuits.tsx
@@ -94,7 +94,10 @@ export default function Circuits() {
                     columns={circuitColumns}
                     onSelectedRowsChange={(rows) => setSelectedCircuit(rows[0])}
                     allowSelect={true}
-                    maxHeight={Math.max((parentRect?.height ?? 50) - 0, 50)}
+                    style={{
+                        height: parentRect?.height ?? 50,
+                        maxHeight: parentRect?.height ?? 50
+                    }}
                 />
             </ResizablePanel>
             <ResizableHandle className={`border-2 border-gray-300 dark:border-gray-600 ${selectedCircuit ? "flex" : "hidden"}`} />

--- a/src/tribler/ui/src/pages/Debug/Tunnels/Exits.tsx
+++ b/src/tribler/ui/src/pages/Debug/Tunnels/Exits.tsx
@@ -51,5 +51,8 @@ export default function Exits() {
         }
     }, 5000, true);
 
-    return <SimpleTable data={exits} columns={exitColumns} />
+    return <SimpleTable
+        className="[&>[data-radix-scroll-area-viewport]]:max-h-[calc(100vh-97px)]"
+        data={exits}
+        columns={exitColumns} />
 }

--- a/src/tribler/ui/src/pages/Debug/Tunnels/Peers.tsx
+++ b/src/tribler/ui/src/pages/Debug/Tunnels/Peers.tsx
@@ -45,5 +45,8 @@ export default function Peers() {
         }
     }, 5000, true);
 
-    return <SimpleTable data={peers} columns={peerColumns} />
+    return <SimpleTable
+        className="[&>[data-radix-scroll-area-viewport]]:max-h-[calc(100vh-97px)]"
+        data={peers}
+        columns={peerColumns} />
 }

--- a/src/tribler/ui/src/pages/Debug/Tunnels/Relays.tsx
+++ b/src/tribler/ui/src/pages/Debug/Tunnels/Relays.tsx
@@ -55,5 +55,8 @@ export default function Relays() {
         }
     }, 5000, true);
 
-    return <SimpleTable data={relays} columns={relayColumns} />
+    return <SimpleTable
+        className="[&>[data-radix-scroll-area-viewport]]:max-h-[calc(100vh-97px)]"
+        data={relays}
+        columns={relayColumns} />
 }

--- a/src/tribler/ui/src/pages/Debug/Tunnels/Swarms.tsx
+++ b/src/tribler/ui/src/pages/Debug/Tunnels/Swarms.tsx
@@ -63,5 +63,8 @@ export default function Swarms() {
         }
     }, 5000, true);
 
-    return <SimpleTable data={swarms} columns={swarmColumns} />
+    return <SimpleTable
+        className="[&>[data-radix-scroll-area-viewport]]:max-h-[calc(100vh-97px)]"
+        data={swarms}
+        columns={swarmColumns} />
 }

--- a/src/tribler/ui/src/pages/Downloads/Details.tsx
+++ b/src/tribler/ui/src/pages/Downloads/Details.tsx
@@ -20,14 +20,15 @@ import { InfoIcon } from "lucide-react";
 export default function DownloadDetails({ download }: { download: Download | undefined }) {
     const { t } = useTranslation();
 
-    const [contentStyle, setContentStyle] = useState<{ height?: string }>({});
+    const [contentStyle, setContentStyle] = useState<{ height?: number, maxHeight?: number }>({});
     const tabsRef = useRef<HTMLTableElement>(null);
 
     useLayoutEffect(() => {
-        if (tabsRef.current && contentStyle?.height !== (tabsRef.current.offsetHeight - 40 + "px")) {
+        if (tabsRef.current && contentStyle?.height !== (tabsRef.current.offsetHeight - 40)) {
             setContentStyle({
                 // The 40px (CSS class h-10) is to compensate for the height of the TabsList
-                height: tabsRef.current.offsetHeight - 40 + "px",
+                height: tabsRef.current.offsetHeight - 40,
+                maxHeight: tabsRef.current.offsetHeight - 40
             })
         }
     });
@@ -111,19 +112,13 @@ export default function DownloadDetails({ download }: { download: Download | und
                 </ScrollArea>
             </TabsContent>
             <TabsContent value="files" style={contentStyle}>
-                <ScrollArea className="h-full">
-                    <Files download={download} key={download.infohash} />
-                </ScrollArea>
+                <Files download={download} key={download.infohash} style={contentStyle} />
             </TabsContent>
             <TabsContent value="trackers" style={contentStyle}>
-                <ScrollArea className="h-full">
-                    <Trackers download={download} />
-                </ScrollArea>
+                <Trackers download={download} style={contentStyle} />
             </TabsContent>
             <TabsContent value="peers" style={contentStyle}>
-                <ScrollArea className="h-full">
-                    <Peers download={download} height={contentStyle.height} />
-                </ScrollArea>
+                <Peers download={download} style={contentStyle} />
             </TabsContent>
         </Tabs>
     )

--- a/src/tribler/ui/src/pages/Downloads/Files.tsx
+++ b/src/tribler/ui/src/pages/Downloads/Files.tsx
@@ -67,7 +67,7 @@ async function updateFiles(setFiles: Dispatch<SetStateAction<FileTreeItem[]>>, d
     }
 }
 
-export default function Files({ download }: { download: Download }) {
+export default function Files({ download, style }: { download: Download, style?: React.CSSProperties }) {
     const { t } = useTranslation();
     const [files, setFiles] = useState<FileTreeItem[]>([]);
     const initialized = useRef(false)
@@ -115,9 +115,8 @@ export default function Files({ download }: { download: Download }) {
 
     return <SimpleTable
         data={files}
+        style={style}
         columns={fileColumns}
         expandable={true}
-        pageSize={50}
-        maxHeight={'none'}
     />
 }

--- a/src/tribler/ui/src/pages/Downloads/Peers.tsx
+++ b/src/tribler/ui/src/pages/Downloads/Peers.tsx
@@ -76,9 +76,9 @@ const peerColumns: ColumnDef<Peer>[] = [
     },
 ]
 
-export default function Peers({ download, height }: { download: Download, height?: string }) {
+export default function Peers({ download, style }: { download: Download, style?: React.CSSProperties }) {
     if (!download.peers)
         return null;
 
-    return <SimpleTable data={download.peers} columns={peerColumns} maxHeight={height}/>
+    return <SimpleTable data={download.peers} columns={peerColumns} style={style} />
 }

--- a/src/tribler/ui/src/pages/Downloads/Trackers.tsx
+++ b/src/tribler/ui/src/pages/Downloads/Trackers.tsx
@@ -11,6 +11,7 @@ import { triblerService } from "@/services/tribler.service";
 import { isErrorDict } from "@/services/reporting";
 import { useTranslation } from "react-i18next";
 import { Icons } from "@/components/icons";
+import { ScrollArea } from "@/components/ui/scroll-area";
 
 
 interface TrackerRow extends Tracker {
@@ -18,7 +19,7 @@ interface TrackerRow extends Tracker {
     removeButton: typeof Button;
 }
 
-export default function Trackers({ download }: { download: Download }) {
+export default function Trackers({ download, style }: { download: Download, style?: React.CSSProperties }) {
     const { t } = useTranslation();
 
     const [trackerDialogOpen, setTrackerDialogOpen] = useState<boolean>(false);
@@ -41,38 +42,38 @@ export default function Trackers({ download }: { download: Download }) {
             header: "",
             accessorKey: "recheckButton",
             cell: (props) => {
-                    return (["[DHT]", "[PeX]"].includes(props.row.original.url) ? <></> :
-                        <Button variant="secondary" className="max-h-6" onClick={(event) => {
-                            triblerService.forceCheckDownloadTracker(download.infohash, props.row.original.url).then((response) => {
-                                if (response === undefined) {
-                                    toast.error(`${"ToastErrorTrackerCheck"} ${"ToastErrorGenNetworkErr"}`);
-                                } else if (isErrorDict(response)){
-                                    toast.error(`${"ToastErrorTrackerCheck"} ${response.error.message}`);
-                                }
-                            });
-                        }}>{t("ForceRecheck")}</Button>)
+                return (["[DHT]", "[PeX]"].includes(props.row.original.url) ? <></> :
+                    <Button variant="secondary" className="max-h-6" onClick={(event) => {
+                        triblerService.forceCheckDownloadTracker(download.infohash, props.row.original.url).then((response) => {
+                            if (response === undefined) {
+                                toast.error(`${"ToastErrorTrackerCheck"} ${"ToastErrorGenNetworkErr"}`);
+                            } else if (isErrorDict(response)) {
+                                toast.error(`${"ToastErrorTrackerCheck"} ${response.error.message}`);
+                            }
+                        });
+                    }}>{t("ForceRecheck")}</Button>)
             }
         },
         {
             header: "",
             accessorKey: "removeButton",
             cell: (props) => {
-                    return (["[DHT]", "[PeX]"].includes(props.row.original.url) ? <></> :
-                        <Button variant="secondary" className="max-h-6" onClick={(event) => {
-                            triblerService.removeDownloadTracker(download.infohash, props.row.original.url).then((response) => {
-                                if (response === undefined) {
-                                    toast.error(`${"ToastErrorTrackerRemove"} ${"ToastErrorGenNetworkErr"}`);
-                                } else if (isErrorDict(response)){
-                                    toast.error(`${"ToastErrorTrackerRemove"} ${response.error.message}`);
-                                } else {
-                                    download.trackers = download.trackers.filter(tracker => {return tracker.url != props.row.original.url});
-                                    var button = event.target as HTMLButtonElement;
-                                    button.disabled = true;
-                                    button.classList.add("cursor-not-allowed");
-                                    button.classList.add("opacity-50");
-                                }
-                            });
-                        }}>❌</Button>)
+                return (["[DHT]", "[PeX]"].includes(props.row.original.url) ? <></> :
+                    <Button variant="secondary" className="max-h-6" onClick={(event) => {
+                        triblerService.removeDownloadTracker(download.infohash, props.row.original.url).then((response) => {
+                            if (response === undefined) {
+                                toast.error(`${"ToastErrorTrackerRemove"} ${"ToastErrorGenNetworkErr"}`);
+                            } else if (isErrorDict(response)) {
+                                toast.error(`${"ToastErrorTrackerRemove"} ${response.error.message}`);
+                            } else {
+                                download.trackers = download.trackers.filter(tracker => { return tracker.url != props.row.original.url });
+                                var button = event.target as HTMLButtonElement;
+                                button.disabled = true;
+                                button.classList.add("cursor-not-allowed");
+                                button.classList.add("opacity-50");
+                            }
+                        });
+                    }}>❌</Button>)
             }
         }
     ]
@@ -81,11 +82,20 @@ export default function Trackers({ download }: { download: Download }) {
         return <Icons.spinner className="ml-4 mt-4" />;
 
     return (
-        <div>
-            <div className="border-b-4 border-muted">
-                <SimpleTable data={download.trackers as TrackerRow[]} columns={trackerColumns} maxHeight={''} />
+        <ScrollArea style={style} className="h=full">
+            <div style={style}>
+                <SimpleTable
+                    className="border-b-4 border-muted"
+                    data={download.trackers as TrackerRow[]}
+                    columns={trackerColumns}
+                />
+                <Button
+                    className="mx-4 my-2 min-w-24 max-h-8"
+                    variant="secondary"
+                    onClick={() => { setTrackerDialogOpen(true) }}>
+                    {t('Add')}
+                </Button>
             </div>
-            <Button className="mx-4 my-2 min-w-24 max-h-8" variant="secondary" onClick={() => { setTrackerDialogOpen(true) }}>{t('Add')}</Button>
 
             <Dialog open={trackerDialogOpen} onOpenChange={setTrackerDialogOpen}>
                 <DialogContent>
@@ -129,6 +139,6 @@ export default function Trackers({ download }: { download: Download }) {
                     </DialogFooter>
                 </DialogContent>
             </Dialog>
-        </div>
+        </ScrollArea>
     )
 }

--- a/src/tribler/ui/src/pages/Downloads/index.tsx
+++ b/src/tribler/ui/src/pages/Downloads/index.tsx
@@ -244,7 +244,10 @@ export default function Downloads({ statusFilter }: { statusFilter: number[] }) 
                                     filters={filters}
                                     allowMultiSelect={true}
                                     onSelectedRowsChange={setSelectedDownloads}
-                                    maxHeight={Math.max((parentRect?.height ?? 50) - 50, 50)}
+                                    style={{
+                                        maxHeight: (parentRect?.height ?? 50) - 50,
+                                        height: (parentRect?.height ?? 50) - 50
+                                    }}
                                     allowColumnToggle="download-columns"
                                     storeSortingState="download-sorting"
                                     rowId={(row) => row.infohash}

--- a/src/tribler/ui/src/pages/Popular/index.tsx
+++ b/src/tribler/ui/src/pages/Popular/index.tsx
@@ -106,7 +106,7 @@ export default function Popular() {
                 />
             }
             <SimpleTable
-                scrollClassName="[&>[data-radix-scroll-area-viewport]]:max-h-[calc(100vh-57px)]"
+                className="[&>[data-radix-scroll-area-viewport]]:max-h-[calc(100vh-57px)]"
                 data={torrents}
                 columns={torrentColumns}
                 storeSortingState="popular-sorting"

--- a/src/tribler/ui/src/pages/Search/index.tsx
+++ b/src/tribler/ui/src/pages/Search/index.tsx
@@ -152,7 +152,7 @@ export default function Search() {
                 />
             }
             <SimpleTable
-                scrollClassName="[&>[data-radix-scroll-area-viewport]]:max-h-[calc(100vh-57px)]"
+                className="[&>[data-radix-scroll-area-viewport]]:max-h-[calc(100vh-57px)]"
                 data={torrents}
                 columns={torrentColumns}
                 storeSortingState="search-sorting"


### PR DESCRIPTION
Fixes https://github.com/Tribler/tribler/issues/8365.
Fixes https://github.com/Tribler/tribler/issues/8492 by removing the need for pagination.

This PR adds virtual scrolling to all tables, including file trees. For lists of a couple of thousand items, the difference is quite dramatic. Before you could barely scroll, now there's no slowdown at all. I've tested with up to 100k items without any issues. I think/hope it's good enough to disable pagination.

A downside is that column sizes can change as you scroll through the list. That's just because the table layout is set to auto, and only a small set of rows is being rendered at a time. I didn't want to go into calculating column sizes manually, but we can always revisit this later.

Note that there is room for additional performance improvements by only requesting updates from the core for the items that are (close to being) visible. Maybe something to consider in the future.
