### PR TITLE
Miscellaneous GUI warning fixes

### DIFF
--- a/src/tribler/ui/src/components/add-torrent.tsx
+++ b/src/tribler/ui/src/components/add-torrent.tsx
@@ -10,7 +10,7 @@ import {
     DropdownMenuSeparator,
     DropdownMenuTrigger,
 } from "./ui/dropdown-menu";
-import {Dialog, DialogClose, DialogContent, DialogFooter, DialogHeader, DialogTitle} from "./ui/dialog";
+import {Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle} from "./ui/dialog";
 import {triblerService} from "@/services/tribler.service";
 import {isErrorDict} from "@/services/reporting";
 import {Input} from "./ui/input";
@@ -110,6 +110,7 @@ export function AddTorrent() {
                 <DialogContent>
                     <DialogHeader>
                         <DialogTitle>{t("MagnetDialogHeader")}</DialogTitle>
+                        <DialogDescription></DialogDescription>
                     </DialogHeader>
                     <div className="grid gap-1 py-4 text-sm">
                         {t("MagnetDialogInputLabel")}

--- a/src/tribler/ui/src/components/layouts/Header.tsx
+++ b/src/tribler/ui/src/components/layouts/Header.tsx
@@ -107,14 +107,16 @@ export function Header() {
                             </DialogDescription>
                         ) : (
                             <ScrollArea className="max-h-[380px]">
-                                <DialogDescription className="text-xs font-mono">
-                                    {shutdownLogs.map((log) => (
-                                        <p>
-                                            {log}
-                                            <br />
-                                        </p>
-                                    ))}
-                                    <div ref={logsEndRef} />
+                                <DialogDescription asChild={true} className="text-xs font-mono">
+                                    <div>
+                                        {shutdownLogs.map((log, idx) => (
+                                            <div key={`shutdown-log-line-${idx}`}>
+                                                {log}
+                                                <br />
+                                            </div>
+                                        ))}
+                                        <div ref={logsEndRef} />
+                                    </div>
                                 </DialogDescription>
                             </ScrollArea>
                         )}

--- a/src/tribler/ui/src/dialogs/SaveAs.tsx
+++ b/src/tribler/ui/src/dialogs/SaveAs.tsx
@@ -355,7 +355,7 @@ export default function SaveAs(props: SaveAsProps & JSX.IntrinsicAttributes & Di
 
                 <div className="flex items-center space-x-2 mt-5">
                     <Checkbox
-                        checked={params.auto_managed}
+                        checked={params.auto_managed || false}
                         id="auto_managed"
                         onCheckedChange={(value) => setParams({...params, auto_managed: !!value})}
                     />

--- a/src/tribler/ui/src/pages/Settings/General.tsx
+++ b/src/tribler/ui/src/pages/Settings/General.tsx
@@ -454,7 +454,7 @@ export default function General() {
                     type="color"
                     id="tray_color"
                     name="tray_color"
-                    value={settings?.tray_icon_color}
+                    value={settings?.tray_icon_color || "#E82901"}
                     hidden={settings?.tray_icon_color === undefined || settings?.tray_icon_color == ""}
                     disabled={settings?.tray_icon_color === undefined || settings?.tray_icon_color == ""}
                     onChange={(evt) => {


### PR DESCRIPTION
This PR:

 - Fixes some minor warnings in the GUI.

AFAIK, there is one warning remaining, on the `Tunnels` / `Circuits` page:

```
The width(0) and height(0) of chart should be greater than 0,
       please check the style of container, or the props width(95%) and height(95%),
       or add a minWidth(0) or minHeight(undefined) or use aspect(undefined) to control the
       height and width.
```

I have no idea how to fix this.