### PR TITLE
Fix export torrent for v2 torrents

### DIFF
--- a/src/tribler/core/libtorrent/restapi/downloads_endpoint.py
+++ b/src/tribler/core/libtorrent/restapi/downloads_endpoint.py
@@ -477,7 +477,7 @@ class DownloadsEndpoint(RESTEndpoint):
                 download.add_trackers(self._get_default_trackers())
             if self.download_manager.config.get("libtorrent/download_defaults/torrent_folder"):
                 await download.get_handle()  # We can only generate a torrent file for a valid handle, wait for it.
-                download.write_backup_torrent_file()
+                await download.write_backup_torrent_file()
             if params.get("only_metadata", "false") != "false":
                 download.stop_after_metainfo()
         except Exception as e:
@@ -676,7 +676,7 @@ class DownloadsEndpoint(RESTEndpoint):
         if not download:
             return DownloadsEndpoint.return_404()
 
-        torrent = download.get_torrent_data()
+        torrent = await download.get_torrent_data()
         if not torrent:
             return DownloadsEndpoint.return_404()
 

--- a/src/tribler/core/libtorrent/torrentdef.py
+++ b/src/tribler/core/libtorrent/torrentdef.py
@@ -2,8 +2,15 @@ from __future__ import annotations
 
 from asyncio import get_running_loop
 from binascii import hexlify
+from hashlib import sha256
+from typing import TYPE_CHECKING
 
 import libtorrent as lt
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+BLOCK_SIZE = 2 ** 14
 
 
 def best_info_hash(info_hashes: lt.info_hash_t, info_hash: lt.sha1_hash) -> bytes:
@@ -102,3 +109,55 @@ class TorrentDef:
         storage = self.torrent_info.files()
         return [i for i in range(storage.num_files())
                 if (storage.file_flags(i) & int(lt.file_flags_t.flag_pad_file)) == 0]
+
+    def _get_piece_range_from_file_idx(self, fstorage: lt.file_storage, file_idx: int) -> Sequence[int]:
+        """
+        Get the piece range from a file index.
+        """
+        start_idx = fstorage.piece_index_at_file(file_idx)  # type: ignore[attr-defined]
+        div, rem = divmod(fstorage.file_size(file_idx), fstorage.piece_length())
+        return range(start_idx, start_idx + div + (rem > 0))
+
+    def get_v2_piece_hash(self, piece_index: int, piece_buffer: bytes) -> bytes:
+        """
+        Get the (32-byte) SHA-256 hash for the specified piece from its buffer.
+        """
+        if self.torrent_info is None:
+            return b""
+
+        storage = self.torrent_info.files()
+        file_idx = storage.file_index_at_piece(piece_index)  # type: ignore[attr-defined]
+        piece_range = list(self._get_piece_range_from_file_idx(storage, file_idx))
+        max_blocks = len(piece_buffer) // BLOCK_SIZE
+
+        if piece_index == piece_range[-1]:
+            # We are the last piece, don't consume the full buffer
+            len_remainder = storage.file_size(file_idx) % storage.piece_length()
+            piece_buffer = piece_buffer[:len_remainder]
+            actual_blocks = len_remainder // BLOCK_SIZE
+            if actual_blocks * BLOCK_SIZE < len_remainder:
+                actual_blocks += 1
+        else:
+            actual_blocks = max_blocks
+
+        # Calculate the Merkle root.
+        hashes = [sha256(piece_buffer[(i * BLOCK_SIZE): ((i + 1) * BLOCK_SIZE)]).digest() for i in range(actual_blocks)]
+        hashes.extend([bytes(32) for _ in range(max_blocks - actual_blocks)])
+        while len(hashes) > 1:
+            hashes = [sha256(l + r).digest() for l, r in zip(*[iter(hashes)] * 2, strict=False)]
+        return hashes[0]
+
+    def get_v2_piece_indices_per_layer(self) -> dict[bytes, list[int]]:
+        """
+        Get the piece indices per file root hash.
+        """
+        if self.torrent_info is None:
+            return {}
+
+        storage = self.torrent_info.files()
+        return {
+            storage.root(f).to_bytes():  # type: ignore[attr-defined]
+                list(self._get_piece_range_from_file_idx(storage, f))
+            for f in self.get_file_indices()
+            if storage.file_size(f) > storage.piece_length()
+        }

--- a/src/tribler/test_unit/core/libtorrent/mocks.py
+++ b/src/tribler/test_unit/core/libtorrent/mocks.py
@@ -107,6 +107,36 @@ TORRENT_UBUNTU_FILE_CONTENT = (
     b'e'
 )
 
+TORRENT_UBUNTU_FILE_CONTENT_V2 = (
+    b'd'
+        b'8:announce39:http://torrent.ubuntu.com:6969/announce'
+        b'13:announce-listl'
+            b'l39:http://torrent.ubuntu.com:6969/announce'
+        b'e'
+        b'l'
+            b'44:http://ipv6.torrent.ubuntu.com:6969/announcee'
+        b'e'
+        b'7:comment29:Ubuntu CD releases.ubuntu.com'
+        b'13:creation datei1429786237e'
+        b'4:infod'
+            b'9:file treed'
+                b'30:ubuntu-15.04-desktop-amd64.isod'
+                    b'0:d'
+                        b'6:lengthi1150844928e'
+                        b'11:pieces root32:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+                    b'e'
+                b'e'
+            b'e'
+            b'12:meta versioni2e'
+            b'4:name30:ubuntu-15.04-desktop-amd64.iso'
+            b'12:piece lengthi524288e'
+        b'e'
+        b'12:piece layersd'
+            # Omitted, should be one key 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' with a ceil(1150844928/524288) * 32 string
+        b'e'
+    b'e'
+)
+
 TORRENT_UBUNTU_FILE = libtorrent.torrent_info(libtorrent.bdecode(TORRENT_UBUNTU_FILE_CONTENT))
 """
 Torrent structure:

--- a/src/tribler/test_unit/core/libtorrent/restapi/test_downloads_endpoint.py
+++ b/src/tribler/test_unit/core/libtorrent/restapi/test_downloads_endpoint.py
@@ -21,7 +21,6 @@ from tribler.core.libtorrent.restapi.downloads_endpoint import DownloadsEndpoint
 from tribler.core.libtorrent.torrentdef import TorrentDef
 from tribler.core.restapi.rest_endpoint import HTTP_BAD_REQUEST, HTTP_INTERNAL_SERVER_ERROR, HTTP_NOT_FOUND
 from tribler.test_unit.core.libtorrent.mocks import (
-    TORRENT_WITH_DIRS,
     TORRENT_WITH_DIRS_CONTENT,
     TORRENT_WITH_VIDEO,
     FakeTDef,
@@ -742,7 +741,7 @@ class TestDownloadsEndpoint(TestBase):
         """
         Test if a graceful error is returned when no torrent data is found.
         """
-        self.download_manager.get_download = Mock(return_value=Mock(get_torrent_data=Mock(return_value=None)))
+        self.download_manager.get_download = Mock(return_value=Mock(get_torrent_data=AsyncMock(return_value=None)))
         request = MockRequest(f"/api/downloads/{'01' * 20}/torrent", "GET", {}, {"infohash": "01" * 20})
 
         response = await self.endpoint.get_torrent(request)
@@ -756,7 +755,8 @@ class TestDownloadsEndpoint(TestBase):
         Test if torrent data is correctly sent over on request.
         """
         download = self.create_mock_download()
-        download.handle = Mock(is_valid=Mock(return_value=True), torrent_file=Mock(return_value=TORRENT_WITH_DIRS))
+        download.handle = Mock(is_valid=Mock(return_value=True))
+        download.get_torrent_data = AsyncMock(return_value=libtorrent.bdecode(TORRENT_WITH_DIRS_CONTENT))
         self.download_manager.get_download = Mock(return_value=download)
         request = MockRequest(f"/api/downloads/{'01' * 20}/torrent", "GET", {}, {"infohash": "01" * 20})
 


### PR DESCRIPTION
Fixes #8729

This PR:

 - Fixes `Download.get_torrent_data()` crashing on pure v2 torrents.
 - Updates `Download.get_torrent_data()` to add trackers to the generated torrent file.


