### PR TITLE
Cast libtorrent alert to str before logging

### DIFF
--- a/src/tribler/core/libtorrent/download_manager/download_manager.py
+++ b/src/tribler/core/libtorrent/download_manager/download_manager.py
@@ -451,9 +451,9 @@ class DownloadManager(TaskManager):
             if is_process_alert:
                 download.process_alert(cast("lt.torrent_alert", alert), alert_type)
             else:
-                logger.debug("Got alert for download without handle %s: %s", infohash, alert)
+                logger.debug("Got alert for download without handle %s: %s", infohash, str(alert))
         elif infohash:
-            logger.debug("Got alert for unknown download %s: %s", infohash, alert)
+            logger.debug("Got alert for unknown download %s: %s", infohash, str(alert))
             if alert_type == "add_torrent_alert":
                 # A torrent got added, but the download is already removed.
                 handle = cast("lt.add_torrent_alert", alert).handle


### PR DESCRIPTION
Fixes #8673

This PR:

 - Fixes the segfault happening when passing libtorrent `alert` instances to Python's logging.

This was found by simply commenting out debug statements until Tribler no longer segfaulted. Then, to fix it, using the same string cast on alerts as we do for other log statements.