### PR TITLE
Updated code base to use ATPs instead of metainfo dicts

### DIFF
--- a/src/tribler/core/libtorrent/download_manager/download.py
+++ b/src/tribler/core/libtorrent/download_manager/download.py
@@ -25,7 +25,6 @@ from ipv8.util import succeed
 from tribler.core.libtorrent.download_manager.download_config import DownloadConfig
 from tribler.core.libtorrent.download_manager.download_state import DownloadState, DownloadStatus
 from tribler.core.libtorrent.download_manager.stream import Stream
-from tribler.core.libtorrent.torrentdef import TorrentDef
 from tribler.core.libtorrent.torrents import check_handle, get_info_from_handle, require_handle
 from tribler.core.notifier import Notification, Notifier
 from tribler.tribler_config import TriblerConfigManager
@@ -34,7 +33,7 @@ if TYPE_CHECKING:
     from collections.abc import Awaitable
 
     from tribler.core.libtorrent.download_manager.download_manager import DownloadManager
-    from tribler.core.libtorrent.torrentdef import MetainfoDict
+    from tribler.core.libtorrent.torrentdef import TorrentDef
 
 Getter = Callable[[Any], Any]
 
@@ -162,7 +161,7 @@ class Download(TaskManager):
         self.future_added = self.wait_for_alert("add_torrent_alert", lambda a: a.handle)
         self.future_removed = self.wait_for_alert("torrent_removed_alert")
         self.future_finished = self.wait_for_alert("torrent_finished_alert")
-        self.future_metainfo = self.wait_for_alert("metadata_received_alert", lambda a: self.tdef.get_metainfo())
+        self.future_metainfo = self.wait_for_alert("metadata_received_alert")
 
         if self.download_manager.config.get("libtorrent/check_after_complete"):
             self.register_task("Recheck torrent after finish", self._recheck_after_finish)
@@ -323,6 +322,19 @@ class Download(TaskManager):
             return
 
         self.handle = alert.handle
+        self.handle.set_flags(self.handle.flags() & (0xffffffff ^ int(lt.torrent_flags.no_verify_files)))
+
+        """
+        Note 1: attempting ``self.tdef.atp = alert.params`` leads to a MemoryError!
+        Note 2: available in params: version, ti, name, save_path, userdata, tracker_id, flags, info_hash
+        """
+        self.tdef.atp.version = alert.params.version
+        self.tdef.atp.ti = alert.params.ti
+        self.tdef.atp.trackerid = alert.params.trackerid
+        self.tdef.atp.flags = alert.params.flags
+        self.tdef.atp.info_hash = alert.params.info_hash
+        self.tdef.atp.info_hashes = alert.params.info_hashes
+
         self._logger.debug("Added torrent %s", str(self.handle.info_hash()))
         self.handle.auto_managed(self.config.get_auto_managed())
 
@@ -416,32 +428,28 @@ class Download(TaskManager):
         if self.checkpoint_disabled:
             return
 
-        if self.tdef.torrent_info is not None:
-            self.config.set_metainfo(cast("MetainfoDict", self.tdef.get_metainfo()))
-        else:
-            self.config.set_metainfo({
-                "infohash": self.tdef.infohash,
-                "name": self.tdef.name,
-                "url": self.tdef.atp.url
-            })
-
         resume_data = alert.params
-        if resume_data.info_hash.to_bytes() != (b"\x00" * 20):
-            self._logger.debug("Resume data is valid for %s", self.tdef.name)
-            # Make save_path relative if the torrent is saved in the Tribler state directory
-            if self.state_dir:
-                save_path = Path(resume_data.save_path).absolute()
-                resume_data.save_path = str(save_path)
-            self.config.set_engineresumedata(resume_data)
-        else:
-            self._logger.debug("Resume data is not available for %s", self.tdef.name)
-            self.config.config["state"]["engineresumedata"] = ""
+        # Skip: info_hash, info_hashes, merkle_tree, save_path, ti
+        for attr in ["active_time", "added_time", "banned_peers", "completed_time", "dht_nodes", "download_limit",
+                     "file_priorities", "finished_time", "flags", "have_pieces", "http_seeds", "last_download",
+                     "last_seen_complete", "last_upload", "max_connections", "max_uploads", "name", "num_complete",
+                     "num_downloaded", "num_incomplete", "peers", "piece_priorities", "renamed_files", "resume_data",
+                     "seeding_time", "storage_mode", "total_downloaded", "total_uploaded", "tracker_tiers",
+                     "trackerid", "trackers", "unfinished_pieces", "upload_limit", "url", "url_seeds",
+                     "verified_pieces", "version"]:
+            setattr(self.tdef.atp, attr, getattr(resume_data, attr))
+        # Make save_path relative if the torrent is saved in the Tribler state directory
+        if self.state_dir:
+            save_path = Path(resume_data.save_path).absolute()
+            self.tdef.atp.save_path = str(save_path)
+        self.tdef.atp.resume_data = resume_data.resume_data
+        self.config.set_engineresumedata(self.tdef.atp)
 
         # Save it to file
         basename = hexlify(self.tdef.infohash).decode() + ".conf"
         Path(self.download_manager.get_checkpoint_dir()).mkdir(parents=True, exist_ok=True)
         filename = self.download_manager.get_checkpoint_dir() / basename
-        self.config.config["download_defaults"]["name"] = self.tdef.name  # store name (for debugging)
+        self.config.config["download_defaults"]["name"] = self.tdef.atp.name  # store name (for debugging)
         try:
             self.config.write(filename)
         except OSError as e:
@@ -510,35 +518,11 @@ class Download(TaskManager):
                 "tracker_info": (self.tdef.atp.trackers or [t.url for t in torrent_info.trackers()] or [""])[0]
             })
 
-        try:
-            metadata = cast("MetainfoDict", {b"info": lt.bdecode(torrent_info.metadata())})
-        except (RuntimeError, ValueError) as e:
-            self._logger.warning(e)
-            return
-
-        tracker_urls = []
-        trackers: list[lt._AnnounceEntryDict] = []
-        try:
-            trackers = handle.trackers()
-        except UnicodeDecodeError as e:
-            self._logger.warning(e)
-        for tracker in trackers:
-            url = tracker["url"]
-            try:
-                tracker_urls.append(url.encode())
-            except UnicodeEncodeError as e:
-                self._logger.warning(e)
-
-        if len(tracker_urls) > 1:
-            metadata[b"announce-list"] = [[tracker] for tracker in tracker_urls]
-        elif tracker_urls:
-            metadata[b"announce"] = tracker_urls[0]
-
-        try:
-            self.set_def(TorrentDef.load_from_dict(metadata))
-        except ValueError as ve:
-            self._logger.exception(ve)
-            return
+        self.tdef.atp.ti = torrent_info
+        tracker_set = set(self.tdef.atp.trackers)
+        tracker_set |= {tracker["url"] for tracker in handle.trackers()}
+        tracker_set |= {tracker.url for tracker in torrent_info.trackers()}
+        self.tdef.atp.trackers = list(tracker_set)
 
         self.set_selected_files()
         self.checkpoint()
@@ -898,23 +882,9 @@ class Download(TaskManager):
             if not filename.is_file():
                 # 2. If there is no saved data for this infohash, checkpoint it without data so we do not
                 #    lose it when we crash or restart before the download becomes known.
-                resume_data = self.config.get_engineresumedata()
-                if resume_data is None:
-                    resume_data = lt.add_torrent_params()
-                self.post_alert("save_resume_data_alert", {"params": resume_data})
+                self.post_alert("save_resume_data_alert", {"params": self.tdef.atp})
             return succeed(None)
         return self.save_resume_data()
-
-    def set_def(self, tdef: TorrentDef) -> None:
-        """
-        Set the torrent definition for this download.
-        """
-        if (self.tdef.torrent_info is None and tdef.torrent_info is not None
-                and len(self.tdef.atp.info_hash.to_bytes()) != 20):
-            # We store SHA-1 conf files. v2 torrents start with SHA-256 infohashes.
-            basename = hexlify(self.tdef.atp.info_hash.to_bytes()).decode() + ".conf"
-            Path(self.download_manager.get_checkpoint_dir() / basename).unlink(missing_ok=True)
-        self.tdef = tdef
 
     @check_handle(None)
     def add_trackers(self, handle: lt.torrent_handle, trackers: list[str]) -> None:

--- a/src/tribler/core/libtorrent/download_manager/download_config.py
+++ b/src/tribler/core/libtorrent/download_manager/download_config.py
@@ -303,18 +303,6 @@ class DownloadConfig:
         """
         return self.config["download_defaults"]["bootstrap_download"]
 
-    def set_metainfo(self, metainfo: dict) -> None:
-        """
-        Set the metainfo dict for this download.
-        """
-        self.config["state"]["metainfo"] = _from_dict(metainfo)
-
-    def get_metainfo(self) -> dict | None:
-        """
-        Get the metainfo dict for this download or None if it cannot be decoded.
-        """
-        return _to_dict(self.config["state"]["metainfo"])
-
     def set_engineresumedata(self, engineresumedata: lt.add_torrent_params) -> None:
         """
         Set the engine resume data dict for this download.

--- a/src/tribler/core/libtorrent/restapi/torrentinfo_endpoint.py
+++ b/src/tribler/core/libtorrent/restapi/torrentinfo_endpoint.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from asyncio.exceptions import TimeoutError as AsyncTimeoutError
-from binascii import hexlify, unhexlify
+from binascii import hexlify
 from pathlib import Path
 from ssl import SSLError
 from typing import TYPE_CHECKING, Literal, TypedDict, cast, overload
@@ -41,7 +41,6 @@ if TYPE_CHECKING:
     from aiohttp.web_request import Request
 
     from tribler.core.libtorrent.download_manager.download_manager import DownloadManager
-    from tribler.core.libtorrent.torrentdef import MetainfoDict, MetainfoV2Dict
 
 logger = logging.getLogger(__name__)
 
@@ -203,11 +202,11 @@ class TorrentInfoEndpoint(RESTEndpoint):
         uri, valid_cert = await unshorten(p_uri)
         scheme = URL(uri).scheme
 
+        torrent_def: TorrentDef | None = None
         if scheme == "file":
             file_path = url_to_path(uri)
             try:
-                tdef = await TorrentDef.load(file_path)
-                metainfo = tdef.get_metainfo()
+                torrent_def = await TorrentDef.load(file_path)
                 skip_check_metainfo = False
             except (OSError, TypeError, ValueError, RuntimeError):
                 return RESTResponse({"error": {
@@ -238,7 +237,7 @@ class TorrentInfoEndpoint(RESTEndpoint):
 
             if response.startswith(b'magnet'):
                 try:
-                    infohash = unhexlify(str(lt.parse_magnet_uri(uri).info_hash))
+                    infohash = TorrentDef(lt.parse_magnet_uri(uri)).infohash
                 except RuntimeError as e:
                     return RESTResponse(
                         {"error": {
@@ -247,17 +246,16 @@ class TorrentInfoEndpoint(RESTEndpoint):
                         }}, status=HTTP_INTERNAL_SERVER_ERROR
                     )
 
-                if skip_check_metainfo:
-                    metainfo = None
-                else:
-                    metainfo = cast("MetainfoDict | MetainfoV2Dict",
-                                    await self.download_manager.get_metainfo(infohash, timeout=60, hops=i_hops,
-                                                                             url=response.decode()))
+                if not skip_check_metainfo:
+                    lookup = (await self.download_manager.get_metainfo(infohash, timeout=60, hops=i_hops,
+                                                                       url=response.decode()))
+                    if lookup is not None:
+                        torrent_def = lookup["tdef"]
             else:
                 try:
-                    metainfo = cast("MetainfoDict | MetainfoV2Dict", lt.bdecode(response))
+                    torrent_def = TorrentDef.load_from_memory(response)
                     skip_check_metainfo = False
-                except RuntimeError:
+                except ValueError:
                     return RESTResponse(
                         {"error": {
                             "handled": True,
@@ -268,7 +266,7 @@ class TorrentInfoEndpoint(RESTEndpoint):
             self._logger.info("magnet scheme detected")
 
             try:
-                infohash = unhexlify(str(lt.parse_magnet_uri(uri).info_hash))
+                infohash = TorrentDef(lt.parse_magnet_uri(uri)).infohash
             except RuntimeError as e:
                 return RESTResponse(
                     {"error": {
@@ -276,11 +274,10 @@ class TorrentInfoEndpoint(RESTEndpoint):
                         "message": f'Error while getting an infohash from magnet: {e.__class__.__name__}: {e}'
                     }}, status=HTTP_BAD_REQUEST
                 )
-            if skip_check_metainfo:
-                metainfo = None
-            else:
-                metainfo = cast("MetainfoDict | MetainfoV2Dict",
-                                await self.download_manager.get_metainfo(infohash, timeout=60, hops=i_hops, url=uri))
+            if not skip_check_metainfo:
+                lookup = await self.download_manager.get_metainfo(infohash, timeout=60, hops=i_hops, url=uri)
+                if lookup is not None:
+                    torrent_def = lookup["tdef"]
         else:
             return RESTResponse({"error": {
                                     "handled": True,
@@ -290,21 +287,13 @@ class TorrentInfoEndpoint(RESTEndpoint):
         if skip_check_metainfo:
             return RESTResponse({"metainfo": "", "download_exists": False, "valid_certificate": True})
 
-        if not metainfo:
+        if not torrent_def or not torrent_def.atp.ti:
             return RESTResponse({"error": {
                                     "handled": True,
                                     "message": "metainfo error"
                                 }}, status=HTTP_INTERNAL_SERVER_ERROR)
 
-        if not isinstance(metainfo, dict) or b"info" not in metainfo:
-            self._logger.warning("Received metainfo is not a valid dictionary")
-            return RESTResponse({"error": {
-                                    "handled": True,
-                                    "message": "invalid response"
-                                }}, status=HTTP_INTERNAL_SERVER_ERROR)
-
         # Add the torrent to metadata.db
-        torrent_def = TorrentDef.load_from_dict(metainfo)
         metadata_dict = tdef_to_metadata_dict(torrent_def)
         self.download_manager.notifier.notify(Notification.torrent_metadata_added, metadata=metadata_dict)
 

--- a/src/tribler/core/libtorrent/torrentdef.py
+++ b/src/tribler/core/libtorrent/torrentdef.py
@@ -2,177 +2,21 @@ from __future__ import annotations
 
 from asyncio import get_running_loop
 from binascii import hexlify
-from typing import TYPE_CHECKING, Any
 
 import libtorrent as lt
 
-if TYPE_CHECKING:
-    from typing import Literal, overload
 
-    ###############
-    # V1 torrents #
-    ###############
-
-    class FileDict(dict):  # noqa: D101
-
-        @overload  # type: ignore[override]
-        def __getitem__(self, key: Literal[b"length"]) -> int: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"path"]) -> list[bytes]: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"path.utf-8"]) -> list[bytes] | None: ...
-
-        def __getitem__(self, key: bytes) -> Any: ...  # noqa: D105
-
-
-    class InfoDict(dict):  # noqa: D101
-
-        @overload  # type: ignore[override]
-        def __getitem__(self, key: Literal[b"files"]) -> list[FileDict]: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"length"]) -> int: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"name"]) -> bytes: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"name.utf-8"]) -> bytes: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"piece length"]) -> int: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"pieces"]) -> bytes: ...
-
-        def __getitem__(self, key: bytes) -> Any: ...  # noqa: D105
-
-
-    class MetainfoDict(dict):  # noqa: D101
-
-        @overload  # type: ignore[override]
-        def __getitem__(self, key: Literal[b"announce"]) -> bytes | None: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"announce-list"]) -> list[list[bytes]] | None: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"comment"]) -> bytes | None: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"created by"]) -> bytes | None: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"creation date"]) -> bytes | None: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"encoding"]) -> bytes | None: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"info"]) -> InfoDict: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"httpseeds"]) -> list[bytes] | None: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"nodes"]) -> list[bytes] | None: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"urllist"]) -> list[bytes] | None: ...
-
-        def __getitem__(self, key: bytes) -> Any: ...  # noqa: D105
-
-    ###############
-    # V2 torrents #
-    ###############
-    class FileSpecV2(dict):  # noqa: D101
-
-        @overload
-        def __getitem__(self, key: Literal[b"length"]) -> int: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"pieces root"]) -> bytes | None: ...
-
-        def __getitem__(self, key: bytes) -> Any: ...  # noqa: D105
-
-
-    class FileV2(dict):  # noqa: D101
-
-        def __getitem__(self, key: Literal[b""]) -> FileSpecV2: ...  # noqa: D105
-
-
-    class DirectoryV2(dict):  # noqa: D101
-
-        def __getitem__(self, key: bytes) -> DirectoryV2 | FileV2: ...  # noqa: D105
-
-
-    class InfoDictV2(dict):  # noqa: D101
-
-        @overload  # type: ignore[override]
-        def __getitem__(self, key: Literal[b"file tree"]) -> DirectoryV2: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"meta version"]) -> int: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"name"]) -> bytes: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"piece length"]) -> int: ...
-
-        def __getitem__(self, key: bytes) -> Any: ...  # noqa: D105
-
-
-    class MetainfoV2Dict(dict):  # noqa: D101
-
-        @overload  # type: ignore[override]
-        def __getitem__(self, key: Literal[b"announce"]) -> bytes | None: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"announce-list"]) -> list[list[bytes]] | None: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"comment"]) -> bytes | None: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"created by"]) -> bytes | None: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"creation date"]) -> bytes | None: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"encoding"]) -> bytes | None: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"info"]) -> InfoDictV2: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"httpseeds"]) -> list[bytes] | None: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"nodes"]) -> list[bytes] | None: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"piece layers"]) -> dict[bytes, bytes] | None: ...
-
-        @overload
-        def __getitem__(self, key: Literal[b"urllist"]) -> list[bytes] | None: ...
-
-        def __getitem__(self, key: bytes) -> Any: ...  # noqa: D105
-
-
-else:
-    FileDict = dict[bytes, Any]
-    InfoDict = dict[bytes, Any]
-    MetainfoDict = dict[bytes, Any]
-
-    FileSpecV2 = dict[bytes, Any]
-    InfoDictV2 = dict[bytes, Any]
-    FileV2 = dict[bytes, Any]
-    DirectoryV2 = dict[bytes, Any]
-    MetainfoV2Dict = dict[bytes, Any]
+def best_info_hash(info_hashes: lt.info_hash_t, info_hash: lt.sha1_hash) -> bytes:
+    """
+    Get the best bytes representation of available info hash material.
+    """
+    if not info_hashes.v2.is_all_zeros():
+        return info_hashes.v2.to_bytes()
+    if not info_hashes.v1.is_all_zeros():
+        return info_hashes.v1.to_bytes()
+    if not info_hash.is_all_zeros():
+        return info_hash.to_bytes()
+    return b"\x00" * 20
 
 
 class TorrentDef:
@@ -214,9 +58,7 @@ class TorrentDef:
         """
         Convenient way to get the info_hash as bytes.
         """
-        if self.torrent_info:
-            return self.torrent_info.info_hash().to_bytes()
-        return self.atp.info_hash.to_bytes()
+        return best_info_hash(self.atp.info_hashes, self.atp.info_hash)
 
     @staticmethod
     def _threaded_load_job(filepath: str) -> TorrentDef:
@@ -250,39 +92,6 @@ class TorrentDef:
             return TorrentDef(lt.load_torrent_buffer(bencoded_data))  # type: ignore[attr-defined]  # missing in lt .pyi
         except RuntimeError as e:
             raise ValueError from e
-
-    @staticmethod
-    def load_from_dict(metainfo: MetainfoDict | MetainfoV2Dict) -> TorrentDef:
-        """
-        Load a metainfo dictionary into a TorrentDef object.
-
-        :param metainfo: The metainfo dictionary
-        """
-        try:
-            return TorrentDef.load_from_memory(lt.bencode(metainfo))
-        except RuntimeError as e:
-            raise ValueError from e
-
-    def get_metainfo(self) -> MetainfoDict | MetainfoV2Dict | None:
-        """
-        Returns the metainfo of the torrent. Might be None if no metainfo is provided.
-        """
-        if self.atp.ti is None:
-            return None
-        return MetainfoDict({
-            b"announce": self.atp.trackers[0].encode() if self.atp.trackers else b"",
-            b"announce-list": [[tracker.encode()] for tracker in self.atp.trackers],
-            b"comment": self.atp.ti.comment().encode(),
-            b"created by": self.atp.ti.creator().encode(),
-            b"creation date": self.atp.ti.creation_date(),
-            b"encoding": "UTF-8",
-            b"httpseeds": [web_seed["url"].encode() for web_seed in self.atp.ti.web_seeds()
-                           if web_seed["type"] == 1],  # type: ignore[typeddict-item]  # missing in lt .pyi
-            b"nodes": [(entry[0].encode(), entry[1]) for entry in self.atp.ti.nodes()],
-            b"urllist": [web_seed["url"].encode() for web_seed in self.atp.ti.web_seeds()
-                         if web_seed["type"] == 0],  # type: ignore[typeddict-item]  # missing in lt .pyi
-            b"info": lt.bdecode(self.atp.ti.info_section())
-        })
 
     def get_file_indices(self) -> list[int]:
         """

--- a/src/tribler/core/rss/rss.py
+++ b/src/tribler/core/rss/rss.py
@@ -7,11 +7,10 @@ from email.utils import formatdate, parsedate
 from io import BytesIO
 from ssl import SSLError
 from time import mktime, time
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 from xml.etree import ElementTree as ET
 from xml.etree.ElementTree import ParseError
 
-import libtorrent
 from aiohttp import ClientConnectorError, ClientResponseError, ClientSession, ServerConnectionError
 from aiohttp.web_exceptions import HTTPNotModified, HTTPOk
 
@@ -26,8 +25,6 @@ if TYPE_CHECKING:
 
     from aiohttp import ClientResponse
     from ipv8.taskmanager import TaskManager
-
-    from tribler.core.libtorrent.torrentdef import MetainfoDict
 
 logger = logging.getLogger(__name__)
 
@@ -83,12 +80,11 @@ class RSSWatcher:
                 continue
 
             try:
-                metainfo = libtorrent.bdecode(response)
-            except RuntimeError as e:
+                torrent_def = TorrentDef.load_from_memory(response)
+            except ValueError as e:
                 logger.warning("Error while reading http uri response: %s", str(e))
                 continue
 
-            torrent_def = TorrentDef.load_from_dict(cast("MetainfoDict", metainfo))
             metadata_dict = tdef_to_metadata_dict(torrent_def)
             self.notifier.notify(Notification.torrent_metadata_added, metadata=metadata_dict)
 

--- a/src/tribler/core/torrent_checker/torrentchecker_session.py
+++ b/src/tribler/core/torrent_checker/torrentchecker_session.py
@@ -483,10 +483,10 @@ class FakeDHTSession(TrackerSession):
         health_list = []
         now = int(time.time())
         for infohash in self.infohash_list:
-            metainfo = await self.download_manager.get_metainfo(infohash, timeout=self.timeout)
-            if metainfo is None:
+            lookup = await self.download_manager.get_metainfo(infohash, timeout=self.timeout)
+            if lookup is None:
                 continue
-            health = HealthInfo(infohash, seeders=metainfo[b"seeders"], leechers=metainfo[b"leechers"],
+            health = HealthInfo(infohash, seeders=lookup["seeders"], leechers=lookup["leechers"],
                                 last_check=now, self_checked=True)
             health_list.append(health)
 

--- a/src/tribler/test_integration/test_anon_download.py
+++ b/src/tribler/test_integration/test_anon_download.py
@@ -167,8 +167,8 @@ class TestAnonymousDownload(TestBase[TriblerTunnelCommunity]):
         with open(config.get_dest_dir() / "ubuntu-15.04-desktop-amd64.iso", "wb") as f:  # noqa: ASYNC230
             f.write(bytes([1] * 524288))
 
-        metainfo = create_torrent_file([config.get_dest_dir() / "ubuntu-15.04-desktop-amd64.iso"], {})["metainfo"]
-        tdef = TorrentDef.load_from_memory(metainfo)
+        atp = create_torrent_file([config.get_dest_dir() / "ubuntu-15.04-desktop-amd64.iso"])["atp"]
+        tdef = TorrentDef(atp)
 
         download = await self.download_manager_seeder.start_download(tdef=tdef, config=config)
         await download.wait_for_status(DownloadStatus.SEEDING)

--- a/src/tribler/test_integration/test_hidden_services.py
+++ b/src/tribler/test_integration/test_hidden_services.py
@@ -198,8 +198,8 @@ class TestHiddenServicesDownload(TestBase[TriblerTunnelCommunity]):
         with open(config.get_dest_dir() / "ubuntu-15.04-desktop-amd64.iso", "wb") as f:  # noqa: ASYNC230
             f.write(bytes([0] * 524288))
 
-        metainfo = create_torrent_file([config.get_dest_dir() / "ubuntu-15.04-desktop-amd64.iso"], {})["metainfo"]
-        tdef = TorrentDef.load_from_memory(metainfo)
+        atp = create_torrent_file([config.get_dest_dir() / "ubuntu-15.04-desktop-amd64.iso"])["atp"]
+        tdef = TorrentDef(atp)
 
         download = await self.download_manager_seeder.start_download(tdef=tdef, config=config)
         await download.wait_for_status(DownloadStatus.SEEDING)

--- a/src/tribler/test_unit/core/libtorrent/download_manager/test_stream.py
+++ b/src/tribler/test_unit/core/libtorrent/download_manager/test_stream.py
@@ -171,10 +171,8 @@ class TestStream(TestBase):
 
         The pieces are 20 byte hashes for the number of pieces in a 6-byte file per 6 files.
         """
-        metainfo = download.tdef.get_metainfo()
-        metainfo[b"info"][b"piece length"] = piece_size
-        metainfo[b"info"][b"pieces"] = b"\x01" * 20 * (6 // piece_size) * 6
-        download.tdef = TorrentDef.load_from_dict(metainfo)
+        download.tdef.atp.ti.files().set_piece_length(piece_size)
+        download.tdef.atp.ti.files().set_num_pieces((6 // piece_size) * 6)
 
     async def test_enable(self) -> None:
         """

--- a/src/tribler/test_unit/core/libtorrent/mocks.py
+++ b/src/tribler/test_unit/core/libtorrent/mocks.py
@@ -125,5 +125,5 @@ class FakeTDef(TorrentDef):
         Initialize with a near-empty atp.
         """
         atp = libtorrent.add_torrent_params()
-        atp.name, atp.info_hash, atp.url = name, libtorrent.sha1_hash(info_hash), url
+        atp.name, atp.info_hashes, atp.url = name, libtorrent.info_hash_t(libtorrent.sha1_hash(info_hash)), url
         super().__init__(atp)

--- a/src/tribler/test_unit/core/libtorrent/restapi/test_downloads_endpoint.py
+++ b/src/tribler/test_unit/core/libtorrent/restapi/test_downloads_endpoint.py
@@ -957,8 +957,6 @@ class TestDownloadsEndpoint(TestBase):
 
         self.assertEqual(200, response.status)
         self.assertTrue(response_body_json["removed"])
-        self.assertEqual(b"", download.tdef.get_metainfo()[b"announce"])
-        self.assertEqual([], download.tdef.get_metainfo()[b"announce-list"])
         self.assertEqual([], download.tdef.atp.trackers)
 
     async def test_remove_tracker_from_metainfo_announce_list(self) -> None:
@@ -979,8 +977,8 @@ class TestDownloadsEndpoint(TestBase):
 
         self.assertEqual(200, response.status)
         self.assertTrue(response_body_json["removed"])
-        self.assertEqual(1, len(download.tdef.get_metainfo()[b"announce-list"]))
-        self.assertEqual(b"http://127.0.0.1/somethingelse", download.tdef.get_metainfo()[b"announce-list"][0][0])
+        self.assertEqual(1, len(download.tdef.atp.trackers))
+        self.assertEqual("http://127.0.0.1/somethingelse", download.tdef.atp.trackers[0])
 
     async def test_remove_tracker_from_metainfo_announce_both_first(self) -> None:
         """
@@ -1003,9 +1001,8 @@ class TestDownloadsEndpoint(TestBase):
 
         self.assertEqual(200, response.status)
         self.assertTrue(response_body_json["removed"])
-        self.assertEqual(1, len(download.tdef.get_metainfo()[b"announce-list"]))
-        self.assertEqual(b"http://127.0.0.1/somethingelse", download.tdef.get_metainfo()[b"announce-list"][0][0])
-        self.assertEqual(b"http://127.0.0.1/somethingelse", download.tdef.get_metainfo()[b"announce"])
+        self.assertEqual(1, len(download.tdef.atp.trackers))
+        self.assertEqual("http://127.0.0.1/somethingelse", download.tdef.atp.trackers[0])
 
     async def test_remove_tracker_from_metainfo_announce_both_second(self) -> None:
         """
@@ -1028,9 +1025,8 @@ class TestDownloadsEndpoint(TestBase):
 
         self.assertEqual(200, response.status)
         self.assertTrue(response_body_json["removed"])
-        self.assertEqual(1, len(download.tdef.get_metainfo()[b"announce-list"]))
-        self.assertEqual(b"http://127.0.0.1/somethingelse", download.tdef.get_metainfo()[b"announce-list"][0][0])
-        self.assertEqual(b"http://127.0.0.1/somethingelse", download.tdef.get_metainfo()[b"announce"])
+        self.assertEqual(1, len(download.tdef.atp.trackers))
+        self.assertEqual("http://127.0.0.1/somethingelse", download.tdef.atp.trackers[0])
 
     async def test_remove_tracker_no_download(self) -> None:
         """

--- a/src/tribler/test_unit/core/libtorrent/test_torrentdef.py
+++ b/src/tribler/test_unit/core/libtorrent/test_torrentdef.py
@@ -3,7 +3,7 @@ import libtorrent
 from ipv8.test.base import TestBase
 
 from tribler.core.libtorrent.torrentdef import TorrentDef
-from tribler.test_unit.core.libtorrent.mocks import TORRENT_WITH_DIRS, FakeTDef
+from tribler.test_unit.core.libtorrent.mocks import FakeTDef
 
 
 class TestTorrentDef(TestBase):
@@ -18,27 +18,6 @@ class TestTorrentDef(TestBase):
         with self.assertRaises(ValueError):
             TorrentDef.load_from_memory(b"")
 
-    def test_create_invalid_tdef_empty_metainfo_validate(self) -> None:
-        """
-        Test if creating a TorrentDef object without metainfo and with validation results in a ValueError.
-        """
-        with self.assertRaises(ValueError):
-            TorrentDef.load_from_dict({})
-
-    def test_create_invalid_tdef_empty_info(self) -> None:
-        """
-        Test if creating a TorrentDef object with metainfo but an empty info dictionary results in a ValueError.
-        """
-        with self.assertRaises(ValueError):
-            TorrentDef.load_from_dict({b"info": {}})
-
-    def test_create_invalid_tdef_empty_info_validate(self) -> None:
-        """
-        Test if a TorrentDef object with metainfo but an empty info dict with validation results in a ValueError.
-        """
-        with self.assertRaises(ValueError):
-            TorrentDef.load_from_dict({b"info": {}})
-
     def test_get_name_utf8(self) -> None:
         """
         Check if we can successfully get the UTF-8 encoded torrent name when using a different encoding.
@@ -47,36 +26,18 @@ class TestTorrentDef(TestBase):
 
         self.assertEqual("\xa1\xc0", tdef.atp.name)
 
-    def test_load_from_dict(self) -> None:
-        """
-        Test if a TorrentDef can be loaded from a dictionary.
-        """
-        metainfo = {b"info": libtorrent.bdecode(TORRENT_WITH_DIRS.metadata())}
-
-        tdef = TorrentDef.load_from_dict(metainfo)
-
-        self.assertEqual(b"\xb3\xba\x19\xc93\xda\x95\x84k\xfd\xf7Z\xd0\x8a\x94\x9cl\xea\xc7\xbc", tdef.infohash)
-
-    def test_get_name_as_unicode_path_utf8(self) -> None:
-        """
-        Test if names for files with a name.utf-8 path can be decoded.
-        """
-        name_bytes = b"\xe8\xaf\xad\xe8\xa8\x80\xe5\xa4\x84\xe7\x90\x86"
-        name_unicode = name_bytes.decode()
-        tdef = TorrentDef.load_from_dict({b"info": {b"name.utf-8": name_bytes,
-                                                    b"files": [{b"path": [b"a.txt"], b"length": 123}],
-                                                    b"piece length": 128, b"pieces": b"\x00" * 20}})
-
-        self.assertEqual(name_unicode, tdef.name)
-
     def test_get_name_as_unicode(self) -> None:
         """
         Test if normal UTF-8 names can be decoded.
         """
         name_bytes = b"\xe8\xaf\xad\xe8\xa8\x80\xe5\xa4\x84\xe7\x90\x86"
         name_unicode = name_bytes.decode()
-        tdef = TorrentDef.load_from_dict({b"info": {b"name": name_bytes,
-                                                    b"files": [{b"path": [b"a.txt"], b"length": 123}],
-                                                    b"piece length": 128, b"pieces": b"\x00" * 20}})
+        tdef = TorrentDef.load_from_memory(libtorrent.bencode({
+            b"info": {
+                b"name": name_bytes,
+                b"files": [{b"path": [b"a.txt"], b"length": 123}],
+                b"piece length": 128, b"pieces": b"\x00" * 20
+            }
+        }))
 
         self.assertEqual(name_unicode, tdef.name)

--- a/src/tribler/test_unit/core/libtorrent/test_torrents.py
+++ b/src/tribler/test_unit/core/libtorrent/test_torrents.py
@@ -183,43 +183,43 @@ class TestTorrents(TestBase):
         """
         Test if torrents can be created from an existing file without any parameters.
         """
-        result = create_torrent_file([Path(__file__).absolute()], {})
+        result = create_torrent_file([Path(__file__).absolute()])
 
         self.assertTrue(result["success"])
         self.assertIsNone(result["torrent_file_path"])
-        self.assertEqual(b"test_torrents.py", libtorrent.bdecode(result["metainfo"])[b"info"][b"name"])
+        self.assertEqual("test_torrents.py", result["atp"].ti.name())
 
     def test_create_torrent_file_with_piece_length(self) -> None:
         """
         Test if torrents can be created with a specified piece length.
         """
-        result = create_torrent_file([Path(__file__).absolute()], {b"piece length": 16})
+        result = create_torrent_file([Path(__file__).absolute()], piece_size=16)
 
-        self.assertEqual(16, libtorrent.bdecode(result["metainfo"])[b"info"][b"piece length"])
+        self.assertEqual(16, result["atp"].ti.piece_length())
 
     def test_create_torrent_file_with_comment(self) -> None:
         """
         Test if torrents can be created with a specified comment.
         """
-        result = create_torrent_file([Path(__file__).absolute()], {b"comment": b"test"})
+        result = create_torrent_file([Path(__file__).absolute()], comment="test")
 
-        self.assertEqual(b"test", libtorrent.bdecode(result["metainfo"])[b"comment"])
+        self.assertEqual("test", result["atp"].ti.comment())
 
     def test_create_torrent_file_with_created_by(self) -> None:
         """
         Test if torrents can be created with a specified created by field.
         """
-        result = create_torrent_file([Path(__file__).absolute()], {b"created by": b"test"})
+        result = create_torrent_file([Path(__file__).absolute()], created_by="test")
 
-        self.assertEqual(b"test", libtorrent.bdecode(result["metainfo"])[b"created by"])
+        self.assertEqual("test", result["atp"].ti.creator())
 
     def test_create_torrent_file_with_announce(self) -> None:
         """
         Test if torrents can be created with a specified announce field.
         """
-        result = create_torrent_file([Path(__file__).absolute()], {b"announce": b"http://127.0.0.1/announce"})
+        result = create_torrent_file([Path(__file__).absolute()], announce="http://127.0.0.1/announce")
 
-        self.assertEqual(b"http://127.0.0.1/announce", libtorrent.bdecode(result["metainfo"])[b"announce"])
+        self.assertEqual("http://127.0.0.1/announce", result["atp"].trackers[0])
 
     def test_create_torrent_file_with_announce_list(self) -> None:
         """
@@ -227,32 +227,32 @@ class TestTorrents(TestBase):
 
         Note that the announce list becomes a list of lists after creating the torrent.
         """
-        tracker_list = [[b"http://127.0.0.1/announce"], [b"http://10.0.0.2/announce"]]
-        result = create_torrent_file([Path(__file__).absolute()], {b"announce-list": tracker_list})
+        tracker_list = ["http://127.0.0.1/announce", "http://10.0.0.2/announce"]
+        result = create_torrent_file([Path(__file__).absolute()], announce_list=tracker_list)
 
-        self.assertEqual(tracker_list, libtorrent.bdecode(result["metainfo"])[b"announce-list"])
+        self.assertEqual(sorted(tracker_list), sorted(result["atp"].trackers))
 
     def test_create_torrent_file_with_nodes(self) -> None:
         """
         Test if torrents can be created with a specified node list.
         """
-        node_list = [[b"127.0.0.1", 80], [b"10.0.0.2", 22]]
-        result = create_torrent_file([Path(__file__).absolute()], {b"nodes": node_list})
+        node_list = [("127.0.0.1", 80), ("10.0.0.2", 22)]
+        result = create_torrent_file([Path(__file__).absolute()], nodes=node_list)
 
-        self.assertEqual(node_list, libtorrent.bdecode(result["metainfo"])[b"nodes"])
+        self.assertEqual(node_list, result["atp"].dht_nodes)
 
     def test_create_torrent_file_with_http_seed(self) -> None:
         """
         Test if torrents can be created with a specified http seed.
         """
-        result = create_torrent_file([Path(__file__).absolute()], {b"httpseeds": b"http://127.0.0.1/file"})
+        result = create_torrent_file([Path(__file__).absolute()], http_seeds=["http://127.0.0.1/file"])
 
-        self.assertEqual(b"http://127.0.0.1/file", libtorrent.bdecode(result["metainfo"])[b"httpseeds"])
+        self.assertEqual("http://127.0.0.1/file", result["atp"].http_seeds[0])
 
     def test_create_torrent_file_with_url_list(self) -> None:
         """
         Test if torrents can be created with a specified url list.
         """
-        result = create_torrent_file([Path(__file__).absolute()], {b"urllist": b"http://127.0.0.1/file"})
+        result = create_torrent_file([Path(__file__).absolute()], url_list=["http://127.0.0.1/file"])
 
-        self.assertEqual(b"http://127.0.0.1/file", libtorrent.bdecode(result["metainfo"])[b"url-list"])
+        self.assertEqual(["http://127.0.0.1/file"], result["atp"].url_seeds)

--- a/src/tribler/test_unit/core/torrent_checker/test_torrentchecker_session.py
+++ b/src/tribler/test_unit/core/torrent_checker/test_torrentchecker_session.py
@@ -369,7 +369,7 @@ class TestTrackerSession(TestBase):
         """
         Test if metainfo can be looked up for a DHT session.
         """
-        metainfo = {b'seeders': 42, b'leechers': 42}
+        metainfo = {"seeders": 42, "leechers": 42}
         self.fake_dht_session.download_manager.get_metainfo = Mock(return_value=succeed(metainfo))
         self.fake_dht_session.add_infohash(b'a' * 20)
         response = await self.fake_dht_session.connect_to_tracker()


### PR DESCRIPTION
_[Updated version/duplicate of #8716, but apparently you can't reopen a PR after force pushing, oops]_

Fixes #8671

This PR:

 - Fixes/updates Tribler's dependency on `TorrentDef.atp.info_hash`, as it is always written as a zero-hash in the resumedata of checkpoints (due to `libtorrent.write_resume_data_buf()`).
 - Updates "all" the usages of metainfo dicts, to use `libtorrent.add_torrent_params` instead.
 - Allow v2-only checkpoints.

These changes are super scary and I tested this _a lot_. I can't break it anymore on my machine. That is not to say there are no more hidden bugs though.
