### PR TITLE
Updated IPv8 pointer + unpinned aiohttp

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,10 @@
 -r pyipv8/requirements.txt
 
-aiohttp==3.11.16
 bitarray
 configobj
 ipv8-rust-tunnels
 libtorrent==2.0.11
 lz4
-marshmallow==3.26.1
 pillow
 pony
 pystray

--- a/src/tribler/core/content_discovery/restapi/search_endpoint.py
+++ b/src/tribler/core/content_discovery/restapi/search_endpoint.py
@@ -26,8 +26,8 @@ class RemoteQueryParameters(MetadataParameters):
     """
 
     uuid = String()
-    channel_pk = String(description="Channel to query, must also define origin_id")
-    origin_id = Integer(default=None, description="Peer id to query, must also define channel_pk")
+    channel_pk = String(metadata={"description": "Channel to query, must also define origin_id"})
+    origin_id = Integer(load_default=None, metadata={"description": "Peer id to query, must also define channel_pk"})
 
 
 class SearchEndpoint(RESTEndpoint):

--- a/src/tribler/core/database/restapi/schema.py
+++ b/src/tribler/core/database/restapi/schema.py
@@ -7,15 +7,19 @@ class MetadataParameters(Schema):
     The REST API schema for metadata parameters.
     """
 
-    first = Integer(default=1, description="Limit the range of the query")
-    last = Integer(default=50, description="Limit the range of the query")
-    sort_by = String(description='Sorts results in forward or backward, based on column name (e.g. "id" vs "-id")')
-    sort_desc = Boolean(default=True)
-    txt_filter = String(description="FTS search on the chosen word* terms")
-    hide_xxx = Boolean(default=False, description="Toggles xxx filter")
+    first = Integer(load_default=1, metadata={"description": "Limit the range of the query"})
+    last = Integer(load_default=50, metadata={"description": "Limit the range of the query"})
+    sort_by = String(metadata={
+        "description": 'Sorts results in forward or backward, based on column name (e.g. "id" vs "-id")'
+    })
+    sort_desc = Boolean(load_default=True)
+    txt_filter = String(metadata={"description": "FTS search on the chosen word* terms"})
+    hide_xxx = Boolean(load_default=False, metadata={"description": "Toggles xxx filter"})
     category = String()
-    exclude_deleted = Boolean(default=False)
-    metadata_type = List(String(description='Limits query to certain metadata types (e.g. "torrent" or "channel")'))
+    exclude_deleted = Boolean(load_default=False)
+    metadata_type = List(String(metadata={
+        "description": 'Limits query to certain metadata types (e.g. "torrent" or "channel")'
+    }))
 
 
 class SearchMetadataParameters(MetadataParameters):
@@ -23,9 +27,12 @@ class SearchMetadataParameters(MetadataParameters):
     The REST API schema for search parameters.
     """
 
-    include_total = Boolean(default=False, description="Include total rows found in query response, expensive if "
-                                                       "there is many rows")
-    max_rowid = Integer(default=None, description="Only return results with rowid lesser than max_rowid")
+    include_total = Boolean(load_default=False, metadata={
+        "description": "Include total rows found in query response, expensive if there are many rows"
+    })
+    max_rowid = Integer(load_default=None, metadata={
+        "description": "Only return results with rowid lesser than max_rowid"
+    })
 
 
 class MetadataSchema(Schema):

--- a/src/tribler/core/restapi/events_endpoint.py
+++ b/src/tribler/core/restapi/events_endpoint.py
@@ -9,7 +9,7 @@ from traceback import format_exception
 from typing import TYPE_CHECKING, TypedDict
 
 import marshmallow.fields
-from aiohttp import web
+from aiohttp import ClientConnectionResetError, web
 from aiohttp_apispec import docs
 from ipv8.REST.schema import schema
 
@@ -194,7 +194,7 @@ class EventsEndpoint(RESTEndpoint):
                 # by creating the list with processed responses we want to remove responses with
                 # ConnectionResetError from `self.events_responses`:
                 processed_responses.append(response)
-            except ConnectionResetError as e:
+            except ClientConnectionResetError as e:
                 # The connection was closed by GUI
                 self._logger.warning(e, exc_info=True)
         self.events_responses = processed_responses


### PR DESCRIPTION
This PR:

 - Updates the code base to allow the newest `aiohttp` and `marshmallow` to be used again.