### PR TITLE
Added DockerHub publish Action

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -2,12 +2,10 @@ name: Publish Docker Image
 
 on: workflow_dispatch
 env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
   REF_NAME: ${{ github.ref_name }}
 
 jobs:
-  build-and-push-image:
+  build-and-push-image-ghcr:
     runs-on: ubuntu-latest
 
     # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
@@ -29,16 +27,16 @@ jobs:
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
-          registry: ${{ env.REGISTRY }}
+          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create tags
         id: git_tag_version
         run: |
-          TAG=$REGISTRY/$IMAGE_NAME:$(git describe --tags)
-          COMMIT=$REGISTRY/$IMAGE_NAME:$REF_NAME
-          VERSION=$REGISTRY/$IMAGE_NAME:latest
+          TAG=ghcr.io/tribler:$(git describe --tags)
+          COMMIT=ghcr.io/tribler:$REF_NAME
+          VERSION=ghcr.io/tribler:latest
           echo "TAG1=${TAG,,}" >> $GITHUB_ENV
           echo "TAG2=${COMMIT,,}" >> $GITHUB_ENV
           echo "TAG3=${VERSION,,}" >> $GITHUB_ENV
@@ -61,6 +59,63 @@ jobs:
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1
         with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-name: ghcr.io/tribler
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+
+  build-and-push-image-dockerhub:
+    runs-on: ubuntu-latest
+
+    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
+          fetch-depth: 0
+          submodules: 'true'
+          fetch-tags: 'true'
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_PAT }}
+
+      - name: Create tags
+        id: git_tag_version
+        run: |
+          TAG=tribler/tribler:$(git describe --tags)
+          COMMIT=tribler/tribler:$REF_NAME
+          VERSION=tribler/tribler:latest
+          echo "TAG1=${TAG,,}" >> $GITHUB_ENV
+          echo "TAG2=${COMMIT,,}" >> $GITHUB_ENV
+          echo "TAG3=${VERSION,,}" >> $GITHUB_ENV
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: build/docker/build.Dockerfile
+          push: true
+          tags: |
+            ${{ env.TAG1 }}
+            ${{ env.TAG2 }}
+            ${{ env.TAG3 }}
+          build-args: |
+            GIT_BRANCH=${{ github.ref_name }}
+            GIT_REPO=https://github.com/${{ github.repository }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: index.docker.io/tribler/tribler
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true


### PR DESCRIPTION
Fixes #6591

This PR:

 - Adds automated Docker Hub uploads (next to our existing ghcr.io upload).

I tested this on my fork _up to_ the actual Docker Hub upload: https://github.com/qstokkink/tribler/actions/runs/15109829800/job/42466571875
**However**, there are a lot of moving parts in this chain. I fully expect a follow-up PR to be necessary. For that reason, I haven't changed the documentation to point to the Docker Hub release yet.