### PR TITLE
Fixed get_files calls for v2 torrents

### DIFF
--- a/src/tribler/core/libtorrent/restapi/downloads_endpoint.py
+++ b/src/tribler/core/libtorrent/restapi/downloads_endpoint.py
@@ -161,20 +161,21 @@ class DownloadsEndpoint(RESTEndpoint):
         files_completion = dict(download.get_state().get_files_completion())
         selected_files = download.config.get_selected_files()
         index_mapping = download.get_def().get_file_indices()
-        num_files = tinfo.num_files() if tinfo else 0
-        for file_index in range(num_files):
+        for file_index in index_mapping:
             fn = Path(tinfo.file_at(file_index).path)
-            if num_files > 1:
+            if len(index_mapping) > 1:
                 fn = fn.relative_to(tinfo.name())
             size = tinfo.file_at(file_index).size
-            files_json.append(cast("JSONFilesInfo", {
-                "index": index_mapping[file_index],
-                # We always return files in Posix format to make GUI independent of Core and simplify testing
-                "name": str(fn.as_posix()),
-                "size": size,
-                "included": (selected_files is None or index_mapping[file_index] in selected_files),
-                "progress": files_completion.get(fn, 0.0)
-            }))
+            files_json.append(
+                JSONFilesInfo(
+                    index=file_index,
+                    # We always return files in Posix format to make GUI independent of Core and simplify testing
+                    name=str(fn.as_posix()),
+                    size=size,
+                    included=(selected_files is None or file_index in selected_files),
+                    progress= files_completion.get(fn, 0.0),
+                )
+            )
         return files_json
 
     @docs(

--- a/src/tribler/core/libtorrent/restapi/torrentinfo_endpoint.py
+++ b/src/tribler/core/libtorrent/restapi/torrentinfo_endpoint.py
@@ -129,43 +129,51 @@ class TorrentInfoEndpoint(RESTEndpoint):
         """
         remapped_indices = tdef.get_file_indices()
         torrent_info = cast("lt.torrent_info", tdef.atp.ti)
-        num_files = torrent_info.num_files()
-        return [JSONMiniFileInfo(index=remapped_indices[fi],
-                                 name=(str(Path(torrent_info.file_at(fi).path).relative_to(torrent_info.name()))
-                                       if num_files > 1 else str(Path(torrent_info.file_at(fi).path))),
-                                 size=torrent_info.file_at(fi).size)
-                for fi in range(torrent_info.num_files())]
+        return [
+            JSONMiniFileInfo(
+                index=fi,
+                name=(str(Path(torrent_info.file_at(fi).path).relative_to(torrent_info.name()))
+                      if len(remapped_indices) > 1 else str(Path(torrent_info.file_at(fi).path))),
+                size=torrent_info.file_at(fi).size,
+            )
+            for fi in remapped_indices
+        ]
 
     @docs(
         tags=["Libtorrent"],
         summary="Return metainfo from a torrent found at a provided URI.",
-        parameters=[{
-            "in": "query",
-            "name": "uri",
-            "description": "URI for which to return torrent information. This URI can either represent "
-                           "a file location, a magnet link or a HTTP(S) url.",
-            "type": "string",
-            "required": True
-        }, {
-            "in": "query",
-            "name": "hops",
-            "description": "The number of anonymization hops to use.",
-            "type": "number",
-            "required": False
-        }, {
-            "in": "query",
-            "name": "skipmagnet",
-            "description": "Don't resolve magnet link metainfo, if you want an immediate response.",
-            "type": "boolean",
-            "required": False
-        }],
+        parameters=[
+            {
+                "in": "query",
+                "name": "uri",
+                "description": "URI for which to return torrent information. This URI can either represent "
+                "a file location, a magnet link or a HTTP(S) url.",
+                "type": "string",
+                "required": True,
+            },
+            {
+                "in": "query",
+                "name": "hops",
+                "description": "The number of anonymization hops to use.",
+                "type": "number",
+                "required": False,
+            },
+            {
+                "in": "query",
+                "name": "skipmagnet",
+                "description": "Don't resolve magnet link metainfo, if you want an immediate response.",
+                "type": "boolean",
+                "required": False,
+            },
+        ],
         responses={
             200: {
                 "description": "Return a hex-encoded json-encoded string with torrent metainfo",
-                "schema": schema(GetMetainfoResponse={"metainfo": String, "download_exists": Boolean,
-                                                      "valid_certificate": Boolean})
+                "schema": schema(
+                    GetMetainfoResponse={"metainfo": String, "download_exists": Boolean, "valid_certificate": Boolean}
+                ),
             }
-        }
+        },
     )
     async def get_torrent_info(self, request: Request) -> RESTResponse:  # noqa: C901, PLR0911, PLR0912, PLR0915
         """


### PR DESCRIPTION
Fixes #8678

This PR:

 - Fixes unhandled exception when viewing files in `v2` torrents, either using `get_files_info_json()` or `get_files()`.

