### PR TITLE
Added headless config option

### DIFF
--- a/src/run_tribler.py
+++ b/src/run_tribler.py
@@ -233,7 +233,7 @@ async def main() -> None:
         torrent_uri = load_torrent_uri(parsed_args)
         server_url, initial_message = await session.find_api_server()
 
-        headless = parsed_args.get("server")
+        headless = parsed_args.get("server") | config.get("headless")
         if server_url:
             logger.info("Core already running at %s", server_url)
             if torrent_uri:

--- a/src/tribler/tribler_config.py
+++ b/src/tribler/tribler_config.py
@@ -167,6 +167,7 @@ class TriblerConfig(TypedDict):
     """
 
     api: ApiConfig
+    headless: bool
 
     ipv8: dict
     statistics: bool
@@ -198,6 +199,7 @@ DEFAULT_CONFIG = {
         "http_port_running": 0,
         "https_port_running": 0,
     },
+    "headless": False,
 
     "ipv8": ipv8_default_config,
     "statistics": False,


### PR DESCRIPTION
Fixes #8520

This PR:

 - Adds a `"headless"` config option, which does the same as the `--server` command line argument.
