### PR TITLE
Updated move_storage to prefer existing file

### DIFF
--- a/src/tribler/core/libtorrent/download_manager/download.py
+++ b/src/tribler/core/libtorrent/download_manager/download.py
@@ -659,7 +659,7 @@ class Download(TaskManager):
         Move the output files to a different location.
         """
         if self.tdef.torrent_info is not None:
-            handle.move_storage(str(new_dir))
+            handle.move_storage(str(new_dir), lt.move_flags_t.dont_replace)
         self.config.set_dest_dir(new_dir)
         return True
 

--- a/src/tribler/test_unit/core/libtorrent/download_manager/test_download.py
+++ b/src/tribler/test_unit/core/libtorrent/download_manager/test_download.py
@@ -102,7 +102,8 @@ class TestDownload(TestBase):
 
         self.assertTrue(success)
         self.assertEqual(Path("some_path"), download.config.get_dest_dir())
-        self.assertEqual(call("some_path"), download.handle.move_storage.call_args)
+        self.assertEqual(call("some_path", libtorrent.move_flags_t.dont_replace),
+                         download.handle.move_storage.call_args)
 
     def test_move_storage_no_metainfo(self) -> None:
         """
@@ -883,7 +884,7 @@ class TestDownload(TestBase):
 
         download.on_torrent_finished_alert(Mock())
 
-        self.assertEqual(call("folder"), download.handle.move_storage.call_args)
+        self.assertEqual(call("folder", libtorrent.move_flags_t.dont_replace), download.handle.move_storage.call_args)
         self.assertEqual(Path("folder"), download.config.get_dest_dir())
 
     async def test_move_after_finish_unset(self) -> None:

--- a/src/tribler/test_unit/core/libtorrent/restapi/test_downloads_endpoint.py
+++ b/src/tribler/test_unit/core/libtorrent/restapi/test_downloads_endpoint.py
@@ -707,7 +707,8 @@ class TestDownloadsEndpoint(TestBase):
         self.assertEqual(200, response.status)
         self.assertTrue(response_body_json["modified"])
         self.assertEqual("01" * 20, response_body_json["infohash"])
-        self.assertEqual(call(str(Path(__file__).parent)), download.handle.move_storage.call_args)
+        self.assertEqual(call(str(Path(__file__).parent), libtorrent.move_flags_t.dont_replace),
+                         download.handle.move_storage.call_args)
 
     async def test_update_download_nothing(self) -> None:
         """


### PR DESCRIPTION
Fixes #8689

This PR:

 - Updates `move_storage()` to use `dont_replace` mode.

This mode doesn't just flat-out leave files that exist. The behavior is a bit more nuanced. The actual behavior is that a file that already exists **does** get overwritten if its contents are wrong, otherwise the file is left.

Suppose we have `readme.txt`, last modified at `14:26`.

<img width="442" height="75" alt="screenshot before" src="https://github.com/user-attachments/assets/a69f2c38-a021-420d-9462-71a8f5827e04" />

Now I start a download that moves-after-completion into this directory with the same file. The target file is not affected:

<img width="762" height="84" alt="screenshot after" src="https://github.com/user-attachments/assets/d9bea06e-35d1-4a99-bdf0-ec59b6440824" />

Now, _I change the contents of the txt file_, at `14:40`:

<img width="440" height="63" alt="screenshot case 2 before" src="https://github.com/user-attachments/assets/6ac272ef-a378-4bd1-82b8-d1466c51d740" />

Again I start a download that moves-after-completion into this directory. Once finished, the file is detected to be different and replaced, at `14:42`:

<img width="756" height="69" alt="screenshot case 2 after" src="https://github.com/user-attachments/assets/1f83d62f-32bd-4703-ade6-2e3deb64cbde" />
