### PR TITLE
Fixed Info.plist not shipping for Mac builds

### DIFF
--- a/build/win/build.py
+++ b/build/win/build.py
@@ -88,7 +88,8 @@ def get_freeze_build_options():
             'build_exe': 'dist/tribler'
         },
         "bdist_mac": {
-            "bundle_name": os.getenv("APPNAME")
+            "bundle_name": os.getenv("APPNAME"),
+            "custom_info_plist": "build/mac/resources/Info.plist"
         }
     }
     if platform.system() == 'Linux':


### PR DESCRIPTION
Fixes #8929

This PR:

 - Fixes the `Info.plist` not shipping on Mac (instead, it ships the default plist).
 
I made a test build to verify the fix: https://github.com/qstokkink/tribler/actions/runs/23235256616
