### PR TITLE
Updated GA Runner Ubuntu 20.04 -> 22.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       matrix:
         include:  # macos-12 is no longer on GitHub Actions, we use the Mac mini for this
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             architecture: x64
           - os: ubuntu-latest
             architecture: aarch64
@@ -114,7 +114,7 @@ jobs:
       # Individual builds #
       #####################
       - name: Build Executables (Ubuntu x64)
-        if: matrix.os == 'ubuntu-20.04' && matrix.architecture == 'x64'
+        if: matrix.os == 'ubuntu-22.04' && matrix.architecture == 'x64'
         run: |
           sudo apt-get update -q -y
           sudo apt-get install -y --allow-downgrades alien devscripts fakeroot gir1.2-gtk-3.0 libgirepository1.0-dev rpm


### PR DESCRIPTION
Fixes #8499

This PR:

 - Updates the GitHub Actions Runner `ubuntu-20.04` to `ubuntu-22.04`.

Support is being dropped tomorrow. This covers all usages (that I could find) within Tribler and IPv8.