### PR TITLE
Added Tribler version to default error reports

### DIFF
--- a/src/tribler/core/notifier.py
+++ b/src/tribler/core/notifier.py
@@ -39,7 +39,7 @@ class Notification(Enum):
                                   ["infohash", "num_seeders", "num_leechers", "last_tracker_check", "health"],
                                   [str, int, int, int, str])
     low_space = Desc("low_space", ["disk_usage_data"], [dict])
-    events_start = Desc("events_start", ["public_key", "version"], [str, str])
+    events_start = Desc("events_start", ["public_key", "version", "sessions"], [str, str, str])
     tribler_exception = Desc("tribler_exception", ["error"], [dict])
     content_discovery_community_unknown_torrent_added = Desc("content_discovery_community_unknown_torrent_added",
                                                              [], [])

--- a/src/tribler/ui/src/App.tsx
+++ b/src/tribler/ui/src/App.tsx
@@ -3,6 +3,7 @@ import {ThemeProvider} from "./contexts/ThemeContext";
 import {router} from "./Router";
 import {Button} from "@/components/ui/button";
 import {useTranslation} from "react-i18next";
+import {triblerService} from "@/services/tribler.service";
 
 import "./i18n";
 
@@ -17,8 +18,8 @@ function collapseError() {
 function reportError() {
     const error_popup_text = document.querySelector("#error_popup_text");
     if (error_popup_text) {
-        const err_text =
-            "Hi! I was using Tribler and THIS happened! :cry:\r\n```\r\n" + error_popup_text.textContent + "\r\n```";
+        const err_text = "Hi! I was using Tribler " + (triblerService.version || "uninitialized") +
+                         " and THIS happened! :cry:\r\n```\r\n" + error_popup_text.textContent + "\r\n```";
         const url = encodeURI("https://github.com/Tribler/tribler/issues/new?body=" + err_text);
         window.open(url, "_blank")?.focus();
     }

--- a/src/tribler/ui/src/services/tribler.service.ts
+++ b/src/tribler/ui/src/services/tribler.service.ts
@@ -22,6 +22,7 @@ export class TriblerService {
     private events: EventSource;
     // Store a cached version of the GuiSettings to prevent from having to call the server every time we need them.
     public guiSettings: GuiSettings = {};
+    public version: string | undefined;
 
     constructor() {
         this.http = axios.create({
@@ -30,6 +31,7 @@ export class TriblerService {
         });
         this.events = new EventSource(this.baseURL + "/events", {withCredentials: true});
         this.addEventListener("tribler_exception", OnError);
+        this.addEventListener("events_start", (event) => this.version = JSON.parse(event.data).version);
         // Gets the GuiSettings
         this.getSettings();
     }


### PR DESCRIPTION
This PR:

 - Adds the Tribler version to the default error report text.
 - Fixes the `Notification.events_start` description to include the `version` key.
