### PR TITLE
Allow empty state directory in win installer

### DIFF
--- a/build/win/resources/tribler.nsi
+++ b/build/win/resources/tribler.nsi
@@ -77,6 +77,7 @@ BrandingText "${PRODUCT}"
 !define MUI_PAGE_HEADER_SUBTEXT "(optional)"
 !define MUI_DIRECTORYPAGE_TEXT_TOP "Specify a custom directory to store database and configuration files."
 !define MUI_DIRECTORYPAGE_TEXT_DESTINATION "$TSTATEDIR"
+!define MUI_DIRECTORYPAGE_VERIFYONLEAVE
 !define MUI_DIRECTORYPAGE_VARIABLE $TSTATEDIR
 SpaceTexts none
 !insertmacro MUI_PAGE_DIRECTORY


### PR DESCRIPTION
Fixes #8936

This PR:

 - Fixes the optional state dir in the Windows installer not being optional.
 
Test build here: https://github.com/qstokkink/tribler/actions/runs/23246692147

