### PR TITLE
Replace tdef innards with ATP

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,12 @@
 -r pyipv8/requirements.txt
 
+aiohttp==3.11.16
 bitarray
 configobj
 ipv8-rust-tunnels
 libtorrent==2.0.11
 lz4
+marshmallow==3.26.1
 pillow
 pony
 pystray

--- a/src/tribler/core/database/orm_bindings/torrent_metadata.py
+++ b/src/tribler/core/database/orm_bindings/torrent_metadata.py
@@ -92,20 +92,18 @@ def tdef_to_metadata_dict(tdef: TorrentDef) -> dict:
     tags = "Unknown"
 
     try:
-        torrent_date = datetime.fromtimestamp(tdef.get_creation_date())  # noqa: DTZ006
+        creation_time = tdef.torrent_info.creation_date() if tdef.torrent_info else tdef.atp.added_time
+        torrent_date = datetime.fromtimestamp(creation_time)  # noqa: DTZ006
     except (ValueError, TypeError):
         torrent_date = EPOCH
 
-    tracker = tdef.get_tracker()
-    if not isinstance(tracker, bytes):
-        tracker = b""
-    tracker_url = tracker.decode()
+    tracker_url = tdef.atp.trackers[0] if tdef.atp.trackers else ""
     tracker_info = get_uniformed_tracker_url(tracker_url) or ''
     return {
-        "infohash": tdef.get_infohash(),
-        "title": tdef.get_name_as_unicode()[:300],
+        "infohash": tdef.infohash,
+        "title": tdef.name[:300],
         "tags": tags[:200],
-        "size": tdef.get_length(),
+        "size": tdef.torrent_info.total_size() if tdef.torrent_info else 0,
         "torrent_date": max(torrent_date, EPOCH),
         "tracker_info": tracker_info,
     }

--- a/src/tribler/core/libtorrent/restapi/create_torrent_endpoint.py
+++ b/src/tribler/core/libtorrent/restapi/create_torrent_endpoint.py
@@ -144,6 +144,7 @@ class CreateTorrentEndpoint(RESTEndpoint):
             download_config = DownloadConfig.from_defaults(self.download_manager.config)
             download_config.set_dest_dir(result["base_dir"])
             download_config.set_hops(self.download_manager.config.get("libtorrent/download_defaults/number_hops"))
-            await self.download_manager.start_download(save_path, TorrentDef(metainfo_dict), download_config)
+            await self.download_manager.start_download(save_path, TorrentDef.load_from_dict(metainfo_dict),
+                                                       download_config)
 
         return RESTResponse(json.dumps({"torrent": base64.b64encode(result["metainfo"]).decode()}))

--- a/src/tribler/core/libtorrent/torrentdef.py
+++ b/src/tribler/core/libtorrent/torrentdef.py
@@ -1,26 +1,17 @@
-"""
-Author(s): Arno Bakker.
-"""
 from __future__ import annotations
 
-import itertools
-import logging
 from asyncio import get_running_loop
-from contextlib import suppress
 from functools import cached_property
-from hashlib import sha1, sha256
-from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, cast, overload
+from typing import TYPE_CHECKING, Any, cast
 
 import aiohttp
 import libtorrent as lt
 
 from tribler.core.libtorrent.torrent_file_tree import TorrentFileTree
-from tribler.core.libtorrent.trackers import is_valid_url
 
 if TYPE_CHECKING:
-    from collections.abc import Generator, Iterable
     from os import PathLike
+    from typing import Literal, overload
 
     ###############
     # V1 torrents #
@@ -228,182 +219,49 @@ else:
     TorrentParameters = dict
 
 
-def escape_as_utf8(string: bytes, encoding: str = "utf8") -> str:
-    """
-    Make a string UTF-8 compliant, destroying characters if necessary.
-
-    :param string: the string to convert
-    :param encoding: the string encoding to use
-    :return: the utf-8 string derivative
-    """
-    try:
-        # Check if the delivered encoding is correct and we can convert to utf8 without any issues.
-        return string.decode(encoding).encode('utf8').decode('utf8')
-    except (LookupError, TypeError, ValueError):
-        try:
-            # The delivered encoding is incorrect, cast it to  latin1 and hope for the best (minor corruption).
-            return string.decode('latin1').encode('utf8', 'ignore').decode('utf8')
-        except (TypeError, ValueError):
-            # This is a very nasty string (e.g. '\u266b'), remove the illegal entries.
-            return string.decode('utf8', 'ignore')
-
-
-def pathlist2filename(pathlist: Iterable[bytes]) -> Path:
-    """
-    Convert a multi-file torrent file 'path' entry to a filename.
-    """
-    return Path(*(x.decode() for x in pathlist))
-
-
-def yield_v2_files(directory: DirectoryV2 | FileV2, path: bytes = b"") -> Generator[tuple[bytes, FileSpecV2]]:
-    """
-    Get the full path and file spec for each file in a v2 subtree.
-    """
-    if b"" in directory:
-        yield path, cast("FileSpecV2", directory[b""])
-    else:
-        for name, subdir in directory.items():
-            if subdir not in [".", ".."]:  # BEP52-specified directory name filtering
-                yield from yield_v2_files(subdir, (path + b"/" + name) if path else name)
-
-
-def _get_length_from_v2_dir(directory: DirectoryV2 | FileV2) -> int:
-    return sum(fspec[b"length"] for _, fspec in yield_v2_files(directory))
-
-
-def _get_pieces_from_v2_dir(directory: DirectoryV2 | FileV2, piece_length: int) -> int:
-    return sum((fspec[b"length"] // piece_length) + (1 if fspec[b"length"] % piece_length > 0 else 0)
-               for _, fspec in yield_v2_files(directory))
-
-
-def get_length_from_metainfo(metainfo: MetainfoDict | MetainfoV2Dict, selectedfiles: set[Path] | None) -> int:
-    """
-    Loop through all files in a torrent and calculate the total size.
-    """
-    # v2 torrent
-    if b"file tree" in metainfo[b"info"]:
-        return _get_length_from_v2_dir(cast("InfoDictV2", metainfo[b"info"])[b"file tree"])
-
-    # single-file v1 torrent
-    if b"files" not in metainfo[b"info"]:
-        return cast("InfoDict", metainfo[b"info"])[b"length"]
-
-    # multi-file v1 torrent
-    files = cast("InfoDict", metainfo[b"info"])[b"files"]
-    total = 0
-    for i in range(len(files)):
-        path = files[i][b"path"]
-        length = files[i][b"length"]
-        if length > 0 and (not selectedfiles or pathlist2filename(path) in selectedfiles):
-            total += length
-    return total
-
-
 class TorrentDef:
     """
     This object acts as a wrapper around some libtorrent metadata.
     It can be used to create new torrents, or analyze existing ones.
     """
 
-    def __init__(self, metainfo: MetainfoDict | MetainfoV2Dict | None = None,
-                 torrent_parameters: TorrentParameters | None = None,
-                 ignore_validation: bool = True) -> None:
+    def __init__(self, atp: lt.add_torrent_params) -> None:
         """
         Create a new TorrentDef object, possibly based on existing data.
 
-        :param metainfo: A dictionary with metainfo, i.e. from a .torrent file.
-        :param torrent_parameters: User-defined parameters for the new TorrentDef.
-        :param ignore_validation: Whether we ignore the libtorrent validation.
+        :param atp: User-defined parameters for the new TorrentDef.
         """
-        self._logger = logging.getLogger(self.__class__.__name__)
-        self.torrent_parameters: TorrentParameters = cast("TorrentParameters", {})
-        self.metainfo: MetainfoDict | MetainfoV2Dict | None = metainfo
-        self.infohash: bytes | None = None
-        self._torrent_info: lt.torrent_info | None = None
+        self.atp = atp
 
-        if self.metainfo is not None:
-            # First, make sure the passed metainfo is valid
-            if not ignore_validation:
-                try:
-                    self._torrent_info = lt.torrent_info(self.metainfo)
-                    self.infohash = self._torrent_info.info_hash().to_bytes()
-                except RuntimeError as exc:
-                    raise ValueError from exc
-            else:
-                try:
-                    if not self.metainfo[b'info']:
-                        msg = "Empty metainfo!"
-                        raise ValueError(msg)
-                    if b"file tree" in self.metainfo[b"info"]:
-                        self.infohash = sha256(lt.bencode(self.metainfo[b"info"])).digest()[:20]
-                    else:
-                        self.infohash = sha1(lt.bencode(self.metainfo[b"info"])).digest()
-                except (KeyError, RuntimeError) as exc:
-                    raise ValueError from exc
-            self.copy_metainfo_to_torrent_parameters()
-
-        elif torrent_parameters is not None:
-            self.torrent_parameters.update(torrent_parameters)
-
-    def copy_metainfo_to_torrent_parameters(self) -> None:  # noqa: C901
+    @property
+    def name(self) -> str:
         """
-        Populate the torrent_parameters dictionary with information from the metainfo.
+        Get the name of this torrent.
         """
-        if self.metainfo is not None:
-            if b"comment" in self.metainfo:
-                self.torrent_parameters[b"comment"] = self.metainfo[b"comment"]
-            if b"created by" in self.metainfo:
-                self.torrent_parameters[b"created by"] = self.metainfo[b"created by"]
-            if b"creation date" in self.metainfo:
-                self.torrent_parameters[b"creation date"] = self.metainfo[b"creation date"]
-            if b"announce" in self.metainfo:
-                self.torrent_parameters[b"announce"] = self.metainfo[b"announce"]
-            if b"announce-list" in self.metainfo:
-                self.torrent_parameters[b"announce-list"] = self.metainfo[b"announce-list"]
-            if b"nodes" in self.metainfo:
-                self.torrent_parameters[b"nodes"] = self.metainfo[b"nodes"]
-            if b"httpseeds" in self.metainfo:
-                self.torrent_parameters[b"httpseeds"] = self.metainfo[b"httpseeds"]
-            if b"urllist" in self.metainfo:
-                self.torrent_parameters[b"urllist"] = self.metainfo[b"urllist"]
-            if b"name" in self.metainfo[b"info"]:
-                self.torrent_parameters[b"name"] = self.metainfo[b"info"][b"name"]
-            if b"piece length" in self.metainfo[b"info"]:
-                self.torrent_parameters[b"piece length"] = self.metainfo[b"info"][b"piece length"]
+        return self.atp.name or (self.torrent_info.name() if self.torrent_info else "Unknown name")
 
     @property
     def torrent_info(self) -> lt.torrent_info | None:
         """
         Get the libtorrent torrent info instance or load it from our metainfo.
         """
-        self.load_torrent_info()
-        return self._torrent_info
+        return self.atp.ti
 
-    def invalidate_torrent_info(self) -> None:
+    @property
+    def infohash(self) -> bytes:
         """
-        Invalidate the torrent info.
+        Convenient way to get the info_hash as bytes.
         """
-        self._torrent_info = None
-
-    def load_torrent_info(self) -> None:
-        """
-        Load the torrent info into memory from our metainfo if it does not exist.
-        """
-        if self._torrent_info is None:
-            self._torrent_info = lt.torrent_info(cast("dict[bytes, Any]", self.metainfo))
-
-    def torrent_info_loaded(self) -> bool:
-        """
-        Check if the libtorrent torrent info is loaded.
-        """
-        return self._torrent_info is not None
+        if self.torrent_info:
+            return self.torrent_info.info_hash().to_bytes()
+        return self.atp.info_hash.to_bytes()
 
     @cached_property
     def torrent_file_tree(self) -> TorrentFileTree:
         """
         Construct a file tree from this torrent definition.
         """
-        return TorrentFileTree.from_lt_file_storage(self.torrent_info.files())  # type: ignore[union-attr]
+        return TorrentFileTree.from_lt_file_storage(cast("lt.torrent_info", self.torrent_info).files())
 
     @staticmethod
     def _threaded_load_job(filepath: str | bytes | PathLike) -> TorrentDef:
@@ -412,9 +270,10 @@ class TorrentDef:
 
         Called from a thread: don't call this directly!
         """
-        with open(filepath, "rb") as torrent_file:
-            file_content = torrent_file.read()
-        return TorrentDef.load_from_memory(file_content)
+        try:
+            return TorrentDef(lt.load_torrent_file(filepath))  # type: ignore[attr-defined]  # missing in lt .pyi
+        except RuntimeError as e:
+            raise ValueError from e
 
     @staticmethod
     async def load(filepath: str | bytes | PathLike) -> TorrentDef:
@@ -432,13 +291,10 @@ class TorrentDef:
 
         :param bencoded_data: The bencoded data to decode and use as metainfo
         """
-        metainfo = lt.bdecode(bencoded_data)
-        # Some versions of libtorrent will not raise an exception when providing invalid data.
-        # This issue is present in 1.0.8 (included with Tribler 7.3.0), but has been fixed since at least 1.2.1.
-        if metainfo is None:
-            msg = "Data is not a bencoded string"
-            raise ValueError(msg)
-        return TorrentDef.load_from_dict(cast("MetainfoDict", metainfo))
+        try:
+            return TorrentDef(lt.load_torrent_buffer(bencoded_data))  # type: ignore[attr-defined]  # missing in lt .pyi
+        except RuntimeError as e:
+            raise ValueError from e
 
     @staticmethod
     def load_from_dict(metainfo: MetainfoDict | MetainfoV2Dict) -> TorrentDef:
@@ -447,7 +303,10 @@ class TorrentDef:
 
         :param metainfo: The metainfo dictionary
         """
-        return TorrentDef(metainfo=metainfo)
+        try:
+            return TorrentDef.load_from_memory(lt.bencode(metainfo))
+        except RuntimeError as e:
+            raise ValueError from e
 
     @staticmethod
     async def load_from_url(url: str) -> TorrentDef:
@@ -457,277 +316,48 @@ class TorrentDef:
         :param url: The HTTP/HTTPS url where to fetch the torrent info from.
         """
         session = aiohttp.ClientSession(raise_for_status=True)
-
         response = await session.get(url)
         body = await response.read()
-
         return TorrentDef.load_from_memory(body)
 
-    def _filter_characters(self, name: bytes) -> str:
+    @staticmethod
+    def load_only_sha1(infohash: bytes, name: str, url: str) -> TorrentDef:
         """
-        Sanitize the names in path to unicode by replacing out all
-        characters that may -even remotely- cause problems with the '?'
-        character.
+        This loads a TorrentDef with only the SHA-1, without resolving it from the given URI.
+        """
+        atp = lt.add_torrent_params()
+        atp.info_hash = lt.sha1_hash(infohash)
+        atp.name = name
+        atp.url = url
+        return TorrentDef(atp)
 
-        :param name: the name to sanitize
-        :return: the sanitized string
+    async def load_torrent_info(self) -> None:
         """
-
-        def filter_character(char: int) -> str:
-            if 0 < char < 128:
-                return chr(char)
-            self._logger.debug("Bad character 0x%X", char)
-            return "?"
-
-        return "".join(map(filter_character, name))
-
-    def set_encoding(self, enc: bytes) -> None:
+        Load the torrent info from the stored url.
         """
-        Set the character encoding for e.g. the 'name' field.
-
-        :param enc: The new encoding of the file.
-        """
-        self.torrent_parameters[b"encoding"] = enc
-
-    def get_encoding(self) -> str:
-        """
-        Returns the used encoding of the TorrentDef.
-        """
-        return self.torrent_parameters.get(b"encoding", b"utf-8").decode()
-
-    def set_tracker(self, url: str) -> None:
-        """
-        Set the tracker of this torrent, according to a given URL.
-        :param url: The tracker url.
-        """
-        if not is_valid_url(url):
-            msg = "Invalid URL"
-            raise ValueError(msg)
-
-        url = url.removesuffix("/")
-        self.torrent_parameters[b"announce"] = url
-
-    def get_tracker(self) -> bytes | None:
-        """
-        Returns the torrent announce URL.
-        """
-        return self.torrent_parameters.get(b"announce", None)
-
-    def get_tracker_hierarchy(self) -> list[list[bytes]]:
-        """
-        Returns the hierarchy of trackers.
-        """
-        return self.torrent_parameters.get(b"announce-list", [])
-
-    def get_trackers(self) -> set[bytes]:
-        """
-        Returns a flat set of all known trackers.
-
-        :return: all known trackers
-        """
-        if self.get_tracker_hierarchy():
-            trackers = itertools.chain.from_iterable(self.get_tracker_hierarchy())
-            return set(filter(None, trackers))
-        tracker = self.get_tracker()
-        if tracker:
-            return {tracker}
-        return set()
-
-    def set_piece_length(self, piece_length: int) -> None:
-        """
-        Set the size of the pieces in which the content is traded.
-        The piece size must be a multiple of the chunk size, the unit in which
-        it is transmitted, which is 16K by default. The default is automatic (value 0).
-
-        :param piece_length: The piece length.
-        """
-        if not isinstance(piece_length, int):
-            msg = "Piece length not an int/long"
-            raise ValueError(msg)  # noqa: TRY004
-
-        self.torrent_parameters[b"piece length"] = piece_length
-
-    def get_piece_length(self) -> int:
-        """
-        Returns the piece size.
-        """
-        return self.torrent_parameters.get(b"piece length", 0)
-
-    def get_nr_pieces(self) -> int:
-        """
-        Returns the number of pieces.
-        """
-        if not self.metainfo:
-            return 0
-        if self._torrent_info:
-            self._torrent_info.num_pieces()
-        if b"pieces" in self.metainfo[b"info"]:
-            return len(cast("InfoDict", self.metainfo[b"info"])[b"pieces"]) // 20
-        return _get_pieces_from_v2_dir(cast("InfoDictV2", self.metainfo[b"info"])[b"file tree"],
-                                       self.metainfo[b"info"][b"piece length"])
-
-    def get_infohash(self) -> bytes | None:
-        """
-        Returns the infohash of the torrent, if metainfo is provided. Might be None if no metainfo is provided.
-        """
-        return self.infohash
+        if self.torrent_info is None:
+            self.atp = (await self.load_from_url(self.atp.url)).atp
 
     def get_metainfo(self) -> MetainfoDict | MetainfoV2Dict | None:
         """
         Returns the metainfo of the torrent. Might be None if no metainfo is provided.
         """
-        return self.metainfo
-
-    def get_name(self) -> bytes | None:
-        """
-        Returns the name as raw string of bytes.
-        """
-        return self.torrent_parameters[b"name"]
-
-    def get_name_utf8(self) -> str:
-        """
-        Not all names are utf-8, attempt to construct it as utf-8 anyway.
-        """
-        return escape_as_utf8(self.get_name() or b"", self.get_encoding())
-
-    def set_name(self, name: bytes) -> None:
-        """
-        Set the name of this torrent.
-
-        :param name: The new name of the torrent
-        """
-        self.torrent_parameters[b"name"] = name
-
-    def get_name_as_unicode(self) -> str:
-        """
-        Returns the info['name'] field as Unicode string.
-
-        If there is an utf-8 encoded name, we assume that it is correctly encoded and use it normally.
-        Otherwise, if there is an encoding[1], we attempt to decode the (bytes) name.
-        Otherwise, we attempt to decode the (bytes) name as UTF-8.
-        Otherwise, we attempt to replace non-UTF-8 characters from the (bytes) name with "?".
-        If all of the above fails, this returns an empty string.
-
-        [1] Some encodings are not supported by python. For instance, the MBCS codec which is used by Windows is not
-        supported (Jan 2010).
-        """
-        if self.metainfo is not None:
-            if b"name.utf-8" in self.metainfo[b"info"]:
-                with suppress(UnicodeError):
-                    return cast("InfoDict", self.metainfo[b"info"])[b"name.utf-8"].decode()
-
-            if (name := self.metainfo[b"info"].get(b"name")) is not None:
-                if (encoding := self.metainfo.get(b"encoding")) is not None:
-                    with suppress(UnicodeError), suppress(LookupError):
-                        return name.decode(encoding.decode())
-                with suppress(UnicodeError):
-                    return name.decode()
-                with suppress(UnicodeError):
-                    return self._filter_characters(name)
-
-        return ""
-
-    def _get_all_files_as_unicode_with_length(self) -> Generator[tuple[Path, int]]:  # noqa: C901, PLR0912
-        """
-        Get a generator for files in the torrent def. No filtering is possible and all tricks are allowed to obtain
-        a unicode list of filenames.
-
-        :return: A unicode filename generator.
-        """
-        if self.metainfo and b"files" in self.metainfo[b"info"]:
-            metainfo_v1 = cast("InfoDict", self.metainfo[b"info"])
-            # Multi-file v1 torrent
-            files = cast("FileDict", metainfo_v1[b"files"])
-            storage = cast("lt.torrent_info", self.torrent_info).files()  # If we have metainfo, we have torrent_info
-
-            for index, file_dict in enumerate(files):
-                # Ignore padding files, to align with v2 metainfo
-                if storage.file_flags(index) != 0:
-                    continue
-                if b"path.utf-8" in file_dict:
-                    # This file has an utf-8 encoded list of elements.
-                    # We assume that it is correctly encoded and use it normally.
-                    try:
-                        yield (Path(*(element.decode() for element in file_dict[b"path.utf-8"])),
-                               file_dict[b"length"])
-                        continue
-                    except UnicodeError:
-                        pass
-
-                if b"path" in file_dict:
-                    # Try to use the 'encoding' field. If it exists, it should contain something like 'utf-8'.
-                    if (encoding := metainfo_v1.get(b"encoding")) is not None:
-                        try:
-                            yield (Path(*(element.decode(encoding.decode()) for element in file_dict[b"path"])),
-                                   file_dict[b"length"])
-                            continue
-                        except UnicodeError:
-                            pass
-                        except LookupError:
-                            # Some encodings are not supported by Python.  For instance, the MBCS codec which is used
-                            # by Windows is not supported (Jan 2010).
-                            pass
-
-                    # Try to convert the names in path to unicode, assuming that it was encoded as utf-8.
-                    try:
-                        yield (Path(*(element.decode() for element in file_dict[b"path"])),
-                               file_dict[b"length"])
-                        continue
-                    except UnicodeError:
-                        pass
-
-                    # Convert the names in path to unicode by replacing out all characters that may - even remotely -
-                    # cause problems with the '?' character.
-                    try:
-                        yield Path(*map(self._filter_characters, file_dict[b"path"])), file_dict[b"length"]
-                        continue
-                    except UnicodeError:
-                        pass
-
-        elif self.metainfo and b"file tree" in self.metainfo[b"info"]:
-            # v2 torrent; all paths are supposed to be UTF-8 here, but still need to be checked
-            metainfo_v2 = cast("InfoDictV2", self.metainfo[b"info"])
-            for path, fspec in yield_v2_files(metainfo_v2[b"file tree"]):
-                # Try to convert the names in path to unicode, assuming that it was encoded as utf-8.
-                try:
-                    yield Path(path.decode()), fspec[b"length"]
-                    continue
-                except UnicodeError:
-                    pass
-
-                # Convert the names in path to unicode by replacing out all characters that may - even remotely -
-                # cause problems with the '?' character.
-                try:
-                    yield Path(self._filter_characters(path)), fspec[b"length"]
-                    continue
-                except UnicodeError:
-                    pass
-
-        elif self.metainfo:
-            # Single-file v1 torrent
-            yield Path(self.get_name_as_unicode()), cast("InfoDict", self.metainfo[b"info"])[b"length"]
-
-    def get_files_with_length(self, exts: set[str] | None = None) -> list[tuple[Path, int]]:
-        """
-        The list of files in the torrent def.
-
-        :param exts: (Optional) list of filename extensions (without leading .) to search for.
-        :return: A list of filenames.
-        """
-        videofiles = []
-        for filename, length in self._get_all_files_as_unicode_with_length():
-            ext = Path(filename).suffix
-            if ext != "" and ext[0] == ".":
-                ext = ext[1:]
-            if exts is None or ext.lower() in exts:
-                videofiles.append((filename, length))
-        return videofiles
-
-    def get_files(self, exts: set[str] | None = None) -> list[Path]:
-        """
-        Return the list of file paths in this torrent.
-        """
-        return [filename for filename, _ in self.get_files_with_length(exts)]
+        if self.atp.ti is None:
+            return None
+        return MetainfoDict({
+            b"announce": self.atp.trackers[0].encode() if self.atp.trackers else b"",
+            b"announce-list": [[tracker.encode()] for tracker in self.atp.trackers],
+            b"comment": self.atp.ti.comment().encode(),
+            b"created by": self.atp.ti.creator().encode(),
+            b"creation date": self.atp.ti.creation_date(),
+            b"encoding": "UTF-8",
+            b"httpseeds": [web_seed["url"].encode() for web_seed in self.atp.ti.web_seeds()
+                           if web_seed["type"] == 1],  # type: ignore[typeddict-item]  # missing in lt .pyi
+            b"nodes": [(entry[0].encode(), entry[1]) for entry in self.atp.ti.nodes()],
+            b"urllist": [web_seed["url"].encode() for web_seed in self.atp.ti.web_seeds()
+                         if web_seed["type"] == 0],  # type: ignore[typeddict-item]  # missing in lt .pyi
+            b"info": lt.bdecode(self.atp.ti.info_section())
+        })
 
     def get_file_indices(self) -> list[int]:
         """
@@ -737,120 +367,3 @@ class TorrentDef:
             return []
         storage = self.torrent_info.files()
         return [i for i in range(storage.num_files()) if storage.file_flags(i) == 0]
-
-    def get_length(self, selectedfiles: set[Path] | None = None) -> int:
-        """
-        Returns the total size of the content in the torrent. If the optional selectedfiles argument is specified, the
-        method returns the total size of only those files.
-
-        :return: A length (long)
-        """
-        if self.metainfo:
-            return get_length_from_metainfo(self.metainfo, selectedfiles)
-        return 0
-
-    def get_creation_date(self) -> int:
-        """
-        Returns the creation date of the torrent.
-        """
-        return self.metainfo.get(b"creation date", 0) if self.metainfo else 0
-
-    def is_multifile_torrent(self) -> bool:
-        """
-        Returns whether this TorrentDef is a multi-file torrent.
-        """
-        if self.metainfo:
-            return b"files" in self.metainfo[b"info"]
-        return False
-
-    def is_private(self) -> bool:
-        """
-        Returns whether this TorrentDef is a private torrent (and is not announced in the DHT).
-        """
-        try:
-            private = int(self.metainfo[b"info"].get(b"private", 0)) if self.metainfo else 0
-        except (ValueError, KeyError) as e:
-            self._logger.warning("%s: %s", e.__class__.__name__, str(e))
-            private = 0
-        return private == 1
-
-    def get_index_of_file_in_files(self, file: str | None) -> int:
-        """
-        Get the index of the given file path in the torrent.
-
-        Raises a ValueError if the path is not found.
-        """
-        if not self.metainfo:
-            msg = "TorrentDef does not have metainfo"
-            raise ValueError(msg)
-
-        if file is not None and b"files" in self.metainfo[b"info"]:
-            info = cast("InfoDict", self.metainfo[b"info"])
-            for i in range(len(info[b"files"])):
-                file_dict = info[b"files"][i]
-
-                intorrentpath = pathlist2filename(file_dict.get(b"path.utf-8", file_dict[b"path"]))
-
-                if intorrentpath == Path(file):
-                    return i
-            msg = "File not found in torrent"
-            raise ValueError(msg)
-
-        if file is not None and b"file tree" in self.metainfo[b"info"]:
-            infov2 = cast("InfoDictV2", self.metainfo[b"info"])
-            i = 0
-            fbytes = file.encode()
-            for path, _ in yield_v2_files(infov2[b"file tree"]):
-                if path == fbytes:
-                    return i
-                i += 1
-            msg = "File not found in torrent"
-            raise ValueError(msg)
-
-        msg = "File not found in single-file torrent"
-        raise ValueError(msg)
-
-
-class TorrentDefNoMetainfo(TorrentDef):
-    """
-    Instances of this class are used when working with a torrent def that contains no metainfo (yet), for instance,
-    when starting a download with only an infohash. Other methods that are using this class do not distinguish between
-    a TorrentDef with and without data and may still expect this class to have various methods in TorrentDef
-    implemented.
-    """
-
-    def __init__(self, infohash: bytes, name: bytes, url: bytes | str | None = None) -> None:
-        """
-        Create a new valid torrent def without metainfo.
-        """
-        torrent_parameters: TorrentParameters = cast("TorrentParameters", {b"name": name})
-        if url is not None:
-            torrent_parameters[b"urllist"] = [url if isinstance(url, bytes) else url.encode()]
-        super().__init__(torrent_parameters=torrent_parameters)
-        self.infohash = infohash
-
-    def get_url(self) -> bytes | str | None:
-        """
-        Get the URL belonging to this torrent.
-        """
-        if urllist := self.torrent_parameters.get(b"urllist"):
-            return urllist[0]
-        return None
-
-    @property
-    def torrent_info(self) -> lt.torrent_info | None:
-        """
-        A torrent def without metinfo has no libtorrent torrent_info.
-        """
-        return None
-
-    def load_torrent_info(self) -> None:
-        """
-        If there cannot be torrent info, we don't need to try and load it.
-        """
-
-    def get_name_as_unicode(self) ->  str:
-        """
-        Get the name of this torrent.
-        """
-        return self.get_name_utf8()

--- a/src/tribler/core/tunnel/community.py
+++ b/src/tribler/core/tunnel/community.py
@@ -167,7 +167,7 @@ class TriblerTunnelCommunity(HiddenTunnelCommunity):
         Add the special IPs that belong to circuits to a download.
         """
         for torrent, peers in list(self.bittorrent_peers.items()):
-            infohash = hexlify(torrent.tdef.get_infohash())
+            infohash = hexlify(torrent.tdef.infohash)
             for peer in peers:
                 self.logger.info("Re-adding peer %s to torrent %s", peer, infohash)
                 torrent.add_peer(peer)
@@ -286,7 +286,7 @@ class TriblerTunnelCommunity(HiddenTunnelCommunity):
             hop_count = download.config.get_hops()
             if hop_count > 0:
                 # Convert the real infohash to the infohash used for looking up introduction points
-                real_info_hash = download.get_def().get_infohash()
+                real_info_hash = download.get_def().infohash
                 info_hash = self.get_lookup_info_hash(real_info_hash)
                 hops[info_hash] = hop_count
                 new_states[info_hash] = ds.get_status()
@@ -377,7 +377,7 @@ class TriblerTunnelCommunity(HiddenTunnelCommunity):
             return None
 
         for download in self.settings.download_manager.get_downloads():
-            if lookup_info_hash == self.get_lookup_info_hash(download.get_def().get_infohash()):
+            if lookup_info_hash == self.get_lookup_info_hash(download.get_def().infohash):
                 return download
         return None
 

--- a/src/tribler/test_integration/test_hidden_services.py
+++ b/src/tribler/test_integration/test_hidden_services.py
@@ -4,7 +4,6 @@ from asyncio import sleep
 from typing import TYPE_CHECKING, cast
 from unittest.mock import Mock
 
-import libtorrent
 from ipv8.community import CommunitySettings
 from ipv8.keyvault.crypto import default_eccrypto
 from ipv8.messaging.anonymization.tunnel import PEER_FLAG_EXIT_BT
@@ -17,7 +16,7 @@ from ipv8.test.mocking.ipv8 import MockIPv8
 from tribler.core.libtorrent.download_manager.download_config import DownloadConfig
 from tribler.core.libtorrent.download_manager.download_manager import DownloadManager
 from tribler.core.libtorrent.download_manager.download_state import DownloadStatus
-from tribler.core.libtorrent.torrentdef import TorrentDef, TorrentDefNoMetainfo
+from tribler.core.libtorrent.torrentdef import TorrentDef
 from tribler.core.libtorrent.torrents import create_torrent_file
 from tribler.core.notifier import Notifier
 from tribler.core.socks5.server import Socks5Server
@@ -109,7 +108,7 @@ class TestHiddenServicesDownload(TestBase[TriblerTunnelCommunity]):
 
         The seeder does not have an overlay!
         """
-        global_settings = cast(GlobalTestSettings, settings)
+        global_settings = cast("GlobalTestSettings", settings)
         my_node_id = global_settings.node_id
         global_settings.node_id += 1
         node_peer = Peer(default_eccrypto.generate_key("curve25519"))
@@ -199,7 +198,7 @@ class TestHiddenServicesDownload(TestBase[TriblerTunnelCommunity]):
             f.write(bytes([0] * 524288))
 
         metainfo = create_torrent_file([config.get_dest_dir() / "ubuntu-15.04-desktop-amd64.iso"], {})["metainfo"]
-        tdef = TorrentDef(metainfo=libtorrent.bdecode(metainfo))
+        tdef = TorrentDef.load_from_memory(metainfo)
 
         download = await self.download_manager_seeder.start_download(tdef=tdef, config=config)
         await download.wait_for_status(DownloadStatus.SEEDING)
@@ -212,7 +211,8 @@ class TestHiddenServicesDownload(TestBase[TriblerTunnelCommunity]):
         """
         config = await self.add_mock_download_config(self.download_manager_downloader, 1)
 
-        return await self.download_manager_downloader.start_download(tdef=TorrentDefNoMetainfo(infohash, b"test"),
+        return await self.download_manager_downloader.start_download(tdef=TorrentDef.load_only_sha1(infohash,
+                                                                                                    "test", ""),
                                                                      config=config)
 
     async def test_hidden_services(self) -> None:

--- a/src/tribler/test_unit/core/database/orm_bindings/test_torrent_metadata.py
+++ b/src/tribler/test_unit/core/database/orm_bindings/test_torrent_metadata.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from ipv8.test.base import TestBase
 
 from tribler.core.database.orm_bindings.torrent_metadata import entries_to_chunk, infohash_to_id, tdef_to_metadata_dict
-from tribler.core.libtorrent.torrentdef import TorrentDefNoMetainfo
+from tribler.core.libtorrent.torrentdef import TorrentDef
 
 
 class MockTorrentMetadata:
@@ -52,7 +52,7 @@ class TestTorrentMetadata(TestBase):
         """
         Test if TorrentDef instances are correctly represented by dictionaries.
         """
-        tdef = TorrentDefNoMetainfo(b"\x01" * 20, b"torrent name", b"http://test.url/")
+        tdef = TorrentDef.load_only_sha1(b"\x01" * 20, "torrent name", "http://test.url/")
 
         value = tdef_to_metadata_dict(tdef)
 

--- a/src/tribler/test_unit/core/libtorrent/download_manager/test_download.py
+++ b/src/tribler/test_unit/core/libtorrent/download_manager/test_download.py
@@ -13,7 +13,7 @@ from validate import Validator
 import tribler
 from tribler.core.libtorrent.download_manager.download import Download, IllegalFileIndex, SaveResumeDataError
 from tribler.core.libtorrent.download_manager.download_config import SPEC_CONTENT, DownloadConfig
-from tribler.core.libtorrent.torrentdef import TorrentDef, TorrentDefNoMetainfo
+from tribler.core.libtorrent.torrentdef import TorrentDef
 from tribler.core.notifier import Notification, Notifier
 from tribler.test_unit.core.libtorrent.mocks import TORRENT_UBUNTU_FILE_CONTENT, TORRENT_WITH_DIRS_CONTENT
 from tribler.test_unit.mocks import MockTriblerConfigManager
@@ -122,7 +122,7 @@ class TestDownload(TestBase):
         """
         Test if storage is not moved for torrents without metainfo.
         """
-        download = Download(TorrentDefNoMetainfo(b"\x01" * 20, b"name"), self.dlmngr, checkpoint_disabled=True,
+        download = Download(TorrentDef.load_only_sha1(b"\x01" * 20, "name", ""), self.dlmngr, checkpoint_disabled=True,
                             config=self.create_mock_download_config())
         download.handle = Mock(is_valid=Mock(return_value=True))
 
@@ -136,7 +136,7 @@ class TestDownload(TestBase):
         """
         Test if checkpoints are not saved if checkpointing is disabled.
         """
-        download = Download(TorrentDefNoMetainfo(b"\x01" * 20, b"name"), self.dlmngr, checkpoint_disabled=True,
+        download = Download(TorrentDef.load_only_sha1(b"\x01" * 20, "name", ""), self.dlmngr, checkpoint_disabled=True,
                             config=self.create_mock_download_config())
         download.handle = Mock(is_valid=Mock(return_value=False))
 
@@ -148,7 +148,7 @@ class TestDownload(TestBase):
         """
         Test if checkpoints are not saved if the handle specifies that it does not need resume data.
         """
-        download = Download(TorrentDefNoMetainfo(b"\x01" * 20, b"name"), self.dlmngr, checkpoint_disabled=True,
+        download = Download(TorrentDef.load_only_sha1(b"\x01" * 20, "name", ""), self.dlmngr, checkpoint_disabled=True,
                             config=self.create_mock_download_config())
         download.checkpoint_disabled = False
         download.handle = Mock(is_valid=Mock(return_value=True), need_save_resume_data=Mock(return_value=False))
@@ -162,7 +162,7 @@ class TestDownload(TestBase):
         Test if checkpoints are saved for torrents without a handle and no existing checkpoint file.
         """
         alerts = []
-        download = Download(TorrentDefNoMetainfo(b"\x01" * 20, b"name"), self.dlmngr, checkpoint_disabled=True,
+        download = Download(TorrentDef.load_only_sha1(b"\x01" * 20, "name", ""), self.dlmngr, checkpoint_disabled=True,
                             config=self.create_mock_download_config())
         download.checkpoint_disabled = False
         download.download_manager = Mock(get_checkpoint_dir=Mock(return_value=Path("foo")))
@@ -183,7 +183,7 @@ class TestDownload(TestBase):
         Test if existing checkpoints are not overwritten by checkpoints without data.
         """
         alerts = []
-        download = Download(TorrentDefNoMetainfo(b"\x01" * 20, b"name"), self.dlmngr, checkpoint_disabled=True,
+        download = Download(TorrentDef.load_only_sha1(b"\x01" * 20, "name", ""), self.dlmngr, checkpoint_disabled=True,
                             config=self.create_mock_download_config())
         download.checkpoint_disabled = False
         download.download_manager = Mock(get_checkpoint_dir=Mock(return_value=Path("foo")))
@@ -200,7 +200,7 @@ class TestDownload(TestBase):
         """
         Test if the default selected files are no files.
         """
-        download = Download(TorrentDefNoMetainfo(b"\x01" * 20, b"name"), self.dlmngr, checkpoint_disabled=True,
+        download = Download(TorrentDef.load_only_sha1(b"\x01" * 20, "name", ""), self.dlmngr, checkpoint_disabled=True,
                             config=self.create_mock_download_config())
         download.handle = Mock(file_priorities=Mock(return_value=[0, 0]))
 
@@ -276,7 +276,7 @@ class TestDownload(TestBase):
         """
         Test if we forward the enabled share mode when requested in the download.
         """
-        download = Download(TorrentDefNoMetainfo(b"\x01" * 20, b"name"), self.dlmngr, checkpoint_disabled=True,
+        download = Download(TorrentDef.load_only_sha1(b"\x01" * 20, "name", ""), self.dlmngr, checkpoint_disabled=True,
                             config=self.create_mock_download_config())
         download.config.set_share_mode(True)
 
@@ -286,7 +286,7 @@ class TestDownload(TestBase):
         """
         Test if we forward the disabled share mode when requested in the download.
         """
-        download = Download(TorrentDefNoMetainfo(b"\x01" * 20, b"name"), self.dlmngr, checkpoint_disabled=True,
+        download = Download(TorrentDef.load_only_sha1(b"\x01" * 20, "name", ""), self.dlmngr, checkpoint_disabled=True,
                             config=self.create_mock_download_config())
         download.config.set_share_mode(False)
 
@@ -296,7 +296,7 @@ class TestDownload(TestBase):
         """
         Test if the share mode can be enabled in a download.
         """
-        download = Download(TorrentDefNoMetainfo(b"\x01" * 20, b"name"), self.dlmngr, checkpoint_disabled=True,
+        download = Download(TorrentDef.load_only_sha1(b"\x01" * 20, "name", ""), self.dlmngr, checkpoint_disabled=True,
                             config=self.create_mock_download_config())
         download.handle = Mock(is_valid=Mock(return_value=True))
 
@@ -310,7 +310,7 @@ class TestDownload(TestBase):
         """
         Test if the share mode can be disabled in a download.
         """
-        download = Download(TorrentDefNoMetainfo(b"\x01" * 20, b"name"), self.dlmngr, checkpoint_disabled=True,
+        download = Download(TorrentDef.load_only_sha1(b"\x01" * 20, "name", ""), self.dlmngr, checkpoint_disabled=True,
                             config=self.create_mock_download_config())
         download.handle = Mock(is_valid=Mock(return_value=True))
 
@@ -324,7 +324,7 @@ class TestDownload(TestBase):
         """
         Test if connected peers and seeds are 0 if there is no handle.
         """
-        download = Download(TorrentDefNoMetainfo(b"\x01" * 20, b"name"), self.dlmngr, checkpoint_disabled=True,
+        download = Download(TorrentDef.load_only_sha1(b"\x01" * 20, "name", ""), self.dlmngr, checkpoint_disabled=True,
                             config=self.create_mock_download_config())
 
         num_seeds, num_peers = download.get_num_connected_seeds_peers()
@@ -336,7 +336,7 @@ class TestDownload(TestBase):
         """
         Test if connected peers and seeds are correctly returned.
         """
-        download = Download(TorrentDefNoMetainfo(b"\x01" * 20, b"name"), self.dlmngr, checkpoint_disabled=True,
+        download = Download(TorrentDef.load_only_sha1(b"\x01" * 20, "name", ""), self.dlmngr, checkpoint_disabled=True,
                             config=self.create_mock_download_config())
         download.handle = Mock(is_valid=Mock(return_value=True), get_peer_info=Mock(return_value=[
             Mock(flags=140347, seed=1024),
@@ -353,7 +353,7 @@ class TestDownload(TestBase):
         """
         Test if setting the priority calls the right methods in download.
         """
-        download = Download(TorrentDefNoMetainfo(b"\x01" * 20, b"name"), self.dlmngr, checkpoint_disabled=True,
+        download = Download(TorrentDef.load_only_sha1(b"\x01" * 20, "name", ""), self.dlmngr, checkpoint_disabled=True,
                             config=self.create_mock_download_config())
         download.handle = Mock(is_valid=Mock(return_value=True))
 
@@ -366,7 +366,7 @@ class TestDownload(TestBase):
         """
         Test if trackers are added to the libtorrent handle.
         """
-        download = Download(TorrentDefNoMetainfo(b"\x01" * 20, b"name"), self.dlmngr, checkpoint_disabled=True,
+        download = Download(TorrentDef.load_only_sha1(b"\x01" * 20, "name", ""), self.dlmngr, checkpoint_disabled=True,
                             config=self.create_mock_download_config())
         download.handle = Mock(is_valid=Mock(return_value=True))
 
@@ -379,7 +379,7 @@ class TestDownload(TestBase):
         """
         Test if error alerts are processed correctly.
         """
-        download = Download(TorrentDefNoMetainfo(b"\x01" * 20, b"name"), self.dlmngr, checkpoint_disabled=True,
+        download = Download(TorrentDef.load_only_sha1(b"\x01" * 20, "name", ""), self.dlmngr, checkpoint_disabled=True,
                             config=self.create_mock_download_config())
 
         download.process_alert(Mock(msg=None, status_code=123, url="http://google.com",
@@ -392,7 +392,7 @@ class TestDownload(TestBase):
         """
         Test if timeout error alerts are processed correctly.
         """
-        download = Download(TorrentDefNoMetainfo(b"\x01" * 20, b"name"), self.dlmngr, checkpoint_disabled=True,
+        download = Download(TorrentDef.load_only_sha1(b"\x01" * 20, "name", ""), self.dlmngr, checkpoint_disabled=True,
                             config=self.create_mock_download_config())
 
         download.process_alert(Mock(msg=None, status_code=0, url="http://google.com",
@@ -405,7 +405,7 @@ class TestDownload(TestBase):
         """
         Test if not working error alerts are processed correctly.
         """
-        download = Download(TorrentDefNoMetainfo(b"\x01" * 20, b"name"), self.dlmngr, checkpoint_disabled=True,
+        download = Download(TorrentDef.load_only_sha1(b"\x01" * 20, "name", ""), self.dlmngr, checkpoint_disabled=True,
                             config=self.create_mock_download_config())
 
         download.process_alert(Mock(msg=None, status_code=-1, url="http://google.com",
@@ -418,7 +418,7 @@ class TestDownload(TestBase):
         """
         Test if a tracking warning alert is processed correctly.
         """
-        download = Download(TorrentDefNoMetainfo(b"\x01" * 20, b"name"), self.dlmngr, checkpoint_disabled=True,
+        download = Download(TorrentDef.load_only_sha1(b"\x01" * 20, "name", ""), self.dlmngr, checkpoint_disabled=True,
                             config=self.create_mock_download_config())
 
         download.process_alert(Mock(message=Mock(return_value="test"), url="http://google.com",
@@ -435,13 +435,12 @@ class TestDownload(TestBase):
         download = Download(tdef, self.dlmngr, checkpoint_disabled=True, config=self.create_mock_download_config())
         download.handle = Mock(torrent_file=Mock(return_value=download.tdef.torrent_info),
                                trackers=Mock(return_value=[{"url": "http://google.com"}]))
-        download.tdef = None
 
         download.on_metadata_received_alert(Mock())
 
         self.assertEqual(tdef.infohash, download.tdef.infohash)
-        self.assertDictEqual(tdef.metainfo[b"info"], download.tdef.metainfo[b"info"])
-        self.assertEqual(b"http://google.com", download.tdef.metainfo[b"announce"])
+        self.assertDictEqual(tdef.get_metainfo()[b"info"], download.tdef.get_metainfo()[b"info"])
+        self.assertEqual(b"http://google.com", download.tdef.get_metainfo()[b"announce"])
 
     def test_on_metadata_received_alert_unicode_error_encode(self) -> None:
         """
@@ -452,13 +451,12 @@ class TestDownload(TestBase):
         download.handle = Mock(trackers=Mock(return_value=[{"url": "\uD800"}]),
                                torrent_file=Mock(return_value=download.tdef.torrent_info),
                                get_peer_info=Mock(return_value=[]))
-        download.tdef = None
 
         download.on_metadata_received_alert(Mock())
 
         self.assertEqual(tdef.infohash, download.tdef.infohash)
-        self.assertDictEqual(tdef.metainfo[b"info"], download.tdef.metainfo[b"info"])
-        self.assertNotIn(b"announce", download.tdef.metainfo)
+        self.assertDictEqual(tdef.get_metainfo()[b"info"], download.tdef.get_metainfo()[b"info"])
+        self.assertEqual(b"", tdef.get_metainfo()[b"announce"])
 
     def test_on_metadata_received_alert_unicode_error_decode(self) -> None:
         """
@@ -471,13 +469,12 @@ class TestDownload(TestBase):
         download.handle = Mock(trackers=lambda: [{"url": b"\xFD".decode()}],
                                torrent_file=Mock(return_value=download.tdef.torrent_info),
                                get_peer_info=Mock(return_value=[]))
-        download.tdef = None
 
         download.on_metadata_received_alert(Mock())
 
         self.assertEqual(tdef.infohash, download.tdef.infohash)
-        self.assertDictEqual(tdef.metainfo[b"info"], download.tdef.metainfo[b"info"])
-        self.assertNotIn(b"announce", download.tdef.metainfo)
+        self.assertDictEqual(tdef.get_metainfo()[b"info"], download.tdef.get_metainfo()[b"info"])
+        self.assertEqual(b"", download.tdef.get_metainfo()[b"announce"])
 
     def test_metadata_received_invalid_torrent_with_error(self) -> None:
         """
@@ -498,7 +495,7 @@ class TestDownload(TestBase):
         """
         Test if no pause or checkpoint happens if the download state is such.
         """
-        download = Download(TorrentDefNoMetainfo(b"\x01" * 20, b"name"), self.dlmngr, checkpoint_disabled=True,
+        download = Download(TorrentDef.load_only_sha1(b"\x01" * 20, "name", ""), self.dlmngr, checkpoint_disabled=True,
                             config=self.create_mock_download_config())
         download.checkpoint_disabled = False
         download.handle = Mock(is_valid=Mock(return_value=True), need_save_resume_data=Mock(return_value=False))
@@ -516,7 +513,7 @@ class TestDownload(TestBase):
         """
         Test if no pause but a checkpoint happens if the download state is such.
         """
-        download = Download(TorrentDefNoMetainfo(b"\x01" * 20, b"name"), self.dlmngr, checkpoint_disabled=True,
+        download = Download(TorrentDef.load_only_sha1(b"\x01" * 20, "name", ""), self.dlmngr, checkpoint_disabled=True,
                             config=self.create_mock_download_config())
         download.checkpoint_disabled = False
         download.handle = Mock(is_valid=Mock(return_value=True), need_save_resume_data=Mock(return_value=False))
@@ -534,7 +531,7 @@ class TestDownload(TestBase):
         """
         Test if a pause but no checkpoint happens if the download state is such.
         """
-        download = Download(TorrentDefNoMetainfo(b"\x01" * 20, b"name"), self.dlmngr, checkpoint_disabled=True,
+        download = Download(TorrentDef.load_only_sha1(b"\x01" * 20, "name", ""), self.dlmngr, checkpoint_disabled=True,
                             config=self.create_mock_download_config())
         download.checkpoint_disabled = False
         download.handle = Mock(is_valid=Mock(return_value=True), need_save_resume_data=Mock(return_value=False))
@@ -552,7 +549,7 @@ class TestDownload(TestBase):
         """
         Test if both a pause and a checkpoint happens if the download state is such.
         """
-        download = Download(TorrentDefNoMetainfo(b"\x01" * 20, b"name"), self.dlmngr, checkpoint_disabled=True,
+        download = Download(TorrentDef.load_only_sha1(b"\x01" * 20, "name", ""), self.dlmngr, checkpoint_disabled=True,
                             config=self.create_mock_download_config())
         download.checkpoint_disabled = False
         download.handle = Mock(is_valid=Mock(return_value=True), need_save_resume_data=Mock(return_value=False))
@@ -570,7 +567,7 @@ class TestDownload(TestBase):
         """
         Test if the tracker status is extracted from a reply alert.
         """
-        download = Download(TorrentDefNoMetainfo(b"\x01" * 20, b"name"), self.dlmngr, checkpoint_disabled=True,
+        download = Download(TorrentDef.load_only_sha1(b"\x01" * 20, "name", ""), self.dlmngr, checkpoint_disabled=True,
                             config=self.create_mock_download_config())
 
         download.on_tracker_reply_alert(Mock(url="http://google.com", num_peers=42))
@@ -581,7 +578,7 @@ class TestDownload(TestBase):
         """
         Test if a correct pieces bitmask is returned when requested.
         """
-        download = Download(TorrentDefNoMetainfo(b"\x01" * 20, b"name"), self.dlmngr, checkpoint_disabled=True,
+        download = Download(TorrentDef.load_only_sha1(b"\x01" * 20, "name", ""), self.dlmngr, checkpoint_disabled=True,
                             config=self.create_mock_download_config())
         download.handle = Mock(status=Mock(return_value=Mock(pieces=[True, False, True, False, False])))
 
@@ -591,7 +588,7 @@ class TestDownload(TestBase):
         """
         Test if an error is raised when loading resume data failed.
         """
-        download = Download(TorrentDefNoMetainfo(b"\x01" * 20, b"name"), self.dlmngr, checkpoint_disabled=True,
+        download = Download(TorrentDef.load_only_sha1(b"\x01" * 20, "name", ""), self.dlmngr, checkpoint_disabled=True,
                             config=self.create_mock_download_config())
 
         future = download.wait_for_alert("save_resume_data_alert", None, "save_resume_data_failed_alert",
@@ -605,7 +602,7 @@ class TestDownload(TestBase):
         """
         Test if the ip filter gets enabled when in torrent status seeding (5) when hops are not zero.
         """
-        download = Download(TorrentDefNoMetainfo(b"\x01" * 20, b"name"), self.dlmngr, checkpoint_disabled=True,
+        download = Download(TorrentDef.load_only_sha1(b"\x01" * 20, "name", ""), self.dlmngr, checkpoint_disabled=True,
                             config=self.create_mock_download_config())
         download.config.set_hops(1)
         download.handle = Mock(is_valid=Mock(return_value=True))
@@ -619,7 +616,7 @@ class TestDownload(TestBase):
         """
         Test if the ip filter does not get enabled when the hop count is zero.
         """
-        download = Download(TorrentDefNoMetainfo(b"\x01" * 20, b"name"), self.dlmngr, checkpoint_disabled=True,
+        download = Download(TorrentDef.load_only_sha1(b"\x01" * 20, "name", ""), self.dlmngr, checkpoint_disabled=True,
                             config=self.create_mock_download_config())
         download.config.set_hops(0)
         download.handle = Mock(is_valid=Mock(return_value=True))
@@ -633,7 +630,7 @@ class TestDownload(TestBase):
         """
         Test if the ip filter does not get enabled when the hop count is zero.
         """
-        download = Download(TorrentDefNoMetainfo(b"\x01" * 20, b"name"), self.dlmngr, checkpoint_disabled=True,
+        download = Download(TorrentDef.load_only_sha1(b"\x01" * 20, "name", ""), self.dlmngr, checkpoint_disabled=True,
                             config=self.create_mock_download_config())
         download.config.set_hops(1)
         download.handle = Mock(is_valid=Mock(return_value=True))
@@ -647,7 +644,7 @@ class TestDownload(TestBase):
         """
         Testing whether making a checkpoint times out when we receive no alert from libtorrent.
         """
-        download = Download(TorrentDefNoMetainfo(b"\x01" * 20, b"name"), self.dlmngr, checkpoint_disabled=True,
+        download = Download(TorrentDef.load_only_sha1(b"\x01" * 20, "name", ""), self.dlmngr, checkpoint_disabled=True,
                             config=self.create_mock_download_config())
         download.futures["save_resume_data"] = [Future()]
 
@@ -662,7 +659,7 @@ class TestDownload(TestBase):
         """
         Test if permission error in writing the download config does not crash the save resume alert handler.
         """
-        download = Download(TorrentDefNoMetainfo(b"\x01" * 20, b"name"), self.dlmngr, checkpoint_disabled=True,
+        download = Download(TorrentDef.load_only_sha1(b"\x01" * 20, "name", ""), self.dlmngr, checkpoint_disabled=True,
                             config=PermissionErrorDownloadConfig(self.create_mock_download_config().config))
         download.checkpoint_disabled = False
         download.download_manager = Mock(get_checkpoint_dir=Mock(return_value=Path(__file__).absolute().parent))
@@ -678,7 +675,7 @@ class TestDownload(TestBase):
 
         See: https://github.com/Tribler/tribler/issues/7036
         """
-        download = Download(TorrentDefNoMetainfo(b"\x01" * 20, b"name"), self.dlmngr, checkpoint_disabled=True,
+        download = Download(TorrentDef.load_only_sha1(b"\x01" * 20, "name", ""), self.dlmngr, checkpoint_disabled=True,
                             config=self.create_mock_download_config())
         fut = Future()
         fut.set_result(Mock(is_dht_running=Mock(return_value=False)))
@@ -697,7 +694,7 @@ class TestDownload(TestBase):
         """
         Test if a tracker status is returned when getting peer info leads to a RuntimeError.
         """
-        download = Download(TorrentDefNoMetainfo(b"\x01" * 20, b"name"), self.dlmngr, checkpoint_disabled=True,
+        download = Download(TorrentDef.load_only_sha1(b"\x01" * 20, "name", ""), self.dlmngr, checkpoint_disabled=True,
                             config=self.create_mock_download_config())
         download.download_manager = Mock(get_session=Mock(return_value=Mock(is_dht_running=Mock(return_value=True))))
         download.handle = Mock(is_valid=Mock(return_value=True), get_peer_info=Mock(side_effect=RuntimeError),
@@ -712,7 +709,7 @@ class TestDownload(TestBase):
         """
         Test if the shutdown method closes the stream and clears the futures dictionary.
         """
-        download = Download(TorrentDefNoMetainfo(b"\x01" * 20, b"name"), self.dlmngr, checkpoint_disabled=True,
+        download = Download(TorrentDef.load_only_sha1(b"\x01" * 20, "name", ""), self.dlmngr, checkpoint_disabled=True,
                             config=self.create_mock_download_config())
         download.stream = Mock()
 
@@ -749,14 +746,15 @@ class TestDownload(TestBase):
         """
         Test if the piece range of a multi-file torrent is correctly determined.
         """
-        tdef = TorrentDef.load_from_memory(TORRENT_WITH_DIRS_CONTENT)
-        tdef.metainfo[b"info"][b"files"][0][b"length"] = 60000
-        tdef.metainfo[b"info"][b"pieces"] = b'\x01' * 80
+        metainfo = libtorrent.bdecode(TORRENT_WITH_DIRS_CONTENT)
+        metainfo[b"info"][b"files"][0][b"length"] = 60000
+        metainfo[b"info"][b"pieces"] = b"\x01" * 80
+        tdef = TorrentDef.load_from_dict(metainfo)
         download = Download(tdef, self.dlmngr, checkpoint_disabled=True, config=self.create_mock_download_config())
 
         file1 = download.file_piece_range(Path("torrent_create") / "abc" / "file2.txt")
         other_indices = [download.file_piece_range(Path("torrent_create") / Path(
-            *[p.decode() for p in tdef.metainfo[b"info"][b"files"][-1-i][b"path"]]
+            *[p.decode() for p in tdef.get_metainfo()[b"info"][b"files"][-1-i][b"path"]]
         )) for i in range(5)]
 
         self.assertEqual([0, 1, 2], file1)

--- a/src/tribler/test_unit/core/libtorrent/download_manager/test_stream.py
+++ b/src/tribler/test_unit/core/libtorrent/download_manager/test_stream.py
@@ -171,10 +171,10 @@ class TestStream(TestBase):
 
         The pieces are 20 byte hashes for the number of pieces in a 6-byte file per 6 files.
         """
-        download.tdef.metainfo[b'info'][b'piece length'] = piece_size
-        download.tdef.torrent_parameters[b'piece length'] = piece_size
-        download.tdef.metainfo[b'info'][b'pieces'] = b"\x01" * 20 * (6 // piece_size) * 6
-        download.tdef.invalidate_torrent_info()
+        metainfo = download.tdef.get_metainfo()
+        metainfo[b"info"][b"piece length"] = piece_size
+        metainfo[b"info"][b"pieces"] = b"\x01" * 20 * (6 // piece_size) * 6
+        download.tdef = TorrentDef.load_from_dict(metainfo)
 
     async def test_enable(self) -> None:
         """

--- a/src/tribler/test_unit/core/libtorrent/test_torrentdef.py
+++ b/src/tribler/test_unit/core/libtorrent/test_torrentdef.py
@@ -5,7 +5,7 @@ import libtorrent
 from aiohttp import ClientResponseError
 from ipv8.test.base import TestBase
 
-from tribler.core.libtorrent.torrentdef import TorrentDef, TorrentDefNoMetainfo
+from tribler.core.libtorrent.torrentdef import TorrentDef
 from tribler.test_unit.core.libtorrent.mocks import TORRENT_WITH_DIRS, TORRENT_WITH_DIRS_CONTENT
 
 
@@ -14,134 +14,41 @@ class TestTorrentDef(TestBase):
     Tests for the TorrentDef class.
     """
 
-    def test_tdef_init_parameters(self) -> None:
-        """
-        Test if a TorrentDef object can be initialized with parameters.
-        """
-        tdef_params = TorrentDef(torrent_parameters={b"announce": "http://test.com"})
-
-        self.assertIn(b"announce", tdef_params.torrent_parameters)
-
     def test_create_invalid_tdef_empty_metainfo(self) -> None:
         """
         Test if creating a TorrentDef object without metainfo results in a ValueError.
         """
         with self.assertRaises(ValueError):
-            TorrentDef(metainfo={})
+            TorrentDef.load_from_memory(b"")
 
     def test_create_invalid_tdef_empty_metainfo_validate(self) -> None:
         """
         Test if creating a TorrentDef object without metainfo and with validation results in a ValueError.
         """
         with self.assertRaises(ValueError):
-            TorrentDef(metainfo={}, ignore_validation=False)
+            TorrentDef.load_from_dict({})
 
     def test_create_invalid_tdef_empty_info(self) -> None:
         """
         Test if creating a TorrentDef object with metainfo but an empty info dictionary results in a ValueError.
         """
         with self.assertRaises(ValueError):
-            TorrentDef(metainfo={b"info": {}})
+            TorrentDef.load_from_dict({b"info": {}})
 
     def test_create_invalid_tdef_empty_info_validate(self) -> None:
         """
         Test if a TorrentDef object with metainfo but an empty info dict with validation results in a ValueError.
         """
         with self.assertRaises(ValueError):
-            TorrentDef(metainfo={b"info": {}}, ignore_validation=False)
-
-    def test_get_name_utf8_unknown(self) -> None:
-        """
-        Test if we can succesfully get the UTF-8 name.
-        """
-        tdef = TorrentDef()
-
-        tdef.set_name(b"\xA1\xC0")
-        tdef.torrent_parameters[b"encoding"] = b"euc_kr"
-
-        self.assertEqual("\xf7", tdef.get_name_utf8())
+            TorrentDef.load_from_dict({b"info": {}})
 
     def test_get_name_utf8(self) -> None:
         """
         Check if we can successfully get the UTF-8 encoded torrent name when using a different encoding.
         """
-        tdef = TorrentDef()
+        tdef = TorrentDef.load_only_sha1(b"\x01" * 20, "\xA1\xC0", "")
 
-        tdef.set_name(b"\xA1\xC0")
-
-        self.assertEqual("\xa1\xc0", tdef.get_name_utf8())
-
-    def test_is_private_non_private(self) -> None:
-        """
-        Test if a torrent marked with private = 0 is not seen as private.
-        """
-        tdef = TorrentDef()
-
-        tdef.metainfo = {b"info": {b"private": 0}}
-
-        self.assertFalse(tdef.is_private())
-
-    def test_is_private_private(self) -> None:
-        """
-        Test if a torrent marked with private = 1 is seen as private.
-        """
-        tdef = TorrentDef()
-
-        tdef.metainfo = {b"info": {b"private": 1}}
-
-        self.assertTrue(tdef.is_private())
-
-    def test_is_private_i1e(self) -> None:
-        """
-        Test if an invalid but common private field setting of i1e (instead of 1) is not valid as private.
-        """
-        tdef = TorrentDef()
-
-        tdef.metainfo = {b"info": {b"private": b"i1e"}}
-
-        self.assertFalse(tdef.is_private())
-
-    def test_is_private_i0e(self) -> None:
-        """
-        Test if an invalid but common private field setting of i0e (instead of 0) is not valid as private.
-        """
-        tdef = TorrentDef()
-
-        tdef.metainfo = {b"info": {b"private": b"i0e"}}
-
-        self.assertFalse(tdef.is_private())
-
-    def test_load_private_from_memory_nothing(self) -> None:
-        """
-        Test if loading the private field set to nothing from an existing torrent works correctly.
-        """
-        tdef = TorrentDef.load_from_memory(TORRENT_WITH_DIRS_CONTENT)
-
-        self.assertFalse(tdef.is_private())
-
-    def test_load_private_from_memory_public(self) -> None:
-        """
-        Test if loading the private field set to 0 from an existing torrent works correctly.
-        """
-        info_dict_index = TORRENT_WITH_DIRS_CONTENT.find(b"4:infod") + 7
-        new_content = (TORRENT_WITH_DIRS_CONTENT[:info_dict_index]
-                       + b"7:privatei0e"
-                       + TORRENT_WITH_DIRS_CONTENT[info_dict_index:])
-        tdef = TorrentDef.load_from_memory(new_content)
-
-        self.assertFalse(tdef.is_private())
-
-    def test_load_private_from_memory_private(self) -> None:
-        """
-        Test if loading the private field set to 1 from an existing torrent works correctly.
-        """
-        info_dict_index = TORRENT_WITH_DIRS_CONTENT.find(b"4:infod") + 7
-        new_content = (TORRENT_WITH_DIRS_CONTENT[:info_dict_index]
-                       + b"7:privatei1e"
-                       + TORRENT_WITH_DIRS_CONTENT[info_dict_index:])
-        tdef = TorrentDef.load_from_memory(new_content)
-
-        self.assertTrue(tdef.is_private())
+        self.assertEqual("\xa1\xc0", tdef.atp.name)
 
     async def test_load_from_url(self) -> None:
         """
@@ -164,115 +71,6 @@ class TestTorrentDef(TestBase):
         ), self.assertRaises(ClientResponseError):
             await TorrentDef.load_from_url("http://127.0.0.1:1234/ubuntu.torrent")
 
-    def test_torrent_default_encoding(self) -> None:
-        """
-        Test if the default encoding is set to UTF-8.
-        """
-        tdef = TorrentDef()
-
-        self.assertEqual("utf-8", tdef.get_encoding())
-
-    def test_torrent_encoding(self) -> None:
-        """
-        Test if the encoding can be set to any string.
-        """
-        tdef = TorrentDef()
-
-        tdef.set_encoding(b"my_fancy_encoding")
-
-        self.assertEqual("my_fancy_encoding", tdef.get_encoding())
-
-    def test_set_tracker_invalid_url(self) -> None:
-        """
-        Test if setting an invalid tracker raises a ValueError.
-        """
-        tdef = TorrentDef()
-
-        with self.assertRaises(ValueError):
-            tdef.set_tracker("http/tracker.org")
-
-    def test_set_tracker_strip_slash(self) -> None:
-        """
-        Test if the final slash in a tracker URL is stripped.
-        """
-        tdef = TorrentDef()
-
-        tdef.set_tracker("http://tracker.org/")
-
-        self.assertEqual("http://tracker.org", tdef.torrent_parameters[b"announce"])
-
-    def test_set_tracker(self) -> None:
-        """
-        Test if a tracker can be set to a valid URL.
-        """
-        tdef = TorrentDef()
-
-        tdef.set_tracker("http://tracker.org")
-
-        self.assertSetEqual({'http://tracker.org'},  tdef.get_trackers())
-
-    def test_get_trackers(self) -> None:
-        """
-        Test if get_trackers returns flat set of trackers.
-        """
-        tdef = TorrentDef()
-        tdef.get_tracker_hierarchy = Mock(return_value=[["t1", "t2"], ["t3"], ["t4"]])
-
-        trackers = tdef.get_trackers()
-
-        self.assertSetEqual({"t1", "t2", "t3", "t4"}, trackers)
-
-    def test_get_default_nr_pieces(self) -> None:
-        """
-        Test if the default number of pieces is zero.
-        """
-        tdef = TorrentDef()
-
-        self.assertEqual(0, tdef.get_nr_pieces())
-
-    def test_get_nr_pieces(self) -> None:
-        """
-        Test if the number of pieces can be retrieved from a TorrentDef.
-        """
-        tdef = TorrentDef()
-
-        tdef.metainfo = {b"info": {b"pieces": b"a" * 40}}
-
-        self.assertEqual(2, tdef.get_nr_pieces())
-
-    def test_is_multifile_empty(self) -> None:
-        """
-        Test if an empty TorrentDef is not classified as a multifile torrent.
-        """
-        tdef = TorrentDef()
-
-        self.assertFalse(tdef.is_multifile_torrent())
-
-    def test_is_multifile(self) -> None:
-        """
-        Test if a TorrentDef is correctly classified as multifile torrent.
-        """
-        tdef = TorrentDef(metainfo={b"info": {b"files": [b"a"]}})
-
-        self.assertTrue(tdef.is_multifile_torrent())
-
-    def test_set_piece_length_invalid_type(self) -> None:
-        """
-        Test if the piece length cannot be set to something other than an int.
-        """
-        tdef = TorrentDef()
-
-        with self.assertRaises(ValueError):
-            tdef.set_piece_length(b"20")
-
-    def test_get_piece_length(self) -> None:
-        """
-        Test if the default piece length is zero.
-        """
-        tdef = TorrentDef()
-
-        self.assertEqual(0, tdef.get_piece_length())
-
     def test_load_from_dict(self) -> None:
         """
         Test if a TorrentDef can be loaded from a dictionary.
@@ -285,30 +83,21 @@ class TestTorrentDef(TestBase):
 
     def test_torrent_no_metainfo(self) -> None:
         """
-        Test if a TorrentDefNoMetainfo can be constructed from torrent file information.
+        Test if a TorrentDef without meta info can be constructed from torrent file information.
         """
-        tdef = TorrentDefNoMetainfo(b"12345678901234567890", b"ubuntu.torrent", "http://google.com")
+        tdef = TorrentDef.load_only_sha1(b"12345678901234567890", "ubuntu.torrent", "http://google.com")
 
-        self.assertEqual(b"ubuntu.torrent", tdef.get_name())
-        self.assertEqual(b"12345678901234567890", tdef.get_infohash())
-        self.assertEqual(0, tdef.get_length())
+        self.assertEqual("ubuntu.torrent", tdef.name)
+        self.assertEqual(b"12345678901234567890", tdef.infohash)
         self.assertIsNone(tdef.get_metainfo())
-        self.assertEqual(b"http://google.com", tdef.get_url())
-        self.assertFalse(tdef.is_multifile_torrent())
-        self.assertEqual("ubuntu.torrent", tdef.get_name_as_unicode())
-        self.assertEqual([], tdef.get_files())
-        self.assertEqual([], tdef.get_files_with_length())
-        self.assertEqual(0, len(tdef.get_trackers()))
-        self.assertFalse(tdef.is_private())
-        self.assertEqual("ubuntu.torrent", tdef.get_name_utf8())
-        self.assertEqual(0, tdef.get_nr_pieces())
+        self.assertEqual("http://google.com", tdef.atp.url)
         self.assertIsNone(tdef.torrent_info)
 
     def test_torrent_no_metainfo_load_info(self) -> None:
         """
-        Test if a TorrentDefNoMetainfo does not load torrent info if there is none to load by definition.
+        Test if a TorrentDef without meta info does not load torrent info if there is none to load by definition.
         """
-        tdef = TorrentDefNoMetainfo(b"12345678901234567890", b"ubuntu.torrent", "http://google.com")
+        tdef = TorrentDef.load_only_sha1(b"12345678901234567890", "ubuntu.torrent", "http://google.com")
 
         tdef.load_torrent_info()
 
@@ -316,48 +105,11 @@ class TestTorrentDef(TestBase):
 
     def test_magnet_no_metainfo(self) -> None:
         """
-        Test if a TorrentDefNoMetainfo can be constructed from magnet link information.
+        Test if a TorrentDef without meta info can be constructed from magnet link information.
         """
-        torrent2 = TorrentDefNoMetainfo(b"12345678901234567890", b"ubuntu.torrent", "magnet:")
+        torrent2 = TorrentDef.load_only_sha1(b"12345678901234567890", "ubuntu.torrent", "magnet:")
 
-        self.assertEqual(0, len(torrent2.get_trackers()))
-
-    def test_get_length(self) -> None:
-        """
-        Test if a TorrentDef has 0 length by default.
-        """
-        tdef = TorrentDef()
-
-        self.assertEqual(0, tdef.get_length())
-
-    def test_get_index(self) -> None:
-        """
-        Test if we can successfully get the index of a file in a torrent.
-        """
-        tdef = TorrentDef(metainfo={b"info": {b"files": [{b"path": [b"a.txt"], b"length": 123}]}})
-
-        self.assertEqual(0, tdef.get_index_of_file_in_files("a.txt"))
-        with self.assertRaises(ValueError):
-            tdef.get_index_of_file_in_files("b.txt")
-        with self.assertRaises(ValueError):
-            tdef.get_index_of_file_in_files(None)
-
-    def test_get_index_utf8(self) -> None:
-        """
-        Test if we can successfully get the index of a path.utf-8 file in a torrent.
-        """
-        tdef = TorrentDef({b"info": {b"files": [{b"path": [b"a.txt"], b"path.utf-8": [b"b.txt"], b"length": 123}]}})
-
-        self.assertEqual(0, tdef.get_index_of_file_in_files("b.txt"))
-
-    def test_get_index_no_metainfo(self) -> None:
-        """
-        Test if attempting to fetch a file from a TorrentDef without metainfo results in a ValueError.
-        """
-        tdef = TorrentDef(metainfo=None)
-
-        with self.assertRaises(ValueError):
-            tdef.get_index_of_file_in_files("b.txt")
+        self.assertEqual(0, len(torrent2.atp.trackers))
 
     def test_get_name_as_unicode_path_utf8(self) -> None:
         """
@@ -365,9 +117,11 @@ class TestTorrentDef(TestBase):
         """
         name_bytes = b"\xe8\xaf\xad\xe8\xa8\x80\xe5\xa4\x84\xe7\x90\x86"
         name_unicode = name_bytes.decode()
-        tdef = TorrentDef(metainfo={b"info": {b"name.utf-8": name_bytes}})
+        tdef = TorrentDef.load_from_dict({b"info": {b"name.utf-8": name_bytes,
+                                                    b"files": [{b"path": [b"a.txt"], b"length": 123}],
+                                                    b"piece length": 128, b"pieces": b"\x00" * 20}})
 
-        self.assertEqual(name_unicode, tdef.get_name_as_unicode())
+        self.assertEqual(name_unicode, tdef.name)
 
     def test_get_name_as_unicode(self) -> None:
         """
@@ -375,88 +129,17 @@ class TestTorrentDef(TestBase):
         """
         name_bytes = b"\xe8\xaf\xad\xe8\xa8\x80\xe5\xa4\x84\xe7\x90\x86"
         name_unicode = name_bytes.decode()
-        tdef = TorrentDef(metainfo={b"info": {b"name": name_bytes}})
+        tdef = TorrentDef.load_from_dict({b"info": {b"name": name_bytes,
+                                                    b"files": [{b"path": [b"a.txt"], b"length": 123}],
+                                                    b"piece length": 128, b"pieces": b"\x00" * 20}})
 
-        self.assertEqual(name_unicode, tdef.get_name_as_unicode())
-
-    def test_get_name_as_unicode_replace_illegal(self) -> None:
-        """
-        Test if illegal characters are replaced with question marks.
-
-        Note: the FF byte ruins the unicode encoding for all following bytes.
-        """
-        name_bytes = b"\xe8\xaf\xad\xe8\xa8\x80\xe5\xa4\x84\xe7\x90\x86"
-        tdef = TorrentDef(metainfo={b"info": {b"name": b"test\xff" + name_bytes}})
-
-        self.assertEqual("test" + "?" * len(b"\xff" + name_bytes),  tdef.get_name_as_unicode())
-
-    def test_get_files_with_length(self) -> None:
-        """
-        Test if get_files_with_length returns the correct result for normal path names.
-        """
-        name_bytes = b"\xe8\xaf\xad\xe8\xa8\x80\xe5\xa4\x84\xe7\x90\x86"
-        name_unicode = name_bytes.decode()
-        tdef = TorrentDef(metainfo={b"info": {b"files": [{b"path.utf-8": [name_bytes], b"length": 123},
-                                                         {b"path.utf-8": [b"file.txt"], b"length": 456}],
-                                              b"name": b"", b"piece length": 128, b"pieces": b"\x00" * 100}})
-
-        self.assertEqual([(Path(name_unicode), 123), (Path('file.txt'), 456)], tdef.get_files_with_length())
-
-    def test_get_files_with_length_valid_path_utf8(self) -> None:
-        """
-        Test if get_files_with_length returns the correct result for path.utf-8 names.
-        """
-        name_bytes = b"\xe8\xaf\xad\xe8\xa8\x80\xe5\xa4\x84\xe7\x90\x86"
-        name_unicode = name_bytes.decode()
-        tdef = TorrentDef(metainfo={b"info": {b"files": [{b"path": [name_bytes], b"length": 123},
-                                                         {b"path": [b"file.txt"], b"length": 456}],
-                                              b"name": b"", b"piece length": 128, b"pieces": b"\x00" * 100}})
-
-        self.assertEqual([(Path(name_unicode), 123), (Path('file.txt'), 456)], tdef.get_files_with_length())
-
-    def test_get_files_with_length_illegal_path(self) -> None:
-        """
-        Test if get_files_with_length sanitizes files with invalid path names.
-        """
-        name_bytes = b"\xe8\xaf\xad\xe8\xa8\x80\xe5\xa4\x84\xe7\x90\x86"
-        tdef = TorrentDef(metainfo={b"info": {b"files": [{b"path": [b"test\xff" + name_bytes], b"length": 123},
-                                                         {b"path": [b"file.txt"], b"length": 456}],
-                                              b"name": b"", b"piece length": 128, b"pieces": b"\x00" * 100}})
-
-        self.assertEqual([(Path("test?????????????"), 123), (Path("file.txt"), 456)], tdef.get_files_with_length())
-
-    def test_get_files_with_length_illegal_path_utf8(self) -> None:
-        """
-        Test if get_files_with_length sanitizes files with invalid path.utf-8 names.
-        """
-        name_bytes = b"\xe8\xaf\xad\xe8\xa8\x80\xe5\xa4\x84\xe7\x90\x86"
-        tdef = TorrentDef(metainfo={b"info": {b"files": [{b"path.utf-8": [b"test\xff" + name_bytes], b"length": 123},
-                                                         {b"path": [b"file.txt"], b"length": 456}],
-                                              b"name": b"", b"piece length": 128, b"pieces": b"\x00" * 100}})
-
-        self.assertEqual([(Path("file.txt"), 456)], tdef.get_files_with_length())
-
-    def test_get_files_with_length_ignore_padding(self) -> None:
-        """
-        Test if get_files_with_length ignores padding files.
-        """
-        tdef = TorrentDef(metainfo={
-            b"info": {
-                b"name": b"torrent name",
-                b"files": [{b"path": [b".pad"], b"length": 123, b"attr": b"p"},
-                           {b"path": [b"file.txt"], b"length": 456}],
-                b"piece length": 128,
-                b"pieces": b"\x00" * 100
-            }
-        })
-
-        self.assertEqual([(Path('file.txt'), 456)], tdef.get_files_with_length())
+        self.assertEqual(name_unicode, tdef.name)
 
     def test_load_torrent_info(self) -> None:
         """
         Test if load_torrent_info() loads the torrent info.
         """
-        tdef = TorrentDef(metainfo={
+        tdef = TorrentDef.load_from_dict({
             b"info": {
                 b"name": b"torrent name",
                 b"files": [{b"path": [b"a.txt"], b"length": 123}],
@@ -467,31 +150,13 @@ class TestTorrentDef(TestBase):
 
         tdef.load_torrent_info()
 
-        self.assertTrue(tdef.torrent_info_loaded())
         self.assertIsNotNone(tdef.torrent_info)
-
-    def test_lazy_load_torrent_info(self) -> None:
-        """
-        Test if accessing torrent_info loads the torrent info.
-        """
-        tdef = TorrentDef(metainfo={
-            b"info": {
-                b"name": b"torrent name",
-                b"files": [{b"path": [b"a.txt"], b"length": 123}],
-                b"piece length": 128,
-                b"pieces": b"\x00" * 20
-            }
-        })
-
-        self.assertFalse(tdef.torrent_info_loaded())
-        self.assertIsNotNone(tdef.torrent_info)
-        self.assertTrue(tdef.torrent_info_loaded())
 
     def test_generate_tree(self) -> None:
         """
         Test if a torrent tree can be generated from a TorrentDef.
         """
-        tdef = TorrentDef(metainfo={
+        tdef = TorrentDef.load_from_dict({
             b"info": {
                 b"name": b"torrent name",
                 b"files": [{b"path": [b"a.txt"], b"length": 123}],

--- a/src/tribler/test_unit/core/libtorrent/test_torrents.py
+++ b/src/tribler/test_unit/core/libtorrent/test_torrents.py
@@ -8,7 +8,7 @@ from ipv8.test.base import TestBase
 
 from tribler.core.libtorrent.download_manager.download import Download
 from tribler.core.libtorrent.download_manager.download_config import SPEC_CONTENT, DownloadConfig
-from tribler.core.libtorrent.torrentdef import TorrentDefNoMetainfo
+from tribler.core.libtorrent.torrentdef import TorrentDef
 from tribler.core.libtorrent.torrents import (
     check_handle,
     common_prefix,
@@ -30,7 +30,7 @@ class TestTorrents(TestBase):
         """
         Test if the default value is returned for missing handles.
         """
-        download = Download(TorrentDefNoMetainfo(b"\x01" * 20, b"name", None), self.dlmngr, checkpoint_disabled=True,
+        download = Download(TorrentDef.load_only_sha1(b"\x01" * 20, "name", ""), self.dlmngr, checkpoint_disabled=True,
                             config=DownloadConfig(ConfigObj(StringIO(SPEC_CONTENT))))
 
         self.assertEqual("default", (check_handle("default")(Download.get_def)(download)))
@@ -39,7 +39,7 @@ class TestTorrents(TestBase):
         """
         Test if the default value is returned for invalid handles.
         """
-        download = Download(TorrentDefNoMetainfo(b"\x01" * 20, b"name", None), self.dlmngr, checkpoint_disabled=True,
+        download = Download(TorrentDef.load_only_sha1(b"\x01" * 20, "name", ""), self.dlmngr, checkpoint_disabled=True,
                             config=DownloadConfig(ConfigObj(StringIO(SPEC_CONTENT))))
         download.handle = Mock(is_valid=Mock(return_value=False))
 
@@ -49,7 +49,7 @@ class TestTorrents(TestBase):
         """
         Test if the given method is called for valid handles.
         """
-        download = Download(TorrentDefNoMetainfo(b"\x01" * 20, b"name", None), self.dlmngr, checkpoint_disabled=True,
+        download = Download(TorrentDef.load_only_sha1(b"\x01" * 20, "name", ""), self.dlmngr, checkpoint_disabled=True,
                             config=DownloadConfig(ConfigObj(StringIO(SPEC_CONTENT))))
         download.handle = Mock(is_valid=Mock(return_value=True))
 
@@ -59,7 +59,7 @@ class TestTorrents(TestBase):
         """
         Test if None is returned for invalid handles.
         """
-        download = Download(TorrentDefNoMetainfo(b"\x01" * 20, b"name", None), self.dlmngr, checkpoint_disabled=True,
+        download = Download(TorrentDef.load_only_sha1(b"\x01" * 20, "name", ""), self.dlmngr, checkpoint_disabled=True,
                             config=DownloadConfig(ConfigObj(StringIO(SPEC_CONTENT))))
         download.handle = Mock(is_valid=Mock(return_value=False))
 
@@ -71,7 +71,7 @@ class TestTorrents(TestBase):
         """
         Test if the result of the given method is given for valid handles.
         """
-        download = Download(TorrentDefNoMetainfo(b"\x01" * 20, b"name", None), self.dlmngr, checkpoint_disabled=True,
+        download = Download(TorrentDef.load_only_sha1(b"\x01" * 20, "name", ""), self.dlmngr, checkpoint_disabled=True,
                             config=DownloadConfig(ConfigObj(StringIO(SPEC_CONTENT))))
         download.handle = Mock(is_valid=Mock(return_value=True))
 
@@ -89,7 +89,7 @@ class TestTorrents(TestBase):
             """
             raise RuntimeError
 
-        download = Download(TorrentDefNoMetainfo(b"\x01" * 20, b"name", None), self.dlmngr, checkpoint_disabled=True,
+        download = Download(TorrentDef.load_only_sha1(b"\x01" * 20, "name", ""), self.dlmngr, checkpoint_disabled=True,
                             config=DownloadConfig(ConfigObj(StringIO(SPEC_CONTENT))))
         download.handle = Mock(is_valid=Mock(return_value=True))
 
@@ -108,7 +108,7 @@ class TestTorrents(TestBase):
             """
             raise ValueError
 
-        download = Download(TorrentDefNoMetainfo(b"\x01" * 20, b"name", None), self.dlmngr, checkpoint_disabled=True,
+        download = Download(TorrentDef.load_only_sha1(b"\x01" * 20, b"name", ""), self.dlmngr, checkpoint_disabled=True,
                             config=DownloadConfig(ConfigObj(StringIO(SPEC_CONTENT))))
         download.handle = Mock(is_valid=Mock(return_value=True))
 

--- a/src/tribler/test_unit/core/tunnel/test_community.py
+++ b/src/tribler/test_unit/core/tunnel/test_community.py
@@ -131,7 +131,7 @@ class TestTriblerTunnelCommunity(TestBase[TriblerTunnelCommunity]):
         Test the readd bittorrent peers method.
         """
         mock_torrent = Mock(add_peer=Mock(return_value=succeed(None)),
-                            tdef=Mock(get_infohash=Mock(return_value=b'a' * 20)))
+                            tdef=Mock(infohash=b'a' * 20))
         self.overlay(0).bittorrent_peers = {mock_torrent: [None]}
 
         self.overlay(0).readd_bittorrent_peers()
@@ -207,7 +207,7 @@ class TestTriblerTunnelCommunity(TestBase[TriblerTunnelCommunity]):
         Test if an old introduction point is recreated.
         """
         mock_state = Mock(get_status=Mock(return_value=DownloadStatus.SEEDING))
-        mock_tdef = Mock(get_infohash=Mock(return_value=b'a'))
+        mock_tdef = Mock(infohash=b'a')
         mock_download = Mock(get_def=Mock(return_value=mock_tdef), add_peer=Mock(return_value=succeed(None)),
                              get_state=Mock(return_value=mock_state), config=Mock(get_hops=Mock(return_value=1)),
                              apply_ip_filter=Mock(return_value=None))


### PR DESCRIPTION
Fixes #8544

This PR:

 - Updates `marshmallow` to be pinned at `3.26.1`, because `4.0.0` is incompatible with IPv8. This also requires `aiohttp==3.11.16`. I opened [an issue for this on IPv8](https://github.com/Tribler/py-ipv8/issues/1339).
 - Updates the `TorrentDef` to lean more on the `atp`.
