### PR TITLE
Various fixes

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   build-and-push-image-ghcr:
     runs-on: ubuntu-latest
-    if: ${{ contains(join(github.event.release.assets.*.name, ', '), '_x64.deb') }}
+    if: ${{ github.event_name == 'workflow_dispatch' || contains(join(github.event.release.assets.*.name, ', '), '_x64.deb') }}
 
     # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
     permissions:
@@ -82,7 +82,7 @@ jobs:
 
   build-and-push-image-dockerhub:
     runs-on: ubuntu-latest
-    if: ${{ contains(join(github.event.release.assets.*.name, ', '), '_x64.deb') }}
+    if: ${{ github.event_name == 'workflow_dispatch' || contains(join(github.event.release.assets.*.name, ', '), '_x64.deb') }}
 
     # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
     permissions:

--- a/src/tribler/core/libtorrent/download_manager/download.py
+++ b/src/tribler/core/libtorrent/download_manager/download.py
@@ -596,8 +596,8 @@ class Download(TaskManager):
         self._logger.info("On tracker error alert: %s", str(alert))
         url = alert.url
 
-        if alert.msg:
-            status = "Error: " + alert.msg
+        if alert.error.message():
+            status = "Error: " + alert.error.message()
         elif alert.status_code > 0:
             status = f"HTTP status code {alert.status_code:d}"
         elif alert.status_code == 0:
@@ -914,13 +914,13 @@ class Download(TaskManager):
                 self.tracker_status.pop(removed)
             for tracker in trackers:
                 url = tracker["url"]
-                peers, status = self.tracker_status.get(url, [-1, "Not contacted yet"])
+                peers, status = cast("tuple[int, str]", self.tracker_status.get(url, [-1, "Not contacted yet"]))
                 result.append(TrackerStatusDict(
                     url=url,
-                    peers=cast("int", peers),
-                    seeds=tracker["scrape_complete"],
-                    leeches=tracker["scrape_incomplete"],
-                    status=cast("str", status)
+                    peers=peers,
+                    seeds=tracker["scrape_complete"] if peers >= 0 else peers,
+                    leeches=tracker["scrape_incomplete"]  if peers >= 0 else peers,
+                    status=status
                 ))
         except UnicodeDecodeError:
             self._logger.warning("UnicodeDecodeError in get_tracker_status")

--- a/src/tribler/test_unit/core/libtorrent/download_manager/test_download.py
+++ b/src/tribler/test_unit/core/libtorrent/download_manager/test_download.py
@@ -366,7 +366,7 @@ class TestDownload(TestBase):
         download = Download(FakeTDef(), self.dlmngr, checkpoint_disabled=True,
                             config=self.create_mock_download_config())
 
-        download.process_alert(Mock(msg=None, status_code=123, url="http://google.com",
+        download.process_alert(Mock(error=Mock(message=Mock(return_value="")), status_code=123, url="http://google.com",
                                     category=Mock(return_value=libtorrent.alert.category_t.error_notification)),
                                "tracker_error_alert")
 
@@ -379,7 +379,7 @@ class TestDownload(TestBase):
         download = Download(FakeTDef(), self.dlmngr, checkpoint_disabled=True,
                             config=self.create_mock_download_config())
 
-        download.process_alert(Mock(msg=None, status_code=0, url="http://google.com",
+        download.process_alert(Mock(error=Mock(message=Mock(return_value="")), status_code=0, url="http://google.com",
                                     category=Mock(return_value=libtorrent.alert.category_t.error_notification)),
                                "tracker_error_alert")
 
@@ -392,7 +392,7 @@ class TestDownload(TestBase):
         download = Download(FakeTDef(), self.dlmngr, checkpoint_disabled=True,
                             config=self.create_mock_download_config())
 
-        download.process_alert(Mock(msg=None, status_code=-1, url="http://google.com",
+        download.process_alert(Mock(error=Mock(message=Mock(return_value="")), status_code=-1, url="http://google.com",
                                     category=Mock(return_value=libtorrent.alert.category_t.error_notification)),
                                "tracker_error_alert")
 

--- a/src/tribler/ui/src/pages/Settings/General.tsx
+++ b/src/tribler/ui/src/pages/Settings/General.tsx
@@ -296,32 +296,6 @@ export default function General() {
 
             <div className="flex items-center space-x-2 py-2">
                 <Checkbox
-                    checked={!!settings?.libtorrent?.download_defaults?.auto_managed}
-                    id="auto_manage"
-                    onCheckedChange={(value) => {
-                        if (settings) {
-                            setSettings({
-                                ...settings,
-                                libtorrent: {
-                                    ...settings.libtorrent,
-                                    download_defaults: {
-                                        ...settings.libtorrent.download_defaults,
-                                        auto_managed: !!value,
-                                    },
-                                },
-                            });
-                        }
-                    }}
-                />
-                <label
-                    htmlFor="auto_manage"
-                    className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 whitespace-nowrap">
-                    {t("AutoManageEnable")}
-                </label>
-            </div>
-
-            <div className="flex items-center space-x-2 py-2">
-                <Checkbox
                     checked={!!settings?.libtorrent?.allow_mmap}
                     onCheckedChange={(value) => {
                         if (settings) {
@@ -363,6 +337,32 @@ export default function General() {
                     htmlFor="clear_orphaned_parts"
                     className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 whitespace-nowrap">
                     {t("ClearOrphanedParts")}
+                </label>
+            </div>
+
+            <div className="flex items-center space-x-2 py-2">
+                <Checkbox
+                    checked={!!settings?.libtorrent?.download_defaults?.auto_managed}
+                    id="auto_manage"
+                    onCheckedChange={(value) => {
+                        if (settings) {
+                            setSettings({
+                                ...settings,
+                                libtorrent: {
+                                    ...settings.libtorrent,
+                                    download_defaults: {
+                                        ...settings.libtorrent.download_defaults,
+                                        auto_managed: !!value,
+                                    },
+                                },
+                            });
+                        }
+                    }}
+                />
+                <label
+                    htmlFor="auto_manage"
+                    className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 whitespace-nowrap">
+                    {t("AutoManageEnable")}
                 </label>
             </div>
 


### PR DESCRIPTION
Fixes #9010
Fixes #9034

This PR:

 - Fixes `on_tracker_error_alert` pulling a message from `msg`, which is always empty.
 - Fixes trackers that reported `tracker_error_alert` setting `peers` to `-1`, but not `seeds` and `leeches`.
 - Fixes `workflow_dispatch` Docker builds always skipping themselves.
 - Updates the IPv8 pointer.

It's looking like other issues deserve their own PR.