### PR TITLE
Added url copy menu for system tray

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,6 @@ lz4
 pillow
 pony
 pystray
+pyperclip
+windows-toasts
 pywin32;sys_platform=="win32"


### PR DESCRIPTION
Fixes #8604

This PR:

 - Adds url copy menu for system tray
 
Hello,
Thanks for the project. I've been using tribler in windows and I appreciate its existence.
I just have a minor annoyance that it doesn’t present me that magic url with api key to open tribler in the browser of my choice. I try to keep tribler portable so I want to open it on portable firefox instance, but it keeps opening on my default browser (edge) so I have to be real fast to copy url before its loading to open it on any other browser.
After few months of this experience I decided to see if I can do anything about it by modifying tribler. I am no python expert by any means but with enough internet and ai chat I was able to add MenuItem that provides an option to copy api url (that magic url) to clipboard.
I have only tested this in windows and so far it seems to work for me. I tried to make it work across mac and linux as well but please feel free to edit if those implementations are not right.
Please take a look at it and integrate it/edit it/etc.
Thanks.
