### PR TITLE
Fixed aarch64 build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,15 +142,20 @@ jobs:
           shell: /bin/sh
           install: |
             apt-get update -q -y
-            apt-get install -q -y --allow-downgrades alien cpio=2.13+dfsg-7 devscripts fakeroot gir1.2-gtk-4.0 libgirepository1.0-dev rpm python3-pip libcairo2-dev
+            apt-get install -q -y software-properties-common
+            add-apt-repository -u ppa:deadsnakes/ppa
+            apt-get install -q -y curl debhelper devscripts gir1.2-gtk-4.0 libgirepository1.0-dev python3.12-dev libcairo2-dev
           run: |
-            python3 -m pip install --upgrade pip
-            python3 -m pip install --upgrade -r /tribler/build/requirements.txt
-            python3 -m pip install meson ninja
+            curl -sSL https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+            python3.12 get-pip.py
+            python3.12 -m pip install --upgrade -r /tribler/build/requirements.txt
+            python3.12 -m pip install meson ninja
 
             cd /tribler
             cp /lib/${{ matrix.architecture }}-linux-gnu/libcrypt.so.1 libcrypt-06cd74a6.so.2  # cx_Freeze workaround
             export PATH="/usr/local/bin:$PATH"
+            unlink /usr/bin/python3
+            ln -s $(echo "`which python3.12`") /usr/bin/python3
             ./build/debian/makedist_debian.sh
 
             cd build/debian


### PR DESCRIPTION
Fixes [the build job](https://github.com/Tribler/tribler/actions/runs/14440822939) for aarch64

This PR:

 - Fixes the aarch64 build using Python 3.10. Successful build: https://github.com/qstokkink/tribler/actions/runs/14445258968
 - Removes unnecessary aarch64 apt packages.

This should definitively fix the aarch64 build. The only unconfirmed 3.12 build after this is Windows x32.