### PR TITLE
Added 'completed on' column

### DIFF
--- a/src/tribler/core/libtorrent/restapi/downloads_endpoint.py
+++ b/src/tribler/core/libtorrent/restapi/downloads_endpoint.py
@@ -333,6 +333,7 @@ class DownloadsEndpoint(RESTEndpoint):
                 "total_pieces": tdef.torrent_info.num_pieces() if tdef.torrent_info else 0,
                 "error": repr(state.get_error()) if state.get_error() else "",
                 "time_added": download.config.get_time_added(),
+                "time_finished": download.tdef.atp.completed_time,
                 # To prevent the queue_position from becoming stale, we get it directly from the download
                 "queue_position": download.get_queue_position(),
                 "auto_managed": download.config.get_auto_managed(),

--- a/src/tribler/ui/public/locales/en_US.json
+++ b/src/tribler/ui/public/locales/en_US.json
@@ -75,6 +75,7 @@
     "Hops": "Hops",
     "ETA": "ETA",
     "AddedOn": "Added on",
+    "CompletedOn": "Completed on",
     "Search": "Search",
     "SelectLanguage": "Select language",
     "SelectTheme": "Select theme",

--- a/src/tribler/ui/public/locales/es_ES.json
+++ b/src/tribler/ui/public/locales/es_ES.json
@@ -75,6 +75,7 @@
     "Hops": "Saltos",
     "ETA": "Tiempo",
     "AddedOn": "Añadido el",
+    "CompletedOn": "Completado sobre",
     "Search": "Buscar",
     "SelectLanguage": "Seleccione idioma",
     "SelectTheme": "Seleccionar tema",

--- a/src/tribler/ui/public/locales/hi_IN.json
+++ b/src/tribler/ui/public/locales/hi_IN.json
@@ -75,6 +75,7 @@
     "Hops": "हॉप्स ",
     "ETA": "इटीऐ",
     "AddedOn": "जोड़ने की तिथि",
+    "CompletedOn": "पर पूर्ण",
     "Search": "खोजें",
     "SelectLanguage": "भाषा चुनें",
     "SelectTheme": "थीम चुनें",

--- a/src/tribler/ui/public/locales/ko_KR.json
+++ b/src/tribler/ui/public/locales/ko_KR.json
@@ -75,6 +75,7 @@
     "Hops": "홉",
     "ETA": "ETA",
     "AddedOn": "추가됨",
+    "CompletedOn": "완성되었습니다",
     "Search": "찾다",
     "SelectLanguage": "언어 선택",
     "SelectTheme": "테마 선택",

--- a/src/tribler/ui/public/locales/pt_BR.json
+++ b/src/tribler/ui/public/locales/pt_BR.json
@@ -75,6 +75,7 @@
     "Hops": "Pulos",
     "ETA": "Tempo estimado",
     "AddedOn": "Adicionado em",
+    "CompletedOn": "Concluído em",
     "Search": "Procurar",
     "SelectLanguage": "Selecione o idioma",
     "SelectTheme": "Selecione o tema",

--- a/src/tribler/ui/public/locales/ru_RU.json
+++ b/src/tribler/ui/public/locales/ru_RU.json
@@ -75,6 +75,7 @@
     "Hops": "Прокси",
     "ETA": "Ост. Время",
     "AddedOn": "Добавлен",
+    "CompletedOn": "Завершено на",
     "Search": "Поиск",
     "SelectLanguage": "Выберите язык",
     "SelectTheme": "Выберите тему",

--- a/src/tribler/ui/public/locales/zh_CN.json
+++ b/src/tribler/ui/public/locales/zh_CN.json
@@ -75,6 +75,7 @@
     "Hops": "跃点数",
     "ETA": "剩余时间",
     "AddedOn": "添加时间",
+    "CompletedOn": "完成",
     "Search": "搜索",
     "SelectLanguage": "选择语言",
     "SelectTheme": "选择主题",

--- a/src/tribler/ui/src/models/download.model.tsx
+++ b/src/tribler/ui/src/models/download.model.tsx
@@ -47,6 +47,7 @@ export interface Download {
     total_pieces: number;
     error: string;
     time_added: number;
+    time_finished: number;
     availability?: number;
     pieces?: string;
     peers: Peer[];

--- a/src/tribler/ui/src/pages/Downloads/index.tsx
+++ b/src/tribler/ui/src/pages/Downloads/index.tsx
@@ -174,6 +174,16 @@ const downloadColumns: ColumnDef<Download>[] = [
             return <span>{formatDateTime(row.original.time_added)}</span>;
         },
     },
+    {
+        accessorKey: "time_finished",
+        header: getHeader("CompletedOn"),
+        meta: {
+            hide_by_default: true,
+        },
+        cell: ({row}) => {
+            return <span>{row.original.time_finished > 0 ? formatDateTime(row.original.time_finished) : "-"}</span>;
+        },
+    },
 ];
 
 function Progress({progress, color}: {progress: number; color: string}) {


### PR DESCRIPTION
Fixes #6693

This PR:

 - Adds a `Completed on` column to the GUI and downloads REST API.

Note that the ATP is persisted by Tribler, but this is not automatically updated by libtorrent.
