### PR TITLE
Added Alpine x86_64 apk build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,8 @@ jobs:
             architecture: x64
           - os: ubuntu-latest
             architecture: aarch64
+          - os: ubuntu-latest
+            architecture: x64
           - os: windows-latest
             architecture: x64
     runs-on: ${{ matrix.os }}
@@ -147,6 +149,41 @@ jobs:
           
           mv tribler_${GITHUB_TAG}_all.deb tribler_${GITHUB_TAG}_${{ matrix.architecture }}.deb
 
+      - name: Setup latest Alpine Linux (Alpine musl x86_64)
+        if: matrix.os == 'ubuntu-latest' && matrix.architecture == 'x64'
+        uses: jirutka/setup-alpine@v1
+        id: alpine-target
+        with:
+          shell-name: alpine-x86_64.sh
+          arch: x86_64
+          branch: v3.23
+          packages: python3-dev py-pip py3-gobject3 py3-lz4 build-base libsodium abuild doas sudo shadow-login
+
+      - name: Build musl Executables (Alpine musl x86_64)
+        if: matrix.os == 'ubuntu-latest' && matrix.architecture == 'x64'
+        env:
+          GITHUB_BUILD_NUMBER: ${{ github.run_number }}
+        shell: alpine-x86_64.sh {0}
+        run: |
+          python3 -m venv ./.venv --system-site-packages
+          . ./.venv/bin/activate 
+          python3 -m pip install -r build/requirements.txt
+          python3 build/setup.py build > /dev/null 2>&1
+          
+          cd build/alpine
+          ./build.sh
+          
+          cp /home/runner/packages/build/x86_64/tribler-*.apk .
+      - name: Move musl artifact (Alpine musl x86_64)
+        if: matrix.os == 'ubuntu-latest' && matrix.architecture == 'x64'
+        run: |
+          mkdir -p dist
+          mv ${{ steps.alpine-target.outputs.root-path }}/home/runner/work/tribler/tribler/build/alpine/tribler-*.apk ./dist/
+          cd dist
+          for x in *.apk; do
+            mv -- "$x" "${x%.apk}.x86_64.apk"
+          done
+
       - name: Build Executables (Ubuntu aarch64)
         if: matrix.os == 'ubuntu-latest' && matrix.architecture == 'aarch64'
         uses: uraimo/run-on-arch-action@v3
@@ -221,3 +258,4 @@ jobs:
             dist/*.exe
             dist/*.dmg
             build/debian/*.deb
+            dist/*.apk

--- a/build/alpine/APKBUILD
+++ b/build/alpine/APKBUILD
@@ -1,0 +1,23 @@
+pkgname=tribler
+pkgdesc="Privacy enhanced BitTorrent client with P2P content discovery "
+url="https://tribler.org/"
+arch="x86_64"
+license="GPL-3"
+depends="libsodium"
+makedepends=""
+checkdepends=""
+subpackages=""
+source="tribler.tar.gz"
+builddir=""
+options="!tracedeps"
+install="$pkgname.post-install $pkgname.post-deinstall"
+
+
+package() {
+	mkdir -p "$pkgdir/usr/share/tribler"
+	cp -r "$srcdir/tribler" "$pkgdir/usr/share/"
+}
+
+check() {
+    :
+}

--- a/build/alpine/build.sh
+++ b/build/alpine/build.sh
@@ -1,0 +1,12 @@
+cd ../../dist/
+tar czf tribler.tar.gz tribler
+cd ../build/alpine
+mv ../../dist/tribler.tar.gz tribler.tar.gz
+echo "pkgver=${GITHUB_TAG}" >> APKBUILD
+echo "pkgrel=${GITHUB_BUILD_NUMBER}" >> APKBUILD
+echo "sha512sums=\"$(sha512sum tribler.tar.gz)\"" >> APKBUILD
+sudo addgroup runner abuild
+abuild-keygen -a -i -n
+mkdir -p packages
+export REPODEST packages
+sg abuild -c "abuild -r"

--- a/build/alpine/tribler.post-deinstall
+++ b/build/alpine/tribler.post-deinstall
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+rm /usr/bin/tribler

--- a/build/alpine/tribler.post-install
+++ b/build/alpine/tribler.post-install
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+ln -s /usr/share/tribler/tribler /usr/bin/tribler


### PR DESCRIPTION
Fixes #8388

This PR:

 - Adds a musl x86_64 apk build for Alpine.

Build https://github.com/qstokkink/tribler/actions/runs/24558766369 tested to work on Alpine x86_64 3.23.3.