### PR TITLE
Added logs search field

### DIFF
--- a/src/tribler/ui/src/pages/Debug/General/index.tsx
+++ b/src/tribler/ui/src/pages/Debug/General/index.tsx
@@ -24,6 +24,7 @@ const generalColumns: ColumnDef<KeyValue>[] = [
 export default function General() {
     const [stats, setStats] = useState<KeyValue[]>([]);
     const [logs, setLogs] = useState<string>("");
+    const [logSearch, setLogSearch] = useState<string>("");
 
     // The following three definitions are for the fancy scrolling-when-at-the-bottom effect of the logs
     const [shouldScrollDown, setShouldScrollDown] = useState<boolean>(true);
@@ -79,16 +80,25 @@ export default function General() {
     return (
         <div className="w-full h-full flex flex-col">
             <SimpleTable data={stats} columns={generalColumns} />
-            <div className="flex-none bg-neutral-100 dark:bg-neutral-900 text-muted-foreground border-y pl-3 py-2 text-sm font-medium flex items-center">
-                Logs
-                <Button variant="ghost" className="h-4 w-4 ml-2 p-0" onClick={() => setPauseLogs((pl) => !pl)}>
+            <div className="flex-none bg-neutral-100 dark:bg-neutral-900 border-y pl-3 py-2 text-sm font-medium flex items-center">
+                <span className="text-muted-foreground flex-none">Logs</span>
+                <Button variant="ghost" className="h-4 w-4 ml-2 p-0 text-muted-foreground flex-none" onClick={() => setPauseLogs((pl) => !pl)}>
                     {pauseLogs ? <Play className="h-4 w-4" /> : <Pause className="h-4 w-4" />}
                 </Button>
+                <div className="flex-grow"></div>
+                <input type="text" className="flex-none bg-background mr-2 border" placeholder="&#128269;" value={logSearch} onChange={(event) => {setLogSearch(event.target.value);}} />
             </div>
             <ScrollArea
                 className="whitespace-pre-wrap break-all overflow-x-auto text-xs pl-3 h-96 flex-grow overflow-scroll overflow-hidden scroll-smooth"
                 ref={logContainerRef}>
-                {logs}
+                {
+                    (logSearch === "" || !logs.includes(logSearch)) ?
+                        logs :
+                    (logs.split(logSearch).map((part, i, parts) => {
+                        if (i == parts.length - 1) return (<>{part}</>);
+                        return (<>{part}<mark>{logSearch}</mark></>);
+                    }))
+                }
             </ScrollArea>
         </div>
     );


### PR DESCRIPTION
Fixes #8478 (last remaining in issue)

This PR:

 - Adds a search/highlight field to the logs page.
 
<img width="2554" height="1355" alt="image" src="https://github.com/user-attachments/assets/2118b8f2-d1b8-43bd-8712-423e5cc7b672" />
