### PR TITLE
Fixed various build issues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,9 +26,9 @@ jobs:
       - name: Install NSIS
         if: matrix.os == 'windows-latest'
         run: |
-          Invoke-WebRequest https://deac-riga.dl.sourceforge.net/project/nsis/NSIS%203/3.10/nsis-3.10.zip?viasf=1 -OutFile C:\WINDOWS\Temp\nsis-3.10.zip
-          Expand-Archive -LiteralPath "C:\WINDOWS\Temp\nsis-3.10.zip" -DestinationPath "C:\WINDOWS\Temp\unzip-nsis-3.10"
-          Move-Item -Path "C:\WINDOWS\Temp\unzip-nsis-3.10\nsis-3.10" -Destination "C:\Program Files (x86)\NSIS"
+          Invoke-WebRequest -UserAgent "Wget" -Uri https://sourceforge.net/projects/nsis/files/NSIS%203/3.12/nsis-3.12.zip/download -OutFile C:\WINDOWS\Temp\nsis-3.12.zip
+          Expand-Archive -LiteralPath "C:\WINDOWS\Temp\nsis-3.12.zip" -DestinationPath "C:\WINDOWS\Temp\unzip-nsis-3.12"
+          Move-Item -Path "C:\WINDOWS\Temp\unzip-nsis-3.12\nsis-3.12" -Destination "C:\Program Files (x86)\NSIS"
       - name: Check out SimpleFC repository (Windows)
         if: matrix.os == 'windows-latest'
         uses: actions/checkout@v6

--- a/build/win/build.py
+++ b/build/win/build.py
@@ -64,10 +64,6 @@ def get_freeze_build_options():
         ("tribler.dist-info/METADATA", "lib/tribler.dist-info/METADATA"),
     ]
 
-    if platform.system() == "Darwin":
-        import libnacl
-        included_files.append((libnacl.nacl._name, "lib/libsodium.dylib"))
-
     # These packages will be excluded from the build
     excluded_packages = [
         'wx',


### PR DESCRIPTION
I assumed that switching libtorrent to a buildable version (#9014) would be the end of our build issues. I assumed wrong. Two remained.

This PR:

 - Fixes the SourceForge NSIS install script.
 - Removes a reference to `libnacl` in the build script.

The build is confirmed to work:
https://github.com/qstokkink/tribler/actions/runs/27538109792
