### PR TITLE
Fixed safe_seeding reenabling through default

### DIFF
--- a/src/tribler/core/libtorrent/restapi/downloads_endpoint.py
+++ b/src/tribler/core/libtorrent/restapi/downloads_endpoint.py
@@ -124,7 +124,7 @@ class DownloadsEndpoint(RESTEndpoint):
         download_config = DownloadConfig.from_defaults(self.download_manager.config)
 
         anon_hops = parameters.get('anon_hops')
-        safe_seeding = bool(parameters.get('safe_seeding', 0))
+        safe_seeding = bool(parameters.get('safe_seeding', download_config.get_safe_seeding()))
 
         if anon_hops is not None:
             if anon_hops > 0 and not safe_seeding:
@@ -132,8 +132,7 @@ class DownloadsEndpoint(RESTEndpoint):
             if anon_hops >= 0:
                 download_config.set_hops(anon_hops)
 
-        if safe_seeding:
-            download_config.set_safe_seeding(True)
+        download_config.set_safe_seeding(safe_seeding)
 
         if 'destination' in parameters:
             download_config.set_dest_dir(parameters['destination'])

--- a/src/tribler/test_unit/core/libtorrent/restapi/test_downloads_endpoint.py
+++ b/src/tribler/test_unit/core/libtorrent/restapi/test_downloads_endpoint.py
@@ -90,6 +90,66 @@ class TestDownloadsEndpoint(TestBase):
         return Download(TorrentDef.load_only_sha1(b"\x01" * 20, "test", ""), self.download_manager, config,
                         hidden=False, checkpoint_disabled=True)
 
+    def test_create_dconf_safe_default_safe(self) -> None:
+        """
+        Test if a default safe config can be overwritten to be safe.
+        """
+        self.download_manager.config.set("libtorrent/download_defaults/safeseeding_enabled", True)
+
+        dconf, _ = self.endpoint.create_dconfig_from_params({"safe_seeding": 1})
+
+        self.assertTrue(dconf.get_safe_seeding())
+
+    def test_create_dconf_unsafe_default_safe(self) -> None:
+        """
+        Test if a default safe config can be overwritten to be unsafe.
+        """
+        self.download_manager.config.set("libtorrent/download_defaults/safeseeding_enabled", True)
+
+        dconf, _ = self.endpoint.create_dconfig_from_params({"safe_seeding": 0})
+
+        self.assertFalse(dconf.get_safe_seeding())
+
+    def test_create_dconf_unset_default_safe(self) -> None:
+        """
+        Test if a default safe config can be overwritten to be unsafe.
+        """
+        self.download_manager.config.set("libtorrent/download_defaults/safeseeding_enabled", True)
+
+        dconf, _ = self.endpoint.create_dconfig_from_params({})
+
+        self.assertTrue(dconf.get_safe_seeding())
+
+    def test_create_dconf_safe_default_unsafe(self) -> None:
+        """
+        Test if a default unsafe config can be overwritten to be safe.
+        """
+        self.download_manager.config.set("libtorrent/download_defaults/safeseeding_enabled", False)
+
+        dconf, _ = self.endpoint.create_dconfig_from_params({"safe_seeding": 1})
+
+        self.assertTrue(dconf.get_safe_seeding())
+
+    def test_create_dconf_unsafe_default_unsafe(self) -> None:
+        """
+        Test if a default unsafe config can be overwritten to be unsafe.
+        """
+        self.download_manager.config.set("libtorrent/download_defaults/safeseeding_enabled", False)
+
+        dconf, _ = self.endpoint.create_dconfig_from_params({"safe_seeding": 0})
+
+        self.assertFalse(dconf.get_safe_seeding())
+
+    def test_create_dconf_unset_default_unsafe(self) -> None:
+        """
+        Test if a default unsafe config can be overwritten to be unsafe.
+        """
+        self.download_manager.config.set("libtorrent/download_defaults/safeseeding_enabled", False)
+
+        dconf, _ = self.endpoint.create_dconfig_from_params({})
+
+        self.assertFalse(dconf.get_safe_seeding())
+
     async def test_get_downloads_unloaded(self) -> None:
         """
         Test if a clean response is returned if the checkpoints are not loaded yet.


### PR DESCRIPTION
Fixes #8549

This PR:

 - Fixes `safe_seeding` reenabling itself if the download default of `safe_seeding: true` is used.
