### PR TITLE
Fixed missing OpenSSL libs for libtorrent

### DIFF
--- a/.github/workflows/periodic_unittests.yml
+++ b/.github/workflows/periodic_unittests.yml
@@ -24,6 +24,9 @@ jobs:
       - run: python -m pip install -r requirements.txt
       - name: Run unit tests
         run: |
+          # Windows libtorrent 2.0.11 OpenSSL 1.1.1n workaround (only for tests, not for production!)
+          python -m pip install libtorrent-windows-dll
+
           cd src
           python run_unit_tests.py -a
       - uses: actions/cache/save@v4

--- a/.github/workflows/pr-comment-validate.yml
+++ b/.github/workflows/pr-comment-validate.yml
@@ -34,6 +34,9 @@ jobs:
         run: |
           cp /opt/homebrew/opt/libsodium/lib/libsodium.dylib /Library/Frameworks/Python.framework/Versions/3.12/lib/libsodium.dylib
       - run: python -m pip install -r requirements.txt
+      # Windows libtorrent 2.0.11 OpenSSL 1.1.1n workaround (only for tests, not for production!)
+      - run: python -m pip install libtorrent-windows-dll
+        if: matrix.os == 'windows-latest'
       - run: |
           cd src
           python run_unit_tests.py -a

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -31,7 +31,11 @@ jobs:
         with:
           path: src/libsodium.dll
           key: cache_libsodium_dll
-      - run: python -m pip install -r requirements.txt
+      - run: |
+          python -m pip install -r requirements.txt
+
+          # Windows libtorrent 2.0.11 OpenSSL 1.1.1n workaround (only for tests, not for production!)
+          python -m pip install libtorrent-windows-dll
       - name: Run unit tests
         run: |
           cd src


### PR DESCRIPTION
Extracted from #8742

This PR:

 - Fixes `ImportError: DLL load failed while importing libtorrent: The specified module could not be found.` 
 
The correct way to fix the missing OpenSSL libraries for the Windows runner is to build OpenSSL ourselves. This avoids any supply chain attacks and it guarantees security. However, this takes an additional 5 minutes per PR. Instead, I'm downloading `dll` files from the Internet because it's MUCH faster. For testing, the security risk should be negligible. For building, we still use the "correct" secure way, of course.