### PR TITLE
Various metainfo fixes

### DIFF
--- a/src/tribler/core/database/orm_bindings/torrent_metadata.py
+++ b/src/tribler/core/database/orm_bindings/torrent_metadata.py
@@ -318,7 +318,7 @@ def define_binding(db: Database, notifier: Notifier | None,  # noqa: C901
                 "origin_id": self.origin_id,
                 "public_key": hexlify(self.public_key).decode(),
                 "status": self.status,
-                "trackers": self.tracker_info.split(",") if self.tracker_info else [],
+                "trackers": [self.tracker_info] if self.tracker_info else [],
             }
 
         def get_type(self) -> int:

--- a/src/tribler/core/libtorrent/download_manager/download_manager.py
+++ b/src/tribler/core/libtorrent/download_manager/download_manager.py
@@ -546,14 +546,6 @@ class DownloadManager(TaskManager):
             logger.info("Successfully retrieved metainfo for %s", infohash_hex)
             self.metainfo_cache[infohash] = MetainfoLookupResult(time=time.time(),
                                                                  meta_info=metainfo)
-            self.notifier.notify(Notification.torrent_metadata_added, metadata={
-                "infohash": infohash,
-                "size": cast("lt.torrent_info", download.tdef.atp.ti).total_size(),
-                "title": download.tdef.name,
-                "metadata_type": 300,
-                "tracker_info": (download.tdef.atp.trackers or [""])[0]
-            })
-
             seeders, leechers = download.get_state().get_num_seeds_peers()
             metainfo[b"seeders"] = seeders
             metainfo[b"leechers"] = leechers

--- a/src/tribler/ui/src/services/tribler.service.ts
+++ b/src/tribler/ui/src/services/tribler.service.ts
@@ -306,7 +306,7 @@ export class TriblerService {
           }
     > {
         try {
-            return (await this.http.get(`/torrentinfo?uri=${uri}&skipmagnet=${skipMagnet}`, config)).data;
+            return (await this.http.get(`/torrentinfo`, {params: {uri, skipmagnet: skipMagnet}, ...config})).data;
         } catch (error) {
             return formatAxiosError(error as Error | AxiosError);
         }


### PR DESCRIPTION
This PR:
* Fixes an issue with `tracker_info` remaining empty while downloading from a magnet link.
* Fixes an issue with the uri not being properly encoded while getting metainfo from within the `SaveAs` dialog.
* ~Fixes an issue with not having the correct trackers after reusing the handle of a metainfo download.~
