### PR TITLE
Remove deprecated BEP-0017 create torrent field

### DIFF
--- a/.github/workflows/pr-comment-validate.yml
+++ b/.github/workflows/pr-comment-validate.yml
@@ -34,7 +34,6 @@ jobs:
         run: |
           cp /opt/homebrew/opt/libsodium/lib/libsodium.dylib /Library/Frameworks/Python.framework/Versions/3.12/lib/libsodium.dylib
       - run: python -m pip install -r requirements.txt
-        if: matrix.os == 'windows-latest'
       - run: |
           cd src
           python run_unit_tests.py -a

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 -r pyipv8/requirements.txt
 
+cryptography==46.0.7  # FIXME: Workaround for deprecated curves!
 ipv8-rust-tunnels
 lz4
 pillow

--- a/src/tribler/core/libtorrent/restapi/create_torrent_endpoint.py
+++ b/src/tribler/core/libtorrent/restapi/create_torrent_endpoint.py
@@ -128,7 +128,6 @@ class CreateTorrentEndpoint(RESTEndpoint):
                 tracker_url_list or None,
                 parameters.get("description"),
                 f"Tribler version: {v}",
-                None,
                 initial_nodes,
                 0,
                 None,

--- a/src/tribler/core/libtorrent/torrents.py
+++ b/src/tribler/core/libtorrent/torrents.py
@@ -178,7 +178,6 @@ def create_torrent_file(export_dir: str,  # noqa: C901,PLR0912,PLR0913
                         announce_list: list[str] | None = None,
                         comment: str | None = None,
                         created_by: str | None = None,
-                        http_seeds: list[str] | None = None,
                         nodes: list[tuple[str, int]] | None = None,
                         piece_size: int = 0,
                         url_list: list[str] | None = None,
@@ -230,12 +229,6 @@ def create_torrent_file(export_dir: str,  # noqa: C901,PLR0912,PLR0913
     if nodes is not None:
         for node in nodes:
             torrent.add_node(*node)
-    # HTTP seeding
-    # http://www.bittorrent.org/beps/bep_0017.html
-    # >> BROKEN in libtorrent=2.1.0-rc1
-    #if http_seeds is not None:
-    #    for http_seed in http_seeds:
-    #        torrent.add_http_seed(http_seed)
 
     # Web seeding
     # http://www.bittorrent.org/beps/bep_0019.html
@@ -249,8 +242,6 @@ def create_torrent_file(export_dir: str,  # noqa: C901,PLR0912,PLR0913
     t1 = torrent.generate()
     torrent_bytes = lt.bencode(t1)
     atp = lt.load_torrent_buffer(torrent_bytes)
-    if http_seeds is not None:  # >> [BROKEN in libtorrent=2.1.0-rc1] workaround
-        atp.http_seeds = http_seeds
 
     return {
         "success": True,

--- a/src/tribler/test_unit/core/libtorrent/restapi/test_create_torrent_endpoint.py
+++ b/src/tribler/test_unit/core/libtorrent/restapi/test_create_torrent_endpoint.py
@@ -113,8 +113,7 @@ class TestCreateTorrentEndpoint(TestBase):
         self.assertEqual(200, response.status)
         self.assertEqual(TORRENT_WITH_DIRS_CONTENT, base64.b64decode(response_body_json["torrent"]))
         self.assertIsNone(call_args[8])
-        self.assertIsNone(call_args[9])
-        self.assertEqual(0, call_args[10])
+        self.assertEqual(0, call_args[9])
 
     @patch(*PATCH_DEFAULT_SPEC)
     async def test_create_with_comment(self) -> None:

--- a/src/tribler/test_unit/core/libtorrent/test_torrents.py
+++ b/src/tribler/test_unit/core/libtorrent/test_torrents.py
@@ -240,15 +240,6 @@ class TestTorrents(TestBase):
 
         self.assertEqual(node_list, result["atp"].dht_nodes)
 
-    def test_create_torrent_file_with_http_seed(self) -> None:
-        """
-        Test if torrents can be created with a specified http seed.
-        """
-        result = create_torrent_file(str(Path(__file__).parent), [Path(__file__).absolute()],
-                                     http_seeds=["http://127.0.0.1/file"])
-
-        self.assertEqual("http://127.0.0.1/file", result["atp"].http_seeds[0])
-
     def test_create_torrent_file_with_url_list(self) -> None:
         """
         Test if torrents can be created with a specified url list.


### PR DESCRIPTION
This PR:

 - Removes BEP-0017 functionality from our create torrent logic.

I asked why this functionality was broken and the answer was that this has been deprecated for many years.

---

I ran into two issues:

```python
File "tribler\pyipv8\ipv8\keyvault\private\m2crypto.py", line 35, in __init__
    super().__init__(ec_pub=ec.generate_private_key(curve))
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cryptography.exceptions.UnsupportedAlgorithm: Curve sect233k1 is not supported
```

To temporarily fix this, I pinned the cryptography version. However, then I figured out that the requirements installation for validation doesn't properly install the dependencies.