### PR TITLE
Catch exceptions while starting SOCKS5 servers

### DIFF
--- a/src/tribler/core/session.py
+++ b/src/tribler/core/session.py
@@ -14,6 +14,7 @@ from ipv8.loader import IPv8CommunityLoader
 from ipv8.messaging.interfaces.dispatcher.endpoint import DispatcherEndpoint
 from ipv8.messaging.interfaces.udp.endpoint import UDPv6Endpoint
 from ipv8_rust_tunnels.endpoint import RustEndpoint
+from ipv8_rust_tunnels.rust_endpoint import RustError
 from ipv8_service import IPv8
 
 from tribler.core.components import (
@@ -222,10 +223,13 @@ class Session:
 
         # Libtorrent
         if self.rust_endpoint:
-            self.download_manager.socks_listen_ports = [
-                self.rust_endpoint.create_socks5_server(port, index+1)
-                for index, port in enumerate(self.config.get("libtorrent/socks_listen_ports"))
-            ]
+            try:
+                self.download_manager.socks_listen_ports = [
+                    self.rust_endpoint.create_socks5_server(port, index+1)
+                    for index, port in enumerate(self.config.get("libtorrent/socks_listen_ports"))
+                ]
+            except RustError:
+                logger.warning("Failed to start SOCKS5 servers")
         await self.download_manager.initialize()
         self.download_manager.start()
 


### PR DESCRIPTION
Fixes https://github.com/Tribler/tribler/issues/8838.
