### PR TITLE
Add metadata dict to ProcessingResult

### DIFF
--- a/src/tribler/core/content_discovery/community.py
+++ b/src/tribler/core/content_discovery/community.py
@@ -256,11 +256,8 @@ class ContentDiscoveryCommunity(Community):
         request_uuid = uuid.uuid4()
 
         def notify_gui(request: SelectRequest, processing_results: list[ProcessingResult]) -> None:
-            results = [
-                r.md_obj.to_simple_dict()
-                for r in processing_results
-                if r.obj_state == ObjState.NEW_OBJECT
-            ]
+            results = [r.data for r in processing_results if r.obj_state == ObjState.NEW_OBJECT]
+
             if self.composition.notifier:
                 self.composition.notifier.notify(Notification.remote_query_results,
                                                  query=kwargs.get("txt_filter"),

--- a/src/tribler/core/database/orm_bindings/torrent_metadata.py
+++ b/src/tribler/core/database/orm_bindings/torrent_metadata.py
@@ -239,7 +239,6 @@ def define_binding(db: Database, notifier: Notifier | None,  # noqa: C901
             if "health" not in kwargs and "infohash" in kwargs:
                 infohash = kwargs["infohash"]
                 health = db.TorrentState.get_for_update(infohash=infohash) or db.TorrentState(infohash=infohash)
-                health.trackers.load()
                 kwargs["health"] = health
 
             if "timestamp" not in kwargs:

--- a/src/tribler/core/database/store.py
+++ b/src/tribler/core/database/store.py
@@ -7,7 +7,7 @@ import re
 import sqlite3
 import threading
 from asyncio import get_running_loop
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 from os.path import getsize
 from pathlib import Path
@@ -61,14 +61,13 @@ class ObjState(enum.Enum):
 class ProcessingResult:
     """
     This class is used to return results of processing of a payload by process_payload.
-    It includes the ORM object created as a result of processing, the state of the object
-    as indicated by ObjState enum, and missing dependencies list that includes a list of query
-    arguments for get_entries to query the sender back through Remote Query Community.
+    It includes a dictionary of the metadata (data), the database rowid, and the
+    state of the object as indicated by the ObjState enum.
     """
 
-    md_obj: TorrentMetadata
-    obj_state: object
-    missing_deps: list = field(default_factory=list)
+    data: dict[str, Any]
+    obj_state: ObjState
+    rowid: list[int]
 
 
 BETA_DB_VERSIONS = [0, 1, 2, 3, 4, 5]
@@ -511,16 +510,24 @@ class MetadataStore:
         # Process unsigned torrents
         if payload.public_key == NULL_KEY:
             node = self.TorrentMetadata.add_ffa_from_dict(payload.to_dict())
-            return [ProcessingResult(md_obj=node, obj_state=ObjState.NEW_OBJECT)] if node else []
+            if node:
+                return [ProcessingResult(data=node.to_simple_dict(),
+                                         obj_state=ObjState.NEW_OBJECT,
+                                         rowid=node.rowid)]
+            return []
 
         # Do we already know about this object? In that case, we keep the first one (i.e., no versioning).
         node = self.TorrentMetadata.get_for_update(public_key=payload.public_key, id_=payload.id_)
         if node:
-            return [ProcessingResult(md_obj=node, obj_state=ObjState.DUPLICATE_OBJECT)]
+            return [ProcessingResult(data=node.to_simple_dict(),
+                                     obj_state=ObjState.DUPLICATE_OBJECT,
+                                     rowid=node.rowid)]
 
         # Process signed torrents
         obj = self.TorrentMetadata.from_payload(payload)
-        return [ProcessingResult(md_obj=obj, obj_state=ObjState.NEW_OBJECT)]
+        return [ProcessingResult(data=obj.to_simple_dict(),
+                                 obj_state=ObjState.NEW_OBJECT,
+                                 rowid=obj.rowid)]
 
     @db_session
     def get_num_torrents(self) -> int:

--- a/src/tribler/test_unit/core/database/test_store.py
+++ b/src/tribler/test_unit/core/database/test_store.py
@@ -52,13 +52,13 @@ class TestMetadataStore(TestBase[MockCommunity]):
             for i in range(10)
         ]
         chunk, _ = entries_to_chunk(md_list, chunk_size=999999999999999)
-        signatures = [d.signature for d in md_list]
+        titles = [d.title for d in md_list]
         for d in md_list:
             d.delete()
 
         uncompressed = self.metadata_store.process_compressed_mdblob(chunk, skip_personal_metadata_payload=False)
 
-        self.assertEqual(signatures, [d.md_obj.signature for d in uncompressed])
+        self.assertEqual(titles, [d.data["name"] for d in uncompressed])
 
     @db_session
     def test_squash_mdblobs_multiple_chunks(self) -> None:
@@ -76,15 +76,15 @@ class TestMetadataStore(TestBase[MockCommunity]):
         # Test splitting into multiple chunks
         chunks1, index = entries_to_chunk(md_list, chunk_size=1)
         chunks2, _ = entries_to_chunk(md_list, chunk_size=999999999999999, start_index=index)
-        signatures = [d.signature for d in md_list]
+        titles = [d.title for d in md_list]
         for d in md_list:
             d.delete()
 
         uncompressed1 = self.metadata_store.process_compressed_mdblob(chunks1, skip_personal_metadata_payload=False)
         uncompressed2 = self.metadata_store.process_compressed_mdblob(chunks2, skip_personal_metadata_payload=False)
 
-        self.assertEqual(signatures[:index], [d.md_obj.signature for d in uncompressed1])
-        self.assertEqual(signatures[index:], [d.md_obj.signature for d in uncompressed2])
+        self.assertEqual(titles[:index], [d.data["name"] for d in uncompressed1])
+        self.assertEqual(titles[index:], [d.data["name"] for d in uncompressed2])
 
     @db_session
     def test_process_invalid_compressed_mdblob(self) -> None:
@@ -129,7 +129,7 @@ class TestMetadataStore(TestBase[MockCommunity]):
         # Check if node metadata object is properly created on payload processing
         result, = self.metadata_store.process_payload(payload)
         self.assertEqual(ObjState.NEW_OBJECT, result.obj_state)
-        self.assertEqual(payload.metadata_type, result.md_obj.to_dict()["metadata_type"])
+        self.assertEqual(md.title, result.data["name"])
 
         # Check that we flag this as duplicate in case we already know about the local node
         result, = self.metadata_store.process_payload(payload)


### PR DESCRIPTION
Fixes https://github.com/Tribler/tribler/issues/8919.

This PR:
* Refactors `process_payload` such that entities are directly converted to dictionaries in the current `db_session`. This should make the process faster and avoids prefetching or "session is over" issues.
* Adds `ProcessingResult.rowid` in case we need the database `Entity` at a later time.
* Removes database logic from the `notify_gui` callback.