### PR TITLE
WIP: Updated code base to use ATPs instead of metainfo dicts

### DIFF
--- a/src/tribler/core/libtorrent/download_manager/download_config.py
+++ b/src/tribler/core/libtorrent/download_manager/download_config.py
@@ -303,18 +303,6 @@ class DownloadConfig:
         """
         return self.config["download_defaults"]["bootstrap_download"]
 
-    def set_metainfo(self, metainfo: dict) -> None:
-        """
-        Set the metainfo dict for this download.
-        """
-        self.config["state"]["metainfo"] = _from_dict(metainfo)
-
-    def get_metainfo(self) -> dict | None:
-        """
-        Get the metainfo dict for this download or None if it cannot be decoded.
-        """
-        return _to_dict(self.config["state"]["metainfo"])
-
     def set_engineresumedata(self, engineresumedata: lt.add_torrent_params) -> None:
         """
         Set the engine resume data dict for this download.

--- a/src/tribler/core/libtorrent/download_manager/download_manager.py
+++ b/src/tribler/core/libtorrent/download_manager/download_manager.py
@@ -27,7 +27,7 @@ from yarl import URL
 from tribler.core.libtorrent.download_manager.download import Download
 from tribler.core.libtorrent.download_manager.download_config import DownloadConfig
 from tribler.core.libtorrent.download_manager.download_state import DownloadState, DownloadStatus
-from tribler.core.libtorrent.torrentdef import MetainfoDict, MetainfoV2Dict, TorrentDef
+from tribler.core.libtorrent.torrentdef import TorrentDef
 from tribler.core.libtorrent.uris import get_url, unshorten, url_to_path
 from tribler.core.notifier import Notification, Notifier
 from tribler.tribler_config import VERSION_SUBDIR
@@ -77,7 +77,9 @@ class MetainfoLookupResult(TypedDict):
     """
 
     time: float
-    meta_info: MetainfoDict | MetainfoV2Dict
+    tdef: TorrentDef
+    seeders: int
+    leechers: int
 
 
 def encode_atp(atp: dict) -> dict:
@@ -498,7 +500,7 @@ class DownloadManager(TaskManager):
                                                               bytearray(decoded[b"r"][b"BFpe"]))
 
     async def get_metainfo(self, infohash: bytes, timeout: float = 7, hops: int | None = -1,
-                           url: str | None = None) -> dict | None:
+                           url: str | None = None) -> MetainfoLookupResult | None:
         """
         Lookup metainfo for a given infohash. The mechanism works by joining the swarm for the infohash connecting
         to a few peers, and downloading the metadata for the torrent.
@@ -512,17 +514,20 @@ class DownloadManager(TaskManager):
         infohash_hex = hexlify(infohash)
         if infohash in self.metainfo_cache:
             logger.info("Returning metainfo from cache for %s", infohash_hex)
-            return self.metainfo_cache[infohash]["meta_info"]
+            return self.metainfo_cache[infohash]
 
+        tdef: TorrentDef | None = None
         logger.info("Trying to fetch metainfo for %s", infohash_hex)
         if infohash in self.metainfo_requests:
             download = self.metainfo_requests[infohash].download
             self.metainfo_requests[infohash].pending += 1
+            tdef = download.tdef
         elif infohash in self.downloads:
             download = self.downloads[infohash]
+            tdef = download.tdef
         else:
             atp = lt.parse_magnet_uri(url) if url and url.startswith("magnet") else lt.add_torrent_params()
-            atp.name, atp.info_hash, atp.url = "metainfo request", lt.sha1_hash(infohash), url or ""
+            atp.name, atp.info_hashes, atp.url = "metainfo request", lt.info_hash_t(lt.sha1_hash(infohash)), url or ""
             tdef = TorrentDef(atp)
             dcfg = DownloadConfig.from_defaults(self.config)
             dcfg.set_hops(hops or self.config.get("libtorrent/download_defaults/number_hops"))
@@ -538,20 +543,19 @@ class DownloadManager(TaskManager):
             self.metainfo_requests[infohash] = MetainfoLookup(download, 1)
 
         try:
-            metainfo = cast("MetainfoDict", download.tdef.get_metainfo()
-                            or await wait_for(shield(download.future_metainfo), timeout))
+            await wait_for(shield(download.future_metainfo), timeout)
         except (CancelledError, TimeoutError) as e:
             logger.warning("%s: %s (timeout=%f)", type(e).__name__, str(e), timeout)
             logger.info("Failed to retrieve metainfo for %s", infohash_hex)
             return None
         else:
             logger.info("Successfully retrieved metainfo for %s", infohash_hex)
-            self.metainfo_cache[infohash] = MetainfoLookupResult(time=time.time(),
-                                                                 meta_info=metainfo)
             seeders, leechers = download.get_state().get_num_seeds_peers()
-            metainfo[b"seeders"] = seeders
-            metainfo[b"leechers"] = leechers
-            return metainfo
+            self.metainfo_cache[infohash] = MetainfoLookupResult(time=time.time(),
+                                                                 tdef=tdef,
+                                                                 seeders=seeders,
+                                                                 leechers=leechers)
+            return self.metainfo_cache[infohash]
         finally:
             if infohash in self.metainfo_requests:
                 self.metainfo_requests[infohash].pending -= 1
@@ -609,7 +613,7 @@ class DownloadManager(TaskManager):
             logger.info("Name: %s. Infohash: %s", tdef.name, tdef.infohash)
             if tdef.infohash in self.metainfo_cache:
                 logger.info("Metainfo found in cache")
-                tdef = TorrentDef.load_from_dict(self.metainfo_cache[tdef.infohash]["meta_info"])
+                tdef = self.metainfo_cache[tdef.infohash]["tdef"]
 
                 # Merge existing tdef with tdef parsed from magnet
                 tdef.atp.trackers = magnet_trackers
@@ -972,7 +976,7 @@ class DownloadManager(TaskManager):
         self.all_checkpoints_are_loaded = True
         self._logger.info("Checkpoints are loaded")
 
-    async def load_checkpoint(self, filename: Path | str) -> bool:  # noqa: C901,PLR0912
+    async def load_checkpoint(self, filename: Path | str) -> bool:
         """
         Load a checkpoint from a given file name.
         """
@@ -986,33 +990,12 @@ class DownloadManager(TaskManager):
             self._logger.exception("Could not open checkpoint file %s", filename)
             return False
 
-        metainfo = config.get_metainfo()
-        if not isinstance(metainfo, dict):
-            self._logger.error("Could not resume checkpoint %s; metainfo is not dict %s %s",
-                               filename, type(metainfo), repr(metainfo))
+        resumedata = config.get_engineresumedata()
+        if resumedata is None or resumedata.info_hashes.v1.to_bytes() == (b"\x00" * 20):
+            self._logger.exception("Could not open checkpoint file %s, missing resumedata.", filename)
             return False
 
-        resumedata = config.get_engineresumedata()
-        if resumedata is None or resumedata.info_hash.to_bytes() == (b"\x00" * 20):
-            try:
-                url = metainfo.get(b"url", b"").decode()
-                if b"infohash" in metainfo:
-                    atp = lt.add_torrent_params()
-                    atp.name, atp.info_hash = metainfo[b"name"].decode(), lt.sha1_hash(metainfo[b"infohash"])
-                    atp.url = url
-                    tdef = TorrentDef(atp)
-                else:
-                    tdef = TorrentDef.load_from_dict(cast("MetainfoDict", metainfo))
-            except (KeyError, ValueError) as e:
-                self._logger.exception("Could not restore tdef from metainfo dict: %s %s ", e, metainfo)
-                return False
-        else:
-            tdef = TorrentDef(resumedata)
-            if b'info' in metainfo:
-                try:
-                    tdef.atp.ti = lt.torrent_info(metainfo)
-                except RuntimeError as e:
-                    self._logger.exception("Could not load torrent_info: %s %s ", e, metainfo)
+        tdef = TorrentDef(resumedata)
 
         if config.get_dest_dir() == "":  # removed torrent ignoring
             self._logger.info("Removing checkpoint %s destdir is %s", filename, config.get_dest_dir())

--- a/src/tribler/core/libtorrent/torrentdef.py
+++ b/src/tribler/core/libtorrent/torrentdef.py
@@ -2,177 +2,8 @@ from __future__ import annotations
 
 from asyncio import get_running_loop
 from binascii import hexlify
-from typing import TYPE_CHECKING, Any
 
 import libtorrent as lt
-
-if TYPE_CHECKING:
-    from typing import Literal, overload
-
-    ###############
-    # V1 torrents #
-    ###############
-
-    class FileDict(dict):  # noqa: D101
-
-        @overload  # type: ignore[override]
-        def __getitem__(self, key: Literal[b"length"]) -> int: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"path"]) -> list[bytes]: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"path.utf-8"]) -> list[bytes] | None: ...
-
-        def __getitem__(self, key: bytes) -> Any: ...  # noqa: D105
-
-
-    class InfoDict(dict):  # noqa: D101
-
-        @overload  # type: ignore[override]
-        def __getitem__(self, key: Literal[b"files"]) -> list[FileDict]: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"length"]) -> int: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"name"]) -> bytes: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"name.utf-8"]) -> bytes: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"piece length"]) -> int: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"pieces"]) -> bytes: ...
-
-        def __getitem__(self, key: bytes) -> Any: ...  # noqa: D105
-
-
-    class MetainfoDict(dict):  # noqa: D101
-
-        @overload  # type: ignore[override]
-        def __getitem__(self, key: Literal[b"announce"]) -> bytes | None: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"announce-list"]) -> list[list[bytes]] | None: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"comment"]) -> bytes | None: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"created by"]) -> bytes | None: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"creation date"]) -> bytes | None: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"encoding"]) -> bytes | None: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"info"]) -> InfoDict: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"httpseeds"]) -> list[bytes] | None: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"nodes"]) -> list[bytes] | None: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"urllist"]) -> list[bytes] | None: ...
-
-        def __getitem__(self, key: bytes) -> Any: ...  # noqa: D105
-
-    ###############
-    # V2 torrents #
-    ###############
-    class FileSpecV2(dict):  # noqa: D101
-
-        @overload
-        def __getitem__(self, key: Literal[b"length"]) -> int: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"pieces root"]) -> bytes | None: ...
-
-        def __getitem__(self, key: bytes) -> Any: ...  # noqa: D105
-
-
-    class FileV2(dict):  # noqa: D101
-
-        def __getitem__(self, key: Literal[b""]) -> FileSpecV2: ...  # noqa: D105
-
-
-    class DirectoryV2(dict):  # noqa: D101
-
-        def __getitem__(self, key: bytes) -> DirectoryV2 | FileV2: ...  # noqa: D105
-
-
-    class InfoDictV2(dict):  # noqa: D101
-
-        @overload  # type: ignore[override]
-        def __getitem__(self, key: Literal[b"file tree"]) -> DirectoryV2: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"meta version"]) -> int: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"name"]) -> bytes: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"piece length"]) -> int: ...
-
-        def __getitem__(self, key: bytes) -> Any: ...  # noqa: D105
-
-
-    class MetainfoV2Dict(dict):  # noqa: D101
-
-        @overload  # type: ignore[override]
-        def __getitem__(self, key: Literal[b"announce"]) -> bytes | None: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"announce-list"]) -> list[list[bytes]] | None: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"comment"]) -> bytes | None: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"created by"]) -> bytes | None: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"creation date"]) -> bytes | None: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"encoding"]) -> bytes | None: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"info"]) -> InfoDictV2: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"httpseeds"]) -> list[bytes] | None: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"nodes"]) -> list[bytes] | None: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"piece layers"]) -> dict[bytes, bytes] | None: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"urllist"]) -> list[bytes] | None: ...
-
-        def __getitem__(self, key: bytes) -> Any: ...  # noqa: D105
-
-
-else:
-    FileDict = dict[bytes, Any]
-    InfoDict = dict[bytes, Any]
-    MetainfoDict = dict[bytes, Any]
-
-    FileSpecV2 = dict[bytes, Any]
-    InfoDictV2 = dict[bytes, Any]
-    FileV2 = dict[bytes, Any]
-    DirectoryV2 = dict[bytes, Any]
-    MetainfoV2Dict = dict[bytes, Any]
 
 
 class TorrentDef:
@@ -216,7 +47,7 @@ class TorrentDef:
         """
         if self.torrent_info:
             return self.torrent_info.info_hash().to_bytes()
-        return self.atp.info_hash.to_bytes()
+        return self.atp.info_hashes.v1.to_bytes()
 
     @staticmethod
     def _threaded_load_job(filepath: str) -> TorrentDef:
@@ -250,39 +81,6 @@ class TorrentDef:
             return TorrentDef(lt.load_torrent_buffer(bencoded_data))  # type: ignore[attr-defined]  # missing in lt .pyi
         except RuntimeError as e:
             raise ValueError from e
-
-    @staticmethod
-    def load_from_dict(metainfo: MetainfoDict | MetainfoV2Dict) -> TorrentDef:
-        """
-        Load a metainfo dictionary into a TorrentDef object.
-
-        :param metainfo: The metainfo dictionary
-        """
-        try:
-            return TorrentDef.load_from_memory(lt.bencode(metainfo))
-        except RuntimeError as e:
-            raise ValueError from e
-
-    def get_metainfo(self) -> MetainfoDict | MetainfoV2Dict | None:
-        """
-        Returns the metainfo of the torrent. Might be None if no metainfo is provided.
-        """
-        if self.atp.ti is None:
-            return None
-        return MetainfoDict({
-            b"announce": self.atp.trackers[0].encode() if self.atp.trackers else b"",
-            b"announce-list": [[tracker.encode()] for tracker in self.atp.trackers],
-            b"comment": self.atp.ti.comment().encode(),
-            b"created by": self.atp.ti.creator().encode(),
-            b"creation date": self.atp.ti.creation_date(),
-            b"encoding": "UTF-8",
-            b"httpseeds": [web_seed["url"].encode() for web_seed in self.atp.ti.web_seeds()
-                           if web_seed["type"] == 1],  # type: ignore[typeddict-item]  # missing in lt .pyi
-            b"nodes": [(entry[0].encode(), entry[1]) for entry in self.atp.ti.nodes()],
-            b"urllist": [web_seed["url"].encode() for web_seed in self.atp.ti.web_seeds()
-                         if web_seed["type"] == 0],  # type: ignore[typeddict-item]  # missing in lt .pyi
-            b"info": lt.bdecode(self.atp.ti.info_section())
-        })
 
     def get_file_indices(self) -> list[int]:
         """

--- a/src/tribler/core/rss/rss.py
+++ b/src/tribler/core/rss/rss.py
@@ -7,11 +7,10 @@ from email.utils import formatdate, parsedate
 from io import BytesIO
 from ssl import SSLError
 from time import mktime, time
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 from xml.etree import ElementTree as ET
 from xml.etree.ElementTree import ParseError
 
-import libtorrent
 from aiohttp import ClientConnectorError, ClientResponseError, ClientSession, ServerConnectionError
 from aiohttp.web_exceptions import HTTPNotModified, HTTPOk
 
@@ -26,8 +25,6 @@ if TYPE_CHECKING:
 
     from aiohttp import ClientResponse
     from ipv8.taskmanager import TaskManager
-
-    from tribler.core.libtorrent.torrentdef import MetainfoDict
 
 logger = logging.getLogger(__name__)
 
@@ -83,12 +80,11 @@ class RSSWatcher:
                 continue
 
             try:
-                metainfo = libtorrent.bdecode(response)
-            except RuntimeError as e:
+                torrent_def = TorrentDef.load_from_memory(response)
+            except ValueError as e:
                 logger.warning("Error while reading http uri response: %s", str(e))
                 continue
 
-            torrent_def = TorrentDef.load_from_dict(cast("MetainfoDict", metainfo))
             metadata_dict = tdef_to_metadata_dict(torrent_def)
             self.notifier.notify(Notification.torrent_metadata_added, metadata=metadata_dict)
 

--- a/src/tribler/core/torrent_checker/torrentchecker_session.py
+++ b/src/tribler/core/torrent_checker/torrentchecker_session.py
@@ -483,10 +483,10 @@ class FakeDHTSession(TrackerSession):
         health_list = []
         now = int(time.time())
         for infohash in self.infohash_list:
-            metainfo = await self.download_manager.get_metainfo(infohash, timeout=self.timeout)
-            if metainfo is None:
+            lookup = await self.download_manager.get_metainfo(infohash, timeout=self.timeout)
+            if lookup is None:
                 continue
-            health = HealthInfo(infohash, seeders=metainfo[b"seeders"], leechers=metainfo[b"leechers"],
+            health = HealthInfo(infohash, seeders=lookup["seeders"], leechers=lookup["leechers"],
                                 last_check=now, self_checked=True)
             health_list.append(health)
 

--- a/src/tribler/test_integration/test_anon_download.py
+++ b/src/tribler/test_integration/test_anon_download.py
@@ -167,8 +167,8 @@ class TestAnonymousDownload(TestBase[TriblerTunnelCommunity]):
         with open(config.get_dest_dir() / "ubuntu-15.04-desktop-amd64.iso", "wb") as f:  # noqa: ASYNC230
             f.write(bytes([1] * 524288))
 
-        metainfo = create_torrent_file([config.get_dest_dir() / "ubuntu-15.04-desktop-amd64.iso"], {})["metainfo"]
-        tdef = TorrentDef.load_from_memory(metainfo)
+        atp = create_torrent_file([config.get_dest_dir() / "ubuntu-15.04-desktop-amd64.iso"])["atp"]
+        tdef = TorrentDef(atp)
 
         download = await self.download_manager_seeder.start_download(tdef=tdef, config=config)
         await download.wait_for_status(DownloadStatus.SEEDING)

--- a/src/tribler/test_integration/test_hidden_services.py
+++ b/src/tribler/test_integration/test_hidden_services.py
@@ -198,8 +198,8 @@ class TestHiddenServicesDownload(TestBase[TriblerTunnelCommunity]):
         with open(config.get_dest_dir() / "ubuntu-15.04-desktop-amd64.iso", "wb") as f:  # noqa: ASYNC230
             f.write(bytes([0] * 524288))
 
-        metainfo = create_torrent_file([config.get_dest_dir() / "ubuntu-15.04-desktop-amd64.iso"], {})["metainfo"]
-        tdef = TorrentDef.load_from_memory(metainfo)
+        atp = create_torrent_file([config.get_dest_dir() / "ubuntu-15.04-desktop-amd64.iso"])["atp"]
+        tdef = TorrentDef(atp)
 
         download = await self.download_manager_seeder.start_download(tdef=tdef, config=config)
         await download.wait_for_status(DownloadStatus.SEEDING)

--- a/src/tribler/test_unit/core/libtorrent/download_manager/test_download.py
+++ b/src/tribler/test_unit/core/libtorrent/download_manager/test_download.py
@@ -161,7 +161,7 @@ class TestDownload(TestBase):
 
         self.assertIsNone(value)
         self.assertEqual(None, alerts[0].category())
-        self.assertEqual(b"\x00" * 20, alerts[0].params.info_hash.to_bytes())
+        self.assertEqual(b"\x01" * 20, alerts[0].params.info_hashes.v1.to_bytes())
 
     async def test_save_checkpoint_no_handle_existing(self) -> None:
         """
@@ -424,57 +424,7 @@ class TestDownload(TestBase):
         download.on_metadata_received_alert(Mock())
 
         self.assertEqual(tdef.infohash, download.tdef.infohash)
-        self.assertDictEqual(tdef.get_metainfo()[b"info"], download.tdef.get_metainfo()[b"info"])
-        self.assertEqual(b"http://google.com", download.tdef.get_metainfo()[b"announce"])
-
-    def test_on_metadata_received_alert_unicode_error_encode(self) -> None:
-        """
-        Test if no exception is raised when the url is not unicode compatible.
-        """
-        tdef = TorrentDef.load_from_memory(TORRENT_WITH_DIRS_CONTENT)
-        download = Download(tdef, self.dlmngr, checkpoint_disabled=True, config=self.create_mock_download_config())
-        download.handle = Mock(trackers=Mock(return_value=[{"url": "\uD800"}]),
-                               torrent_file=Mock(return_value=download.tdef.torrent_info),
-                               get_peer_info=Mock(return_value=[]))
-
-        download.on_metadata_received_alert(Mock())
-
-        self.assertEqual(tdef.infohash, download.tdef.infohash)
-        self.assertDictEqual(tdef.get_metainfo()[b"info"], download.tdef.get_metainfo()[b"info"])
-        self.assertEqual(b"", tdef.get_metainfo()[b"announce"])
-
-    def test_on_metadata_received_alert_unicode_error_decode(self) -> None:
-        """
-        Test if no exception is raised when the url is not unicode compatible.
-
-        See: https://github.com/Tribler/tribler/issues/7223
-        """
-        tdef = TorrentDef.load_from_memory(TORRENT_WITH_DIRS_CONTENT)
-        download = Download(tdef, self.dlmngr, checkpoint_disabled=True, config=self.create_mock_download_config())
-        download.handle = Mock(trackers=lambda: [{"url": b"\xFD".decode()}],
-                               torrent_file=Mock(return_value=download.tdef.torrent_info),
-                               get_peer_info=Mock(return_value=[]))
-
-        download.on_metadata_received_alert(Mock())
-
-        self.assertEqual(tdef.infohash, download.tdef.infohash)
-        self.assertDictEqual(tdef.get_metainfo()[b"info"], download.tdef.get_metainfo()[b"info"])
-        self.assertEqual(b"", download.tdef.get_metainfo()[b"announce"])
-
-    def test_metadata_received_invalid_torrent_with_error(self) -> None:
-        """
-        Test if no torrent def is loaded when a RuntimeError/ValueError occurs when parsing the metadata.
-        """
-        tdef = TorrentDef.load_from_memory(TORRENT_WITH_DIRS_CONTENT)
-        download = Download(tdef, self.dlmngr, checkpoint_disabled=True, config=self.create_mock_download_config())
-        download.handle = Mock(trackers=Mock(return_value=[]),
-                               torrent_file=Mock(return_value=Mock(metadata=Mock(return_value=b""))),
-                               get_peer_info=Mock(return_value=[]))
-        download.tdef = None
-
-        download.on_metadata_received_alert(Mock())
-
-        self.assertIsNone(download.tdef)
+        self.assertEqual(["http://google.com"], download.tdef.atp.trackers)
 
     def test_torrent_checked_alert_no_pause_no_checkpoint(self) -> None:
         """
@@ -692,12 +642,12 @@ class TestDownload(TestBase):
         metainfo = libtorrent.bdecode(TORRENT_WITH_DIRS_CONTENT)
         metainfo[b"info"][b"files"][0][b"length"] = 60000
         metainfo[b"info"][b"pieces"] = b"\x01" * 80
-        tdef = TorrentDef.load_from_dict(metainfo)
+        tdef = TorrentDef.load_from_memory(libtorrent.bencode(metainfo))
         download = Download(tdef, self.dlmngr, checkpoint_disabled=True, config=self.create_mock_download_config())
 
         file1 = download.file_piece_range(Path("abc") / "file2.txt")
         other_indices = [download.file_piece_range(Path(
-            *[p.decode() for p in tdef.get_metainfo()[b"info"][b"files"][-1-i][b"path"]]
+            *[p.decode() for p in metainfo[b"info"][b"files"][-1-i][b"path"]]
         )) for i in range(5)]
 
         self.assertEqual([0, 1, 2], file1)

--- a/src/tribler/test_unit/core/libtorrent/download_manager/test_download_manager.py
+++ b/src/tribler/test_unit/core/libtorrent/download_manager/test_download_manager.py
@@ -59,6 +59,15 @@ class TestDownloadManager(TestBase):
         config.set_dest_dir(Path(""))
         return config
 
+    def atp_from_dict(self, tinfo_dict: "libtorrent._Entry") -> libtorrent.add_torrent_params:
+        """
+        Create an add_torrent_params object with correct info hash.
+        """
+        atp = libtorrent.add_torrent_params()
+        atp.ti = libtorrent.torrent_info(tinfo_dict)
+        atp.info_hashes = libtorrent.info_hash_t(atp.ti.info_hash())
+        return atp
+
     async def test_get_metainfo_valid_metadata(self) -> None:
         """
         Testing if the metainfo is retrieved when the handle has valid metadata immediately.
@@ -66,6 +75,7 @@ class TestDownloadManager(TestBase):
         download = Download(TorrentDef.load_from_memory(TORRENT_WITH_DIRS_CONTENT), self.manager,
                             checkpoint_disabled=True, config=self.create_mock_download_config())
         download.handle = Mock(is_valid=Mock(return_value=True))
+        download.future_metainfo = succeed(None)
         download.get_state = Mock(return_value=Mock(get_num_seeds_peers=Mock(return_value=(42, 7))))
         config = self.create_mock_download_config()
 
@@ -73,9 +83,9 @@ class TestDownloadManager(TestBase):
                  patch.object(self.manager, "remove_download", AsyncMock()), \
                  patch.object(DownloadConfig, "from_defaults", Mock(return_value=config)):
             metainfo = await self.manager.get_metainfo(download.tdef.infohash)
-            self.assertEqual(7, metainfo.pop(b"leechers"))
-            self.assertEqual(42, metainfo.pop(b"seeders"))
-            self.assertEqual(download.tdef.get_metainfo(), metainfo)
+            self.assertEqual(7, metainfo.get("leechers"))
+            self.assertEqual(42, metainfo.get("seeders"))
+            self.assertEqual(download.tdef.infohash, metainfo["tdef"].infohash)
 
     async def test_get_metainfo_add_fail(self) -> None:
         """
@@ -94,13 +104,14 @@ class TestDownloadManager(TestBase):
         download = Download(TorrentDef.load_from_memory(TORRENT_WITH_DIRS_CONTENT), self.manager,
                             checkpoint_disabled=True, config=DownloadConfig(ConfigObj(StringIO(SPEC_CONTENT))))
         download.handle = Mock(is_valid=Mock(return_value=True))
+        download.future_metainfo = succeed(None)
         config = DownloadConfig(ConfigObj(StringIO(SPEC_CONTENT)))
 
         with patch.object(self.manager, "start_download", AsyncMock(return_value=download)), \
                 patch.object(self.manager, "remove_download", AsyncMock()), \
                 patch.object(DownloadConfig, "from_defaults", Mock(return_value=config)):
-            results = await asyncio.gather(self.manager.get_metainfo(b"\x00" * 20),
-                                           self.manager.get_metainfo(b"\x00" * 20))
+            results = await asyncio.gather(self.manager.get_metainfo(download.tdef.infohash),
+                                           self.manager.get_metainfo(download.tdef.infohash))
 
         self.assertDictEqual(*results)
 
@@ -108,9 +119,16 @@ class TestDownloadManager(TestBase):
         """
         Testing if cached metainfo is returned, if available.
         """
-        self.manager.metainfo_cache[b"a" * 20] = {'meta_info': 'test', 'time': 0}
+        atp = libtorrent.add_torrent_params()
+        atp.name = "test"
+        self.manager.metainfo_cache[b"a" * 20] = {
+            "tdef": TorrentDef(atp),
+            "time": 0,
+            "seeders": 1,
+            "leechers": 2
+        }
 
-        self.assertEqual("test", await self.manager.get_metainfo(b"a" * 20))
+        self.assertEqual("test", (await self.manager.get_metainfo(b"a" * 20))["tdef"].name)
 
     async def test_get_metainfo_with_already_added_torrent(self) -> None:
         """
@@ -119,12 +137,12 @@ class TestDownloadManager(TestBase):
         download = Download(TorrentDef.load_from_memory(TORRENT_WITH_DIRS_CONTENT), self.manager,
                             checkpoint_disabled=True, config=DownloadConfig(ConfigObj(StringIO(SPEC_CONTENT))))
         download.handle = Mock(is_valid=Mock(return_value=True))
+        download.future_metainfo = succeed(None)
         self.manager.downloads[download.tdef.infohash] = download
 
         metainfo = await self.manager.get_metainfo(download.tdef.infohash)
-        metainfo.pop(b"seeders")
-        metainfo.pop(b"leechers")
-        self.assertEqual(download.tdef.get_metainfo(), metainfo)
+
+        self.assertEqual(download.tdef, metainfo["tdef"])
 
     async def test_start_download_while_getting_metainfo(self) -> None:
         """
@@ -265,7 +283,7 @@ class TestDownloadManager(TestBase):
         Test if no checkpoint can be loaded from a file with empty metainfo.
         """
         download_config = self.create_mock_download_config()
-        download_config.set_metainfo({b"info": {}, b"url": ""})
+        download_config.set_engineresumedata(libtorrent.add_torrent_params())
         with patch.dict(tribler.core.libtorrent.download_manager.download_manager.__dict__,
                         {"ConfigObj": Mock(return_value=download_config.config)}):
             value = await self.manager.load_checkpoint("foo.conf")
@@ -277,12 +295,14 @@ class TestDownloadManager(TestBase):
         Test if no checkpoint can be loaded from a file with a bad url.
         """
         download_config = self.create_mock_download_config()
-        download_config.set_metainfo({b"url": b"\x80", b"info": {
+        atp = self.atp_from_dict({b"url": b"\x80", b"info": {
             b"name": b"torrent name",
             b"files": [{b"path": [b"a.txt"], b"length": 123}],
             b"piece length": 128,
             b"pieces": b"\x00" * 20
         }})
+        atp.url = b"\x80"
+        download_config.set_engineresumedata(atp)
         with patch.dict(tribler.core.libtorrent.download_manager.download_manager.__dict__,
                         {"ConfigObj": Mock(return_value=download_config.config)}):
             value = await self.manager.load_checkpoint("foo.conf")
@@ -294,12 +314,12 @@ class TestDownloadManager(TestBase):
         Test if a checkpoint can be loaded.
         """
         download_config = self.create_mock_download_config()
-        download_config.set_metainfo({b"info": {
+        download_config.set_engineresumedata(self.atp_from_dict({b"info": {
             b"name": b"torrent name",
             b"files": [{b"path": [b"a.txt"], b"length": 123}],
             b"piece length": 128,
             b"pieces": b"\x00" * 20
-        }})
+        }}))
         download_config.set_dest_dir(Path(__file__).absolute().parent)
         with patch.dict(tribler.core.libtorrent.download_manager.download_manager.__dict__,
                         {"ConfigObj": Mock(return_value=download_config.config)}), \
@@ -313,9 +333,11 @@ class TestDownloadManager(TestBase):
         Test if no checkpoint is restored from uninitialized engineresumedata.
         """
         download_config = self.create_mock_download_config()
-        download_config.set_metainfo({b"name": b"torrent name", b"infohash": b"\x01" * 20})
+        atp = libtorrent.add_torrent_params()
+        atp.name = "torrent name"
+        atp.info_hashes = libtorrent.info_hash_t(libtorrent.sha1_hash(b"\x01" * 20))
+        download_config.set_engineresumedata(atp)
         download_config.set_dest_dir(Path(__file__).absolute().parent)
-        download_config.set_engineresumedata(libtorrent.add_torrent_params())
         self.manager.start_download = AsyncMock()
         with patch.dict(tribler.core.libtorrent.download_manager.download_manager.__dict__,
                         {"ConfigObj": Mock(return_value=download_config.config)}):
@@ -497,10 +519,9 @@ class TestDownloadManager(TestBase):
                             checkpoint_disabled=True, config=self.create_mock_download_config())
         self.manager.downloads[download.tdef.infohash] = download
 
-        self.manager.update_trackers(download.tdef.infohash, [b"127.0.0.1/test-announce1"])
+        self.manager.update_trackers(download.tdef.infohash, ["127.0.0.1/test-announce1"])
 
-        self.assertEqual(b"127.0.0.1/test-announce1", download.tdef.get_metainfo()[b"announce"])
-        self.assertListEqual([b"127.0.0.1/test-announce1"], download.tdef.get_metainfo()[b"announce-list"][0])
+        self.assertEqual(download.tdef.atp.trackers, ["127.0.0.1/test-announce1"])
 
     def test_update_trackers_list(self) -> None:
         """
@@ -510,12 +531,10 @@ class TestDownloadManager(TestBase):
                             checkpoint_disabled=True, config=self.create_mock_download_config())
         self.manager.downloads[download.tdef.infohash] = download
 
-        self.manager.update_trackers(download.tdef.infohash, [f"127.0.0.1/test-announce{i}".encode() for i in range(2)])
+        self.manager.update_trackers(download.tdef.infohash, [f"127.0.0.1/test-announce{i}" for i in range(2)])
 
-        self.assertIn(download.tdef.get_metainfo()[b"announce"], [b"127.0.0.1/test-announce0",
-                                                                  b"127.0.0.1/test-announce1"])
-        self.assertSetEqual({f"127.0.0.1/test-announce{i}".encode() for i in range(2)},
-                            {t[0] for t in download.tdef.get_metainfo()[b"announce-list"]})
+        self.assertEqual(sorted(download.tdef.atp.trackers),
+                         sorted(["127.0.0.1/test-announce0", "127.0.0.1/test-announce1"]))
 
     def test_update_trackers_list_append(self) -> None:
         """
@@ -525,10 +544,7 @@ class TestDownloadManager(TestBase):
                             checkpoint_disabled=True, config=self.create_mock_download_config())
         self.manager.downloads[download.tdef.infohash] = download
 
-        self.manager.update_trackers(download.tdef.infohash, [b"127.0.0.1/test-announce0"])
-        self.manager.update_trackers(download.tdef.infohash, [b"127.0.0.1/test-announce1"])
+        self.manager.update_trackers(download.tdef.infohash, ["127.0.0.1/test-announce0"])
+        self.manager.update_trackers(download.tdef.infohash, ["127.0.0.1/test-announce1"])
 
-        self.assertIn(download.tdef.get_metainfo()[b"announce"],
-                      [b"127.0.0.1/test-announce0", b"127.0.0.1/test-announce1"])
-        self.assertSetEqual({f"127.0.0.1/test-announce{i}".encode() for i in range(2)},
-                            {t[0] for t in download.tdef.get_metainfo()[b"announce-list"]})
+        self.assertEqual(download.tdef.atp.trackers, ["127.0.0.1/test-announce0", "127.0.0.1/test-announce1"])

--- a/src/tribler/test_unit/core/libtorrent/download_manager/test_stream.py
+++ b/src/tribler/test_unit/core/libtorrent/download_manager/test_stream.py
@@ -171,10 +171,8 @@ class TestStream(TestBase):
 
         The pieces are 20 byte hashes for the number of pieces in a 6-byte file per 6 files.
         """
-        metainfo = download.tdef.get_metainfo()
-        metainfo[b"info"][b"piece length"] = piece_size
-        metainfo[b"info"][b"pieces"] = b"\x01" * 20 * (6 // piece_size) * 6
-        download.tdef = TorrentDef.load_from_dict(metainfo)
+        download.tdef.atp.ti.files().set_piece_length(piece_size)
+        download.tdef.atp.ti.files().set_num_pieces((6 // piece_size) * 6)
 
     async def test_enable(self) -> None:
         """

--- a/src/tribler/test_unit/core/libtorrent/mocks.py
+++ b/src/tribler/test_unit/core/libtorrent/mocks.py
@@ -125,5 +125,5 @@ class FakeTDef(TorrentDef):
         Initialize with a near-empty atp.
         """
         atp = libtorrent.add_torrent_params()
-        atp.name, atp.info_hash, atp.url = name, libtorrent.sha1_hash(info_hash), url
+        atp.name, atp.info_hashes, atp.url = name, libtorrent.info_hash_t(libtorrent.sha1_hash(info_hash)), url
         super().__init__(atp)

--- a/src/tribler/test_unit/core/libtorrent/restapi/test_downloads_endpoint.py
+++ b/src/tribler/test_unit/core/libtorrent/restapi/test_downloads_endpoint.py
@@ -957,8 +957,6 @@ class TestDownloadsEndpoint(TestBase):
 
         self.assertEqual(200, response.status)
         self.assertTrue(response_body_json["removed"])
-        self.assertEqual(b"", download.tdef.get_metainfo()[b"announce"])
-        self.assertEqual([], download.tdef.get_metainfo()[b"announce-list"])
         self.assertEqual([], download.tdef.atp.trackers)
 
     async def test_remove_tracker_from_metainfo_announce_list(self) -> None:
@@ -979,8 +977,8 @@ class TestDownloadsEndpoint(TestBase):
 
         self.assertEqual(200, response.status)
         self.assertTrue(response_body_json["removed"])
-        self.assertEqual(1, len(download.tdef.get_metainfo()[b"announce-list"]))
-        self.assertEqual(b"http://127.0.0.1/somethingelse", download.tdef.get_metainfo()[b"announce-list"][0][0])
+        self.assertEqual(1, len(download.tdef.atp.trackers))
+        self.assertEqual("http://127.0.0.1/somethingelse", download.tdef.atp.trackers[0])
 
     async def test_remove_tracker_from_metainfo_announce_both_first(self) -> None:
         """
@@ -1003,9 +1001,8 @@ class TestDownloadsEndpoint(TestBase):
 
         self.assertEqual(200, response.status)
         self.assertTrue(response_body_json["removed"])
-        self.assertEqual(1, len(download.tdef.get_metainfo()[b"announce-list"]))
-        self.assertEqual(b"http://127.0.0.1/somethingelse", download.tdef.get_metainfo()[b"announce-list"][0][0])
-        self.assertEqual(b"http://127.0.0.1/somethingelse", download.tdef.get_metainfo()[b"announce"])
+        self.assertEqual(1, len(download.tdef.atp.trackers))
+        self.assertEqual("http://127.0.0.1/somethingelse", download.tdef.atp.trackers[0])
 
     async def test_remove_tracker_from_metainfo_announce_both_second(self) -> None:
         """
@@ -1028,9 +1025,8 @@ class TestDownloadsEndpoint(TestBase):
 
         self.assertEqual(200, response.status)
         self.assertTrue(response_body_json["removed"])
-        self.assertEqual(1, len(download.tdef.get_metainfo()[b"announce-list"]))
-        self.assertEqual(b"http://127.0.0.1/somethingelse", download.tdef.get_metainfo()[b"announce-list"][0][0])
-        self.assertEqual(b"http://127.0.0.1/somethingelse", download.tdef.get_metainfo()[b"announce"])
+        self.assertEqual(1, len(download.tdef.atp.trackers))
+        self.assertEqual("http://127.0.0.1/somethingelse", download.tdef.atp.trackers[0])
 
     async def test_remove_tracker_no_download(self) -> None:
         """

--- a/src/tribler/test_unit/core/libtorrent/test_torrentdef.py
+++ b/src/tribler/test_unit/core/libtorrent/test_torrentdef.py
@@ -3,7 +3,7 @@ import libtorrent
 from ipv8.test.base import TestBase
 
 from tribler.core.libtorrent.torrentdef import TorrentDef
-from tribler.test_unit.core.libtorrent.mocks import TORRENT_WITH_DIRS, FakeTDef
+from tribler.test_unit.core.libtorrent.mocks import FakeTDef
 
 
 class TestTorrentDef(TestBase):
@@ -18,27 +18,6 @@ class TestTorrentDef(TestBase):
         with self.assertRaises(ValueError):
             TorrentDef.load_from_memory(b"")
 
-    def test_create_invalid_tdef_empty_metainfo_validate(self) -> None:
-        """
-        Test if creating a TorrentDef object without metainfo and with validation results in a ValueError.
-        """
-        with self.assertRaises(ValueError):
-            TorrentDef.load_from_dict({})
-
-    def test_create_invalid_tdef_empty_info(self) -> None:
-        """
-        Test if creating a TorrentDef object with metainfo but an empty info dictionary results in a ValueError.
-        """
-        with self.assertRaises(ValueError):
-            TorrentDef.load_from_dict({b"info": {}})
-
-    def test_create_invalid_tdef_empty_info_validate(self) -> None:
-        """
-        Test if a TorrentDef object with metainfo but an empty info dict with validation results in a ValueError.
-        """
-        with self.assertRaises(ValueError):
-            TorrentDef.load_from_dict({b"info": {}})
-
     def test_get_name_utf8(self) -> None:
         """
         Check if we can successfully get the UTF-8 encoded torrent name when using a different encoding.
@@ -47,36 +26,18 @@ class TestTorrentDef(TestBase):
 
         self.assertEqual("\xa1\xc0", tdef.atp.name)
 
-    def test_load_from_dict(self) -> None:
-        """
-        Test if a TorrentDef can be loaded from a dictionary.
-        """
-        metainfo = {b"info": libtorrent.bdecode(TORRENT_WITH_DIRS.metadata())}
-
-        tdef = TorrentDef.load_from_dict(metainfo)
-
-        self.assertEqual(b"\xb3\xba\x19\xc93\xda\x95\x84k\xfd\xf7Z\xd0\x8a\x94\x9cl\xea\xc7\xbc", tdef.infohash)
-
-    def test_get_name_as_unicode_path_utf8(self) -> None:
-        """
-        Test if names for files with a name.utf-8 path can be decoded.
-        """
-        name_bytes = b"\xe8\xaf\xad\xe8\xa8\x80\xe5\xa4\x84\xe7\x90\x86"
-        name_unicode = name_bytes.decode()
-        tdef = TorrentDef.load_from_dict({b"info": {b"name.utf-8": name_bytes,
-                                                    b"files": [{b"path": [b"a.txt"], b"length": 123}],
-                                                    b"piece length": 128, b"pieces": b"\x00" * 20}})
-
-        self.assertEqual(name_unicode, tdef.name)
-
     def test_get_name_as_unicode(self) -> None:
         """
         Test if normal UTF-8 names can be decoded.
         """
         name_bytes = b"\xe8\xaf\xad\xe8\xa8\x80\xe5\xa4\x84\xe7\x90\x86"
         name_unicode = name_bytes.decode()
-        tdef = TorrentDef.load_from_dict({b"info": {b"name": name_bytes,
-                                                    b"files": [{b"path": [b"a.txt"], b"length": 123}],
-                                                    b"piece length": 128, b"pieces": b"\x00" * 20}})
+        tdef = TorrentDef.load_from_memory(libtorrent.bencode({
+            b"info": {
+                b"name": name_bytes,
+                b"files": [{b"path": [b"a.txt"], b"length": 123}],
+                b"piece length": 128, b"pieces": b"\x00" * 20
+            }
+        }))
 
         self.assertEqual(name_unicode, tdef.name)

--- a/src/tribler/test_unit/core/libtorrent/test_torrents.py
+++ b/src/tribler/test_unit/core/libtorrent/test_torrents.py
@@ -183,43 +183,43 @@ class TestTorrents(TestBase):
         """
         Test if torrents can be created from an existing file without any parameters.
         """
-        result = create_torrent_file([Path(__file__).absolute()], {})
+        result = create_torrent_file([Path(__file__).absolute()])
 
         self.assertTrue(result["success"])
         self.assertIsNone(result["torrent_file_path"])
-        self.assertEqual(b"test_torrents.py", libtorrent.bdecode(result["metainfo"])[b"info"][b"name"])
+        self.assertEqual("test_torrents.py", result["atp"].ti.name())
 
     def test_create_torrent_file_with_piece_length(self) -> None:
         """
         Test if torrents can be created with a specified piece length.
         """
-        result = create_torrent_file([Path(__file__).absolute()], {b"piece length": 16})
+        result = create_torrent_file([Path(__file__).absolute()], piece_size=16)
 
-        self.assertEqual(16, libtorrent.bdecode(result["metainfo"])[b"info"][b"piece length"])
+        self.assertEqual(16, result["atp"].ti.piece_length())
 
     def test_create_torrent_file_with_comment(self) -> None:
         """
         Test if torrents can be created with a specified comment.
         """
-        result = create_torrent_file([Path(__file__).absolute()], {b"comment": b"test"})
+        result = create_torrent_file([Path(__file__).absolute()], comment="test")
 
-        self.assertEqual(b"test", libtorrent.bdecode(result["metainfo"])[b"comment"])
+        self.assertEqual("test", result["atp"].ti.comment())
 
     def test_create_torrent_file_with_created_by(self) -> None:
         """
         Test if torrents can be created with a specified created by field.
         """
-        result = create_torrent_file([Path(__file__).absolute()], {b"created by": b"test"})
+        result = create_torrent_file([Path(__file__).absolute()], created_by="test")
 
-        self.assertEqual(b"test", libtorrent.bdecode(result["metainfo"])[b"created by"])
+        self.assertEqual("test", result["atp"].ti.creator())
 
     def test_create_torrent_file_with_announce(self) -> None:
         """
         Test if torrents can be created with a specified announce field.
         """
-        result = create_torrent_file([Path(__file__).absolute()], {b"announce": b"http://127.0.0.1/announce"})
+        result = create_torrent_file([Path(__file__).absolute()], announce="http://127.0.0.1/announce")
 
-        self.assertEqual(b"http://127.0.0.1/announce", libtorrent.bdecode(result["metainfo"])[b"announce"])
+        self.assertEqual("http://127.0.0.1/announce", result["atp"].trackers[0])
 
     def test_create_torrent_file_with_announce_list(self) -> None:
         """
@@ -227,32 +227,32 @@ class TestTorrents(TestBase):
 
         Note that the announce list becomes a list of lists after creating the torrent.
         """
-        tracker_list = [[b"http://127.0.0.1/announce"], [b"http://10.0.0.2/announce"]]
-        result = create_torrent_file([Path(__file__).absolute()], {b"announce-list": tracker_list})
+        tracker_list = ["http://127.0.0.1/announce", "http://10.0.0.2/announce"]
+        result = create_torrent_file([Path(__file__).absolute()], announce_list=tracker_list)
 
-        self.assertEqual(tracker_list, libtorrent.bdecode(result["metainfo"])[b"announce-list"])
+        self.assertEqual(sorted(tracker_list), sorted(result["atp"].trackers))
 
     def test_create_torrent_file_with_nodes(self) -> None:
         """
         Test if torrents can be created with a specified node list.
         """
-        node_list = [[b"127.0.0.1", 80], [b"10.0.0.2", 22]]
-        result = create_torrent_file([Path(__file__).absolute()], {b"nodes": node_list})
+        node_list = [("127.0.0.1", 80), ("10.0.0.2", 22)]
+        result = create_torrent_file([Path(__file__).absolute()], nodes=node_list)
 
-        self.assertEqual(node_list, libtorrent.bdecode(result["metainfo"])[b"nodes"])
+        self.assertEqual(node_list, result["atp"].dht_nodes)
 
     def test_create_torrent_file_with_http_seed(self) -> None:
         """
         Test if torrents can be created with a specified http seed.
         """
-        result = create_torrent_file([Path(__file__).absolute()], {b"httpseeds": b"http://127.0.0.1/file"})
+        result = create_torrent_file([Path(__file__).absolute()], http_seeds=["http://127.0.0.1/file"])
 
-        self.assertEqual(b"http://127.0.0.1/file", libtorrent.bdecode(result["metainfo"])[b"httpseeds"])
+        self.assertEqual("http://127.0.0.1/file", result["atp"].http_seeds[0])
 
     def test_create_torrent_file_with_url_list(self) -> None:
         """
         Test if torrents can be created with a specified url list.
         """
-        result = create_torrent_file([Path(__file__).absolute()], {b"urllist": b"http://127.0.0.1/file"})
+        result = create_torrent_file([Path(__file__).absolute()], url_list=["http://127.0.0.1/file"])
 
-        self.assertEqual(b"http://127.0.0.1/file", libtorrent.bdecode(result["metainfo"])[b"url-list"])
+        self.assertEqual(["http://127.0.0.1/file"], result["atp"].url_seeds)

--- a/src/tribler/test_unit/core/torrent_checker/test_torrentchecker_session.py
+++ b/src/tribler/test_unit/core/torrent_checker/test_torrentchecker_session.py
@@ -369,7 +369,7 @@ class TestTrackerSession(TestBase):
         """
         Test if metainfo can be looked up for a DHT session.
         """
-        metainfo = {b'seeders': 42, b'leechers': 42}
+        metainfo = {"seeders": 42, "leechers": 42}
         self.fake_dht_session.download_manager.get_metainfo = Mock(return_value=succeed(metainfo))
         self.fake_dht_session.add_infohash(b'a' * 20)
         response = await self.fake_dht_session.connect_to_tracker()


### PR DESCRIPTION
Fixes #8671

This PR:

 - Fixes/updates Tribler's dependency on `TorrentDef.atp.info_hash`, as it is always written as a zero-hash in the resumedata of checkpoints (due to `libtorrent.write_resume_data_buf()`).
 - Updates "all" the usages of metainfo dicts, to use `libtorrent.add_torrent_params` instead.

This is super scary. I'll keep this in WIP for a bit, to continue testing. However, feedback is already welcome!

_Current issue: v2-only torrents._
