### PR TITLE
Fixed libsodium vcpkg install

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -172,7 +172,7 @@ jobs:
       - name: Fetch libsodium.dll (Windows)
         if: matrix.os == 'windows-latest'
         run: |
-          vcpkg install libsodium:libsodium_x64-windows
+          vcpkg install libsodium
           Copy C:/vcpkg/packages/libsodium_x64-windows/bin/libsodium.dll src/libsodium.dll
       - name: Build Executables (Windows)
         if: matrix.os == 'windows-latest'


### PR DESCRIPTION
Fixes [the failing build](https://github.com/Tribler/tribler/actions/runs/15069331721).

This PR:

 - Updates `vcpkg install libsodium` to not use a custom triplet selector, which didn't work anymore (suddenly) but is x64 by default anyway.
 
I tested this on my own fork: https://github.com/qstokkink/tribler/actions/runs/15070835574
