### PR TITLE
Fixed Watch folder load exception

### DIFF
--- a/src/tribler/core/libtorrent/torrentdef.py
+++ b/src/tribler/core/libtorrent/torrentdef.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Any
 import libtorrent as lt
 
 if TYPE_CHECKING:
-    from os import PathLike
     from typing import Literal, overload
 
     ###############
@@ -220,7 +219,7 @@ class TorrentDef:
         return self.atp.info_hash.to_bytes()
 
     @staticmethod
-    def _threaded_load_job(filepath: str | bytes | PathLike) -> TorrentDef:
+    def _threaded_load_job(filepath: str) -> TorrentDef:
         """
         Perform the actual loading of the torrent.
 
@@ -232,7 +231,7 @@ class TorrentDef:
             raise ValueError from e
 
     @staticmethod
-    async def load(filepath: str | bytes | PathLike) -> TorrentDef:
+    async def load(filepath: str) -> TorrentDef:
         """
         Create a TorrentDef object from a .torrent file.
 

--- a/src/tribler/core/watch_folder/manager.py
+++ b/src/tribler/core/watch_folder/manager.py
@@ -71,7 +71,7 @@ class WatchFolderManager:
         logger.debug("Add watched torrent file: %s", str(path))
         try:
             if path.name.endswith(".torrent"):
-                tdef = await TorrentDef.load(path)
+                tdef = await TorrentDef.load(str(path))
                 if not self.session.download_manager.download_exists(tdef.infohash):
                     logger.info("Starting download from torrent file %s", path.name)
                     await self.session.download_manager.start_download(torrent_file=str(path), tdef=tdef)


### PR DESCRIPTION
Fixes #8681

This PR:

 - Fixes `TorrentDef._threaded_load_job` pretending that it can handle `Path` instances (it can't).
