### PR TITLE
Add placeholders to show P2P settings interface format

### DIFF
--- a/src/tribler/ui/src/pages/Settings/Connection.tsx
+++ b/src/tribler/ui/src/pages/Settings/Connection.tsx
@@ -69,6 +69,7 @@ export default function Connection() {
                 </Label>
                 <Input
                     id="ipv8_ipv4"
+                    placeholder="0.0.0.0"
                     value={
                         (
                             settings?.ipv8?.interfaces || [
@@ -102,6 +103,7 @@ export default function Connection() {
                 </Label>
                 <Input
                     id="ipv8_ipv6"
+                    placeholder="::"
                     value={
                         (
                             settings?.ipv8?.interfaces || [


### PR DESCRIPTION
Fixes #8702

This PR:

 - Adds placeholder values to show the P2P interface specification format, should they be removed (for example, accidentally).
