### PR TITLE
Fixed recursion error in SimpleTable TableCell className

### DIFF
--- a/src/tribler/ui/src/components/ui/simple-table.tsx
+++ b/src/tribler/ui/src/components/ui/simple-table.tsx
@@ -611,12 +611,12 @@ function SimpleTable<T extends object>({
                                                 onRowDoubleClick(row.original);
                                             }
                                         }}>
-                                        {row.getVisibleCells().map((cell, colIndex) => (
+                                        {row.getVisibleCells().map((cell, colIndex, arr) => (
                                             <TableCell
                                                 key={cell.id}
                                                 className={cn({
                                                     "pl-4": colIndex === 0,
-                                                    "pr-4": colIndex + 1 === row.getVisibleCells().length,
+                                                    "pr-4": colIndex + 1 === arr.length,
                                                 })}>
                                                 {flexRender(cell.column.columnDef.cell, cell.getContext())}
                                             </TableCell>


### PR DESCRIPTION
Fixes #8944

This PR:

 - Fixes the `too much recursion` error in the `TableCell`, assumed to be caused by the `row.getVisibleCells()` inside.
