### PR TITLE
Added REST API support for custom torrent tags

### DIFF
--- a/src/tribler/core/database/restapi/schema.py
+++ b/src/tribler/core/database/restapi/schema.py
@@ -13,9 +13,10 @@ class MetadataParameters(Schema):
         "description": 'Sorts results in forward or backward, based on column name (e.g. "id" vs "-id")'
     })
     sort_desc = Boolean(load_default=True)
-    txt_filter = String(metadata={"description": "FTS search on the chosen word* terms"})
+    fts_text = String(metadata={"description": "FTS search on the chosen word* terms"})
     hide_xxx = Boolean(load_default=False, metadata={"description": "Toggles xxx filter"})
     category = String()
+    tags = List(String())
     exclude_deleted = Boolean(load_default=False)
     metadata_type = List(String(metadata={
         "description": 'Limits query to certain metadata types (e.g. "torrent" or "channel")'

--- a/src/tribler/test_unit/core/database/test_store.py
+++ b/src/tribler/test_unit/core/database/test_store.py
@@ -234,3 +234,50 @@ class TestMetadataStore(TestBase[MockCommunity]):
         self.assertEqual(20, ordered1.size)
         self.assertEqual(10, ordered2.size)
         self.assertEqual(1, ordered3.size)
+
+    @db_session
+    def test_get_entries_query_tags(self) -> None:
+        """
+        Test if entries can be fetched by partial tags.
+        """
+        self.metadata_store.TorrentMetadata.add_ffa_from_dict({"infohash": b"\xab" * 20, "title": "abc", "size": 3,
+                                                               "tags": "tag1,tag4,tag2"})
+        self.metadata_store.TorrentMetadata.add_ffa_from_dict({"infohash": b"\xcd" * 20, "title": "def", "size": 2,
+                                                               "tags": "tag2,tag3"})
+        self.metadata_store.TorrentMetadata.add_ffa_from_dict({"infohash": b"\xef" * 20, "title": "ghi", "size": 1,
+                                                               "tags": "tag4,tag3"})
+
+        ordered1, ordered2 = self.metadata_store.get_entries_query(sort_by="size", tags=["tag4"])[:]
+        self.assertEqual(3, ordered1.size)
+        self.assertEqual(1, ordered2.size)
+
+    @db_session
+    def test_get_entries_query_category(self) -> None:
+        """
+        Test if entries can be fetched by category (single tag).
+        """
+        self.metadata_store.TorrentMetadata.add_ffa_from_dict({"infohash": b"\xab" * 20, "title": "abc", "size": 3,
+                                                               "tags": "tag1,tag4,tag2"})
+        self.metadata_store.TorrentMetadata.add_ffa_from_dict({"infohash": b"\xcd" * 20, "title": "def", "size": 2,
+                                                               "tags": "tag2,tag3"})
+        self.metadata_store.TorrentMetadata.add_ffa_from_dict({"infohash": b"\xef" * 20, "title": "ghi", "size": 1,
+                                                               "tags": "tag4,tag3"})
+
+        ordered1, ordered2 = self.metadata_store.get_entries_query(sort_by="size", tags=["tag2"])[:]
+        self.assertEqual(3, ordered1.size)
+        self.assertEqual(2, ordered2.size)
+
+    @db_session
+    def test_get_entries_query_tags_multiple(self) -> None:
+        """
+        Test if entries can be fetched by multiple tags.
+        """
+        self.metadata_store.TorrentMetadata.add_ffa_from_dict({"infohash": b"\xab" * 20, "title": "abc", "size": 3,
+                                                               "tags": "tag1,tag4,tag2"})
+        self.metadata_store.TorrentMetadata.add_ffa_from_dict({"infohash": b"\xcd" * 20, "title": "def", "size": 2,
+                                                               "tags": "tag2,tag3"})
+        self.metadata_store.TorrentMetadata.add_ffa_from_dict({"infohash": b"\xef" * 20, "title": "ghi", "size": 1,
+                                                               "tags": "tag4,tag3"})
+
+        ordered1, = self.metadata_store.get_entries_query(sort_by="size", tags=["tag1", "tag2"])[:]
+        self.assertEqual(3, ordered1.size)


### PR DESCRIPTION
Fixes #8357

This PR:

 - Adds custom tag support to the REST API.
 - Fixes the `MetadataParameters` schema showing `txt_filter` instead of `fts_text`, rendering the Swagger interface inoperable.

Notes:
 - The tags are stored as a comma-separated list in a string. SQL/Pony really doesn't like this in a WHERE statement: `g.tags.split(x)` will produce an `AttributeError`.
 - It is possible to do a proper split in SQL. However, this is pretty heavy. Instead, as a lighter option, I opted for tag string end matching. Practically, this means that searching for the "horse" tag will return "seahorse" tags as well. If this becomes an issue, we will have to revisit this.
