### PR TITLE
Fixed move after complete regression

### DIFF
--- a/src/tribler/core/libtorrent/download_manager/download.py
+++ b/src/tribler/core/libtorrent/download_manager/download.py
@@ -605,7 +605,7 @@ class Download(TaskManager):
             self.notifier.notify(Notification.torrent_finished, infohash=infohash, name=name, hidden=self.hidden)
 
         completed_dir = self.config.get_completed_dir()
-        if completed_dir is not None and completed_dir != self.config.get_dest_dir():
+        if completed_dir and completed_dir != self.config.get_dest_dir():
             self.move_storage(Path(completed_dir))
 
     def update_lt_status(self, lt_status: lt.torrent_status) -> None:


### PR DESCRIPTION
Fixes #8674

This PR:

 - Adds unit tests for move after completion behavior.
 - Fixes an empty string not being equivalent to `None`/"don't move" for move after completion.
