### PR TITLE
Various Fixes

### DIFF
--- a/src/run_tribler.py
+++ b/src/run_tribler.py
@@ -308,7 +308,7 @@ async def main() -> bool:
             # Don't open a new tab if we're (a) only adding a torrent with a session open, or (b) running headless.
             if not headless and (not torrent_uri or (initial_message is not None
                                                      and json.loads(initial_message).get("sessions", "0") == "0")):
-                open_webbrowser_tab(server_url + f"?key={config.get('api/key')}")
+                open_webbrowser_tab(server_url + f"/ui/#/downloads/all?key={config.get('api/key')}")
             # Block this process until our download has been delivered.
             if torrent_uri:
                 logger.info("Starting torrent using existing core")

--- a/src/tribler/core/libtorrent/restapi/downloads_endpoint.py
+++ b/src/tribler/core/libtorrent/restapi/downloads_endpoint.py
@@ -279,7 +279,9 @@ class DownloadsEndpoint(RESTEndpoint):
             num_seeds, num_peers = state.get_num_seeds_peers()
             num_connected_seeds, num_connected_peers = download.get_num_connected_seeds_peers()
 
-            tracker_info: list[TrackerStatusDict] = download.get_tracker_status()
+            tracker_info: list[TrackerStatusDict] = (download.get_tracker_status()
+                                                     if download.handle is not None and download.handle.is_valid()
+                                                     else [])
             num_seeds_scraped = max([ti.get("seeds", 0) for ti in tracker_info]) if tracker_info else 0
             num_peers_scraped = max([ti.get("leeches", 0) for ti in tracker_info]) if tracker_info else 0
             if (num_seeds_scraped + num_peers_scraped) > (num_seeds + num_peers):

--- a/src/tribler/test_unit/core/libtorrent/restapi/test_downloads_endpoint.py
+++ b/src/tribler/test_unit/core/libtorrent/restapi/test_downloads_endpoint.py
@@ -236,6 +236,23 @@ class TestDownloadsEndpoint(TestBase):
         self.assertEqual(1, response_body_json["checkpoints"]["loaded"])
         self.assertTrue(response_body_json["checkpoints"]["all_loaded"])
 
+    async def test_get_downloads_invalid_handle_download(self) -> None:
+        """
+        Test if a download with an invalid handle doesn't get its tracker info polled, which causes a RuntimeError.
+        """
+        dl = self.create_mock_download()
+        dl.handle = Mock(is_valid = Mock(return_value=False))
+        dl.get_tracker_status = Mock(side_effect=RuntimeError("invalid torrent handle used [libtorrent:20]"))
+        self.set_loaded_downloads([dl])
+        request = MockRequest("/api/downloads", query={})
+
+        response = await self.endpoint.get_downloads(request)
+        response_body_json = await response_to_json(response)
+
+        self.assertEqual(200, response.status)
+        self.assertEqual(1, len(response_body_json["downloads"]))
+
+
     async def test_get_downloads_filter_download_pass(self) -> None:
         """
         Test if the information of a download that passes the filter is correctly presented.

--- a/src/tribler/ui/src/pages/Downloads/Files.tsx
+++ b/src/tribler/ui/src/pages/Downloads/Files.tsx
@@ -132,5 +132,13 @@ export default function Files({download, style}: {download: Download; style?: Re
     // The API call may not be finished yet or the download is still getting metainfo.
     if (files.length === 0) return <span className="flex pl-4 pt-2 text-muted-foreground">No files available</span>;
 
-    return <SimpleTable data={files} style={style} columns={fileColumns} expandable={true} />;
+    return (
+        <SimpleTable
+            data={files}
+            style={style}
+            columns={fileColumns}
+            expandable={true}
+            storeSortingState="details-files-sorting"
+        />
+    );
 }

--- a/src/tribler/ui/src/pages/Downloads/Peers.tsx
+++ b/src/tribler/ui/src/pages/Downloads/Peers.tsx
@@ -120,5 +120,12 @@ const peerColumns: ColumnDef<Peer>[] = [
 export default function Peers({download, style}: {download: Download; style?: React.CSSProperties}) {
     if (!download.peers) return null;
 
-    return <SimpleTable data={download.peers} columns={peerColumns} style={style} />;
+    return (
+        <SimpleTable
+            data={download.peers}
+            columns={peerColumns}
+            style={style}
+            storeSortingState="details-peers-sorting"
+        />
+    );
 }

--- a/src/tribler/ui/src/pages/Downloads/Trackers.tsx
+++ b/src/tribler/ui/src/pages/Downloads/Trackers.tsx
@@ -62,6 +62,7 @@ export default function Trackers({download, style}: {download: Download; style?:
                         className="border-b-4 border-muted"
                         data={download.trackers as TrackerRow[]}
                         allowSelect={true}
+                        storeSortingState="details-trackers-sorting"
                         selectOnRightClick={true}
                         onSelectedRowsChange={setSelectedTrackers}
                         columns={trackerColumns}


### PR DESCRIPTION
Fixes #8996
Fixes #9009
Fixes stuck secondary processes (part of #8993)

This PR:

 - Fixes connections to an existing core launching a wrong web url and getting stuck.
 - Fixes `DownloadsEndpoint.get_downloads()` not checking for a handle before calling `get_tracker_status()`.
 - Updates the download details' `Files`, `Peers`, and `Trackers` SimpleTables to use `storeSortingState`.