### PR TITLE
Build fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -188,6 +188,8 @@ jobs:
       - name: Build Executables (MacOS)
         if: startsWith(matrix.os, 'macos-15')
         run: |
+          brew install libsodium
+          find "$(brew --cellar)/libsodium/" -name "libsodium.dylib" -exec cp {} /Library/Frameworks/Python.framework/Versions/3.12/lib/ \;
           ./build/mac/makedist_macos.sh
 
       - name: Fetch libsodium.dll (Windows)

--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -57,7 +57,7 @@ jobs:
           tag: ${{ github.ref_name }}
 
       - name: Build and push Docker image
-        if: ${{ steps.build_exists.outputs.tag == "not found" }}
+        if: ${{ steps.build_exists.outputs.tag == 'not found' }}
         id: push
         uses: docker/build-push-action@v7
         with:
@@ -73,7 +73,7 @@ jobs:
             GIT_REPO=https://github.com/${{ github.repository }}
 
       - name: Generate artifact attestation
-        if: ${{ steps.build_exists.outputs.tag == "not found" }}
+        if: ${{ steps.build_exists.outputs.tag == 'not found' }}
         uses: actions/attest-build-provenance@v4
         with:
           subject-name: ghcr.io/tribler/tribler
@@ -124,7 +124,7 @@ jobs:
           tag: ${{ github.ref_name }}
 
       - name: Build and push Docker image
-        if: ${{ steps.build_exists.outputs.tag == "not found" }}
+        if: ${{ steps.build_exists.outputs.tag == 'not found' }}
         id: push
         uses: docker/build-push-action@v7
         with:
@@ -140,7 +140,7 @@ jobs:
             GIT_REPO=https://github.com/${{ github.repository }}
 
       - name: Generate artifact attestation
-        if: ${{ steps.build_exists.outputs.tag == "not found" }}
+        if: ${{ steps.build_exists.outputs.tag == 'not found' }}
         uses: actions/attest-build-provenance@v4
         with:
           subject-name: index.docker.io/tribler/tribler

--- a/build/win/build.py
+++ b/build/win/build.py
@@ -64,6 +64,10 @@ def get_freeze_build_options():
         ("tribler.dist-info/METADATA", "lib/tribler.dist-info/METADATA"),
     ]
 
+    if platform.system() == "Darwin":
+        import libnacl
+        included_files.append((libnacl.nacl._name, "lib/libsodium.dylib"))
+
     # These packages will be excluded from the build
     excluded_packages = [
         'wx',

--- a/build/win/build.py
+++ b/build/win/build.py
@@ -89,7 +89,11 @@ def get_freeze_build_options():
         },
         "bdist_mac": {
             "bundle_name": os.getenv("APPNAME"),
-            "custom_info_plist": "build/mac/resources/Info.plist"
+            "custom_info_plist": "build/mac/resources/Info.plist",
+            "plist_items": [
+                ("CFBundleVersion", os.getenv("GITHUB_TAG")),
+                ("CFBundleShortVersionString", os.getenv("GITHUB_TAG"))
+            ]
         }
     }
     if platform.system() == 'Linux':


### PR DESCRIPTION
Fixes #8954
Fixes #8962

This PR:

 - Adds `libsodium.dylib` to the Mac build.
 - Fixes the Mac build version being set to `__VERSION__`.
 - Fixes double quotes in `build_docker.yml` instead of single quotes.
