### PR TITLE
Don't produce 'unexpected crash' on a broken torrent

### DIFF
--- a/src/tribler/core/libtorrent/restapi/torrentinfo_endpoint.py
+++ b/src/tribler/core/libtorrent/restapi/torrentinfo_endpoint.py
@@ -322,7 +322,13 @@ class TorrentInfoEndpoint(RESTEndpoint):
         """
         Return metainfo from a torrent found at a provided .torrent file.
         """
-        tdef = TorrentDef.load_from_memory(await request.read())
+        try:
+            tdef = TorrentDef.load_from_memory(await request.read())
+        except ValueError:
+            return RESTResponse({"error": {
+                "handled": True,
+                "message": "metainfo error"
+            }}, status=HTTP_INTERNAL_SERVER_ERROR)
         infohash = tdef.infohash
 
         # Check if the torrent is already in the downloads


### PR DESCRIPTION
Fixes #8813

This PR:

 - Updates `TorrentInfoEndpoint.get_torrent_info_from_file` to be consistent with `TorrentInfoEndpoint.get_torrent_info` and return handled errors instead of unhandled errors when given invalid torrent input.