### PR TITLE
Allow files from different folders in torrent create

### DIFF
--- a/src/tribler/core/libtorrent/restapi/create_torrent_endpoint.py
+++ b/src/tribler/core/libtorrent/restapi/create_torrent_endpoint.py
@@ -1,15 +1,17 @@
 import asyncio
 import base64
 import json
+import re
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
+from tempfile import TemporaryFile
 
 import libtorrent as lt
 from aiohttp import web
 from aiohttp.web_request import Request
 from aiohttp_apispec import docs, json_schema
 from ipv8.REST.schema import schema
-from marshmallow.fields import String
+from marshmallow.fields import Boolean, String
 
 from tribler.core.libtorrent.download_manager.download_config import DownloadConfig
 from tribler.core.libtorrent.download_manager.download_manager import DownloadManager
@@ -39,7 +41,8 @@ class CreateTorrentEndpoint(RESTEndpoint):
         """
         super().__init__(client_max_size=client_max_size)
         self.download_manager = download_manager
-        self.app.add_routes([web.post("", self.create_torrent)])
+        self.app.add_routes([web.post("", self.create_torrent),
+                             web.post("/dryrun", self.probe_writable)])
 
     @docs(
         tags=["Libtorrent"],
@@ -62,18 +65,26 @@ class CreateTorrentEndpoint(RESTEndpoint):
             }
         }
     )
-    @json_schema(schema(CreateTorrentRequest={
-        "files": [String],
-        "name": String,
-        "description": String,
-        "trackers": [String],
-        "export_dir": String
-    }))
+    @json_schema(
+        schema(
+            CreateTorrentRequest={
+                "files": [String],
+                "filenames": [String],
+                "name": String,
+                "description": String,
+                "trackers": [String],
+                "export_dir": String,
+                "initial_nodes": [String]
+            }
+        )
+    )
     async def create_torrent(self, request: Request) -> RESTResponse:
         """
         Create a torrent from local files and return it in base64 encoding.
         """
         parameters = await request.json()
+        download_config = DownloadConfig.from_defaults(self.download_manager.config)
+        download_config.set_hops(self.download_manager.config.get("libtorrent/download_defaults/number_hops"))
 
         if parameters.get("files"):
             file_path_list = [Path(p) for p in parameters["files"]]
@@ -85,9 +96,16 @@ class CreateTorrentEndpoint(RESTEndpoint):
 
         tracker_url_list = parameters.get("trackers", [])
 
-        export_dir = None
         if parameters.get("export_dir"):
             export_dir = Path(parameters["export_dir"])
+            download_config.set_dest_dir(export_dir)
+
+        initial_nodes = None
+        if parameters.get("initial_nodes"):
+            # List of format: <string><space><port>
+            # regexpr groups:    1       X     2
+            initial_nodes = [(t[0], int(t[1])) for node in parameters["initial_nodes"]
+                             if (m := re.match("(.*) ([0-9]*$)", node)) is not None and (t := m.group(1, 2))]
 
         try:
             v = version("tribler")
@@ -98,31 +116,80 @@ class CreateTorrentEndpoint(RESTEndpoint):
             result = await asyncio.get_event_loop().run_in_executor(
                 None,
                 create_torrent_file,
+                str(download_config.get_dest_dir()),
                 file_path_list,
+                parameters.get("filenames"),
+                parameters.get("name"),
                 tracker_url_list[0] if tracker_url_list else None,
                 tracker_url_list if tracker_url_list else None,
                 parameters.get("description"),
                 f"Tribler version: {v}",
                 None,
-                None,
+                initial_nodes,
                 0,
-                (str(export_dir / f"{parameters.get("name", "unknown")}.torrent")
-                 if export_dir and export_dir.exists() else None),
                 None
             )
         except (OSError, UnicodeDecodeError, RuntimeError) as e:
             self._logger.exception(e)
             return return_handled_exception(e)
 
-        # Download this torrent if specified
-        if "download" in request.query and request.query["download"] and request.query["download"] == "1":
-            download_config = DownloadConfig.from_defaults(self.download_manager.config)
-            download_config.set_dest_dir(result["base_dir"])
-            download_config.set_hops(self.download_manager.config.get("libtorrent/download_defaults/number_hops"))
-            await self.download_manager.start_download(result["torrent_file_path"],
-                                                       TorrentDef(result["atp"]),
-                                                       download_config)
+        await self.download_manager.start_download(tdef=TorrentDef(result["atp"]), config=download_config)
 
         return RESTResponse(json.dumps({"torrent": base64.b64encode(
             lt.bencode(lt.write_torrent_file(result["atp"]))  # type: ignore[attr-defined]
         ).decode()}))
+
+    @docs(
+        tags=["Libtorrent"],
+        summary="Check if a torrent could be created with the given parameters.",
+        parameters=[],
+        responses={
+            200: {
+                "schema": schema(DryRunCreateTorrentResponse={"success": Boolean}),
+                "examples": {"success": "true"}
+            },
+            HTTP_BAD_REQUEST: {
+                "schema": schema(HandledErrorSchema={"error": "any failures that may have occurred"}),
+                "examples": {"error": {"handled": True, "message": "name already exists"}}
+            }
+        }
+    )
+    @json_schema(schema(DryRunCreateTorrentRequest={
+        "name": String,
+        "export_dir": String
+    }))
+    async def probe_writable(self, request: Request) -> RESTResponse:
+        """
+        Check if a torrent could be created with the given parameters.
+        """
+        parameters = await request.json()
+        name = parameters.get("name")
+
+        if not name:  # Empty string or None (should have been handled in the GUI)
+            return RESTResponse({"error": {
+                                    "handled": True,
+                                    "message": "invalid name"
+                                }}, status=HTTP_BAD_REQUEST)
+
+        export_dir = parameters.get("export_dir",
+                                    self.download_manager.config.get("libtorrent/download_defaults/saveas"))
+
+        path = Path(export_dir) / name
+        if path.exists():
+            # Attempting to overwrite an existing folder.
+            return RESTResponse({"success": False})
+
+        # The first existing parent must be writable
+        writable = False
+        while path.parent:
+            path = path.parent
+            if path.exists():
+                try:
+                    with TemporaryFile(dir=str(path), mode="w"):
+                        pass
+                    writable = True
+                except OSError:
+                    writable = False
+                break
+
+        return RESTResponse({"success": writable})

--- a/src/tribler/test_integration/test_anon_download.py
+++ b/src/tribler/test_integration/test_anon_download.py
@@ -167,7 +167,8 @@ class TestAnonymousDownload(TestBase[TriblerTunnelCommunity]):
         with open(config.get_dest_dir() / "ubuntu-15.04-desktop-amd64.iso", "wb") as f:  # noqa: ASYNC230
             f.write(bytes([1] * 524288))
 
-        atp = create_torrent_file([config.get_dest_dir() / "ubuntu-15.04-desktop-amd64.iso"])["atp"]
+        atp = create_torrent_file(str(config.get_dest_dir()),
+                                  [config.get_dest_dir() / "ubuntu-15.04-desktop-amd64.iso"])["atp"]
         tdef = TorrentDef(atp)
 
         download = await self.download_manager_seeder.start_download(tdef=tdef, config=config)

--- a/src/tribler/test_integration/test_hidden_services.py
+++ b/src/tribler/test_integration/test_hidden_services.py
@@ -198,7 +198,8 @@ class TestHiddenServicesDownload(TestBase[TriblerTunnelCommunity]):
         with open(config.get_dest_dir() / "ubuntu-15.04-desktop-amd64.iso", "wb") as f:  # noqa: ASYNC230
             f.write(bytes([0] * 524288))
 
-        atp = create_torrent_file([config.get_dest_dir() / "ubuntu-15.04-desktop-amd64.iso"])["atp"]
+        atp = create_torrent_file(str(config.get_dest_dir()),
+                                  [config.get_dest_dir() / "ubuntu-15.04-desktop-amd64.iso"])["atp"]
         tdef = TorrentDef(atp)
 
         download = await self.download_manager_seeder.start_download(tdef=tdef, config=config)

--- a/src/tribler/test_unit/core/libtorrent/test_torrents.py
+++ b/src/tribler/test_unit/core/libtorrent/test_torrents.py
@@ -183,17 +183,16 @@ class TestTorrents(TestBase):
         """
         Test if torrents can be created from an existing file without any parameters.
         """
-        result = create_torrent_file([Path(__file__).absolute()])
+        result = create_torrent_file(str(Path(__file__).parent), [Path(__file__).absolute()])
 
         self.assertTrue(result["success"])
-        self.assertIsNone(result["torrent_file_path"])
         self.assertEqual("test_torrents.py", result["atp"].ti.name())
 
     def test_create_torrent_file_with_piece_length(self) -> None:
         """
         Test if torrents can be created with a specified piece length.
         """
-        result = create_torrent_file([Path(__file__).absolute()], piece_size=16)
+        result = create_torrent_file(str(Path(__file__).parent), [Path(__file__).absolute()], piece_size=16)
 
         self.assertEqual(16, result["atp"].ti.piece_length())
 
@@ -201,7 +200,7 @@ class TestTorrents(TestBase):
         """
         Test if torrents can be created with a specified comment.
         """
-        result = create_torrent_file([Path(__file__).absolute()], comment="test")
+        result = create_torrent_file(str(Path(__file__).parent), [Path(__file__).absolute()], comment="test")
 
         self.assertEqual("test", result["atp"].ti.comment())
 
@@ -209,7 +208,7 @@ class TestTorrents(TestBase):
         """
         Test if torrents can be created with a specified created by field.
         """
-        result = create_torrent_file([Path(__file__).absolute()], created_by="test")
+        result = create_torrent_file(str(Path(__file__).parent), [Path(__file__).absolute()], created_by="test")
 
         self.assertEqual("test", result["atp"].ti.creator())
 
@@ -217,7 +216,8 @@ class TestTorrents(TestBase):
         """
         Test if torrents can be created with a specified announce field.
         """
-        result = create_torrent_file([Path(__file__).absolute()], announce="http://127.0.0.1/announce")
+        result = create_torrent_file(str(Path(__file__).parent), [Path(__file__).absolute()],
+                                     announce="http://127.0.0.1/announce")
 
         self.assertEqual("http://127.0.0.1/announce", result["atp"].trackers[0])
 
@@ -228,7 +228,8 @@ class TestTorrents(TestBase):
         Note that the announce list becomes a list of lists after creating the torrent.
         """
         tracker_list = ["http://127.0.0.1/announce", "http://10.0.0.2/announce"]
-        result = create_torrent_file([Path(__file__).absolute()], announce_list=tracker_list)
+        result = create_torrent_file(str(Path(__file__).parent), [Path(__file__).absolute()],
+                                     announce_list=tracker_list)
 
         self.assertEqual(sorted(tracker_list), sorted(result["atp"].trackers))
 
@@ -237,7 +238,7 @@ class TestTorrents(TestBase):
         Test if torrents can be created with a specified node list.
         """
         node_list = [("127.0.0.1", 80), ("10.0.0.2", 22)]
-        result = create_torrent_file([Path(__file__).absolute()], nodes=node_list)
+        result = create_torrent_file(str(Path(__file__).parent), [Path(__file__).absolute()], nodes=node_list)
 
         self.assertEqual(node_list, result["atp"].dht_nodes)
 
@@ -245,7 +246,8 @@ class TestTorrents(TestBase):
         """
         Test if torrents can be created with a specified http seed.
         """
-        result = create_torrent_file([Path(__file__).absolute()], http_seeds=["http://127.0.0.1/file"])
+        result = create_torrent_file(str(Path(__file__).parent), [Path(__file__).absolute()],
+                                     http_seeds=["http://127.0.0.1/file"])
 
         self.assertEqual("http://127.0.0.1/file", result["atp"].http_seeds[0])
 
@@ -253,6 +255,7 @@ class TestTorrents(TestBase):
         """
         Test if torrents can be created with a specified url list.
         """
-        result = create_torrent_file([Path(__file__).absolute()], url_list=["http://127.0.0.1/file"])
+        result = create_torrent_file(str(Path(__file__).parent), [Path(__file__).absolute()],
+                                     url_list=["http://127.0.0.1/file"])
 
         self.assertEqual(["http://127.0.0.1/file"], result["atp"].url_seeds)

--- a/src/tribler/ui/public/locales/en_US.json
+++ b/src/tribler/ui/public/locales/en_US.json
@@ -238,5 +238,8 @@
     "MoveToBottomShort": "Move to bottom",
     "MoveDownShort": "Move down",
     "ToastErrorDownloadQueue": "Failed to update queue position!",
-    "ToastErrorDownloadAutoManaged": "Failed to update auto-managed flag!"
+    "ToastErrorDownloadAutoManaged": "Failed to update auto-managed flag!",
+    "Advanced": "Advanced",
+    "Description": "Description",
+    "InitialNodes": "Initial nodes"
 }

--- a/src/tribler/ui/public/locales/es_ES.json
+++ b/src/tribler/ui/public/locales/es_ES.json
@@ -238,5 +238,8 @@
     "MoveToBottomShort": "Moverse a la parte inferior",
     "MoveDownShort": "Moverse hacia abajo",
     "ToastErrorDownloadQueue": "¡No se pudo actualizar la posición de la cola!",
-    "ToastErrorDownloadAutoManaged": "¡No se pudo actualizar la bandera administrada automáticamente!"
+    "ToastErrorDownloadAutoManaged": "¡No se pudo actualizar la bandera administrada automáticamente!",
+    "Advanced": "Avanzado",
+    "Description": "Descripción",
+    "InitialNodes": "Nodos iniciales"
 }

--- a/src/tribler/ui/public/locales/hi_IN.json
+++ b/src/tribler/ui/public/locales/hi_IN.json
@@ -238,5 +238,8 @@
     "MoveToBottomShort": "नीचे की ओर बढ़ें",
     "MoveDownShort": "नीचे की ओर",
     "ToastErrorDownloadQueue": "कतार की स्थिति को अपडेट करने में विफल!",
-    "ToastErrorDownloadAutoManaged": "ऑटो-प्रबंधित ध्वज को अपडेट करने में विफल!"
+    "ToastErrorDownloadAutoManaged": "ऑटो-प्रबंधित ध्वज को अपडेट करने में विफल!",
+    "Advanced": "विकसित",
+    "Description": "विवरण",
+    "InitialNodes": "प्रारंभिक नोड्स"
 }

--- a/src/tribler/ui/public/locales/ko_KR.json
+++ b/src/tribler/ui/public/locales/ko_KR.json
@@ -238,5 +238,8 @@
     "MoveToBottomShort": "바닥으로 이동하십시오",
     "MoveDownShort": "아래로 이동하십시오",
     "ToastErrorDownloadQueue": "큐 위치를 업데이트하지 못했습니다!",
-    "ToastErrorDownloadAutoManaged": "자동 관리 깃발을 업데이트하지 못했습니다!"
+    "ToastErrorDownloadAutoManaged": "자동 관리 깃발을 업데이트하지 못했습니다!",
+    "Advanced": "고급의",
+    "Description": "설명",
+    "InitialNodes": "초기 노드"
 }

--- a/src/tribler/ui/public/locales/pt_BR.json
+++ b/src/tribler/ui/public/locales/pt_BR.json
@@ -238,5 +238,8 @@
     "MoveToBottomShort": "Mova -se para o fundo",
     "MoveDownShort": "Mover para baixo",
     "ToastErrorDownloadQueue": "Falha ao atualizar a posição da fila!",
-    "ToastErrorDownloadAutoManaged": "Falha ao atualizar a bandeira gerenciada automaticamente!"
+    "ToastErrorDownloadAutoManaged": "Falha ao atualizar a bandeira gerenciada automaticamente!",
+    "Advanced": "Avançado",
+    "Description": "Descrição",
+    "InitialNodes": "Nós iniciais"
 }

--- a/src/tribler/ui/public/locales/ru_RU.json
+++ b/src/tribler/ui/public/locales/ru_RU.json
@@ -238,5 +238,8 @@
     "MoveToBottomShort": "Перейти к дне",
     "MoveDownShort": "Двигаться вниз",
     "ToastErrorDownloadQueue": "Не удалось обновить позицию очереди!",
-    "ToastErrorDownloadAutoManaged": "Не удалось обновить флаг с автоматическим управлением!"
+    "ToastErrorDownloadAutoManaged": "Не удалось обновить флаг с автоматическим управлением!",
+    "Advanced": "Передовой",
+    "Description": "Описание",
+    "InitialNodes": "Начальные узлы"
 }

--- a/src/tribler/ui/public/locales/zh_CN.json
+++ b/src/tribler/ui/public/locales/zh_CN.json
@@ -238,5 +238,8 @@
     "MoveToBottomShort": "移至底部",
     "MoveDownShort": "向下移动",
     "ToastErrorDownloadQueue": "无法更新队列位置！",
-    "ToastErrorDownloadAutoManaged": "无法更新自动管理的标志！"
+    "ToastErrorDownloadAutoManaged": "无法更新自动管理的标志！",
+    "Advanced": "先进的",
+    "Description": "描述",
+    "InitialNodes": "初始节点"
 }

--- a/src/tribler/ui/src/components/icons.tsx
+++ b/src/tribler/ui/src/components/icons.tsx
@@ -41,4 +41,20 @@ export const Icons = {
             </svg>
         );
     },
+    checkmark: (props: IconProps) => {
+        return (
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" {...props}>
+                <circle cx="12" cy="12" r="12" fill="#62c955"/>
+                <path d="M 7 12 l 4 5 l 6 -11" fill="transparent" stroke="white" strokeWidth="2" />
+            </svg>
+        )
+    },
+    redcross: (props: IconProps) => {
+        return (
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" {...props}>
+                <circle cx="12" cy="12" r="12" fill="#c96155"/>
+                <path d="M 6 6 l 12 12 M 6 18 l 12 -12" fill="transparent" stroke="white" strokeWidth="2" />
+            </svg>
+        )
+    },
 };

--- a/src/tribler/ui/src/dialogs/CreateTorrent.tsx
+++ b/src/tribler/ui/src/dialogs/CreateTorrent.tsx
@@ -1,8 +1,9 @@
-import SimpleTable from "@/components/ui/simple-table";
+import SimpleTable, {getHeader} from "@/components/ui/simple-table";
 import {useEffect, useState} from "react";
 import toast from "react-hot-toast";
-import {Dialog, DialogClose, DialogContent, DialogFooter, DialogHeader, DialogTitle} from "@/components/ui/dialog";
+import {Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle} from "@/components/ui/dialog";
 import {Button} from "@/components/ui/button";
+import {ScrollArea} from "@/components/ui/scroll-area";
 import {DialogProps} from "@radix-ui/react-dialog";
 import {JSX} from "react/jsx-runtime";
 import {Checkbox} from "@/components/ui/checkbox";
@@ -16,39 +17,161 @@ import {ErrorDict, isErrorDict} from "@/services/reporting";
 import SelectRemotePath from "./SelectRemotePath";
 import {PathInput} from "@/components/path-input";
 import {Settings} from "@/models/settings.model";
+import {Icons} from "@/components//icons";
+import {ArrowDown, ArrowUp, Plus, Trash2} from "lucide-react";
 
 interface Filename {
+    selected?: string;
     path: string;
+    suggestion: string;
+    src: string;
 }
 
-const filenameColumns: ColumnDef<Filename>[] = [
-    {
-        accessorKey: "path",
-        header: "Filename",
-        cell: ({row}) => {
-            return <span className="break-all line-clamp-1 text-xs">{row.original.path}</span>;
-        },
-    },
-];
+enum NameValid {
+  Pending = 1,
+  Valid,
+  Invalid,
+}
+
 
 export default function CreateTorrent(props: JSX.IntrinsicAttributes & DialogProps) {
     const [name, setName] = useState<string>("");
+    const [isNameValid, setIsNameValid] = useState<NameValid>(NameValid.Pending);
+    const [debounceNameInput, setDebounceNameInput] = useState<[HTMLInputElement | undefined, string]>([undefined, ""]);
+
     const [description, setDescription] = useState<string>("");
     const [destination, setDestination] = useState<string>("");
-    const [seed, setSeed] = useState<boolean>(false);
+    const [trackers, setTrackers] = useState<string>("");
+    const [initialNodes, setInitialNodes] = useState<string>("");
 
     const [openFileDialog, setOpenFileDialog] = useState<boolean>(false);
     const [openDirDialog, setOpenDirDialog] = useState<boolean>(false);
     const [files, setFiles] = useState<Filename[]>([]);
+    const [onlyFile, setOnlyFile] = useState<string | undefined>(undefined);
+    const [selectedRows, setSelectedRows] = useState<Filename[]>([]);
+    const [hasNoSelection, setHasNoSelection] = useState(true);
 
     const {t} = useTranslation();
 
     useEffect(() => {
         if (props.open) {
             resetPath();
+            setOnlyFile(undefined);
             setFiles([]);
+            setSelectedRows([]);
+            setHasNoSelection(true);
+            setName("");
+            setIsNameValid(NameValid.Pending);
+            setDescription("");
+            setTrackers("");
+            setInitialNodes("");
         }
     }, [props.open]);
+
+    function handleFileSubmit(index: number, value: string) {
+        let changed = false;
+        const newFiles = files.map((c, i) => {
+            if (i == index) {
+                if (c.src != value) {
+                    changed = true;
+                    return {path: "", src: value, suggestion: value.replace(/^.*[\\/]/, ""), selected: c.selected};
+                }
+            }
+            return c;
+        })
+        if (changed)
+            setFiles(newFiles);
+    }
+
+    const filenameColumns: ColumnDef<Filename>[] = [
+        {
+            accessorKey: "suggestion",
+            header: getHeader("Name"),
+            cell: ({row}) => {
+                const [value, setValue] = useState(row.original.path);
+                const [selected, setSelected] = useState(row.original.selected);
+                useEffect(() => {
+                    row.original.path = value;
+                    let changed = false;
+                    const newFiles = files.map((c, i) => {
+                        if (("" + i) == row.id) {
+                            if (c.path != value) {
+                                changed = true;
+                                return {...c, path: value};
+                            }
+                        }
+                        return c;
+                    })
+                    if (changed)
+                        setFiles(newFiles);
+                }, [value]);
+                useEffect(() => {
+                    if (selected === undefined) {
+                        // Update to switch off, check if we already knew about this update.
+                        let changed = false;
+                        const newlySelected = selectedRows.filter((e, i, a) => {
+                            if (e.selected == row.id){
+                                changed = true;
+                                return false;
+                            } else {
+                                return true;
+                            }
+                        });
+                        if (changed) {
+                            row.original.selected = selected;
+                            setSelectedRows(newlySelected);
+                            setHasNoSelection(newlySelected.length == 0);
+                        }
+                    } else {
+                        // Update to switch on, check if we already knew about this update.
+                        if (selectedRows.find((element) => element.selected == row.id) === undefined){
+                            row.original.selected = selected;
+                            let changed = false;
+                            const newlySelected = selectedRows.map((c, i) => {
+                                if (("" + i) == row.id) {
+                                    changed = true;
+                                    return {...c, selected: row.id};
+                                }
+                                return c;
+                            })
+                            if (!changed)
+                                newlySelected.push({...row.original, selected: row.id});
+                            setSelectedRows(newlySelected);
+                            setHasNoSelection(false);
+                        }
+                    }
+                }, [selected]);
+                return (
+                        <form className="flex flex-row items-center">
+                            <Checkbox className="mr-2" checked={selected !== undefined} onCheckedChange={(e) => {setSelected(e ? row.id : undefined);}} />
+                            <Input list="placeholders" disabled={row.original.src === ""}
+                                placeholder={row.original.suggestion}
+                                value={value}
+                                onChange={e => setValue(e.target.value)} />
+                            <datalist id="placeholders">
+                                <option value={row.original.suggestion} />
+                            </datalist>
+                        </form>
+                        );
+            },
+        },
+        {
+            accessorKey: "src",
+            header: getHeader("Files"),
+            cell: ({ getValue, row: { index }, column: { id }, table }) => {
+                const initialValue = getValue<string>();
+                const [value, setValue] = useState<string>(initialValue);
+                useEffect(() => {
+                    handleFileSubmit(index, value);
+                }, [value]);
+                useEffect(() => {
+                    setValue(initialValue);
+                }, [initialValue]);
+                return (<PathInput directory={false} path={value}
+                            onPathChange={(userValue) => {setValue(userValue);}} />);
+            },
+        },
+    ];
 
     async function resetPath() {
         const settings = await triblerService.getSettings();
@@ -61,92 +184,231 @@ export default function CreateTorrent(props: JSX.IntrinsicAttributes & DialogPro
         }
     }
 
-    async function addDir(dirname: string) {
-        const response = await triblerService.listFiles(dirname, true);
-        if (response === undefined) {
-            toast.error(`${t("ToastErrorDirectoryAdd")} ${t("ToastErrorGenNetworkErr")}`);
-        } else if (isErrorDict(response)) {
-            toast.error(`${t("ToastErrorDirectoryAdd")} ${response.error.message}`);
+    async function addFile() {
+        setFiles([...files, {path: "", src: "", suggestion: "", selected: undefined}]);
+    }
+
+    function setInvalidName(target: HTMLInputElement){
+        setIsNameValid(NameValid.Invalid);
+        target.style.borderColor = "#c96155";
+    }
+
+    function setValidName(target: HTMLInputElement){
+        setIsNameValid(NameValid.Valid);
+        target.style.borderColor = "#62c955";
+    }
+
+    function setPending(target: HTMLInputElement){
+        setIsNameValid(NameValid.Pending);
+        target.style.borderColor = "";
+    }
+
+    async function requestNameValidity(target: HTMLInputElement) {
+        let name = target.value;
+        if (name == "") {
+            setInvalidName(target);
+            return
         } else {
-            setFiles([...files, ...response.paths.filter((item) => !item.dir)]);
+            setPending(target);
+        }
+
+        const response = await triblerService.dryCreateTorrent(name, destination);
+        if (response === undefined) {
+            setInvalidName(target);
+        } else if (isErrorDict(response)) {
+            setInvalidName(target);
+        } else {
+            if (response) {
+                setValidName(target);
+            } else {
+                setInvalidName(target);
+            }
         }
     }
 
-    async function addFile(filename: string) {
-        setFiles([...files, {path: filename}]);
+    function removeSelected() {
+        const selectedRowIds = selectedRows.map((c, i) => {return c.selected;});
+        const newFiles = files.filter((e, i, a) => {
+            return !selectedRowIds.includes(e.selected);
+        }).map((c, i) => {
+            if (c.selected !== undefined)
+                c.selected = "" + i;
+            return c;
+        });
+        setSelectedRows([]);  // All selected elements are now removed, easy.
+        setFiles(newFiles);
     }
+
+    function swapFileIndices(farr: Filename[], i: number, j: number) {
+        const t = farr[i];
+        farr[i] = farr[j];
+        farr[j] = t;
+        if (farr[i].selected !== undefined)
+            farr[i].selected = "" + i;
+        if (farr[j].selected !== undefined)
+            farr[j].selected = "" + j;
+    }
+
+    function moveUpSelected() {
+        const selectedRowIds = selectedRows.map((c, i) => c.selected);
+        let couldSwapPreceding = !selectedRowIds.includes("0");
+        const newFiles = [...files];
+        for(let i = 1; i < files.length; i++){
+            if (selectedRowIds.includes("" + i)){
+                if (!selectedRowIds.includes("" + (i-1)) || couldSwapPreceding) {
+                    swapFileIndices(newFiles, i-1, i);
+                    couldSwapPreceding = true;
+                } else {
+                    couldSwapPreceding = false;
+                }
+            }
+        }
+        setSelectedRows([]);  // Invalidate and recalculate, expensive!
+        setFiles(newFiles);
+    }
+
+    function moveDownSelected() {
+        const selectedRowIds = selectedRows.map((c, i) => c.selected);
+        let couldSwapPreceding = !selectedRowIds.includes("" + (files.length - 1));
+        const newFiles = [...files];
+        for(let i = files.length - 2; i >= 0; i--){
+            if (selectedRowIds.includes("" + i)){
+                if (!selectedRowIds.includes("" + (i+1)) || couldSwapPreceding) {
+                    swapFileIndices(newFiles, i+1, i);
+                    couldSwapPreceding = true;
+                } else {
+                    couldSwapPreceding = false;
+                }
+            }
+        }
+        setSelectedRows([]);  // Invalidate and recalculate, expensive!
+        setFiles(newFiles);
+    }
+
+    useEffect(() => {
+        const delayedNameValidityUpdate = setTimeout(() => {
+            if (debounceNameInput[0] !== undefined)
+                requestNameValidity(debounceNameInput[0]);
+        }, 500)
+
+        return () => clearTimeout(delayedNameValidityUpdate)
+    }, [debounceNameInput]);
+
+    useEffect(() => {
+        const actualFiles = files.filter((e, i, a) => {return e.suggestion != ""});
+        if (actualFiles.length == 1) {
+            // Single-file torrent!
+            if (actualFiles[0].path != ""){
+                // Use the user override, if available.
+                setOnlyFile(actualFiles[0].path.replace(/^.*[\\/]/, ""));
+            } else {
+                // Otherwise, just go with the filename.
+                setOnlyFile(actualFiles[0].suggestion);
+            }
+        } else {
+            setOnlyFile(undefined);
+        }
+    }, [files]);
 
     return (
         <Dialog {...props}>
             <DialogContent className="sm:max-w-6xl">
                 <DialogHeader>
-                    <DialogTitle>Create a new torrent</DialogTitle>
+                    <DialogTitle>{t("CreateTorrent")}</DialogTitle>
+                    <DialogDescription className="break-all text-xs"></DialogDescription>
                 </DialogHeader>
 
-                <div className="flex flex-col gap-4">
-                    <Label htmlFor="name" className="whitespace-nowrap pr-5 pt-2">
-                        Name
-                    </Label>
-                    <Input
-                        id="name"
-                        className="col-span-2"
-                        value={name}
-                        onChange={(event) => setName(event.target.value)}
-                    />
+                <ScrollArea className="max-h-[512px]">
+                    <div className="flex flex-col gap-4 mx-4">
+                        <Label htmlFor="destination" className="whitespace-nowrap pr-5 pt-2">
+                            {t("Destination")}
+                        </Label>
+                        <PathInput path={destination} onPathChange={setDestination} />
 
-                    <Label htmlFor="description" className="whitespace-nowrap pr-5 pt-2">
-                        Description
-                    </Label>
-                    <Textarea
-                        id="description"
-                        className="col-span-2"
-                        value={description}
-                        onChange={(event) => setDescription(event.target.value)}
-                    />
+                        <Label htmlFor="name" className="whitespace-nowrap pr-5 pt-2">
+                            {t("Name")}
+                        </Label>
+                        <div className="relative flex items-center">
+                            <Input
+                                id="name"
+                                hidden={onlyFile !== undefined}
+                                disabled={onlyFile !== undefined}
+                                className="grow pl-6"
+                                onChange={(event) => {
+                                    setName(event.target.value);
+                                    setPending(event.target);
+                                    setDebounceNameInput([event.target, event.target.value]);
+                                }}
+                            />
+                            <div className="absolute left-2" hidden={onlyFile !== undefined}>
+                                {isNameValid == NameValid.Valid ? <Icons.checkmark /> : (
+                                    isNameValid == NameValid.Invalid ? <Icons.redcross /> : <Icons.spinner />
+                                )}
+                            </div>
+                            <div className="absolute left-2" hidden={onlyFile === undefined}>
+                                <Label> {onlyFile} </Label>
+                            </div>
+                        </div>
 
-                    <Label htmlFor="files" className="whitespace-nowrap pr-5 pt-2">
-                        Files
-                    </Label>
+                        <Label htmlFor="files" className="whitespace-nowrap pr-5 pt-2">
+                            {t("Files")}
+                        </Label>
+                        <SimpleTable data={files} columns={filenameColumns} />
+                        <div className="flex">
+                            <Button variant="outline" type="button" className={files.length === 0 ? "animate-bounce mr-4" : "mr-4"} onClick={() => {
+                                    addFile();
+                                }}>
+                                <Plus />
+                            </Button>
+                            <div className="grow"></div>
+                            <Button variant="outline" type="button" disabled={hasNoSelection} onClick={moveUpSelected}>
+                                <ArrowUp />
+                            </Button>
+                            <Button variant="outline" type="button" disabled={hasNoSelection} className="mr-4" onClick={moveDownSelected}>
+                                <ArrowDown />
+                            </Button>
+                            <Button variant="outline" type="button" disabled={hasNoSelection} className="bg-destructive-foreground" onClick={removeSelected}>
+                                <Trash2 className="stroke-destructive" />
+                            </Button>
+                        </div>
 
-                    <SimpleTable data={files} columns={filenameColumns} allowSelect={false} style={{maxHeight: 200}} />
+                        <details className="col-span-2">
+                            <summary>{t("Advanced")}</summary>
 
-                    <div>
-                        <SelectRemotePath
-                            initialPath={destination}
-                            selectDir={true}
-                            open={openDirDialog}
-                            onOpenChange={setOpenDirDialog}
-                            onSelect={addDir}
-                        />
-                        <SelectRemotePath
-                            initialPath={destination}
-                            selectDir={false}
-                            open={openFileDialog}
-                            onOpenChange={setOpenFileDialog}
-                            onSelect={addFile}
-                        />
-                        <Button variant="outline" type="button" onClick={() => setOpenDirDialog(true)}>
-                            Add directory
-                        </Button>
-                        <Button variant="outline" type="button" onClick={() => setOpenFileDialog(true)}>
-                            Add files
-                        </Button>
+                            <Label htmlFor="description" className="whitespace-nowrap pr-5 pt-2">
+                                {t("Description")}
+                            </Label>
+                            <Textarea
+                                id="description"
+                                className="col-span-2"
+                                value={description}
+                                onChange={(event) => setDescription(event.target.value)}
+                            />
+
+                            <Label htmlFor="trackers" className="whitespace-nowrap pr-5 pt-2">
+                                {t("Trackers")}
+                            </Label>
+                            <Textarea
+                                id="trackers"
+                                placeholder="http://tracker.com/announce&#10;udp://anothertracker:8080/&#10; ..."
+                                className="col-span-2"
+                                value={trackers}
+                                onChange={(event) => setTrackers(event.target.value.replace(/[^\S\r\n]/g, ""))}
+                            />
+
+                            <Label htmlFor="initialNodes" className="whitespace-nowrap pr-5 pt-2">
+                                {t("InitialNodes")}
+                            </Label>
+                            <Textarea
+                                id="initialNodes"
+                                className="col-span-2"
+                                placeholder='your.router.node 4804&#10;2001:db8:100:0:d5c8:db3f:995e:c0f7 1941&#10; ...'
+                                value={initialNodes}
+                                onChange={(event) => setInitialNodes(event.target.value)}
+                            />
+                        </details>
                     </div>
-
-                    <Label htmlFor="destination" className="whitespace-nowrap pr-5 pt-2">
-                        Torrent file destination
-                    </Label>
-                    <PathInput path={destination} onPathChange={setDestination} />
-
-                    <div className="flex items-center space-x-2 pt-2">
-                        <Checkbox id="seed" checked={seed} onCheckedChange={(value) => setSeed(!!value)} />
-                        <label
-                            htmlFor="seed"
-                            className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 text-left">
-                            Seed this torrent after creation
-                        </label>
-                    </div>
-                </div>
+                </ScrollArea>
 
                 <DialogFooter>
                     <Button
@@ -155,11 +417,13 @@ export default function CreateTorrent(props: JSX.IntrinsicAttributes & DialogPro
                         onClick={() => {
                             triblerService
                                 .createTorrent(
-                                    name,
+                                    onlyFile === undefined ? name : onlyFile,
                                     description,
-                                    files.map((f) => f.path),
+                                    files.filter((e, i, a) => {return e.src != ""}).map((f) => f.path),
+                                    files.filter((e, i, a) => {return e.src != ""}).map((f) => f.src),
                                     destination,
-                                    seed
+                                    trackers.split(/\r?\n/),
+                                    initialNodes.split(/\r?\n/)
                                 )
                                 .then((response) => {
                                     if (response === undefined) {
@@ -175,7 +439,7 @@ export default function CreateTorrent(props: JSX.IntrinsicAttributes & DialogPro
                                 });
                             if (props.onOpenChange) props.onOpenChange(false);
                         }}
-                        disabled={files.length === 0}>
+                        disabled={(files.filter((e, i, a) => {return e.suggestion != ""}).length === 0 || isNameValid != NameValid.Valid) && onlyFile === undefined}>
                         {t("CreateTorrentButton")}
                     </Button>
                     <DialogClose asChild>

--- a/src/tribler/ui/src/services/tribler.service.ts
+++ b/src/tribler/ui/src/services/tribler.service.ts
@@ -551,20 +551,41 @@ export class TriblerService {
         }
     }
 
-    async createTorrent(
+    async dryCreateTorrent(
         name: string,
-        description: string,
-        files: string[],
-        exportDir: string,
-        download: boolean
+        exportDir: string
     ): Promise<undefined | ErrorDict | {torrent: string}> {
         try {
             return (
-                await this.http.post(`/createtorrent?download=${+download}`, {
+                await this.http.post("/createtorrent/dryrun", {
+                    name: name,
+                    export_dir: exportDir,
+                })
+            ).data.success;
+        } catch (error) {
+            return formatAxiosError(error as Error | AxiosError);
+        }
+    }
+
+    async createTorrent(
+        name: string,
+        description: string,
+        filenames: string[],
+        files: string[],
+        exportDir: string,
+        trackers: string[],
+        initialNodes: string[]
+    ): Promise<undefined | ErrorDict | {torrent: string}> {
+        try {
+            return (
+                await this.http.post("/createtorrent", {
                     name: name,
                     description: description,
+                    filenames: filenames,
                     files: files,
                     export_dir: exportDir,
+                    trackers: trackers,
+                    initial_nodes: initialNodes
                 })
             ).data.torrent;
         } catch (error) {


### PR DESCRIPTION
Fixes #4674
Fixes #8630
Fixes #8656

This PR:

 - Adds the ability to select files from different folders when creating a torrent.
 - Adds the ability to add initial nodes when creating a torrent.
 - Adds the ability to specify trackers when creating a torrent.
 - Adds a custom round check mark and a red X SVG icon for the GUI.
 - Adds a torrent create "dry run" REST API route. I added this here and not in the file browser, to accommodate for future changes checking not only the name but also other torrent creation parameters.
 - Updates the create torrent GUI to show when the torrent name cannot be edited.

