### PR TITLE
Fix loading metainfo

### DIFF
--- a/src/tribler/core/libtorrent/download_manager/download_manager.py
+++ b/src/tribler/core/libtorrent/download_manager/download_manager.py
@@ -1028,9 +1028,6 @@ class DownloadManager(TaskManager):
             return False
 
         metainfo = config.get_metainfo()
-        if not metainfo:
-            self._logger.error("Could not resume checkpoint %s; metainfo not found", filename)
-            return False
         if not isinstance(metainfo, dict):
             self._logger.error("Could not resume checkpoint %s; metainfo is not dict %s %s",
                                filename, type(metainfo), repr(metainfo))
@@ -1048,6 +1045,11 @@ class DownloadManager(TaskManager):
                 return False
         else:
             tdef = TorrentDef(resumedata)
+            if b'info' in metainfo:
+                try:
+                    tdef.atp.ti = lt.torrent_info(metainfo)
+                except RuntimeError as e:
+                    self._logger.exception("Could not load torrent_info: %s %s ", e, metainfo)
 
         config.state_dir = self.state_dir
         if config.get_dest_dir() == "":  # removed torrent ignoring


### PR DESCRIPTION
Currently, downloads aren't loading their metainfo correctly, and as a result re-download their metainfo after every restart. This PR fixes this, and also addresses the issue that stopped torrents always show "Stopped 0%" after a restart, instead showing the actual progress. For some reason, downloads that are seeding don't have this 0% issue (which is probably why we haven't seen any bug reports yet).

Also fixes an issue where a stopped download can't be moved after a restart, since moving file storage doesn't appear to be working when libtorrent's `handle.get_metainfo` returns false. Possibly also related to https://github.com/Tribler/tribler/issues/8548.
