### PR TITLE
Fix torrent discovery

### DIFF
--- a/src/tribler/core/content_discovery/community.py
+++ b/src/tribler/core/content_discovery/community.py
@@ -105,7 +105,7 @@ class ContentDiscoveryCommunity(Community):
         for field in self.composition.binary_fields:
             value = parameters.get(field)
             if value is not None:
-                parameters[field] = unhexlify(value.encode()) if decode else hexlify(value.encode()).decode()
+                parameters[field] = unhexlify(value.encode()) if decode else hexlify(value).decode()
 
     def sanitize_query(self, query_dict: dict[str, Any], cap: int = 100) -> dict[str, Any]:
         """
@@ -181,8 +181,7 @@ class ContentDiscoveryCommunity(Community):
         for health_info in health_list:
             # Get a single result per infohash to avoid duplicates
             if health_info.infohash in to_resolve:
-                infohash = hexlify(health_info.infohash).decode()
-                self.send_remote_select(peer=peer, infohash=infohash, last=1)
+                self.send_remote_select(peer=peer, infohash=health_info.infohash, last=1)
 
     @db_session
     def process_torrents_health(self, health_list: list[HealthInfo]) -> set[bytes]:


### PR DESCRIPTION
Currently, our main source of torrent discovery is through swarm health information. When we receive an infohash that we haven't seen before, we immediately request the `TorrentMetadata`. These requests are expected to be mostly successful, because peers only send swarm information if they have the `TorrentMetadata` as well. It turns out, these requests always fail, because we're requesting an infohash that is *double* hex-encoded.

After merging this fix, torrent discovery should be fixed. This means that, combined with the earlier tracker fixes, we should be getting more tracker information. So, hopefully, this will also (partially) fix our swarm health problem.
