### PR TITLE
Various fixes

### DIFF
--- a/src/run_unit_tests.py
+++ b/src/run_unit_tests.py
@@ -25,8 +25,8 @@ if platform.system() == "Darwin":
     The unit tests on Mac lock up on multiprocess getaddrinfo calls. We establish the lan addresses once here before
     spawning any children.
     """
-    from ipv8.messaging.interfaces.lan_addresses.interfaces import get_lan_addresses
-    get_lan_addresses()
+    from ipv8.messaging.interfaces.lan_addresses.interfaces import get_providers
+    get_providers().clear()
 
 
 def task_tribler_test(*test_names: str) -> tuple[bool, int, float, list[tuple[str, str, str]], str]:

--- a/src/tribler/core/components.py
+++ b/src/tribler/core/components.py
@@ -345,6 +345,7 @@ class RSSComponent(ComponentLauncher):
 
 @set_in_session("tunnel_community")
 @precondition('session.config.get("tunnel_community/enabled")')
+@precondition("session.rust_endpoint is not None")
 @after("DHTDiscoveryComponent")
 @walk_strategy("tribler.core.tunnel.discovery", "GoldenRatioStrategy", -1)
 @overlay("tribler.core.tunnel.community", "TriblerTunnelCommunity")

--- a/src/tribler/core/libtorrent/download_manager/download_manager.py
+++ b/src/tribler/core/libtorrent/download_manager/download_manager.py
@@ -445,8 +445,10 @@ class DownloadManager(TaskManager):
                 self.downloads[infohash].update_lt_status(handle.status())
                 self.downloads[infohash].process_alert(cast("lt.state_changed_alert", alert), alert_type)
 
-        infohash = (best_info_hash(alert.params.info_hashes, alert.params.info_hash)
-                    if hasattr(alert, "params") else b"")
+        infohash = (best_info_hash(alert.params.info_hashes, alert.params.info_hash) if hasattr(alert, "params")
+                    else (
+            best_info_hash(alert.handle.info_hashes(), alert.handle.info_hash()) if hasattr(alert, "handle") else b""
+        ))
         download = self.downloads.get(infohash)
         if download and download.config.get_hops() == hops:
             download.process_alert(cast("lt.torrent_alert", alert), alert_type)

--- a/src/tribler/core/libtorrent/torrentdef.py
+++ b/src/tribler/core/libtorrent/torrentdef.py
@@ -100,4 +100,5 @@ class TorrentDef:
         if self.torrent_info is None:
             return []
         storage = self.torrent_info.files()
-        return [i for i in range(storage.num_files()) if storage.file_flags(i) == 0]
+        return [i for i in range(storage.num_files())
+                if (storage.file_flags(i) & int(lt.file_flags_t.flag_pad_file)) == 0]

--- a/src/tribler/core/restapi/statistics_endpoint.py
+++ b/src/tribler/core/restapi/statistics_endpoint.py
@@ -141,7 +141,7 @@ class StatisticsEndpoint(RESTEndpoint):
             lt_stats["total_sent_bytes"] = sum([s["sent_bytes"] for s in lt_stats["sessions"]])
             stats_dict["libtorrent"] = lt_stats
 
-        if self.session:
+        if self.session and self.session.rust_endpoint:
             stats_dict["socks5_sessions"] = self.session.rust_endpoint.get_socks5_statistics()
 
         version = getattr(rust_endpoint, "__version__", "unknown")

--- a/src/tribler/test_unit/core/libtorrent/test_torrentdef.py
+++ b/src/tribler/test_unit/core/libtorrent/test_torrentdef.py
@@ -41,3 +41,57 @@ class TestTorrentDef(TestBase):
         }))
 
         self.assertEqual(name_unicode, tdef.name)
+
+    def test_get_file_indices_no_info(self) -> None:
+        """
+        Test if no files are returned when there is no torrent info.
+        """
+        tdef = TorrentDef(libtorrent.add_torrent_params())
+
+        self.assertListEqual([], tdef.get_file_indices())
+
+    def test_get_file_indices(self) -> None:
+        """
+        Test if files are returned as given by the torrent info.
+
+        Note: The torrent_info bytes are generated using ``libtorrent.generate()``, which has the unfortunate tendency
+              to segfault when called repeatedly while testing. The same holds for the following tests as well.
+        """
+        tdef = TorrentDef(libtorrent.add_torrent_params())
+        tdef.atp.ti = libtorrent.torrent_info(
+            b"d13:creation datei1759840893e4:infod5:filesl"
+            b"d6:lengthi1e4:pathl5:a.txteed6:lengthi1e4:pathl5:b.txteee4:name4:test12:piece lengthi16384e"
+            b"6:pieces20:\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01ee"
+        )
+
+        self.assertEqual(2, len(tdef.get_file_indices()))
+        self.assertListEqual([0, 1], tdef.get_file_indices())
+
+    def test_get_file_indices_exclude_pad(self) -> None:
+        """
+        Test if files do not return pad files.
+        """
+        tdef = TorrentDef(libtorrent.add_torrent_params())
+        tdef.atp.ti = libtorrent.torrent_info(
+            b"d13:creation datei1759840997e4:infod5:filesl"
+            b"d6:lengthi1e4:pathl5:a.txteed4:attr1:p6:lengthi1e4:pathl5:b.txteee4:name4:test12:piece lengthi16384e"
+            b"6:pieces20:\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01ee"
+        )
+
+        self.assertEqual(1, len(tdef.get_file_indices()))
+        self.assertListEqual([0], tdef.get_file_indices())
+
+    def test_get_file_indices_hidden(self) -> None:
+        """
+        Test if files with flags that are not padding files are still returned.
+        """
+        tdef = TorrentDef(libtorrent.add_torrent_params())
+        tdef.atp.ti = libtorrent.torrent_info(
+            b"d13:creation datei1759841092e4:infod5:filesl"
+            b"d6:lengthi1e4:pathl5:a.txteed4:attr1:h6:lengthi1e4:pathl5:b.txteed4:attr1:x6:lengthi1e"
+            b"4:pathl5:c.txteed6:lengthi1e4:pathl5:d.txteee4:name4:test12:piece lengthi16384e"
+            b"6:pieces20:\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01ee"
+        )
+
+        self.assertEqual(4, len(tdef.get_file_indices()))
+        self.assertListEqual([0, 1, 2, 3], tdef.get_file_indices())

--- a/src/tribler/ui/src/services/tribler.service.ts
+++ b/src/tribler/ui/src/services/tribler.service.ts
@@ -111,8 +111,10 @@ export class TriblerService {
             );
             new_list[new_list.length - 2] = 101; // b"e"
             new_list[new_list.length - 1] = 101; // b"e"
-        } else {
+        } else if (selected_files !== undefined) {
             var new_list = new Uint8Array([108, 101]); // b"le"
+        } else {
+            return raw_bytes;
         }
 
         // Merge everything into the output buffer


### PR DESCRIPTION
Fixes #8778
Fixes #8728
Fixes #8770

This PR:

 - Fixes startup error(s) when `Sesssion.rust_endpoint` is `None`.
 - Fixes Mac validation tests taking eons (i.e., 7 minutes) in LAN address detection overhead.
 - Fixes an error where torrents with file flags would have no (visible) files.
 - Fixes `torrent_finished_alert` not propagating due to it needing `handle.info_hash()` instead of `params.info_hash`.
 - Fixes torrents downloading without selected files when `Always ask download settings` was disabled. Changed to all files by default.
