### PR TITLE
Adding StartupWMClass to .desktop file

### DIFF
--- a/build/debian/tribler/usr/share/applications/org.tribler.Tribler.desktop
+++ b/build/debian/tribler/usr/share/applications/org.tribler.Tribler.desktop
@@ -7,3 +7,4 @@ Terminal=false
 Type=Application
 Categories=Application;Network;P2P
 MimeType=x-scheme-handler/ppsp;x-scheme-handler/tswift;x-scheme-handler/magnet;application/x-bittorrent
+StartupWMClass=Tribler


### PR DESCRIPTION


This PR:

 - Updates - the `tribler/build/debian/tribler/usr/share/applications/org.tribler.Tribler.desktop` file to add: `StartupWMClass=Tribler`

I use Gnome DE in NixOS and for a while now it has bugged me that the icon for Tribler in the dash/panel when the program is running was the system default gear icon. 

I poked around and found that Gnome uses the [Application ID](https://developer.gnome.org/documentation/tutorials/application-id.html) to determine what to show as the icon in this case. 

I used `alt+F2` to pull up the run command window, then ran `lg` and found that gnome thinks the Tribler application id is just "Tribler". But since the icons are all `org.tribler.Tribler` then Gnome does not know what icon to use for the running window and just uses the default one.

So I tested adding the `StartWMClass` to the .desktop file and found that it fixes the issue.

I have attached a couple of screenshots showing how it looks on my system with and without the change. 

