### PR TITLE
Fixed checkpoint loading and completion hash checking

### DIFF
--- a/src/tribler/core/libtorrent/download_manager/download_config.py
+++ b/src/tribler/core/libtorrent/download_manager/download_config.py
@@ -304,17 +304,23 @@ class DownloadConfig:
         """
         return _to_dict(self.config["state"]["metainfo"])
 
-    def set_engineresumedata(self, engineresumedata: dict) -> None:
+    def set_engineresumedata(self, engineresumedata: lt.add_torrent_params) -> None:
         """
         Set the engine resume data dict for this download.
         """
-        self.config["state"]["engineresumedata"] = _from_dict(engineresumedata)
+        self.config["state"]["engineresumedata"] = base64.b64encode(lt.write_resume_data_buf(engineresumedata)).decode()
 
-    def get_engineresumedata(self) -> dict | None:
+    def get_engineresumedata(self) -> lt.add_torrent_params | None:
         """
         Get the engine resume data dict for this download or None if it cannot be decoded.
         """
-        return _to_dict(self.config["state"]["engineresumedata"])
+        resume_data = self.config["state"]["engineresumedata"]
+        if resume_data:
+            try:
+                return lt.read_resume_data(base64.b64decode(resume_data))
+            except RuntimeError:
+                return None
+        return None
 
     def set_stop_after_metainfo(self, value: bool) -> None:
         """

--- a/src/tribler/core/libtorrent/torrentdef.py
+++ b/src/tribler/core/libtorrent/torrentdef.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from asyncio import get_running_loop
+from binascii import hexlify
 from typing import TYPE_CHECKING, Any
 
 import aiohttp
@@ -229,6 +230,12 @@ class TorrentDef:
         :param atp: User-defined parameters for the new TorrentDef.
         """
         self.atp = atp
+
+    def __str__(self) -> str:
+        """
+        We are essentially the ATP dictionary itself.
+        """
+        return f"TorrentDef(name=\"{self.name}\", infohash={hexlify(self.infohash).decode()}, url=\"{self.atp.url}\")"
 
     @property
     def name(self) -> str:


### PR DESCRIPTION
Fixes #8521
Fixes #8578

This PR:

 - Adds a pretty print string to `TorrentDef`.
 - Fixes resume data not being loaded from checkpoints.
 - Fixes hashchecking on startup not properly detecting already-finished torrents.
 - Fixes the printed ATP for each download always being an empty dictionary.
 - Updates `DownloadConfig.get_engineresumedata()` to return `add_torrent_params` instead of a `dict`.
 - Removes `Download.get_atp()` (use `.tdef.atp` instead).
 
