### PR TITLE
Ignore FromPlatformFlagConstDisallowed for aarch64 build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,6 +159,7 @@ jobs:
             --volume "${PWD}:/tribler"
           env: |
             GITHUB_TAG: ${{ env.GITHUB_TAG }}
+            BUILDKIT_DOCKERFILE_CHECK: skip=FromPlatformFlagConstDisallowed
           shell: /bin/sh
           install: |
             apt-get update -q -y


### PR DESCRIPTION
This PR:

 - Fixes the aarch64 build failure, due to `run-on-arch-action`'s [Dockerfile](https://github.com/uraimo/run-on-arch-action/blob/master/Dockerfiles/Dockerfile.aarch64.ubuntu22.04) `--platform` syntax.

Successful build using this code here: https://github.com/qstokkink/tribler/actions/runs/23240611663