### PR TITLE
Fixed build errors due to windows-2022 runner software updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,12 @@ jobs:
       ########################################
       # NSIS installer (Windows, always x86) #
       ########################################
+      - name: Install NSIS
+        if: matrix.os == 'windows-latest'
+        run: |
+          Invoke-WebRequest https://deac-riga.dl.sourceforge.net/project/nsis/NSIS%203/3.10/nsis-3.10.zip?viasf=1 -OutFile C:\WINDOWS\Temp\nsis-3.10.zip
+          Expand-Archive -LiteralPath "C:\WINDOWS\Temp\nsis-3.10.zip" -DestinationPath "C:\WINDOWS\Temp\unzip-nsis-3.10"
+          Move-Item -Path "C:\WINDOWS\Temp\unzip-nsis-3.10\nsis-3.10" -Destination "C:\Program Files (x86)\NSIS"
       - name: Check out SimpleFC repository (Windows)
         if: matrix.os == 'windows-latest'
         uses: actions/checkout@v4
@@ -42,6 +48,7 @@ jobs:
           msbuild nsProcess.vcxproj /p:PlatformToolset=v143 /p:Configuration="Release UNICODE"
           copy "Release UNICODE\nsProcess.dll" "C:\Program Files (x86)\NSIS\Plugins\x86-unicode\nsProcess.dll"
           cd ../Include
+          New-Item -ItemType Directory -Force -Path "C:\Program Files (x86)\NSIS\Include"
           copy nsProcess.nsh "C:\Program Files (x86)\NSIS\Include\nsProcess.nsh"
 
       #######################
@@ -103,7 +110,7 @@ jobs:
       - name: Determine release tag
         shell: bash
         run: |
-          git fetch --tags
+          git fetch --no-tags origin 'refs/tags/v*:refs/tags/v*'
           git for-each-ref --count=1 --sort=-creatordate --format '%(refname)' refs/tags > raw_tag.txt
           GITHUB_TAG=$(git name-rev --tags --name-only $(cat raw_tag.txt))
           echo "GITHUB_TAG=${GITHUB_TAG#v}" >> $GITHUB_ENV
@@ -173,6 +180,14 @@ jobs:
         run: |
           vcpkg install libsodium
           Copy C:/vcpkg/packages/libsodium_x64-windows/bin/libsodium.dll src/libsodium.dll
+      - name: Fetch old OpenSSL for libtorrent (Windows)
+        if: matrix.os == 'windows-latest'
+        run: |
+          Remove-Item -Path "C:\Program Files\OpenSSL" -Force -Recurse
+          Write-Output '{"$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json","dependencies": ["openssl"],"overrides": [{"name": "openssl","version-string": "1.1.1n"}]}' | Out-File -FilePath ".\vcpkg.json"
+          vcpkg x-update-baseline --add-initial-baseline
+          vcpkg install
+          New-Item -Path "C:\Program Files\OpenSSL" -ItemType SymbolicLink -Value "C:\vcpkg\packages\openssl_x64-windows\"
       - name: Build Executables (Windows)
         if: matrix.os == 'windows-latest'
         run: |

--- a/build/win/makedist_win.bat
+++ b/build/win/makedist_win.bat
@@ -48,7 +48,7 @@ REM --- Doing this in ugly way for now
 if not defined SKIP_SIGNING_TRIBLER_BINARIES (
     openssl req  -nodes -new -x509 -config build\win\keygen_config.txt -keyout key.pem -out pub_key.pem
     openssl pkcs12 -export -in pub_key.pem -inkey key.pem -out ot_cert.pfx -passout pass:
-    "C:\Program Files (x86)\Windows Kits\10\bin\10.0.19041.0\x64\signtool.exe" sign /f ot_cert.pfx /d "Tribler" /t "http://timestamp.digicert.com" dist\tribler\tribler.exe
+    "C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64\signtool.exe" sign /f ot_cert.pfx /fd SHA256 /d "Tribler" /t "http://timestamp.digicert.com" dist\tribler\tribler.exe
 )
 
 @echo Running NSIS
@@ -60,7 +60,7 @@ move Tribler_*.exe ..
 cd ..
 REM Arno: Sign installer
 if not defined SKIP_SIGNING_TRIBLER_BINARIES (
-    "C:\Program Files (x86)\Windows Kits\10\bin\10.0.19041.0\x64\signtool.exe" sign /f ..\ot_cert.pfx /d "Tribler" /t "http://timestamp.digicert.com" Tribler_*.exe
+    "C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64\signtool.exe" sign /f ..\ot_cert.pfx /fd SHA256 /d "Tribler" /t "http://timestamp.digicert.com" Tribler_*.exe
 )
 
 endlocal

--- a/doc/building/windows.rst
+++ b/doc/building/windows.rst
@@ -8,7 +8,7 @@ Additionally, you will need to install:
 - ``NSIS``, the ``SimpleFC`` plugin, and the ``nsProcess`` plugin.
 - The latest ``libsodium.dll`` release.
 - ``Microsoft Visual Studio 2022 Enterprise``. ``2022 Community`` will also work, but you need to edit `tribler.nsi` in the appropriate place.
-- ``Windows Kits 10.0.19041.0``.
+- ``Windows Kits 10.0.26100.0``.
 - ``OpenSSL``.
 
 .. note::


### PR DESCRIPTION
Fixes #8737

This PR:

 - Fixes the installer build not working at all, due to `NSIS` no longer being installed by default.
 - Fixes the `Determine release tag` GitHub Actions step being broken, due to `git 2.51.0` being installed.
 - Fixes `libtorrent` not including `libcrypto-1_1-x64.dll` and `libssl-1_1-x64.dll`, due to `OpenSSL 3` being installed by default instead of `OpenSSL 1.1.1n`.
 - Fixes `signtool.exe` not being found, due to Windows Kit `10.0.19041.0` not being installed.

I have confirmed these fixes with a custom build: https://github.com/qstokkink/tribler/actions/runs/17552867831
I installed and ran the Windows build on my machine to verify.