### PR TITLE
Fix state freeze after updating the hop count

### DIFF
--- a/src/tribler/core/libtorrent/download_manager/download_manager.py
+++ b/src/tribler/core/libtorrent/download_manager/download_manager.py
@@ -758,6 +758,8 @@ class DownloadManager(TaskManager):
             self._logger.warning("DHT readiness task was cancelled")
         if not atp.save_path:
             atp.save_path = atp.name or (atp.ti.name() if atp.ti else "Unknown name")
+        # Ensure the update_subscribe flag is set. This may not be the case when updating the hop count.
+        atp.flags |= lt.torrent_flags.update_subscribe
         ltsession.async_add_torrent(atp)
 
     def get_libtorrent_version(self) -> str:

--- a/src/tribler/test_unit/core/libtorrent/download_manager/test_download_manager.py
+++ b/src/tribler/test_unit/core/libtorrent/download_manager/test_download_manager.py
@@ -194,7 +194,7 @@ class TestDownloadManager(TestBase):
         self.manager.dht_ready_task = Future()
         self.manager.dht_readiness_timeout = 0.001
 
-        self.assertIsNone(await self.manager.start_handle(download, Mock(save_path="")))
+        self.assertIsNone(await self.manager.start_handle(download, Mock(save_path="", flags=0)))
 
     async def test_start_handle_wait_for_dht(self) -> None:
         """


### PR DESCRIPTION
I noticed that `apt.flags` can magically change to 8 (the `apply_ip_filter` flag). The same goes for the output of `handle.flags()`. Despite this, everything works as if the flags are still set correctly. However, since we're using this value when updating the hop count, this can freeze the download state (because the `update_subscribe` flag isn't getting set).

Since we always want state updates anyway, I've manually set the  flag in `_async_add_torrent`.
