### PR TITLE
Build optimizations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,7 +150,6 @@ jobs:
             python3.12 -m pip install meson ninja
 
             cd /tribler
-            cp /lib/${{ matrix.architecture }}-linux-gnu/libcrypt.so.1 libcrypt-06cd74a6.so.2  # cx_Freeze workaround
             export PATH="/usr/local/bin:$PATH"
             unlink /usr/bin/python3
             ln -s $(echo "`which python3.12`") /usr/bin/python3

--- a/build/requirements.txt
+++ b/build/requirements.txt
@@ -1,6 +1,7 @@
 -r ../requirements.txt
 
-cx_Freeze==7.2.3; sys_platform != 'darwin'
+# cx_Freeze>=8.0.0 causes https://github.com/Tribler/tribler/issues/8636
+cx_Freeze==7.2.10; sys_platform != 'darwin'
 PyInstaller; sys_platform == 'darwin'
 
 setuptools

--- a/build/win/build.py
+++ b/build/win/build.py
@@ -64,9 +64,6 @@ def get_freeze_build_options():
         ("tribler.dist-info/METADATA", "lib/tribler.dist-info/METADATA"),
     ]
 
-    if platform.system() == "Linux" and platform.machine() == "aarch64":
-        included_files.append(("libcrypt-06cd74a6.so.2", "lib/libcrypt-06cd74a6.so.2"))
-
     # These packages will be excluded from the build
     excluded_packages = [
         'wx',

--- a/build/win/resources/tribler.nsi
+++ b/build/win/resources/tribler.nsi
@@ -110,10 +110,6 @@ Section "!Main EXE" SecMain
     ; Install MSVCR 2008, 2012 and 2015
     SetOutPath "$INSTDIR"
 
-    ; Libraries dependant on 2015 are: Python, Qt5
-    File "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Redist\MSVC\v143\vc_redist.x64.exe"
-    ExecWait "$INSTDIR\vc_redist.x64.exe /q /norestart"
-
     FileOpen $9 "$INSTDIR\tribler.exe.log" w
     FileWrite $9 ""
     FileClose $9


### PR DESCRIPTION
Fixes #8636

This PR:

 - Updates `cx_Freeze` to the highest permissible version (`7.2.10`, `>=8.0.0` does not work).
 - Updates the Windows build to not manually install `vc_redist.x64` anymore.
 - Removes the `aarch64` workaround due to `cx_Freeze<7.2.4`.

Build confirmed to work (https://github.com/qstokkink/tribler/actions/runs/15752332883).
