### PR TITLE
Added warning popdown for max tracker setting

### DIFF
--- a/src/tribler/ui/public/locales/en_US.json
+++ b/src/tribler/ui/public/locales/en_US.json
@@ -45,6 +45,7 @@
     "MinusOneIsUnlimited": "-1 = unlimited",
     "EnableAnnounceAll": "Announce to all torrent trackers",
     "MaxTrackerConnections": "Max concurrent tracker connections",
+    "MaxTrackerConnectionsWarning": "This setting is high and may make your Tribler slow or inoperable!",
     "Password": "Password",
     "UploadRate": "Upload rate limit",
     "DownloadRate": "Download rate limit",

--- a/src/tribler/ui/public/locales/es_ES.json
+++ b/src/tribler/ui/public/locales/es_ES.json
@@ -45,6 +45,7 @@
     "MinusOneIsUnlimited": "-1 = ilimitadas",
     "EnableAnnounceAll": "Anunciar a todos los rastreadores de torrents",
     "MaxTrackerConnections": "Conexiones de seguimiento simultáneas máximas",
+    "MaxTrackerConnectionsWarning": "¡Esta configuración es alta y puede hacer que su Tribler sea lento o inoperable!",
     "Password": "Contraseña",
     "UploadRate": "Límite de velocidad de subida",
     "DownloadRate": "Límite de velocidad de descarga",

--- a/src/tribler/ui/public/locales/hi_IN.json
+++ b/src/tribler/ui/public/locales/hi_IN.json
@@ -45,6 +45,7 @@
     "MinusOneIsUnlimited": "-1 =  असीमित",
     "EnableAnnounceAll": "सभी टॉरेंट ट्रैकर्स को घोषणा करें",
     "MaxTrackerConnections": "अधिकतम समवर्ती ट्रैकर कनेक्शन",
+    "MaxTrackerConnectionsWarning": "यह सेटिंग उच्च है और आपके Tribler को धीमा या निष्क्रिय बना सकती है!",
     "Password": "पासवर्ड",
     "UploadRate": "प्रदान दर सीमा",
     "DownloadRate": "आदान दर सीमा",

--- a/src/tribler/ui/public/locales/ko_KR.json
+++ b/src/tribler/ui/public/locales/ko_KR.json
@@ -45,6 +45,7 @@
     "MinusOneIsUnlimited": "-1 = 무제한",
     "EnableAnnounceAll": "모든 토렌트 추적자에게 공지",
     "MaxTrackerConnections": "최대 동시 추적기 연결",
+    "MaxTrackerConnectionsWarning": "이 설정은 높아서 Tribler가 느리거나 작동 할 수 없게 만들 수 있습니다!",
     "Password": "비밀번호",
     "UploadRate": "올리기 속도 제한",
     "DownloadRate": "내려받기 속도 제한",

--- a/src/tribler/ui/public/locales/pt_BR.json
+++ b/src/tribler/ui/public/locales/pt_BR.json
@@ -45,6 +45,7 @@
     "MinusOneIsUnlimited": "-1 = sem limites",
     "EnableAnnounceAll": "Anuncie a todos os rastreadores de torrent",
     "MaxTrackerConnections": "Máximo de conexões simultâneas do rastreador",
+    "MaxTrackerConnectionsWarning": "Essa configuração é alta e pode tornar seu Tribler lento ou inoperante!",
     "Password": "Senha",
     "UploadRate": "Limite de upload",
     "DownloadRate": "Limite de upload",

--- a/src/tribler/ui/public/locales/ru_RU.json
+++ b/src/tribler/ui/public/locales/ru_RU.json
@@ -45,6 +45,7 @@
     "MinusOneIsUnlimited": "-1 = без ограничения",
     "EnableAnnounceAll": "Анонсируйте на всех торрент-трекерах",
     "MaxTrackerConnections": "Максимальное количество одновременных подключений к трекеру",
+    "MaxTrackerConnectionsWarning": "Эта настройка высока и может сделать ваш Tribler медленным или неработоспособным!",
     "Password": "Пароль",
     "UploadRate": "Исходящий трафик",
     "DownloadRate": "Входящий трафик",

--- a/src/tribler/ui/public/locales/zh_CN.json
+++ b/src/tribler/ui/public/locales/zh_CN.json
@@ -45,6 +45,7 @@
     "MinusOneIsUnlimited": "-1 = 无限制",
     "EnableAnnounceAll": "向所有种子追踪者宣布",
     "MaxTrackerConnections": "最大并发跟踪器连接数",
+    "MaxTrackerConnectionsWarning": "此设置很高，可能会使您的Tribler慢或无法使用！",
     "Password": "密码",
     "UploadRate": "上传速率限制",
     "DownloadRate": "下载速率限制",

--- a/src/tribler/ui/src/pages/Settings/Connection.tsx
+++ b/src/tribler/ui/src/pages/Settings/Connection.tsx
@@ -319,6 +319,14 @@ export default function Connection() {
                         }
                     }}
                 />
+                <div></div>
+                {(settings?.libtorrent?.max_concurrent_http_announces === undefined)
+                    || (settings.libtorrent.max_concurrent_http_announces <= 150) ? (<div></div>) :
+                    (<Label className="whitespace-nowrap p-2 text-muted-foreground bg-secondary">
+                        {t('MaxTrackerConnectionsWarning')}
+                    </Label>)
+                }
+
             </div>
 
             <SaveButton


### PR DESCRIPTION
Fixes #8514

This PR:

 - Adds a small warning note when the maximum number of trackers is set to a high value (>150).

[warningtrackers.webm](https://github.com/user-attachments/assets/0778dbb0-8630-41f0-96fa-9a6bf50a760a)
