### PR TITLE
Fix issue with downloads moving after restart

### DIFF
--- a/src/tribler/core/libtorrent/download_manager/download_config.py
+++ b/src/tribler/core/libtorrent/download_manager/download_config.py
@@ -192,11 +192,12 @@ class DownloadConfig:
         """
         self.config["download_defaults"]["completed_dir"] = str(path)
 
-    def get_completed_dir(self) -> str | None:
+    def get_completed_dir(self) -> Path | None:
         """
         Gets the directory where to move this Download upon completed.
         """
-        return self.config["download_defaults"].get("completed_dir")
+        completed_dir = self.config["download_defaults"].get("completed_dir")
+        return Path(completed_dir) if completed_dir else None
 
     def set_hops(self, hops: int) -> None:
         """

--- a/src/tribler/core/libtorrent/restapi/downloads_endpoint.py
+++ b/src/tribler/core/libtorrent/restapi/downloads_endpoint.py
@@ -329,7 +329,7 @@ class DownloadsEndpoint(RESTEndpoint):
                 "upload_limit": download.get_upload_limit(),
                 "download_limit": download.get_download_limit(),
                 "destination": str(download.config.get_dest_dir()),
-                "completed_dir": download.config.get_completed_dir(),
+                "completed_dir": str(download.config.get_completed_dir() or ""),
                 "total_pieces": tdef.torrent_info.num_pieces() if tdef.torrent_info else 0,
                 "error": repr(state.get_error()) if state.get_error() else "",
                 "time_added": download.config.get_time_added(),


### PR DESCRIPTION
Fixes https://github.com/Tribler/tribler/issues/8685. Possibly also https://github.com/Tribler/tribler/issues/869 and https://github.com/Tribler/tribler/issues/8697

Tribler was calling `move_storage` after every restart because `get_completed_dir` and `get_dest_dir` are returning different types of objects (one being a `str` and the other `Path`). Because of this the paths are never considered equal, and we kept calling `move_storage` after every restart.

