### PR TITLE
Switched libtorrent to stable 2.0.13 tag

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ pillow
 pony
 pystray
 pywin32;sys_platform=="win32"
+libtorrent==2.0.13
 
---extra-index-url https://tribler.github.io/pypi/simple/
-libtorrent==2.1.0
+aiohttp==3.13.5

--- a/src/tribler/core/libtorrent/download_manager/download_manager.py
+++ b/src/tribler/core/libtorrent/download_manager/download_manager.py
@@ -367,9 +367,9 @@ class DownloadManager(TaskManager):
         else:
             self.set_proxy_settings(ltsession, SOCKS5_PROXY_DEF, ("127.0.0.1", self.socks_listen_ports[hops - 1]))
 
-        ltsession.add_extension(lt.create_ut_metadata_plugin)
-        ltsession.add_extension(lt.create_ut_pex_plugin)
-        ltsession.add_extension(lt.create_smart_ban_plugin)
+        ltsession.add_extension("ut_metadata")
+        ltsession.add_extension("ut_pex")
+        ltsession.add_extension("smart_ban")
 
         # Set listen port & start the DHT
         if hops == 0:

--- a/src/tribler/core/libtorrent/torrentdef.py
+++ b/src/tribler/core/libtorrent/torrentdef.py
@@ -6,6 +6,7 @@ from hashlib import sha256
 from typing import TYPE_CHECKING
 
 import libtorrent as lt
+from packaging.version import Version
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -58,7 +59,9 @@ class TorrentDef:
         """
         Get the description of this torrent.
         """
-        return self.atp.comment
+        if Version(lt.__version__) < Version("2.1"):
+            return self.torrent_info.comment() if self.torrent_info else ""
+        return self.atp.comment  # type: ignore[attr-defined]
 
     @property
     def torrent_info(self) -> lt.torrent_info | None:

--- a/src/tribler/test_unit/core/libtorrent/test_torrents.py
+++ b/src/tribler/test_unit/core/libtorrent/test_torrents.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock
 
 import libtorrent
 from ipv8.test.base import TestBase
+from packaging.version import Version
 
 from tribler.core.libtorrent.download_manager.download import Download
 from tribler.core.libtorrent.download_manager.download_config import DownloadConfig
@@ -200,7 +201,10 @@ class TestTorrents(TestBase):
         """
         result = create_torrent_file(str(Path(__file__).parent), [Path(__file__).absolute()], comment="test")
 
-        self.assertEqual("test", result["atp"].comment)
+        if Version(libtorrent.__version__) < Version("2.1"):
+            self.assertEqual("test", result["atp"].ti.comment())
+        else:
+            self.assertEqual("test", result["atp"].comment)
 
     def test_create_torrent_file_with_created_by(self) -> None:
         """
@@ -208,7 +212,10 @@ class TestTorrents(TestBase):
         """
         result = create_torrent_file(str(Path(__file__).parent), [Path(__file__).absolute()], created_by="test")
 
-        self.assertEqual("test", result["atp"].created_by)
+        if Version(libtorrent.__version__) < Version("2.1"):
+            self.assertEqual("test", result["atp"].ti.creator())
+        else:
+            self.assertEqual("test", result["atp"].created_by)
 
     def test_create_torrent_file_with_announce(self) -> None:
         """


### PR DESCRIPTION
This PR:

 - Adds support for `libtorrent` `2.0.13`, next to `2.1` experimental.
 - Updates the default `libtorrent` version to be `2.0.13`.
 - Updates the default `aiohttp` version to be `3.15.3`. Created new issue: https://github.com/Tribler/py-ipv8/issues/1366

This should allow us to make builds again 🥳 
