### PR TITLE
Fixed README Python 3.12 badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 |doi| |openhub|
-|python_3_10| |contributors| |pr_closed| |issues_closed|
+|python_3_12| |contributors| |pr_closed| |issues_closed|
 
 
 


### PR DESCRIPTION
This PR:

 - Fixes the `README`'s Python version badge not being linked properly.
