### PR TITLE
Fix SOCKS5 hop count

### DIFF
--- a/src/tribler/core/libtorrent/download_manager/download_manager.py
+++ b/src/tribler/core/libtorrent/download_manager/download_manager.py
@@ -757,8 +757,11 @@ class DownloadManager(TaskManager):
         # Otherwise, e.g. if added to the Session init sequence, this results in startup
         # time increasing by 10-20 seconds.
         # See https://github.com/Tribler/tribler/issues/5319
-        if hops in self.dht_ready_tasks:
-            await self.dht_ready_tasks[hops]
+        try:
+            if hops in self.dht_ready_tasks:
+                await self.dht_ready_tasks[hops]
+        except CancelledError:
+            self._logger.warning("DHT readiness task was cancelled")
         if not atp.save_path:
             atp.save_path = atp.name or (atp.ti.name() if atp.ti else "Unknown name")
         ltsession.async_add_torrent(atp)

--- a/src/tribler/core/restapi/statistics_endpoint.py
+++ b/src/tribler/core/restapi/statistics_endpoint.py
@@ -84,6 +84,14 @@ class StatisticsEndpoint(RESTEndpoint):
             lt_stats["total_sent_bytes"] = sum([s["sent_bytes"] for s in lt_stats["sessions"]])
             stats_dict["libtorrent"] = lt_stats
 
+        if self.session and self.session.socks_servers:
+            socks5_stats = []
+            for index, server in enumerate(self.session.socks_servers):
+                socks5_stats.append({"hops": index,
+                                     "sessions": len(server.sessions),
+                                     "associates": sum([1 for session in server.sessions if session.udp_connection])})
+            stats_dict["socks5_sessions"] = socks5_stats
+
         return RESTResponse({"tribler_statistics": stats_dict})
 
     @docs(

--- a/src/tribler/core/session.py
+++ b/src/tribler/core/session.py
@@ -135,7 +135,8 @@ class Session:
 
         # Libtorrent
         self.download_manager = DownloadManager(self.config, self.notifier)
-        self.socks_servers = [Socks5Server(port) for port in self.config.get("libtorrent/socks_listen_ports")]
+        self.socks_servers = [Socks5Server(index+1, port)
+                              for index, port in enumerate(self.config.get("libtorrent/socks_listen_ports"))]
 
         # IPv8
         rescue_keys(self.config)

--- a/src/tribler/test_unit/core/restapi/test_statistics_endpoint.py
+++ b/src/tribler/test_unit/core/restapi/test_statistics_endpoint.py
@@ -30,6 +30,7 @@ class TestStatisticsEndpoint(TestBase):
         endpoint = StatisticsEndpoint()
         endpoint.session = Mock(download_manager=None)
         endpoint.session.mds = Mock(get_db_file_size=Mock(return_value=42), get_num_torrents=Mock(return_value=7))
+        endpoint.session.socks_servers = []
         request = MockRequest("/api/statistics/tribler")
 
         response = endpoint.get_tribler_stats(request)


### PR DESCRIPTION
Fix for allowing multiple SOCKS5 sessions to the `TunnelCommunity`.
Requires `ipv8-rust-tunnel` 0.1.30.