### PR TITLE
Fixed docker concurrency

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -7,6 +7,10 @@ on:
 env:
   REF_NAME: ${{ github.ref_name }}
 
+concurrency:
+  group: docker-publish-group
+  cancel-in-progress: true
+
 jobs:
   build-and-push-image-ghcr:
     runs-on: ubuntu-latest
@@ -45,7 +49,15 @@ jobs:
           echo "TAG2=${COMMIT,,}" >> $GITHUB_ENV
           echo "TAG3=${VERSION,,}" >> $GITHUB_ENV
 
+      - uses: tyriis/docker-image-tag-exists@v2.1.0
+        id: build_exists
+        with:
+          registry: ghcr.io
+          repository: tribler/tribler
+          tag: ${{ github.ref_name }}
+
       - name: Build and push Docker image
+        if: ${{ steps.build_exists.outputs.tag == "not found" }}
         id: push
         uses: docker/build-push-action@v7
         with:
@@ -61,6 +73,7 @@ jobs:
             GIT_REPO=https://github.com/${{ github.repository }}
 
       - name: Generate artifact attestation
+        if: ${{ steps.build_exists.outputs.tag == "not found" }}
         uses: actions/attest-build-provenance@v4
         with:
           subject-name: ghcr.io/tribler/tribler
@@ -103,7 +116,15 @@ jobs:
           echo "TAG2=${COMMIT,,}" >> $GITHUB_ENV
           echo "TAG3=${VERSION,,}" >> $GITHUB_ENV
 
+      - uses: tyriis/docker-image-tag-exists@v2.1.0
+        id: build_exists
+        with:
+          registry: docker.io
+          repository: tribler/tribler
+          tag: ${{ github.ref_name }}
+
       - name: Build and push Docker image
+        if: ${{ steps.build_exists.outputs.tag == "not found" }}
         id: push
         uses: docker/build-push-action@v7
         with:
@@ -119,6 +140,7 @@ jobs:
             GIT_REPO=https://github.com/${{ github.repository }}
 
       - name: Generate artifact attestation
+        if: ${{ steps.build_exists.outputs.tag == "not found" }}
         uses: actions/attest-build-provenance@v4
         with:
           subject-name: index.docker.io/tribler/tribler

--- a/build/docker/build.Dockerfile
+++ b/build/docker/build.Dockerfile
@@ -25,6 +25,8 @@ RUN mkdir -p /home/ubuntu/custombin \
   && echo 'gdbus call --session --dest=org.freedesktop.portal.Desktop --object-path=/org/freedesktop/portal/desktop --method=org.freedesktop.portal.OpenURI.OpenURI "" "$1" "{}"' >> /home/ubuntu/custombin/x-www-browser \
   && chmod 777 /home/ubuntu/custombin/x-www-browser
 
+USER ubuntu
+
 # This is supposed to give icons on Xorg systems, but it doesn't seem to always work.
 ENV TMPDIR="/hosttmp/"
 


### PR DESCRIPTION
Fixes #8963
Fixes #8953

This PR:

 - Adds an explicit `USER ubuntu` to the Dockerfile.
 - Fixes a new release trying to publish 5 new Docker images.