### PR TITLE
Automatically create a Docker build after a new release

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -1,6 +1,9 @@
 name: Publish Docker Image
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+  release:
+    types: [created]
 env:
   REF_NAME: ${{ github.ref_name }}
 


### PR DESCRIPTION
This PR:

 - Updates the Docker build Action to automatically run after a new release is created.

This PR is in response to me discovering that I forgot to manually trigger a Docker build in between Tribler versions 8.1.3 and 8.3.1. Now, it will be impossible to forget about this because we won't need to remember 🙂 