### PR TITLE
Added docker.io doc pointer and fix ghcr build

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1
         with:
-          subject-name: ghcr.io/tribler
+          subject-name: ghcr.io/tribler/tribler
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
 

--- a/doc/basics/docker.rst
+++ b/doc/basics/docker.rst
@@ -10,7 +10,13 @@ Currently, only running the (unstable!) ``latest`` release is supported.
 Preparation
 -----------
 
-Fetch the docker image:
+Fetch the docker image from ``docker.io``:
+
+.. code-block::
+
+    docker pull tribler/tribler:latest
+
+Or, from ``ghcr.io``:
 
 .. code-block::
 


### PR DESCRIPTION
This PR:

 - Adds a pointer in the docks on how to pull from `docker.io`. Tested to work.
 - Fixes the `ghcr.io` Docker build:  https://github.com/Tribler/tribler/actions/runs/15167195523.
