### PR TITLE
Always ask for download even when starting from CLI

### DIFF
--- a/src/tribler/core/notifier.py
+++ b/src/tribler/core/notifier.py
@@ -49,6 +49,7 @@ class Notification(Enum):
     torrent_metadata_added = Desc("torrent_metadata_added", ["metadata"], [dict])
     new_torrent_metadata_created = Desc("new_torrent_metadata_created", ["infohash", "title"],
                                         [(bytes, type(None)), (str, type(None))])
+    ask_add_download = Desc("ask_add_download", ["uri"], [str])
 
 
 class Notifier:

--- a/src/tribler/core/restapi/events_endpoint.py
+++ b/src/tribler/core/restapi/events_endpoint.py
@@ -31,6 +31,7 @@ topics_to_send_to_gui = [
     Notification.remote_query_results,
     Notification.low_space,
     Notification.report_config_error,
+    Notification.ask_add_download,
 ]
 
 

--- a/src/tribler/tribler_config.py
+++ b/src/tribler/tribler_config.py
@@ -196,6 +196,8 @@ class LibtorrentConfig(TypedDict):
     active_lsd_limit: int
     active_limit: int
 
+    ask_download_settings: bool
+
 
 class RecommenderConfig(TypedDict):
     """
@@ -338,7 +340,8 @@ DEFAULT_CONFIG = {
         active_dht_limit=88,
         active_tracker_limit=1600,
         active_lsd_limit=60,
-        active_limit=500
+        active_limit=500,
+        ask_download_settings=False
         ),
     "recommender": RecommenderConfig(enabled=True),
     "rendezvous": RendezvousConfig(enabled=True),
@@ -506,7 +509,7 @@ if __name__ == "__main__":
             typed_dicts_sources.append("".join(getlines(__file__)[entry.lineno-1:entry.end_lineno]))
             unsourced.remove(entry.targets[0].id)
     typed_dicts_sources += [inspect.getsource(globals()[k]) for k in unsourced]
-    src_typed_dicts = "\n".join(typed_dicts_sources)
+    src_typed_dicts = "\n".join(sorted(typed_dicts_sources))
 
     mypy_opts = Options()
     ast_tcm = ast.parse(inspect.getsource(TriblerConfigManager))

--- a/src/tribler/tribler_config.pyi
+++ b/src/tribler/tribler_config.pyi
@@ -35,45 +35,6 @@ class ApiConfig(TypedDict):
     http_port_running: int
     https_port_running: int
 
-class RendezvousConfig(TypedDict):
-    """
-    Settings for the rendezvous component.
-    """
-
-    enabled: bool
-
-class IPv8LoggerConfig(TypedDict):
-    """
-    The IPv8 logger configuration.
-    """
-
-    level: str
-
-class TriblerConfig(TypedDict):
-    """
-    The main Tribler settings and all of its components' sub-settings.
-    """
-
-    api: ApiConfig
-    headless: bool
-
-    ipv8: IPv8Config
-    statistics: bool
-
-    content_discovery_community: ContentDiscoveryCommunityConfig
-    database: DatabaseConfig
-    libtorrent: LibtorrentConfig
-    recommender: RecommenderConfig
-    rendezvous: RendezvousConfig
-    rss: RSSConfig
-    torrent_checker: TorrentCheckerConfig
-    tunnel_community: TunnelCommunityConfig
-    versioning: VersioningConfig
-    watch_folder: WatchFolderConfig
-
-    state_dir: str
-    memory_db: bool
-
 class ContentDiscoveryCommunityConfig(TypedDict):
     """
     Settings for the content discovery component.
@@ -81,27 +42,9 @@ class ContentDiscoveryCommunityConfig(TypedDict):
 
     enabled: bool
 
-class RSSConfig(TypedDict):
+class DatabaseConfig(TypedDict):
     """
-    Settings for the rss component.
-    """
-
-    enabled: bool
-    urls: list[str]
-
-class IPv8InterfaceConfig(TypedDict):
-    """
-    An IPv8 network interface.
-    """
-
-    interface: str
-    ip: str
-    port: int
-    worker_threads: NotRequired[int]
-
-class VersioningConfig(TypedDict):
-    """
-    Settings for the versioning component.
+    Settings for the database component.
     """
 
     enabled: bool
@@ -125,44 +68,52 @@ class DownloadDefaultsConfig(TypedDict):
     auto_managed: bool
     completed_dir: str
 
-class DatabaseConfig(TypedDict):
+class IPv8Config(TypedDict):
     """
-    Settings for the database component.
-    """
-
-    enabled: bool
-
-class TorrentCheckerConfig(TypedDict):
-    """
-    Settings for the torrent checker component.
+    The main IPv8 configuration dictionary.
     """
 
-    enabled: bool
+    interfaces: list[IPv8InterfaceConfig]
+    keys: list[IPv8KeysConfig]
+    logger: IPv8LoggerConfig
+    working_directory: str
+    walker_interval: float
+    overlays: list[IPv8OverlayConfig]
 
-class RecommenderConfig(TypedDict):
+class IPv8InterfaceConfig(TypedDict):
     """
-    Settings for the user recommender component.
-    """
-
-    enabled: bool
-
-class TunnelCommunityConfig(TypedDict):
-    """
-    Settings for the tunnel community component.
+    An IPv8 network interface.
     """
 
-    enabled: bool
-    min_circuits: int
-    max_circuits: int
+    interface: str
+    ip: str
+    port: int
+    worker_threads: NotRequired[int]
 
-class WatchFolderConfig(TypedDict):
+class IPv8KeysConfig(TypedDict):
     """
-    Settings for the watch folder component.
+    An IPv8 key configuration.
     """
 
-    enabled: bool
-    directory: str
-    check_interval: float
+    alias: str
+    generation: str
+    file: str
+
+class IPv8LoggerConfig(TypedDict):
+    """
+    The IPv8 logger configuration.
+    """
+
+    level: str
+
+class IPv8WalkerConfig(TypedDict):
+    """
+    An IPv8 walker configuration.
+    """
+
+    strategy: str
+    peers: int
+    init: dict
 
 class LibtorrentConfig(TypedDict):
     """
@@ -199,35 +150,86 @@ class LibtorrentConfig(TypedDict):
     active_lsd_limit: int
     active_limit: int
 
-class IPv8WalkerConfig(TypedDict):
+    ask_download_settings: bool
+
+class RSSConfig(TypedDict):
     """
-    An IPv8 walker configuration.
+    Settings for the rss component.
     """
 
-    strategy: str
-    peers: int
-    init: dict
+    enabled: bool
+    urls: list[str]
 
-class IPv8Config(TypedDict):
+class RecommenderConfig(TypedDict):
     """
-    The main IPv8 configuration dictionary.
-    """
-
-    interfaces: list[IPv8InterfaceConfig]
-    keys: list[IPv8KeysConfig]
-    logger: IPv8LoggerConfig
-    working_directory: str
-    walker_interval: float
-    overlays: list[IPv8OverlayConfig]
-
-class IPv8KeysConfig(TypedDict):
-    """
-    An IPv8 key configuration.
+    Settings for the user recommender component.
     """
 
-    alias: str
-    generation: str
-    file: str
+    enabled: bool
+
+class RendezvousConfig(TypedDict):
+    """
+    Settings for the rendezvous component.
+    """
+
+    enabled: bool
+
+class TorrentCheckerConfig(TypedDict):
+    """
+    Settings for the torrent checker component.
+    """
+
+    enabled: bool
+
+class TriblerConfig(TypedDict):
+    """
+    The main Tribler settings and all of its components' sub-settings.
+    """
+
+    api: ApiConfig
+    headless: bool
+
+    ipv8: IPv8Config
+    statistics: bool
+
+    content_discovery_community: ContentDiscoveryCommunityConfig
+    database: DatabaseConfig
+    libtorrent: LibtorrentConfig
+    recommender: RecommenderConfig
+    rendezvous: RendezvousConfig
+    rss: RSSConfig
+    torrent_checker: TorrentCheckerConfig
+    tunnel_community: TunnelCommunityConfig
+    versioning: VersioningConfig
+    watch_folder: WatchFolderConfig
+
+    state_dir: str
+    memory_db: bool
+
+class TunnelCommunityConfig(TypedDict):
+    """
+    Settings for the tunnel community component.
+    """
+
+    enabled: bool
+    min_circuits: int
+    max_circuits: int
+
+class VersioningConfig(TypedDict):
+    """
+    Settings for the versioning component.
+    """
+
+    enabled: bool
+
+class WatchFolderConfig(TypedDict):
+    """
+    Settings for the watch folder component.
+    """
+
+    enabled: bool
+    directory: str
+    check_interval: float
 
 
 class TriblerConfigManager:
@@ -361,6 +363,8 @@ class TriblerConfigManager:
     def set(self, option: Literal["libtorrent/active_lsd_limit"], value: int) -> None: ...
     @overload
     def set(self, option: Literal["libtorrent/active_limit"], value: int) -> None: ...
+    @overload
+    def set(self, option: Literal["libtorrent/ask_download_settings"], value: bool) -> None: ...
     @overload
     def set(self, option: Literal["recommender/enabled"], value: bool) -> None: ...
     @overload
@@ -570,6 +574,8 @@ class TriblerConfigManager:
     def get(self, option: Literal["libtorrent/active_lsd_limit"]) -> int: ...
     @overload
     def get(self, option: Literal["libtorrent/active_limit"]) -> int: ...
+    @overload
+    def get(self, option: Literal["libtorrent/ask_download_settings"]) -> bool: ...
     @overload
     def get(self, option: Literal["recommender/enabled"]) -> bool: ...
     @overload

--- a/src/tribler/ui/src/dialogs/SaveAs.tsx
+++ b/src/tribler/ui/src/dialogs/SaveAs.tsx
@@ -238,7 +238,7 @@ export default function SaveAs(props: SaveAsProps & JSX.IntrinsicAttributes & Di
         }
     }
 
-    if (props.open && props.onOpenChange && triblerService.guiSettings.ask_download_settings === false) {
+    if (props.open && props.onOpenChange && settings?.libtorrent?.ask_download_settings === false) {
         OnDownloadClicked();
         return <></>;
     }

--- a/src/tribler/ui/src/models/settings.model.tsx
+++ b/src/tribler/ui/src/models/settings.model.tsx
@@ -68,6 +68,7 @@ export interface Settings {
         announce_to_all_trackers: boolean;
         max_concurrent_http_announces: number;
         check_after_complete: boolean;
+        ask_download_settings: boolean;
         download_defaults: {
             anonymity_enabled: boolean;
             number_hops: number;
@@ -121,7 +122,6 @@ export interface AutoManageSettings {
 
 export interface GuiSettings {
     translation?: string;
-    ask_download_settings?: boolean;
     dev_mode?: boolean;
     lang?: string;
     theme?: string;

--- a/src/tribler/ui/src/pages/Settings/General.tsx
+++ b/src/tribler/ui/src/pages/Settings/General.tsx
@@ -223,13 +223,13 @@ export default function General() {
 
             <div className="flex items-center space-x-2 py-2">
                 <Checkbox
-                    checked={!!settings?.ui?.ask_download_settings}
+                    checked={!!settings?.libtorrent?.ask_download_settings}
                     onCheckedChange={(value) => {
                         if (settings) {
                             setSettings({
                                 ...settings,
-                                ui: {
-                                    ...settings?.ui,
+                                libtorrent: {
+                                    ...settings?.libtorrent,
                                     ask_download_settings: !!value,
                                 },
                             });


### PR DESCRIPTION
Fixes #8695

This PR:

 - Adds a `cli` parameter to the `DownloadsEndpoint` to signal that a torrent was started through the CLI we haven't checked for user permission, which we may need if the "Always ask" setting is enabled.
 - Adds a UI event listener for when our core wants our GUI to start a download.
 - Adds sorting to the `tribler_config.py` type stub generation to cut down on diff size when regenerating.
 - Updates the "unknown" `ui/ask_download_settings` to live in `libtorrent/ask_download_settings` because it is now also used by the core.