### PR TITLE
Support for showing multiple SaveAs dialogs

### DIFF
--- a/src/tribler/ui/src/pages/Settings/General.tsx
+++ b/src/tribler/ui/src/pages/Settings/General.tsx
@@ -165,7 +165,7 @@ export default function General() {
 
             <div className="flex items-center space-x-2 py-2">
                 <Checkbox
-                    checked={settings?.ui?.ask_download_settings}
+                    checked={settings?.ui?.ask_download_settings !== false}
                     onCheckedChange={(value) => {
                         if (settings) {
                             setSettings({


### PR DESCRIPTION
Fixes https://github.com/Tribler/tribler/issues/8356.

When "Always ask download settings" is enabled, and the user adds multiple torrents, Tribler will now show the `SaveAs` dialog for one torrent at a time.

I didn't add an additional menu option for adding torrents silently, as that defeats the purpose of having a GUI setting.